### PR TITLE
feat(model-backend): add protobuf for model-backend service

### DIFF
--- a/model/model.proto
+++ b/model/model.proto
@@ -69,7 +69,23 @@ service Model {
       get: "/models"
     };
   }
+
+  rpc GetModel (GetModelRequest) returns (GetModelResponse) {
+    option (google.api.http) = {
+      get: "/models/{name}/{version}"
+    };
+  }
 }
+
+message GetModelRequest {
+    string name    = 1 [(google.api.field_behavior) = REQUIRED];
+    string version = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+message GetModelResponse {
+    ModelInfo models = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
 
 message LoadModelRequest {
     string name = 1 [(google.api.field_behavior) = REQUIRED];
@@ -106,11 +122,11 @@ message PredictModelResponse {
 message ListModelRequest {}
 
 message ListModelResponse {
-    repeated CreateModelResponse models = 1;
+    repeated ModelInfo models = 1;
 }
 
 message CreateModelsResponse {
-    repeated CreateModelResponse models = 1;
+    repeated ModelInfo models = 1;
 }
 
 message CreateModelRequest {
@@ -131,7 +147,7 @@ message ModelVersion {
   string status        = 6;
 }
 
-message CreateModelResponse {
+message ModelInfo {
   int32 id                       = 1;
   string name                    = 2;
   bool optimized                 = 3;
@@ -146,6 +162,7 @@ message CreateModelResponse {
   string icon                    = 12;
   string Author                  = 13;
   string fullName                = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated ModelVersion versions = 15;
 }
 
 message ClassificationOutput {

--- a/model/model.proto
+++ b/model/model.proto
@@ -61,7 +61,9 @@ message PredictModelResponse {
 }
 
 message ListModelRequest {}
-message ListModelResponse {}
+message ListModelResponse {
+    repeated CreateModelResponse models = 1;
+}
 
 message Timestamp {
   google.protobuf.Timestamp timestamp = 1;

--- a/model/model.proto
+++ b/model/model.proto
@@ -79,7 +79,6 @@ service Model {
 
 message GetModelRequest {
     string name    = 1 [(google.api.field_behavior) = REQUIRED];
-    string version = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message GetModelResponse {

--- a/model/model.proto
+++ b/model/model.proto
@@ -1,0 +1,101 @@
+syntax = "proto3";
+package instill.model;
+
+option go_package = "github.com/instill-ai/protobufs/model";
+
+// Protobuf standard
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/timestamp.proto";
+// Google api
+import "google/api/annotations.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+
+service Model {
+  rpc createModel (stream CreateModelRequest) returns (CreateModelResponse) {
+    option (google.api.http) = {
+      post: "/models"
+      body: "*"
+    };
+  }
+
+  rpc loadModel (LoadModelRequest) returns (LoadModelResponse) {}
+
+  rpc unloadModel (UnloadModelRequest) returns (UnloadModelResponse) {}
+
+  rpc predictModel (PredictModelRequest) returns (PredictModelResponse) {}
+
+  rpc listModels (ListModelRequest) returns (ListModelResponse) {}
+}
+
+message LoadModelRequest {
+    string modelId = 1 [(google.api.field_behavior) = REQUIRED];
+}
+message LoadModelResponse {
+    // OPTIONAL - If nontrivial cost is involved in
+    // determining the size, return 0 here and
+    // do the sizing in the modelSize function
+    uint64 sizeInBytes = 1;
+
+    // EXPERIMENTAL - Applies only if limitModelConcurrency = true
+    // was returned from runtimeStatus rpc.
+    // See RuntimeStatusResponse.limitModelConcurrency for more detail
+    uint32 maxConcurrency = 2;
+}
+
+message UnloadModelRequest {
+    string modelId = 1 [(google.api.field_behavior) = REQUIRED];
+}
+message UnloadModelResponse {}
+
+message PredictModelRequest {
+    string modelId      = 1 [(google.api.field_behavior) = REQUIRED];
+    string modelVersion = 2 [(google.api.field_behavior) = REQUIRED];
+}
+message PredictModelResponse {}
+
+message ListModelRequest {}
+message ListModelResponse {}
+
+message Timestamp {
+  google.protobuf.Timestamp timestamp = 1;
+}
+
+message CreateModelRequest {
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+  string description = 2 [(google.api.field_behavior) = OPTIONAL];
+  string type = 3 [(google.api.field_behavior) = REQUIRED];
+  string framework = 4 [(google.api.field_behavior) = REQUIRED];
+  bool optimized = 5 [(google.api.field_behavior) = OPTIONAL];
+  string visibility = 6 [(google.api.field_behavior) = OPTIONAL];
+  string filename = 7 [(google.api.field_behavior) = REQUIRED];
+  bytes content = 8 [(google.api.field_behavior) = REQUIRED];
+}
+
+message ModelVersion {
+  int32 version = 1;
+  int32 modelId = 2;
+  string description = 3;
+  Timestamp created_at = 4;
+  Timestamp updated_at = 5;
+  string status = 6;
+}
+
+message CreateModelResponse {
+  string id = 1;
+  string name = 2;
+  bool optimized = 3;
+  string description = 4;
+  string type = 5;
+  string framework = 6;
+  Timestamp created_at = 7;
+  Timestamp updated_at = 8;
+  string organization = 9;
+  string visibility = 10;
+  repeated ModelVersion versions = 11;
+  string icon = 12;
+  string Author = 13;
+  double duration = 14;
+}

--- a/model/model.proto
+++ b/model/model.proto
@@ -25,7 +25,7 @@ service Model {
 
   rpc unloadModel (UnloadModelRequest) returns (UnloadModelResponse) {}
 
-  rpc predictModel (PredictModelRequest) returns (PredictModelResponse) {}
+  rpc predictModel (stream PredictModelRequest) returns (PredictModelResponse) {}
 
   rpc listModels (ListModelRequest) returns (ListModelResponse) {}
 }
@@ -51,8 +51,9 @@ message UnloadModelRequest {
 message UnloadModelResponse {}
 
 message PredictModelRequest {
-    string modelId      = 1 [(google.api.field_behavior) = REQUIRED];
-    string modelVersion = 2 [(google.api.field_behavior) = REQUIRED];
+        string modelId      = 1 [(google.api.field_behavior) = REQUIRED];
+    int32 modelVersion  = 2 [(google.api.field_behavior) = REQUIRED];
+    bytes content       = 3 [(google.api.field_behavior) = REQUIRED];
 }
 message PredictModelResponse {}
 
@@ -76,7 +77,7 @@ message CreateModelRequest {
 
 message ModelVersion {
   int32 version = 1;
-  int32 modelId = 2;
+  string modelId = 2;
   string description = 3;
   Timestamp created_at = 4;
   Timestamp updated_at = 5;

--- a/model/model.proto
+++ b/model/model.proto
@@ -14,7 +14,7 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 
 service Model {
-  rpc createModel (stream CreateModelRequest) returns (CreateModelResponse) {
+  rpc createModel (stream CreateModelRequest) returns (CreateModelsResponse) {
     option (google.api.http) = {
       post: "/models"
       body: "*"
@@ -62,6 +62,10 @@ message PredictModelResponse {
 
 message ListModelRequest {}
 message ListModelResponse {
+    repeated CreateModelResponse models = 1;
+}
+
+message CreateModelsResponse {
     repeated CreateModelResponse models = 1;
 }
 

--- a/model/model.proto
+++ b/model/model.proto
@@ -15,25 +15,66 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 
 service Model {
-  rpc createModel (stream CreateModelRequest) returns (CreateModelsResponse) {
+  rpc Liveness(google.protobuf.Empty) returns (HealthCheckResponse) {
+    option (google.api.http) = {
+      get: "/__liveness"
+      additional_bindings: [
+        {
+          get: "/health/pipeline"
+        }
+      ]
+    };
+  }
+
+  rpc Readiness(google.protobuf.Empty) returns (HealthCheckResponse){
+    option (google.api.http) = {
+      get: "/__readiness"
+    };
+  }
+
+  rpc CreateModel (stream CreateModelRequest) returns (CreateModelsResponse) {
     option (google.api.http) = {
       post: "/models"
       body: "*"
     };
   }
 
-  rpc loadModel (LoadModelRequest) returns (LoadModelResponse) {}
+  rpc LoadModel (LoadModelRequest) returns (LoadModelResponse) {
+    option (google.api.http) = {
+      post: "/models/{name}/load"
+      body: "*"
+    };
+  }
 
-  rpc unloadModel (UnloadModelRequest) returns (UnloadModelResponse) {}
+  rpc UnloadModel (UnloadModelRequest) returns (UnloadModelResponse) {
+    option (google.api.http) = {
+      post: "/models/{name}/unload"
+      body: "*"
+    };
+  }
 
-  rpc predictModel (stream PredictModelRequest) returns (PredictModelResponse) {}
+  // This method handle upload file request
+  rpc PredictModelByUpload (stream PredictModelRequest) returns (PredictModelResponse) {}
 
-  rpc listModels (ListModelRequest) returns (ListModelResponse) {}
+  // This method handle request with file in body such as url/base64 encode
+  rpc PredictModel (PredictModelRequest) returns (PredictModelResponse) {
+    option (google.api.http) = {
+      post: "/models/{name}/outputs"
+      body: "*"
+    };
+  }
+
+  rpc ListModels (ListModelRequest) returns (ListModelResponse) {
+    option (google.api.http) = {
+      get: "/models"
+    };
+  }
 }
 
 message LoadModelRequest {
-    string modelId = 1 [(google.api.field_behavior) = REQUIRED];
+    string name = 1 [(google.api.field_behavior) = REQUIRED];
 }
+
 message LoadModelResponse {
     // OPTIONAL - If nontrivial cost is involved in
     // determining the size, return 0 here and
@@ -47,8 +88,9 @@ message LoadModelResponse {
 }
 
 message UnloadModelRequest {
-    string modelId = 1 [(google.api.field_behavior) = REQUIRED];
+    string name = 1 [(google.api.field_behavior) = REQUIRED];
 }
+
 message UnloadModelResponse {}
 
 message PredictModelRequest {
@@ -62,6 +104,7 @@ message PredictModelResponse {
 }
 
 message ListModelRequest {}
+
 message ListModelResponse {
     repeated CreateModelResponse models = 1;
 }
@@ -75,14 +118,14 @@ message Timestamp {
 }
 
 message CreateModelRequest {
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
+  string name        = 1 [(google.api.field_behavior) = REQUIRED];
   string description = 2 [(google.api.field_behavior) = OPTIONAL];
-  string type = 3 [(google.api.field_behavior) = REQUIRED];
-  string framework = 4 [(google.api.field_behavior) = REQUIRED];
-  bool optimized = 5 [(google.api.field_behavior) = OPTIONAL];
-  string visibility = 6 [(google.api.field_behavior) = OPTIONAL];
-  string filename = 7 [(google.api.field_behavior) = REQUIRED];
-  bytes content = 8 [(google.api.field_behavior) = REQUIRED];
+  string type        = 3 [(google.api.field_behavior) = REQUIRED];
+  string framework   = 4 [(google.api.field_behavior) = REQUIRED];
+  bool optimized     = 5 [(google.api.field_behavior) = OPTIONAL];
+  string visibility  = 6 [(google.api.field_behavior) = OPTIONAL];
+  string filename    = 7 [(google.api.field_behavior) = REQUIRED];
+  bytes content      = 8 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ModelVersion {
@@ -91,24 +134,24 @@ message ModelVersion {
   string description   = 3;
   Timestamp created_at = 4;
   Timestamp updated_at = 5;
-  string status = 6;
+  string status        = 6;
 }
 
 message CreateModelResponse {
-  string id = 1;
-  string name = 2;
-  bool optimized = 3;
-  string description = 4;
-  string type = 5;
-  string framework = 6;
-  Timestamp created_at = 7;
-  Timestamp updated_at = 8;
-  string organization = 9;
-  string visibility = 10;
+  string id                      = 1;
+  string name                    = 2;
+  bool optimized                 = 3;
+  string description             = 4;
+  string type                    = 5;
+  string framework               = 6;
+  Timestamp created_at           = 7;
+  Timestamp updated_at           = 8;
+  string organization            = 9;
+  string visibility              = 10;
   repeated ModelVersion versions = 11;
-  string icon = 12;
-  string Author = 13;
-  double duration = 14;
+  string icon                    = 12;
+  string Author                  = 13;
+  double duration                = 14;
 }
 
 message ClassificationOutput {
@@ -121,10 +164,10 @@ message ClassificationOutputs {
 }
 
 message Box {
-    float top = 1;
-    float left = 2;
-    float width = 3;
-    float height = 4;
+    float top     = 1;
+    float left    = 2;
+    float width   = 3;
+    float height  = 4;
 }
 
 message BoundingBoxPrediction {
@@ -139,4 +182,8 @@ message DetectionOutput {
 
 message DetectionOutputs {
     repeated DetectionOutput contents = 1;
+}
+
+message HealthCheckResponse {
+    int32 status = 1;
 }

--- a/model/model.proto
+++ b/model/model.proto
@@ -18,11 +18,9 @@ service Model {
   rpc Liveness(google.protobuf.Empty) returns (HealthCheckResponse) {
     option (google.api.http) = {
       get: "/__liveness"
-      additional_bindings: [
-        {
+      additional_bindings {
           get: "/health/pipeline"
         }
-      ]
     };
   }
 
@@ -32,7 +30,9 @@ service Model {
     };
   }
 
-  rpc CreateModel (stream CreateModelRequest) returns (CreateModelsResponse) {
+  rpc CreateModelByUpload (stream CreateModelRequest) returns (CreateModelsResponse) {}
+
+  rpc CreateModel (CreateModelRequest) returns (CreateModelsResponse) {
     option (google.api.http) = {
       post: "/models"
       body: "*"
@@ -130,7 +130,7 @@ message CreateModelRequest {
 
 message ModelVersion {
   int32 version        = 1;
-  string model_id      = 2;
+  int32 model_id       = 2;
   string description   = 3;
   Timestamp created_at = 4;
   Timestamp updated_at = 5;
@@ -138,7 +138,7 @@ message ModelVersion {
 }
 
 message CreateModelResponse {
-  string id                      = 1;
+  int32 id                       = 1;
   string name                    = 2;
   bool optimized                 = 3;
   string description             = 4;

--- a/model/model.proto
+++ b/model/model.proto
@@ -72,7 +72,7 @@ service Model {
 
   rpc GetModel (GetModelRequest) returns (GetModelResponse) {
     option (google.api.http) = {
-      get: "/models/{name}/{version}"
+      get: "/models/{name}"
     };
   }
 }
@@ -82,7 +82,7 @@ message GetModelRequest {
 }
 
 message GetModelResponse {
-    ModelInfo models = 1 [(google.api.field_behavior) = REQUIRED];
+    ModelInfo model = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 

--- a/model/model.proto
+++ b/model/model.proto
@@ -29,9 +29,9 @@ service Model {
     };
   }
 
-  rpc CreateModelByUpload (stream CreateModelRequest) returns (CreateModelsResponse) {}
+  rpc CreateModelByUpload (stream CreateModelRequest) returns (ModelInfo) {}
 
-  rpc CreateModel (CreateModelRequest) returns (CreateModelsResponse) {
+  rpc CreateModel (CreateModelRequest) returns (ModelInfo) {
     option (google.api.http) = {
       post: "/models"
       body: "*"
@@ -92,8 +92,7 @@ message UpdateModelRequest {
 
 message UpdateModelInfo {
   string name                    = 1 [(google.api.field_behavior) = REQUIRED];
-  string description             = 2;
-  ModelStatus status             = 3;
+  ModelStatus status             = 2;
 }
 
 message GetModelRequest {
@@ -137,10 +136,6 @@ message ListModelResponse {
     repeated ModelInfo models = 1;
 }
 
-message CreateModelsResponse {
-    repeated ModelInfo models = 1;
-}
-
 enum CVTask {
   UNDEFINED      = 0;
   CLASSIFICATION = 1;
@@ -148,16 +143,16 @@ enum CVTask {
 }
 
 message CreateModelRequest {
-
-  bytes content      = 1 [(google.api.field_behavior) = REQUIRED];
-  string type        = 2 [(google.api.field_behavior) = OPTIONAL];
-  string framework   = 3 [(google.api.field_behavior) = OPTIONAL];
-  string description = 4 [(google.api.field_behavior) = OPTIONAL];
-  bool optimized     = 5 [(google.api.field_behavior) = OPTIONAL];
-  string visibility  = 6 [(google.api.field_behavior) = OPTIONAL];
+  string name        = 1 [(google.api.field_behavior) = REQUIRED];
+  int32 version      = 2 [(google.api.field_behavior) = REQUIRED];
+  bytes content      = 3 [(google.api.field_behavior) = REQUIRED];
+  string type        = 4 [(google.api.field_behavior) = OPTIONAL];
+  string framework   = 5 [(google.api.field_behavior) = OPTIONAL];
+  string description = 6 [(google.api.field_behavior) = OPTIONAL];
+  bool optimized     = 7 [(google.api.field_behavior) = OPTIONAL];
+  string visibility  = 8 [(google.api.field_behavior) = OPTIONAL];
   // CV task type such as object detection, classification
-  CVTask cv_task     = 7 [(google.api.field_behavior) = OPTIONAL];
-  int32 version      = 8 [(google.api.field_behavior) = REQUIRED];
+  CVTask cv_task     = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 message ModelVersion {
@@ -173,17 +168,16 @@ message ModelInfo {
   int32 id                       = 1;
   string name                    = 2;
   bool optimized                 = 3;
-  string description             = 4;
-  string type                    = 5;
-  string framework               = 6;
-  google.protobuf.Timestamp created_at           = 7;
-  google.protobuf.Timestamp updated_at           = 8;
-  string organization            = 9;
-  string visibility              = 10;
-  repeated ModelVersion versions = 11;
-  string icon                    = 12;
-  string Author                  = 13;
-  string fullName                = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string type                    = 4;
+  string framework               = 5;
+  string organization            = 6;
+  string visibility              = 7;
+  repeated ModelVersion versions = 8;
+  string icon                    = 9;
+  string Author                  = 10;
+  string fullName                = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated string contents       = 12;
+  CVTask cv_task                 = 13;
 }
 
 message ClassificationOutput {

--- a/model/model.proto
+++ b/model/model.proto
@@ -67,12 +67,22 @@ service Model {
       get: "/models/{name}"
     };
   }
+
+  rpc DeleteModel (DeleteModelRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/models/{name}"
+    };
+  }
 }
 
 enum ModelStatus {
     OFFLINE            = 0;
     ONLINE             = 1;
     ERROR              = 2;
+}
+
+message DeleteModelRequest {
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message UpdateModelRequest {

--- a/model/model.proto
+++ b/model/model.proto
@@ -4,6 +4,7 @@ package instill.model;
 option go_package = "github.com/instill-ai/protobufs/model";
 
 // Protobuf standard
+import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/field_mask.proto";
@@ -51,13 +52,13 @@ message UnloadModelRequest {
 message UnloadModelResponse {}
 
 message PredictModelRequest {
-    string modelId      = 1 [(google.api.field_behavior) = REQUIRED];
-    int32 modelVersion  = 2 [(google.api.field_behavior) = REQUIRED];
-    bytes content       = 3 [(google.api.field_behavior) = REQUIRED];
-    string modelType    = 4 [(google.api.field_behavior) = REQUIRED];
+    string name      = 1 [(google.api.field_behavior) = REQUIRED];
+    int32 version    = 2 [(google.api.field_behavior) = REQUIRED];
+    bytes content    = 3 [(google.api.field_behavior) = REQUIRED];
+    int32 type       = 4 [(google.api.field_behavior) = REQUIRED];
 }
 message PredictModelResponse {
-    repeated string data    = 1 [(google.api.field_behavior) = REQUIRED];
+    google.protobuf.Any data  = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListModelRequest {}
@@ -85,9 +86,9 @@ message CreateModelRequest {
 }
 
 message ModelVersion {
-  int32 version = 1;
-  string modelId = 2;
-  string description = 3;
+  int32 version        = 1;
+  string model_id      = 2;
+  string description   = 3;
   Timestamp created_at = 4;
   Timestamp updated_at = 5;
   string status = 6;
@@ -108,4 +109,34 @@ message CreateModelResponse {
   string icon = 12;
   string Author = 13;
   double duration = 14;
+}
+
+message ClassificationOutput {
+    string category = 1;
+    float score     = 2;
+}
+
+message ClassificationOutputs {
+    repeated ClassificationOutput contents = 1;
+}
+
+message Box {
+    float top = 1;
+    float left = 2;
+    float width = 3;
+    float height = 4;
+}
+
+message BoundingBoxPrediction {
+    string category = 1;
+    float score     = 2;
+    Box box         = 3;
+}
+
+message DetectionOutput {
+    repeated BoundingBoxPrediction contents = 1;
+}
+
+message DetectionOutputs {
+    repeated DetectionOutput contents = 1;
 }

--- a/model/model.proto
+++ b/model/model.proto
@@ -18,7 +18,7 @@ service Model {
     option (google.api.http) = {
       get: "/__liveness"
       additional_bindings: {
-          get: "/health/pipeline"
+          get: "/health/model"
       }
     };
   }

--- a/model/model.proto
+++ b/model/model.proto
@@ -51,9 +51,10 @@ message UnloadModelRequest {
 message UnloadModelResponse {}
 
 message PredictModelRequest {
-        string modelId      = 1 [(google.api.field_behavior) = REQUIRED];
+    string modelId      = 1 [(google.api.field_behavior) = REQUIRED];
     int32 modelVersion  = 2 [(google.api.field_behavior) = REQUIRED];
     bytes content       = 3 [(google.api.field_behavior) = REQUIRED];
+    string modelType    = 4 [(google.api.field_behavior) = REQUIRED];
 }
 message PredictModelResponse {}
 

--- a/model/model.proto
+++ b/model/model.proto
@@ -18,9 +18,9 @@ service Model {
   rpc Liveness(google.protobuf.Empty) returns (HealthCheckResponse) {
     option (google.api.http) = {
       get: "/__liveness"
-      additional_bindings {
+      additional_bindings: {
           get: "/health/pipeline"
-        }
+      }
     };
   }
 
@@ -113,27 +113,21 @@ message CreateModelsResponse {
     repeated CreateModelResponse models = 1;
 }
 
-message Timestamp {
-  google.protobuf.Timestamp timestamp = 1;
-}
-
 message CreateModelRequest {
-  string name        = 1 [(google.api.field_behavior) = REQUIRED];
-  string description = 2 [(google.api.field_behavior) = OPTIONAL];
-  string type        = 3 [(google.api.field_behavior) = REQUIRED];
-  string framework   = 4 [(google.api.field_behavior) = REQUIRED];
+  bytes content      = 1 [(google.api.field_behavior) = REQUIRED];
+  string type        = 2 [(google.api.field_behavior) = OPTIONAL];
+  string framework   = 3 [(google.api.field_behavior) = OPTIONAL];
+  string description = 4 [(google.api.field_behavior) = OPTIONAL];
   bool optimized     = 5 [(google.api.field_behavior) = OPTIONAL];
   string visibility  = 6 [(google.api.field_behavior) = OPTIONAL];
-  string filename    = 7 [(google.api.field_behavior) = REQUIRED];
-  bytes content      = 8 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ModelVersion {
   int32 version        = 1;
   int32 model_id       = 2;
   string description   = 3;
-  Timestamp created_at = 4;
-  Timestamp updated_at = 5;
+  google.protobuf.Timestamp created_at = 4;
+  google.protobuf.Timestamp updated_at = 5;
   string status        = 6;
 }
 
@@ -144,14 +138,14 @@ message CreateModelResponse {
   string description             = 4;
   string type                    = 5;
   string framework               = 6;
-  Timestamp created_at           = 7;
-  Timestamp updated_at           = 8;
+  google.protobuf.Timestamp created_at           = 7;
+  google.protobuf.Timestamp updated_at           = 8;
   string organization            = 9;
   string visibility              = 10;
   repeated ModelVersion versions = 11;
   string icon                    = 12;
   string Author                  = 13;
-  double duration                = 14;
+  string fullName                = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 message ClassificationOutput {

--- a/model/model.proto
+++ b/model/model.proto
@@ -70,7 +70,7 @@ service Model {
     };
   }
 
-  rpc GetModel (GetModelRequest) returns (GetModelResponse) {
+  rpc GetModel (GetModelRequest) returns (ModelInfo) {
     option (google.api.http) = {
       get: "/models/{name}"
     };
@@ -80,11 +80,6 @@ service Model {
 message GetModelRequest {
     string name    = 1 [(google.api.field_behavior) = REQUIRED];
 }
-
-message GetModelResponse {
-    ModelInfo model = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
 
 message LoadModelRequest {
     string name = 1 [(google.api.field_behavior) = REQUIRED];

--- a/model/model.proto
+++ b/model/model.proto
@@ -123,18 +123,12 @@ message UnloadModelRequest {
 message UnloadModelResponse {}
 
 message PredictModelRequest {
-    enum CVTask {
-        CLASSIFICATION = 0;
-        DETECTION      = 1;
-    }
     // model name
     string name      = 1 [(google.api.field_behavior) = REQUIRED];
     // model version
     int32 version    = 2 [(google.api.field_behavior) = REQUIRED];
     // byte array of image content
     bytes content    = 3 [(google.api.field_behavior) = REQUIRED];
-    // CV task type such as object detection, classification
-    CVTask type      = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListModelRequest {}
@@ -148,12 +142,19 @@ message CreateModelsResponse {
 }
 
 message CreateModelRequest {
+  enum CVTask {
+    UNDEFINED      = 0;
+    CLASSIFICATION = 1;
+    DETECTION      = 2;
+  }
   bytes content      = 1 [(google.api.field_behavior) = REQUIRED];
   string type        = 2 [(google.api.field_behavior) = OPTIONAL];
   string framework   = 3 [(google.api.field_behavior) = OPTIONAL];
   string description = 4 [(google.api.field_behavior) = OPTIONAL];
   bool optimized     = 5 [(google.api.field_behavior) = OPTIONAL];
   string visibility  = 6 [(google.api.field_behavior) = OPTIONAL];
+  // CV task type such as object detection, classification
+  CVTask cv_task     = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 message ModelVersion {

--- a/model/model.proto
+++ b/model/model.proto
@@ -69,20 +69,21 @@ service Model {
   }
 }
 
+enum ModelStatus {
+    OFFLINE            = 0;
+    ONLINE             = 1;
+    ERROR              = 2;
+}
+
 message UpdateModelRequest {
   UpdateModelInfo model                 = 1 [(google.api.field_behavior) = REQUIRED];
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message UpdateModelInfo {
-  enum Status {
-    OFFLINE            = 0;
-    ONLINE             = 1;
-    ERROR              = 2;
-  }
-  string name        = 1 [(google.api.field_behavior) = REQUIRED];
-  string description = 2;
-  Status status      = 3;
+  string name                    = 1 [(google.api.field_behavior) = REQUIRED];
+  string description             = 2;
+  ModelStatus status             = 3;
 }
 
 message GetModelRequest {
@@ -146,12 +147,12 @@ message CreateModelRequest {
 }
 
 message ModelVersion {
-  int32 version        = 1;
-  int32 model_id       = 2;
-  string description   = 3;
+  int32 version                        = 1;
+  int32 model_id                       = 2;
+  string description                   = 3;
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp updated_at = 5;
-  string status        = 6;
+  ModelStatus status                   = 6;
 }
 
 message ModelInfo {

--- a/model/model.proto
+++ b/model/model.proto
@@ -4,7 +4,6 @@ package instill.model;
 option go_package = "github.com/instill-ai/protobufs/model";
 
 // Protobuf standard
-import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/field_mask.proto";
@@ -41,16 +40,16 @@ service Model {
 
   rpc UpdateModel (UpdateModelRequest) returns (ModelInfo) {
     option (google.api.http) = {
-      patch: "/models/{name}"
+      patch: "/models/{model.name}"
       body: "*"
     };
   }
 
   // This method handle upload file request
-  rpc PredictModelByUpload (stream PredictModelRequest) returns (google.protobuf.Any) {}
+  rpc PredictModelByUpload (stream PredictModelRequest) returns (google.protobuf.Struct) {}
 
   // This method handle request with file in body such as url/base64 encode
-  rpc PredictModel (PredictModelRequest) returns (google.protobuf.Any) {
+  rpc PredictModel (PredictModelRequest) returns (google.protobuf.Struct) {
     option (google.api.http) = {
       post: "/models/{name}/outputs"
       body: "*"
@@ -71,11 +70,20 @@ service Model {
 }
 
 message UpdateModelRequest {
-  string name        = 1 [(google.api.field_behavior) = REQUIRED];
-  string description = 2;
-  string status      = 3;
+  UpdateModelInfo model                 = 1 [(google.api.field_behavior) = REQUIRED];
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
+message UpdateModelInfo {
+  enum Status {
+    OFFLINE            = 0;
+    ONLINE             = 1;
+    ERROR              = 2;
+  }
+  string name        = 1 [(google.api.field_behavior) = REQUIRED];
+  string description = 2;
+  Status status      = 3;
+}
 
 message GetModelRequest {
     string name    = 1 [(google.api.field_behavior) = REQUIRED];

--- a/model/model.proto
+++ b/model/model.proto
@@ -56,7 +56,9 @@ message PredictModelRequest {
     bytes content       = 3 [(google.api.field_behavior) = REQUIRED];
     string modelType    = 4 [(google.api.field_behavior) = REQUIRED];
 }
-message PredictModelResponse {}
+message PredictModelResponse {
+    repeated string data    = 1 [(google.api.field_behavior) = REQUIRED];
+}
 
 message ListModelRequest {}
 message ListModelResponse {}

--- a/model/model.proto
+++ b/model/model.proto
@@ -112,10 +112,18 @@ message UnloadModelRequest {
 message UnloadModelResponse {}
 
 message PredictModelRequest {
+    enum CVTask {
+        CLASSIFICATION = 0;
+        DETECTION      = 1;
+    }
+    // model name
     string name      = 1 [(google.api.field_behavior) = REQUIRED];
+    // model version
     int32 version    = 2 [(google.api.field_behavior) = REQUIRED];
+    // byte array of image content
     bytes content    = 3 [(google.api.field_behavior) = REQUIRED];
-    int32 type       = 4 [(google.api.field_behavior) = REQUIRED];
+    // CV task type such as object detection, classification
+    CVTask type      = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListModelRequest {}

--- a/model/model.proto
+++ b/model/model.proto
@@ -39,25 +39,18 @@ service Model {
     };
   }
 
-  rpc LoadModel (LoadModelRequest) returns (LoadModelResponse) {
+  rpc UpdateModel (UpdateModelRequest) returns (ModelInfo) {
     option (google.api.http) = {
-      post: "/models/{name}/load"
-      body: "*"
-    };
-  }
-
-  rpc UnloadModel (UnloadModelRequest) returns (UnloadModelResponse) {
-    option (google.api.http) = {
-      post: "/models/{name}/unload"
+      patch: "/models/{name}"
       body: "*"
     };
   }
 
   // This method handle upload file request
-  rpc PredictModelByUpload (stream PredictModelRequest) returns (PredictModelResponse) {}
+  rpc PredictModelByUpload (stream PredictModelRequest) returns (google.protobuf.Any) {}
 
   // This method handle request with file in body such as url/base64 encode
-  rpc PredictModel (PredictModelRequest) returns (PredictModelResponse) {
+  rpc PredictModel (PredictModelRequest) returns (google.protobuf.Any) {
     option (google.api.http) = {
       post: "/models/{name}/outputs"
       body: "*"
@@ -76,6 +69,13 @@ service Model {
     };
   }
 }
+
+message UpdateModelRequest {
+  string name        = 1 [(google.api.field_behavior) = REQUIRED];
+  string description = 2;
+  string status      = 3;
+}
+
 
 message GetModelRequest {
     string name    = 1 [(google.api.field_behavior) = REQUIRED];
@@ -108,9 +108,6 @@ message PredictModelRequest {
     int32 version    = 2 [(google.api.field_behavior) = REQUIRED];
     bytes content    = 3 [(google.api.field_behavior) = REQUIRED];
     int32 type       = 4 [(google.api.field_behavior) = REQUIRED];
-}
-message PredictModelResponse {
-    google.protobuf.Any data  = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListModelRequest {}

--- a/model/model.proto
+++ b/model/model.proto
@@ -162,7 +162,6 @@ message ModelInfo {
   string icon                    = 12;
   string Author                  = 13;
   string fullName                = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
-  repeated ModelVersion versions = 15;
 }
 
 message ClassificationOutput {

--- a/model/model.proto
+++ b/model/model.proto
@@ -170,14 +170,11 @@ message ModelInfo {
   bool optimized                 = 3;
   string type                    = 4;
   string framework               = 5;
-  string organization            = 6;
-  string visibility              = 7;
-  repeated ModelVersion versions = 8;
-  string icon                    = 9;
-  string Author                  = 10;
-  string fullName                = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
-  repeated string contents       = 12;
-  CVTask cv_task                 = 13;
+  string visibility              = 6;
+  repeated ModelVersion versions = 7;
+  string fullName                = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated string contents       = 9;
+  CVTask cv_task                 = 10;
 }
 
 message ClassificationOutput {

--- a/model/model.proto
+++ b/model/model.proto
@@ -141,12 +141,14 @@ message CreateModelsResponse {
     repeated ModelInfo models = 1;
 }
 
+enum CVTask {
+  UNDEFINED      = 0;
+  CLASSIFICATION = 1;
+  DETECTION      = 2;
+}
+
 message CreateModelRequest {
-  enum CVTask {
-    UNDEFINED      = 0;
-    CLASSIFICATION = 1;
-    DETECTION      = 2;
-  }
+
   bytes content      = 1 [(google.api.field_behavior) = REQUIRED];
   string type        = 2 [(google.api.field_behavior) = OPTIONAL];
   string framework   = 3 [(google.api.field_behavior) = OPTIONAL];
@@ -155,6 +157,7 @@ message CreateModelRequest {
   string visibility  = 6 [(google.api.field_behavior) = OPTIONAL];
   // CV task type such as object detection, classification
   CVTask cv_task     = 7 [(google.api.field_behavior) = OPTIONAL];
+  int32 version      = 8 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ModelVersion {


### PR DESCRIPTION
Because

- As a user, I need model backend support gRPC to manage my vision AI models

This commit

- Add protobuf definition for model-backend which contain methods:
  1. Liveness and Readiness
  2. CreateModelByUpload (used for gRPC stream upload): upload the model file into Triton server but do not load it into the server yet
  3. LoadModel: load model into Triton server
  4. UnloadModel: unload model from Triton server
  5. PredictModelByUpload (used for gRPC stream): inference model with an input image
  6. ListModels: list all models
  7. GetModel: get model information by name
