### PR TITLE
ci: make new opened issue to trigger workflow

### DIFF
--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -3,10 +3,12 @@ name: Add PR to project
 on:
   pull_request:
     types:
+      - opened
       - ready_for_review
 jobs:
   track_pr:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Get project data
         env:


### PR DESCRIPTION
Because

- current workflow only triggers when a PR changes from draft -> ready for review status. We want to trigger the workflow whenever there is a new non-draft PR created.

This commit

- add trigger event opened and exclude draft PRs
