### PR TITLE
docs(docs): add temporary OpenAPI specs

### DIFF
--- a/model/model.swagger.json
+++ b/model/model.swagger.json
@@ -1,0 +1,534 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "model/model.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "Model"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/__liveness": {
+      "get": {
+        "operationId": "Model_Liveness",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/instillmodelHealthCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "Model"
+        ]
+      }
+    },
+    "/__readiness": {
+      "get": {
+        "operationId": "Model_Readiness",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/instillmodelHealthCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "Model"
+        ]
+      }
+    },
+    "/health/model": {
+      "get": {
+        "operationId": "Model_Liveness2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/instillmodelHealthCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "Model"
+        ]
+      }
+    },
+    "/models": {
+      "get": {
+        "operationId": "Model_ListModels",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/modelListModelResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "Model"
+        ]
+      },
+      "post": {
+        "operationId": "Model_CreateModel",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/modelCreateModelsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/modelCreateModelRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Model"
+        ]
+      }
+    },
+    "/models/{model.name}": {
+      "patch": {
+        "operationId": "Model_UpdateModel",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/modelModelInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "model.name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/modelUpdateModelRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Model"
+        ]
+      }
+    },
+    "/models/{name}": {
+      "get": {
+        "operationId": "Model_GetModel",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/modelModelInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Model"
+        ]
+      },
+      "delete": {
+        "operationId": "Model_DeleteModel",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Model"
+        ]
+      }
+    },
+    "/models/{name}/outputs": {
+      "post": {
+        "summary": "This method handle request with file in body such as url/base64 encode",
+        "operationId": "Model_PredictModel",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "description": "model name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "format": "int32",
+                  "title": "model version",
+                  "required": [
+                    "version"
+                  ]
+                },
+                "content": {
+                  "type": "string",
+                  "format": "byte",
+                  "title": "byte array of image content",
+                  "required": [
+                    "content"
+                  ]
+                }
+              },
+              "required": [
+                "version",
+                "content"
+              ]
+            }
+          }
+        ],
+        "tags": [
+          "Model"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "CreateModelRequestCVTask": {
+      "type": "string",
+      "enum": [
+        "UNDEFINED",
+        "CLASSIFICATION",
+        "DETECTION"
+      ],
+      "default": "UNDEFINED"
+    },
+    "instillmodelHealthCheckResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "modelCreateModelRequest": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string",
+          "format": "byte",
+          "required": [
+            "content"
+          ]
+        },
+        "type": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "optimized": {
+          "type": "boolean"
+        },
+        "visibility": {
+          "type": "string"
+        },
+        "cvTask": {
+          "$ref": "#/definitions/CreateModelRequestCVTask",
+          "title": "CV task type such as object detection, classification"
+        }
+      },
+      "required": [
+        "content"
+      ]
+    },
+    "modelCreateModelsResponse": {
+      "type": "object",
+      "properties": {
+        "models": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/modelModelInfo"
+          }
+        }
+      }
+    },
+    "modelListModelResponse": {
+      "type": "object",
+      "properties": {
+        "models": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/modelModelInfo"
+          }
+        }
+      }
+    },
+    "modelModelInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        },
+        "optimized": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "organization": {
+          "type": "string"
+        },
+        "visibility": {
+          "type": "string"
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/modelModelVersion"
+          }
+        },
+        "icon": {
+          "type": "string"
+        },
+        "Author": {
+          "type": "string"
+        },
+        "fullName": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "modelModelStatus": {
+      "type": "string",
+      "enum": [
+        "OFFLINE",
+        "ONLINE",
+        "ERROR"
+      ],
+      "default": "OFFLINE"
+    },
+    "modelModelVersion": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "modelId": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "description": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "$ref": "#/definitions/modelModelStatus"
+        }
+      }
+    },
+    "modelUpdateModelInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "required": [
+            "name"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/modelModelStatus"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "modelUpdateModelRequest": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/modelUpdateModelInfo"
+        },
+        "updateMask": {
+          "type": "string",
+          "required": [
+            "update_mask"
+          ]
+        }
+      },
+      "required": [
+        "updateMask"
+      ]
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "protobufNullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pipeline/pipeline.swagger.json
+++ b/pipeline/pipeline.swagger.json
@@ -1,0 +1,596 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "pipeline/pipeline.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "Pipeline"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/__liveness": {
+      "get": {
+        "operationId": "Pipeline_Liveness",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/instillpipelineHealthCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "Pipeline"
+        ]
+      }
+    },
+    "/__readiness": {
+      "get": {
+        "operationId": "Pipeline_Readiness",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/instillpipelineHealthCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "Pipeline"
+        ]
+      }
+    },
+    "/health/pipeline": {
+      "get": {
+        "operationId": "Pipeline_Liveness2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/instillpipelineHealthCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "Pipeline"
+        ]
+      }
+    },
+    "/pipelines": {
+      "get": {
+        "operationId": "Pipeline_ListPipelines",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/pipelineListPipelinesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "view",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "VIEW_UNSPECIFIED",
+              "BASIC",
+              "WITH_RECIPE"
+            ],
+            "default": "VIEW_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "Pipeline"
+        ]
+      },
+      "post": {
+        "operationId": "Pipeline_CreatePipeline",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/pipelinePipelineInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pipelineCreatePipelineRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Pipeline"
+        ]
+      }
+    },
+    "/pipelines/{name}": {
+      "get": {
+        "operationId": "Pipeline_GetPipeline",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/pipelinePipelineInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Pipeline"
+        ]
+      },
+      "delete": {
+        "operationId": "Pipeline_DeletePipeline",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "properties": {}
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Pipeline"
+        ]
+      }
+    },
+    "/pipelines/{name}/outputs": {
+      "post": {
+        "operationId": "Pipeline_TriggerPipeline",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "contents": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/pipelineTriggerPipelineContent"
+                  },
+                  "required": [
+                    "contents"
+                  ]
+                }
+              },
+              "required": [
+                "contents"
+              ]
+            }
+          }
+        ],
+        "tags": [
+          "Pipeline"
+        ]
+      }
+    },
+    "/pipelines/{pipeline.name}": {
+      "patch": {
+        "operationId": "Pipeline_UpdatePipeline",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/pipelinePipelineInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pipeline.name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/pipelinePipelineInfo"
+            }
+          },
+          {
+            "name": "updateMask",
+            "in": "query",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Pipeline"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "HealthCheckResponseServingStatusCode": {
+      "type": "string",
+      "enum": [
+        "UNKNOWN",
+        "SERVING",
+        "NOT_SERVING",
+        "SERVICE_UNKNOWN"
+      ],
+      "default": "UNKNOWN"
+    },
+    "ListPipelinesRequestView": {
+      "type": "string",
+      "enum": [
+        "VIEW_UNSPECIFIED",
+        "BASIC",
+        "WITH_RECIPE"
+      ],
+      "default": "VIEW_UNSPECIFIED"
+    },
+    "googlerpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "instillpipelineHealthCheckResponse": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/HealthCheckResponseServingStatusCode"
+        },
+        "status": {
+          "type": "string"
+        }
+      }
+    },
+    "pipelineCreatePipelineRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "required": [
+            "name"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "active": {
+          "type": "boolean",
+          "required": [
+            "active"
+          ]
+        },
+        "recipe": {
+          "$ref": "#/definitions/pipelineRecipe"
+        }
+      },
+      "required": [
+        "name",
+        "active"
+      ]
+    },
+    "pipelineDestination": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "required": [
+            "type"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "required": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ]
+    },
+    "pipelineListPipelinesResponse": {
+      "type": "object",
+      "properties": {
+        "contents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pipelinePipelineInfo"
+          }
+        },
+        "nextPageToken": {
+          "type": "string"
+        }
+      }
+    },
+    "pipelineLogicOperator": {
+      "type": "object"
+    },
+    "pipelineModel": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "required": [
+            "name"
+          ]
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32",
+          "required": [
+            "version"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    },
+    "pipelinePipelineInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "recipe": {
+          "$ref": "#/definitions/pipelineRecipe"
+        },
+        "fullName": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "pipelineRecipe": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/pipelineSource"
+        },
+        "destination": {
+          "$ref": "#/definitions/pipelineDestination"
+        },
+        "model": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pipelineModel"
+          },
+          "required": [
+            "model"
+          ]
+        },
+        "logicOperator": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/pipelineLogicOperator"
+          },
+          "required": [
+            "logic_operator"
+          ]
+        }
+      },
+      "required": [
+        "model",
+        "logicOperator"
+      ]
+    },
+    "pipelineScheduler": {
+      "type": "object",
+      "properties": {
+        "crontab": {
+          "type": "string",
+          "required": [
+            "crontab"
+          ]
+        }
+      },
+      "required": [
+        "crontab"
+      ]
+    },
+    "pipelineSource": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "required": [
+            "type"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "required": [
+            "name"
+          ]
+        },
+        "scheduler": {
+          "$ref": "#/definitions/pipelineScheduler"
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ]
+    },
+    "pipelineTriggerPipelineContent": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "base64": {
+          "type": "string"
+        },
+        "chunk": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+        }
+      },
+      "additionalProperties": {},
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+    },
+    "protobufNullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    }
+  }
+}


### PR DESCRIPTION
Because

- we decide to put the OpenAPI specs inside the `pipeline` or `model`

This commit

- add temporary OpenAPI specs
- close #9 
