### PR TITLE
fix: remove version from creating model, the model version will be au…

### DIFF
--- a/model/model.proto
+++ b/model/model.proto
@@ -144,15 +144,14 @@ enum CVTask {
 
 message CreateModelRequest {
   string name        = 1 [(google.api.field_behavior) = REQUIRED];
-  int32 version      = 2 [(google.api.field_behavior) = REQUIRED];
-  bytes content      = 3 [(google.api.field_behavior) = REQUIRED];
-  string type        = 4 [(google.api.field_behavior) = OPTIONAL];
-  string framework   = 5 [(google.api.field_behavior) = OPTIONAL];
-  string description = 6 [(google.api.field_behavior) = OPTIONAL];
-  bool optimized     = 7 [(google.api.field_behavior) = OPTIONAL];
-  string visibility  = 8 [(google.api.field_behavior) = OPTIONAL];
+  bytes content      = 2 [(google.api.field_behavior) = REQUIRED];
+  string type        = 3 [(google.api.field_behavior) = OPTIONAL];
+  string framework   = 4 [(google.api.field_behavior) = OPTIONAL];
+  string description = 5 [(google.api.field_behavior) = OPTIONAL];
+  bool optimized     = 6 [(google.api.field_behavior) = OPTIONAL];
+  string visibility  = 7 [(google.api.field_behavior) = OPTIONAL];
   // CV task type such as object detection, classification
-  CVTask cv_task     = 9 [(google.api.field_behavior) = OPTIONAL];
+  CVTask cv_task     = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
 message ModelVersion {


### PR DESCRIPTION
…to increased

Because

- To make the model API convenient to users, the model version should be auto increased

This commit

- Remove version from create model method's parameter
