### PR TITLE
fix(pipeline): use `full_name` instead of `fullName`

### DIFF
--- a/pipeline/pipeline.proto
+++ b/pipeline/pipeline.proto
@@ -76,7 +76,7 @@ message PipelineInfo {
   google.protobuf.Timestamp created_at = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   google.protobuf.Timestamp updated_at = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   instill.pipeline.Recipe recipe = 7;
-  string fullName = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string full_name = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 message CreatePipelineRequest {


### PR DESCRIPTION
Because

- the convention is snake_case in the field name, we should follow the convention

This commit

- use `full_name` instead of `fullName`
