### PR TITLE
refactor(model): reformat fields name

### DIFF
--- a/model/model.proto
+++ b/model/model.proto
@@ -112,28 +112,6 @@ message GetModelRequest {
     string name    = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
-message LoadModelRequest {
-    string name = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-message LoadModelResponse {
-    // OPTIONAL - If nontrivial cost is involved in
-    // determining the size, return 0 here and
-    // do the sizing in the modelSize function
-    uint64 sizeInBytes = 1;
-
-    // EXPERIMENTAL - Applies only if limitModelConcurrency = true
-    // was returned from runtimeStatus rpc.
-    // See RuntimeStatusResponse.limitModelConcurrency for more detail
-    uint32 maxConcurrency = 2;
-}
-
-message UnloadModelRequest {
-    string name = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-message UnloadModelResponse {}
-
 message PredictModelRequest {
     // model name
     string name      = 1 [(google.api.field_behavior) = REQUIRED];


### PR DESCRIPTION
Because

- Field definitions in the .proto files must use lower_case_underscore_separated_names. These names will be mapped to the native naming convention in generated code for each programming language.

This commit

- Update all fields with the above format
- Remove unsued messages
- close #21 
