### PR TITLE
fix(model): move name and version out of updated model info message struct

### DIFF
--- a/model/model.proto
+++ b/model/model.proto
@@ -40,7 +40,7 @@ service Model {
 
   rpc UpdateModel (UpdateModelRequest) returns (ModelInfo) {
     option (google.api.http) = {
-      patch: "/models/{model.name}/versions/{model.version}"
+      patch: "/models/{name}/versions/{version}"
       body: "*"
     };
   }
@@ -97,15 +97,15 @@ message DeleteModelVersionRequest {
 }
 
 message UpdateModelRequest {
-  UpdateModelInfo model                 = 1 [(google.api.field_behavior) = REQUIRED];
-  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+  string name                           = 1 [(google.api.field_behavior) = REQUIRED];
+  int32 version                         = 2 [(google.api.field_behavior) = REQUIRED];
+  UpdateModelInfo model                 = 3 [(google.api.field_behavior) = REQUIRED];
+  google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 message UpdateModelInfo {
-  string name                    = 1 [(google.api.field_behavior) = REQUIRED];
-  int32 version                  = 2 [(google.api.field_behavior) = REQUIRED];
-  ModelStatus status             = 3;
-  string description             = 4;
+  ModelStatus status             = 1;
+  string description             = 2;
 }
 
 message GetModelRequest {

--- a/model/model.proto
+++ b/model/model.proto
@@ -41,7 +41,7 @@ service Model {
   rpc UpdateModel (UpdateModelRequest) returns (ModelInfo) {
     option (google.api.http) = {
       patch: "/models/{name}/versions/{version}"
-      body: "*"
+      body: "model"
     };
   }
 


### PR DESCRIPTION
Because

- Model name and version is not allowed to update

This commit

- Move model name and version out of updated model info message struct
