### PR TITLE
refactor: simplify output and update patch

### DIFF
--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -146,18 +146,24 @@ message CreateModelBinaryFileUploadResponse {
   Model model = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
+// UpdateModelVersionPatch represents a patch to update a model
+message UpdateModelVersionPatch {
+  // Model version description
+  string description = 1;
+  // Model version status
+  ModelVersion.Status status = 2;
+}
+
 // CreateModelRequest represents a request to update a model
 message UpdateModelVersionRequest {
   // Model name
   string name = 1 [ (google.api.field_behavior) = REQUIRED ];
   // Model version
   uint64 version = 2 [ (google.api.field_behavior) = REQUIRED ];
-  // Model version description
-  string description = 3 [ (google.api.field_behavior) = OPTIONAL ];
-  // Model version status
-  ModelVersion.Status status = 4 [ (google.api.field_behavior) = OPTIONAL ];
+  // Model version patch to update
+  UpdateModelVersionPatch version_patch = 3 [ (google.api.field_behavior) = REQUIRED ];
   // Update mask for a model instance
-  google.protobuf.FieldMask field_mask = 5
+  google.protobuf.FieldMask field_mask = 4
       [ (google.api.field_behavior) = REQUIRED ];
 }
 
@@ -359,7 +365,7 @@ service ModelService {
       returns (UpdateModelVersionResponse) {
     option (google.api.http) = {
       patch : "/models/{name}/versions/{version}"
-      body : "*"
+      body : "version_patch"
     };
   }
 

--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -219,12 +219,6 @@ message Input {
   }
 }
 
-// Output represents the output from a model
-message Output {
-  // Struct output
-  google.protobuf.Struct output = 1;
-}
-
 // TriggerModelRequest represents a request to trigger a model
 message TriggerModelRequest {
   // Model name
@@ -238,7 +232,7 @@ message TriggerModelRequest {
 // TriggerModelResponse represents a response for the output of a model
 message TriggerModelResponse {
   // Output from a model
-  Output output = 1;
+  google.protobuf.Struct output = 1;
 }
 
 // TriggerModelBinaryFileUploadRequest represents a request to trigger a model
@@ -255,7 +249,7 @@ message TriggerModelBinaryFileUploadRequest {
 // a model
 message TriggerModelBinaryFileUploadResponse {
   // Output from a model
-  Output output = 1;
+  google.protobuf.Struct output = 1;
 }
 
 // ClassificationOutput represents the output of classification task

--- a/instill/pipeline/v1alpha/pipeline.proto
+++ b/instill/pipeline/v1alpha/pipeline.proto
@@ -218,12 +218,6 @@ message Input {
   }
 }
 
-// Output represents the output from a pipeline
-message Output {
-  // Struct output
-  google.protobuf.Struct output = 1;
-}
-
 // TriggerPipelineRequest represents a request to trigger a pipeline
 message TriggerPipelineRequest {
   // Pipeline name
@@ -235,7 +229,7 @@ message TriggerPipelineRequest {
 // TriggerPipelineResponse represents a response for the output of a pipeline
 message TriggerPipelineResponse {
   // Output from a pipeline
-  Output output = 1;
+  google.protobuf.Struct output = 1;
 }
 
 // TriggerPipelineBinaryFileUploadRequest represents a request to trigger a pipeline
@@ -249,7 +243,7 @@ message TriggerPipelineBinaryFileUploadRequest {
 // TriggerPipelineBinaryFileUploadResponse represents a response for the output of a pipeline
 message TriggerPipelineBinaryFileUploadResponse {
   // Output from a pipeline
-  Output output = 1;
+  google.protobuf.Struct output = 1;
 }
 
 // Pipeline service responds to incoming pipeline requests.

--- a/instill/pipeline/v1alpha/pipeline.proto
+++ b/instill/pipeline/v1alpha/pipeline.proto
@@ -177,18 +177,24 @@ message GetPipelineResponse {
   Pipeline pipeline = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
+// UpdatePipelinePatch represents a patch to update a pipeline
+message UpdatePipelinePatch {
+  // Pipeline description
+  string description = 1;
+  // Pipeline activity status
+  bool active = 2;
+  // Pipeline recipe
+  Recipe recipe = 3;
+}
+
 // UpdatePipelineRequest represents a request to update a pipeline
 message UpdatePipelineRequest {
   // Pipeline name
   string name = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // Pipeline description
-  string description = 2 [ (google.api.field_behavior) = OPTIONAL ];
-  // Pipeline activity status
-  bool active = 3 [ (google.api.field_behavior) = OPTIONAL ];
-  // Pipeline recipe
-  Recipe recipe = 4 [ (google.api.field_behavior) = OPTIONAL ];
+  // Pipeline patch to update
+  UpdatePipelinePatch pipeline_patch = 2 [ (google.api.field_behavior) = REQUIRED ];
   // Update mask for a pipeline instance
-  google.protobuf.FieldMask field_mask = 5
+  google.protobuf.FieldMask field_mask = 3
       [ (google.api.field_behavior) = REQUIRED ];
 }
 
@@ -298,7 +304,7 @@ service PipelineService {
   rpc UpdatePipeline(UpdatePipelineRequest) returns (UpdatePipelineResponse) {
     option (google.api.http) = {
       patch : "/pipelines/{name}"
-      body : "*"
+      body : "pipeline_patch"
     };
   }
 


### PR DESCRIPTION
Because

- we are tinkering with the interface for adopting the new protobufs for `pipeline-backend` and `model-backend`

This commit

- simplify the output JSON structure
- introduce update patch message
