### PR TITLE
fix: fix openapi using snake case

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -26,6 +26,8 @@ plugins:
       - generate_unbound_methods=true
   - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.7.2-1
     out: gen/openapiv2
+    opt:
+      - json_names_for_fields=false
   - remote: buf.build/sawadashota/plugins/protoc-gen-doc:v1.5.0
     out: gen/grpc-doc
     opt:

--- a/instill/model/v1alpha/model.swagger.json
+++ b/instill/model/v1alpha/model.swagger.json
@@ -279,7 +279,7 @@
             }
           },
           {
-            "name": "fieldMask",
+            "name": "field_mask",
             "description": "Update mask for a model instance.",
             "in": "query",
             "required": true,
@@ -389,11 +389,11 @@
     "instillmodelv1alphaInput": {
       "type": "object",
       "properties": {
-        "imageUrl": {
+        "image_url": {
           "type": "string",
           "title": "Image type URL"
         },
-        "imageBase64": {
+        "image_base64": {
           "type": "string",
           "title": "Image type base64"
         }
@@ -433,7 +433,7 @@
           "type": "string",
           "title": "Model name"
         },
-        "fullName": {
+        "full_name": {
           "type": "string",
           "title": "Model full name (i.e., [user_name/org_name]/model_name)",
           "readOnly": true
@@ -442,7 +442,7 @@
           "$ref": "#/definitions/ModelTask",
           "title": "Model task"
         },
-        "modelVersions": {
+        "model_versions": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/v1alphaModelVersion"
@@ -539,7 +539,7 @@
           "format": "uint64",
           "title": "Model version"
         },
-        "modelId": {
+        "model_id": {
           "type": "string",
           "format": "uint64",
           "title": "Model version corresponding model ID"
@@ -548,12 +548,12 @@
           "type": "string",
           "title": "Model version description"
         },
-        "createdAt": {
+        "created_at": {
           "type": "string",
           "format": "date-time",
           "title": "Model version creation time"
         },
-        "updatedAt": {
+        "updated_at": {
           "type": "string",
           "format": "date-time",
           "title": "Model version update time"
@@ -614,7 +614,7 @@
     "v1alphaUpdateModelVersionResponse": {
       "type": "object",
       "properties": {
-        "modelVersion": {
+        "model_version": {
           "$ref": "#/definitions/v1alphaModelVersion",
           "title": "A model version instance"
         }

--- a/instill/pipeline/v1alpha/pipeline.swagger.json
+++ b/instill/pipeline/v1alpha/pipeline.swagger.json
@@ -132,7 +132,7 @@
         },
         "parameters": [
           {
-            "name": "pageSize",
+            "name": "page_size",
             "description": "Page size.",
             "in": "query",
             "required": false,
@@ -140,7 +140,7 @@
             "format": "uint64"
           },
           {
-            "name": "pageToken",
+            "name": "page_token",
             "description": "Page token.",
             "in": "query",
             "required": false,
@@ -292,7 +292,7 @@
             }
           },
           {
-            "name": "fieldMask",
+            "name": "field_mask",
             "description": "Update mask for a pipeline instance.",
             "in": "query",
             "required": true,
@@ -394,11 +394,11 @@
     "instillpipelinev1alphaInput": {
       "type": "object",
       "properties": {
-        "imageUrl": {
+        "image_url": {
           "type": "string",
           "title": "Image type URL"
         },
-        "imageBase64": {
+        "image_base64": {
           "type": "string",
           "title": "Image type base64"
         }
@@ -579,7 +579,7 @@
           },
           "title": "A list of pipelines"
         },
-        "nextPageToken": {
+        "next_page_token": {
           "type": "string",
           "title": "Next page token"
         }
@@ -609,13 +609,13 @@
           "type": "boolean",
           "title": "Pipeline activity status"
         },
-        "createdAt": {
+        "created_at": {
           "type": "string",
           "format": "date-time",
           "title": "Pipeline creation time",
           "readOnly": true
         },
-        "updatedAt": {
+        "updated_at": {
           "type": "string",
           "format": "date-time",
           "title": "Pipeline update time",
@@ -625,7 +625,7 @@
           "$ref": "#/definitions/v1alphaRecipe",
           "title": "Pipeline recipe"
         },
-        "fullName": {
+        "full_name": {
           "type": "string",
           "title": "Pipeline full name (i.e., [user_name/org_name]/pipeline_name)",
           "readOnly": true


### PR DESCRIPTION
Because

- response output standard follows snake_case to disambiguate REST and gRPC naming convention

This commit

- configure `openapiv2` plugin with `json_names_for_fields=false` based on the [official guideline](https://grpc-ecosystem.github.io/grpc-gateway/docs/development/grpc-gateway_v2_migration_guide/#we-now-use-the-camelcase-json-names-by-default)
