### PR TITLE
feat(model): add method create model by GitHub

### DIFF
--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -336,7 +336,12 @@ service ModelService {
   // CreateModelByGitHubRequest message and returns a
   // CreateModelByGitHubResponse message.
   rpc CreateModelByGitHub(CreateModelByGitHubRequest)
-      returns (CreateModelByGitHubResponse) {}
+      returns (CreateModelByGitHubResponse) {
+        option (google.api.http) = {
+          post : "/models"
+          body : "*"
+        };
+      }
 
   // CreateModelBinaryFileUpload method receives a
   // CreateModelBinaryFileUploadRequest message and returns a

--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -107,6 +107,10 @@ message Model {
   Task task = 4;
   // Model versions
   repeated ModelVersion model_versions = 5;
+  // Model GitHub URL
+  // have value when create model by CreateModelByGitHub
+  // empty value when model created by CreateModelBinaryFileUpload
+  string github_url = 6;
 }
 
 // CreateModelBinaryFileUploadRequest represents a request to create a model

--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -110,7 +110,7 @@ message Model {
   // Model GitHub URL
   // have value when creating model by CreateModelByGitHub
   // empty value when creating model by CreateModelBinaryFileUpload
-  string github_url = 6;
+  string github_url = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // CreateModelBinaryFileUploadRequest represents a request to create a model

--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -11,6 +11,27 @@ import "google/protobuf/timestamp.proto";
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 
+// GitRef represents the git reference
+message GitRef {
+  // git reference
+  oneof ref {
+    // git branch
+    string branch = 1;
+    // git tag
+    string tag = 2;
+    // git commit
+    string commit = 3;
+  }
+}
+
+// GitHub represents the GitHub source a model is created from
+message GitHub {
+  // GitHub repository URL
+  string repo_url = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // git reference
+  GitRef git_ref = 2 [ (google.api.field_behavior) = REQUIRED ];
+}
+
 // LivenessRequest represents a request to check a service liveness status
 message LivenessRequest {
   // Service name to check for its liveness status
@@ -107,10 +128,8 @@ message Model {
   Task task = 4;
   // Model versions
   repeated ModelVersion model_versions = 5;
-  // Model GitHub URL
-  // have value when creating model by CreateModelByGitHub
-  // empty value when creating model by CreateModelBinaryFileUpload
-  string github_url = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Model GitHub source (has value when model created by CreateModelByGitHub and is empty when created by CreateModelBinaryFileUpload)
+  GitHub github = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // CreateModelBinaryFileUploadRequest represents a request to create a model
@@ -138,14 +157,8 @@ message CreateModelByGitHubRequest {
   string name = 1 [ (google.api.field_behavior) = REQUIRED ];
   // Model description
   string description = 2 [ (google.api.field_behavior) = OPTIONAL ];
-  // GitHub URL repository
-  string repository = 3 [ (google.api.field_behavior) = REQUIRED ];
-  // GitHub branch
-  string branch = 4 [ (google.api.field_behavior) = OPTIONAL ];
-  // GitHub tag
-  string tag = 5 [ (google.api.field_behavior) = OPTIONAL ];
-  // GitHub commit
-  string commit = 6 [ (google.api.field_behavior) = OPTIONAL ];
+  // Model GitHub source
+  GitHub github = 3 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // CreateModelByGitHubResponse represents a response for a model

--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -128,6 +128,23 @@ message CreateModelBinaryFileUploadResponse {
   Model model = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
+// CreateModelByGitHubRequest represents a request to create a model from a GitHub repo
+message CreateModelByGitHubRequest {
+  // Model name
+  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // GitHub URL repository
+  string github_url = 2 [ (google.api.field_behavior) = REQUIRED ];
+  // Model description
+  string description = 3 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// CreateModelByGitHubResponse represents a response for a model
+// instance
+message CreateModelByGitHubResponse {
+  // A model instance
+  Model model = 1 [ (google.api.field_behavior) = REQUIRED ];
+}
+
 // UpdateModelVersionPatch represents a patch to update a model
 message UpdateModelVersionPatch {
   // Model version description
@@ -310,6 +327,12 @@ service ModelService {
       get : "/__readiness"
     };
   }
+
+  // CreateModelByGitHub method receives a
+  // CreateModelByGitHubRequest message and returns a
+  // CreateModelByGitHubResponse message.
+  rpc CreateModelByGitHub(CreateModelByGitHubRequest)
+      returns (CreateModelByGitHubResponse) {}
 
   // CreateModelBinaryFileUpload method receives a
   // CreateModelBinaryFileUploadRequest message and returns a

--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -108,8 +108,8 @@ message Model {
   // Model versions
   repeated ModelVersion model_versions = 5;
   // Model GitHub URL
-  // have value when create model by CreateModelByGitHub
-  // empty value when model created by CreateModelBinaryFileUpload
+  // have value when creating model by CreateModelByGitHub
+  // empty value when creating model by CreateModelBinaryFileUpload
   string github_url = 6;
 }
 

--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -136,10 +136,16 @@ message CreateModelBinaryFileUploadResponse {
 message CreateModelByGitHubRequest {
   // Model name
   string name = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // GitHub URL repository
-  string github_url = 2 [ (google.api.field_behavior) = REQUIRED ];
   // Model description
-  string description = 3 [ (google.api.field_behavior) = OPTIONAL ];
+  string description = 2 [ (google.api.field_behavior) = OPTIONAL ];
+  // GitHub URL repository
+  string repository = 3 [ (google.api.field_behavior) = REQUIRED ];
+  // GitHub branch
+  string branch = 4 [ (google.api.field_behavior) = OPTIONAL ];
+  // GitHub tag
+  string tag = 5 [ (google.api.field_behavior) = OPTIONAL ];
+  // GitHub commit
+  string commit = 6 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // CreateModelByGitHubResponse represents a response for a model


### PR DESCRIPTION
Because

- It is convenient for users when creating a model from their GitHub repository

This commit

- Add a method to create a model by GitHub URL
