### PR TITLE
fix(model): move github from model to model version

### DIFF
--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -103,6 +103,8 @@ message ModelVersion {
   google.protobuf.Timestamp updated_at = 5;
   // Model version status
   Status status = 6;
+  // Model GitHub source (has value when model created by CreateModelByGitHub and is empty when created by CreateModelBinaryFileUpload)
+  GitHub github = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // Model represents the content of a model
@@ -128,8 +130,6 @@ message Model {
   Task task = 4;
   // Model versions
   repeated ModelVersion model_versions = 5;
-  // Model GitHub source (has value when model created by CreateModelByGitHub and is empty when created by CreateModelBinaryFileUpload)
-  GitHub github = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // CreateModelBinaryFileUploadRequest represents a request to create a model


### PR DESCRIPTION
Because

- Model version have GitHub information including repository, branch, tag and commit hash

This commit

- Move GitHub from Model message to ModelVersion message
