### PR TITLE
fix(model): support inferencing multiple files 

### DIFF
--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -271,8 +271,10 @@ message TriggerModelBinaryFileUploadRequest {
   string name = 1 [ (google.api.field_behavior) = REQUIRED ];
   // Model version
   uint64 version = 2 [ (google.api.field_behavior) = REQUIRED ];
-  // Model content in bytes
-  bytes bytes = 3 [ (google.api.field_behavior) = REQUIRED ];
+  // list of image's file length
+  repeated uint64 file_lengths = 3 [ (google.api.field_behavior) = REQUIRED ];
+  // Content of images in bytes
+  bytes bytes = 4 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // TriggerModelBinaryFileUploadResponse represents a response for the output of


### PR DESCRIPTION

Because

- It is convenient to make inferences with multiple files

This commit

- Support making inference with multiple files by adding length of files in the request
