### PR TITLE
chore(model): use id to construct resource name

### DIFF
--- a/instill/model/v1alpha/definition.proto
+++ b/instill/model/v1alpha/definition.proto
@@ -31,29 +31,33 @@ message ModelDefinition {
   };
 
   // ModelDefinition resource name. It must have the format of
-  // "model-definitions/{uuid}"
+  // "model-definitions/{model-definition}"
   string name = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // ModelDefinition id in UUIDv4
+  // ModelDefinition ID in UUIDv4
   string uid = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // ModelDefinition name
-  string title = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // ModelDefinition resource ID (the last segment of the resource name) used to
+  // construct the resource name.
+  string id = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+
+  // ModelDefinition display official title
+  string title = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition documentation url
-  string documentation_url = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  string documentation_url = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition icon
-  string icon = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  string icon = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition spec
-  Spec spec = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  Spec spec = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition public flag, i.e., true if this definition is available to
   // all workspaces
-  bool public = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  bool public = 8 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition custom flag, i.e., true if this is a custom model
   // definition
-  bool custom = 8 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  bool custom = 9 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition create time
-  google.protobuf.Timestamp create_time = 9
+  google.protobuf.Timestamp create_time = 10
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition update time
-  google.protobuf.Timestamp update_time = 10
+  google.protobuf.Timestamp update_time = 11
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 

--- a/instill/model/v1alpha/definition.swagger.json
+++ b/instill/model/v1alpha/definition.swagger.json
@@ -12,7 +12,16 @@
   ],
   "paths": {},
   "definitions": {
-    "googlerpcStatus": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
       "type": "object",
       "properties": {
         "code": {
@@ -29,15 +38,6 @@
           }
         }
       }
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "@type": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": {}
     }
   }
 }

--- a/instill/model/v1alpha/model.swagger.json
+++ b/instill/model/v1alpha/model.swagger.json
@@ -12,7 +12,16 @@
   ],
   "paths": {},
   "definitions": {
-    "googlerpcStatus": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
       "type": "object",
       "properties": {
         "code": {
@@ -29,15 +38,6 @@
           }
         }
       }
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "@type": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": {}
     }
   }
 }

--- a/instill/model/v1alpha/model_service.swagger.json
+++ b/instill/model/v1alpha/model_service.swagger.json
@@ -30,7 +30,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -62,7 +62,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -94,7 +94,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -126,7 +126,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -136,8 +136,8 @@
             "description": "Page size: the maximum number of resources to return. The service may\nreturn fewer than this value. If unspecified, at most 10 users will be\nreturned. The maximum value is 100; values above 100 will be coereced to\n100.",
             "in": "query",
             "required": false,
-            "type": "integer",
-            "format": "int32"
+            "type": "string",
+            "format": "int64"
           },
           {
             "name": "page_token",
@@ -179,7 +179,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -189,8 +189,8 @@
             "description": "Page size: the maximum number of resources to return. The service may\nreturn fewer than this value. If unspecified, at most 10 users will be\nreturned. The maximum value is 100; values above 100 will be coereced to\n100.",
             "in": "query",
             "required": false,
-            "type": "integer",
-            "format": "int32"
+            "type": "string",
+            "format": "int64"
           },
           {
             "name": "page_token",
@@ -230,7 +230,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -241,7 +241,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/instillmodelv1alphaModel"
+              "$ref": "#/definitions/v1alphaModel"
             }
           }
         ],
@@ -264,7 +264,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -283,7 +283,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/instillmodelv1alphaModel"
+              "$ref": "#/definitions/v1alphaModel"
             }
           },
           {
@@ -313,7 +313,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -346,7 +346,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -377,7 +377,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -410,7 +410,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -441,7 +441,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -474,7 +474,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -505,7 +505,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -538,7 +538,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -580,7 +580,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -635,7 +635,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -692,7 +692,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -734,7 +734,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "#/definitions/googlerpcStatus"
+              "$ref": "#/definitions/rpcStatus"
             }
           }
         },
@@ -752,8 +752,8 @@
             "description": "Page size: the maximum number of resources to return. The service may\nreturn fewer than this value. If unspecified, at most 10 users will be\nreturned. The maximum value is 100; values above 100 will be coereced to\n100.",
             "in": "query",
             "required": false,
-            "type": "integer",
-            "format": "int32"
+            "type": "string",
+            "format": "int64"
           },
           {
             "name": "page_token",
@@ -783,18 +783,6 @@
     }
   },
   "definitions": {
-    "ModelInstanceState": {
-      "type": "string",
-      "enum": [
-        "STATE_UNSPECIFIED",
-        "STATE_OFFLINE",
-        "STATE_ONLINE",
-        "STATE_ERROR"
-      ],
-      "default": "STATE_UNSPECIFIED",
-      "description": "- STATE_UNSPECIFIED: State: UNSPECIFIED\n - STATE_OFFLINE: State: OFFLINE\n - STATE_ONLINE: State: ONLINE\n - STATE_ERROR: State: ERROR",
-      "title": "State enumerates the lifecycling state of a model instance"
-    },
     "ModelInstanceTask": {
       "type": "string",
       "enum": [
@@ -816,24 +804,6 @@
       "default": "VISIBILITY_UNSPECIFIED",
       "description": "- VISIBILITY_UNSPECIFIED: Visibility: UNSPECIFIED, equivalent to PRIVATE.\n - VISIBILITY_PRIVATE: Visibility: PRIVATE\n - VISIBILITY_PUBLIC: Visibility: PUBLIC",
       "title": "Model visibility including public or private"
-    },
-    "googlerpcStatus": {
-      "type": "object",
-      "properties": {
-        "code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
-        }
-      }
     },
     "instillmodelv1alphaHealthCheckRequest": {
       "type": "object",
@@ -890,7 +860,223 @@
       },
       "title": "LivenessResponse represents a response for a service liveness status"
     },
-    "instillmodelv1alphaModel": {
+    "instillmodelv1alphaReadinessResponse": {
+      "type": "object",
+      "properties": {
+        "health_check_response": {
+          "$ref": "#/definitions/instillmodelv1alphaHealthCheckResponse",
+          "title": "HealthCheckResponse message"
+        }
+      },
+      "title": "ReadinessResponse represents a response for a service readiness status"
+    },
+    "instillmodelv1alphaSpec": {
+      "type": "object",
+      "properties": {
+        "documentation_url": {
+          "type": "string",
+          "title": "Spec documentation URL",
+          "readOnly": true
+        },
+        "specification": {
+          "type": "object",
+          "title": "Spec specification",
+          "required": [
+            "specification"
+          ]
+        }
+      },
+      "title": "//////////////////////////////////\nSpec represents a spec data model",
+      "required": [
+        "specification"
+      ]
+    },
+    "instillmodelv1alphaView": {
+      "type": "string",
+      "enum": [
+        "VIEW_UNSPECIFIED",
+        "VIEW_BASIC",
+        "VIEW_FULL"
+      ],
+      "default": "VIEW_UNSPECIFIED",
+      "description": "View represents a view of any resource. The resource view is implemented by\nadding a parameter to the method request which allows the client to specify\nwhich view of the resource it wants to receive in the response.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource"
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "protobufNullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1alphaCreateModelBinaryFileUploadResponse": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/v1alphaModel",
+          "title": "The created model"
+        }
+      },
+      "title": "CreateModelBinaryFileUploadResponse represents a response for a model\ninstance"
+    },
+    "v1alphaCreateModelResponse": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/v1alphaModel",
+          "title": "The created model"
+        }
+      },
+      "title": "CreateModelResponse represents a response for a model"
+    },
+    "v1alphaDeleteModelResponse": {
+      "type": "object",
+      "title": "DeleteModelResponse represents an empty response"
+    },
+    "v1alphaDeployModelInstanceResponse": {
+      "type": "object",
+      "properties": {
+        "instance": {
+          "$ref": "#/definitions/v1alphaModelInstance",
+          "title": "Deployed model instance"
+        }
+      },
+      "title": "DeployModelInstanceResponse represents a response for a deployed model\ninstance\nTODO: should use [Long-running operations](https://google.aip.dev/151)"
+    },
+    "v1alphaGetModelDefinitionResponse": {
+      "type": "object",
+      "properties": {
+        "model_definition": {
+          "$ref": "#/definitions/v1alphaModelDefinition",
+          "title": "A model definition instance"
+        }
+      },
+      "title": "GetModelDefinitionResponse represents a response for a model definition"
+    },
+    "v1alphaGetModelInstanceCardResponse": {
+      "type": "object",
+      "properties": {
+        "readme": {
+          "$ref": "#/definitions/v1alphaModelInstanceCard",
+          "title": "Retrieved model instance card"
+        }
+      },
+      "title": "GetModelInstanceCardResponse represents a response to fetch a model\ninstance's README card"
+    },
+    "v1alphaGetModelInstanceResponse": {
+      "type": "object",
+      "properties": {
+        "instance": {
+          "$ref": "#/definitions/v1alphaModelInstance",
+          "title": "Retrieved model instance"
+        }
+      },
+      "title": "GetModelInstanceResponse represents a response for a model instance"
+    },
+    "v1alphaGetModelResponse": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/v1alphaModel",
+          "title": "The retrieved model"
+        }
+      },
+      "title": "GetModelResponse represents a response for a model"
+    },
+    "v1alphaListModelDefinitionResponse": {
+      "type": "object",
+      "properties": {
+        "model_definitions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1alphaModelDefinition"
+          },
+          "title": "a list of ModelDefinition instances"
+        },
+        "next_page_token": {
+          "type": "string",
+          "title": "Next page token"
+        },
+        "total_size": {
+          "type": "string",
+          "format": "int64",
+          "title": "Total count of model definitions"
+        }
+      },
+      "title": "ListModelDefinitionResponse represents a response to list all supported model\ndefinitions"
+    },
+    "v1alphaListModelInstanceResponse": {
+      "type": "object",
+      "properties": {
+        "instances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1alphaModelInstance"
+          },
+          "title": "a list of Model instances"
+        },
+        "next_page_token": {
+          "type": "string",
+          "title": "Next page token"
+        },
+        "total_size": {
+          "type": "string",
+          "format": "int64",
+          "title": "Total count of model instances"
+        }
+      },
+      "title": "ListModelInstanceResponse represents a response for a list of model instances"
+    },
+    "v1alphaListModelResponse": {
+      "type": "object",
+      "properties": {
+        "models": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1alphaModel"
+          },
+          "title": "a list of Models"
+        },
+        "next_page_token": {
+          "type": "string",
+          "title": "Next page token"
+        },
+        "total_size": {
+          "type": "string",
+          "format": "int64",
+          "title": "Total count of models"
+        }
+      },
+      "title": "ListModelResponse represents a response for a list of models"
+    },
+    "v1alphaModel": {
       "type": "object",
       "properties": {
         "name": {
@@ -948,200 +1134,27 @@
       },
       "title": "Model represents a model"
     },
-    "instillmodelv1alphaReadinessResponse": {
-      "type": "object",
-      "properties": {
-        "health_check_response": {
-          "$ref": "#/definitions/instillmodelv1alphaHealthCheckResponse",
-          "title": "HealthCheckResponse message"
-        }
-      },
-      "title": "ReadinessResponse represents a response for a service readiness status"
-    },
-    "instillmodelv1alphaSpec": {
-      "type": "object",
-      "properties": {
-        "documentation_url": {
-          "type": "string",
-          "title": "Spec documentation URL",
-          "readOnly": true
-        },
-        "specification": {
-          "type": "object",
-          "title": "Spec specification",
-          "required": [
-            "specification"
-          ]
-        }
-      },
-      "title": "//////////////////////////////////\nSpec represents a spec data model",
-      "required": [
-        "specification"
-      ]
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "@type": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": {}
-    },
-    "protobufNullValue": {
-      "type": "string",
-      "enum": [
-        "NULL_VALUE"
-      ],
-      "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
-    },
-    "v1alphaCreateModelResponse": {
-      "type": "object",
-      "properties": {
-        "model": {
-          "$ref": "#/definitions/instillmodelv1alphaModel",
-          "title": "The created model"
-        }
-      },
-      "title": "CreateModelResponse represents a response for a model"
-    },
-    "v1alphaDeleteModelResponse": {
-      "type": "object",
-      "title": "DeleteModelResponse represents an empty response"
-    },
-    "v1alphaDeployModelInstanceResponse": {
-      "type": "object",
-      "properties": {
-        "instance": {
-          "$ref": "#/definitions/v1alphaModelInstance",
-          "title": "Deployed model instance"
-        }
-      },
-      "title": "DeployModelInstanceResponse represents a response for a deployed model\ninstance\nTODO: should use [Long-running operations](https://google.aip.dev/151)"
-    },
-    "v1alphaGetModelDefinitionResponse": {
-      "type": "object",
-      "properties": {
-        "model_definition": {
-          "$ref": "#/definitions/v1alphaModelDefinition",
-          "title": "A model definition instance"
-        }
-      },
-      "title": "GetModelDefinitionResponse represents a response for a model definition"
-    },
-    "v1alphaGetModelInstanceCardResponse": {
-      "type": "object",
-      "properties": {
-        "readme": {
-          "$ref": "#/definitions/v1alphaModelInstanceCard",
-          "title": "Retrieved model instance card"
-        }
-      },
-      "title": "GetModelInstanceCardResponse represents a response to fetch a model\ninstance's README card"
-    },
-    "v1alphaGetModelInstanceResponse": {
-      "type": "object",
-      "properties": {
-        "instance": {
-          "$ref": "#/definitions/v1alphaModelInstance",
-          "title": "Retrieved model instance"
-        }
-      },
-      "title": "GetModelInstanceResponse represents a response for a model instance"
-    },
-    "v1alphaGetModelResponse": {
-      "type": "object",
-      "properties": {
-        "model": {
-          "$ref": "#/definitions/instillmodelv1alphaModel",
-          "title": "The retrieved model"
-        }
-      },
-      "title": "GetModelResponse represents a response for a model"
-    },
-    "v1alphaListModelDefinitionResponse": {
-      "type": "object",
-      "properties": {
-        "model_definitions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1alphaModelDefinition"
-          },
-          "title": "a list of ModelDefinition instances"
-        },
-        "next_page_token": {
-          "type": "string",
-          "title": "Next page token"
-        },
-        "total_size": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Total count of model definitions"
-        }
-      },
-      "title": "ListModelDefinitionResponse represents a response to list all supported model\ndefinitions"
-    },
-    "v1alphaListModelInstanceResponse": {
-      "type": "object",
-      "properties": {
-        "instances": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1alphaModelInstance"
-          },
-          "title": "a list of Model instances"
-        },
-        "next_page_token": {
-          "type": "string",
-          "title": "Next page token"
-        },
-        "total_size": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Total count of model instances"
-        }
-      },
-      "title": "ListModelInstanceResponse represents a response for a list of model instances"
-    },
-    "v1alphaListModelResponse": {
-      "type": "object",
-      "properties": {
-        "models": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/instillmodelv1alphaModel"
-          },
-          "title": "a list of Models"
-        },
-        "next_page_token": {
-          "type": "string",
-          "title": "Next page token"
-        },
-        "total_size": {
-          "type": "integer",
-          "format": "int32",
-          "title": "Total count of models"
-        }
-      },
-      "title": "ListModelResponse represents a response for a list of models"
-    },
     "v1alphaModelDefinition": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string",
-          "title": "ModelDefinition resource name. It must have the format of\n\"model-definitions/{uuid}\"",
+          "title": "ModelDefinition resource name. It must have the format of\n\"model-definitions/{model-definition}\"",
           "readOnly": true
         },
         "uid": {
           "type": "string",
-          "title": "ModelDefinition id in UUIDv4",
+          "title": "ModelDefinition ID in UUIDv4",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "ModelDefinition resource ID (the last segment of the resource name) used to\nconstruct the resource name.",
           "readOnly": true
         },
         "title": {
           "type": "string",
-          "title": "ModelDefinition name",
+          "title": "ModelDefinition display official title",
           "readOnly": true
         },
         "documentation_url": {
@@ -1202,7 +1215,7 @@
           "readOnly": true
         },
         "state": {
-          "$ref": "#/definitions/ModelInstanceState",
+          "$ref": "#/definitions/v1alphaModelInstanceState",
           "title": "Model instance state"
         },
         "task": {
@@ -1266,11 +1279,23 @@
       },
       "description": "ModelInstanceCard represents the README card for a model instance. There\nexists one one and exactly one README card per model instance."
     },
+    "v1alphaModelInstanceState": {
+      "type": "string",
+      "enum": [
+        "STATE_UNSPECIFIED",
+        "STATE_OFFLINE",
+        "STATE_ONLINE",
+        "STATE_ERROR"
+      ],
+      "default": "STATE_UNSPECIFIED",
+      "description": "- STATE_UNSPECIFIED: State: UNSPECIFIED\n - STATE_OFFLINE: State: OFFLINE\n - STATE_ONLINE: State: ONLINE\n - STATE_ERROR: State: ERROR",
+      "title": "State enumerates the lifecycling state of a model instance"
+    },
     "v1alphaRenameModelResponse": {
       "type": "object",
       "properties": {
         "model": {
-          "$ref": "#/definitions/instillmodelv1alphaModel",
+          "$ref": "#/definitions/v1alphaModel",
           "title": "Renamed model"
         }
       },
@@ -1310,21 +1335,11 @@
       "type": "object",
       "properties": {
         "model": {
-          "$ref": "#/definitions/instillmodelv1alphaModel",
+          "$ref": "#/definitions/v1alphaModel",
           "title": "The updated model"
         }
       },
       "title": "UpdateModelResponse represents a response for a model"
-    },
-    "v1alphaView": {
-      "type": "string",
-      "enum": [
-        "VIEW_UNSPECIFIED",
-        "VIEW_BASIC",
-        "VIEW_FULL"
-      ],
-      "default": "VIEW_UNSPECIFIED",
-      "description": "View represents a view of any resource. The resource view is implemented by\nadding a parameter to the method request which allows the client to specify\nwhich view of the resource it wants to receive in the response.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource"
     }
   }
 }


### PR DESCRIPTION
Because

- we want to use `id` to construct the resource name
This commit

- use `id` not `uid` to construct the resource name
