### PR TITLE
chore(model): add `model_spec` and `model_instance_spec` in `ModelDefinition`

### DIFF
--- a/instill/connector/v1alpha/connector.proto
+++ b/instill/connector/v1alpha/connector.proto
@@ -14,7 +14,6 @@ import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
 
 import "instill/connector/v1alpha/connector_definition.proto";
-import "instill/connector/v1alpha/spec.proto";
 
 // Connector represents a connector data model
 message Connector {

--- a/instill/model/v1alpha/definition.proto
+++ b/instill/model/v1alpha/definition.proto
@@ -17,7 +17,7 @@ import "google/api/field_behavior.proto";
 message ModelDefinition {
   option (google.api.resource) = {
     type : "api.instill.tech/ModelDefinition"
-    pattern : "model-definitions/{uuid}"
+    pattern : "model-definitions/{model-definition}"
   };
 
   // ModelDefinition resource name. It must have the format of

--- a/instill/model/v1alpha/definition.proto
+++ b/instill/model/v1alpha/definition.proto
@@ -12,16 +12,6 @@ import "google/protobuf/timestamp.proto";
 import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
 
-////////////////////////////////////
-// Spec represents a spec data model
-message Spec {
-  // Spec documentation URL
-  string documentation_url = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Spec specification
-  google.protobuf.Struct specification = 2
-      [ (google.api.field_behavior) = REQUIRED ];
-}
-
 ///////////////////////////////////////////////////////////////////
 // ModelDefinition represents the definition of a model
 message ModelDefinition {
@@ -45,19 +35,26 @@ message ModelDefinition {
   string documentation_url = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition icon
   string icon = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // ModelDefinition spec
-  Spec spec = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // ModelDefinition public flag, i.e., true if this definition is available to
-  // all workspaces
-  bool public = 8 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // ModelDefinition custom flag, i.e., true if this is a custom model
-  // definition
-  bool custom = 9 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+
+  // ModelDefinition model specification represents the JSON schema used to
+  // validate the JSON configurations of a model created from a specific model
+  // source. Must be a valid JSON that includes what fields are needed to
+  // create/display a model.
+  google.protobuf.Struct model_spec = 7
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+
+  // ModelDefinition model instance specification represents the JSON schema
+  // used to validate the JSON configurations of a model instance from a
+  // specific model source. Must be a valid JSON that includes what fields are
+  // needed to display a model instance.
+  google.protobuf.Struct model_instance_spec = 8
+      [ (google.api.field_behavior) = REQUIRED ];
+
   // ModelDefinition create time
-  google.protobuf.Timestamp create_time = 10
+  google.protobuf.Timestamp create_time = 9
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition update time
-  google.protobuf.Timestamp update_time = 11
+  google.protobuf.Timestamp update_time = 10
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 

--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -47,8 +47,10 @@ message Model {
     (google.api.field_behavior) = IMMUTABLE,
     (google.api.resource_reference).type = "api.instill.tech/ModelDefinition"
   ];
-  // Model definition configuration
-  Spec configuration = 6 [ (google.api.field_behavior) = IMMUTABLE ];
+  // Model configuration represents the configuration JSON object that has been
+  // validated using the `model_spec` JSON schema of a ModelDefinition
+  google.protobuf.Struct configuration = 6
+      [ (google.api.field_behavior) = IMMUTABLE ];
   // Model visibility including public or private
   Visibility visibility = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Model owner
@@ -119,8 +121,11 @@ message ModelInstance {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.resource_reference).type = "api.instill.tech/ModelDefinition"
   ];
-  // Model instance configuration
-  Spec configuration = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Model instance configuration represents the JSON configuration that has
+  // been validated using the `model_instance_spec` JSON schema of a
+  // ModelDefinition
+  google.protobuf.Struct configuration = 7
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Model instance create time
   google.protobuf.Timestamp create_time = 8
       [ (google.api.field_behavior) = OUTPUT_ONLY ];

--- a/instill/model/v1alpha/model_service.swagger.json
+++ b/instill/model/v1alpha/model_service.swagger.json
@@ -870,27 +870,6 @@
       },
       "title": "ReadinessResponse represents a response for a service readiness status"
     },
-    "instillmodelv1alphaSpec": {
-      "type": "object",
-      "properties": {
-        "documentation_url": {
-          "type": "string",
-          "title": "Spec documentation URL",
-          "readOnly": true
-        },
-        "specification": {
-          "type": "object",
-          "title": "Spec specification",
-          "required": [
-            "specification"
-          ]
-        }
-      },
-      "title": "//////////////////////////////////\nSpec represents a spec data model",
-      "required": [
-        "specification"
-      ]
-    },
     "instillmodelv1alphaView": {
       "type": "string",
       "enum": [
@@ -1102,8 +1081,8 @@
           "title": "Model definition resource name"
         },
         "configuration": {
-          "$ref": "#/definitions/instillmodelv1alphaSpec",
-          "title": "Model definition configuration"
+          "type": "object",
+          "title": "Model configuration represents the configuration JSON object that has been\nvalidated using the `model_spec` JSON schema of a ModelDefinition"
         },
         "visibility": {
           "$ref": "#/definitions/ModelVisibility",
@@ -1167,19 +1146,17 @@
           "title": "ModelDefinition icon",
           "readOnly": true
         },
-        "spec": {
-          "$ref": "#/definitions/instillmodelv1alphaSpec",
-          "title": "ModelDefinition spec"
-        },
-        "public": {
-          "type": "boolean",
-          "title": "ModelDefinition public flag, i.e., true if this definition is available to\nall workspaces",
+        "model_spec": {
+          "type": "object",
+          "description": "ModelDefinition model specification represents the JSON schema used to\nvalidate the JSON configurations of a model created from a specific model\nsource. Must be a valid JSON that includes what fields are needed to\ncreate/display a model.",
           "readOnly": true
         },
-        "custom": {
-          "type": "boolean",
-          "title": "ModelDefinition custom flag, i.e., true if this is a custom model\ndefinition",
-          "readOnly": true
+        "model_instance_spec": {
+          "type": "object",
+          "description": "ModelDefinition model instance specification represents the JSON schema\nused to validate the JSON configurations of a model instance from a\nspecific model source. Must be a valid JSON that includes what fields are\nneeded to display a model instance.",
+          "required": [
+            "model_instance_spec"
+          ]
         },
         "create_time": {
           "type": "string",
@@ -1194,7 +1171,10 @@
           "readOnly": true
         }
       },
-      "title": "/////////////////////////////////////////////////////////////////\nModelDefinition represents the definition of a model"
+      "title": "/////////////////////////////////////////////////////////////////\nModelDefinition represents the definition of a model",
+      "required": [
+        "model_instance_spec"
+      ]
     },
     "v1alphaModelInstance": {
       "type": "object",
@@ -1228,8 +1208,9 @@
           "readOnly": true
         },
         "configuration": {
-          "$ref": "#/definitions/instillmodelv1alphaSpec",
-          "title": "Model instance configuration"
+          "type": "object",
+          "title": "Model instance configuration represents the JSON configuration that has\nbeen validated using the `model_instance_spec` JSON schema of a\nModelDefinition",
+          "readOnly": true
         },
         "create_time": {
           "type": "string",


### PR DESCRIPTION
Because

A model and a model instance from the same model definition may require different fields. Use the model definition `GitHub` as an example, to create a model, a repository is required. But for each imported model instance, an extra `tag` field is needed. Therefore, for each supported model definition, we provide specifications for both model and model instance.

This commit

- remove `public` and `custom` fields from `ModelDefinition` message
- remove `Spec` message and add `model_spec` and `model_instance_spec` in `ModelDefinition` message
