### PR TITLE
chore(model): add publish/unpublish methods

### DIFF
--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -290,6 +290,38 @@ message RenameModelResponse {
   Model model = 1;
 }
 
+// PublishModelRequest represents a request to publish a model
+message PublishModelRequest {
+  // Resource name of the model.
+  // For example "models/{model}"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Model"
+  ];
+}
+
+// PublishModelResponse represents a response for the published model
+message PublishModelResponse {
+  // Published model
+  Model model = 1;
+}
+
+// UnpublishModelRequest represents a request to unpublish a model
+message UnpublishModelRequest {
+  // Resource name of the model.
+  // For example "models/{model}"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Model"
+  ];
+}
+
+// UnpublishModelResponse represents a response for the unpublished model
+message UnpublishModelResponse {
+  // Unpublished model
+  Model model = 1;
+}
+
 // ListModelInstanceRequest represents a request to list all instances of a
 // model
 message ListModelInstanceRequest {

--- a/instill/model/v1alpha/model_service.proto
+++ b/instill/model/v1alpha/model_service.proto
@@ -170,6 +170,26 @@ service ModelService {
     option (google.api.method_signature) = "name,new_model_id";
   }
 
+  // PublishModel method receives a PublishModelRequest message and returns a
+  // PublishModelResponse
+  rpc PublishModel(PublishModelRequest) returns (PublishModelResponse) {
+    option (google.api.http) = {
+      post : "/v1alpha/{name=models/*}:publish"
+      body : "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // UnpublishModel method receives a UnpublishModelRequest message and returns a
+  // UnpublishModelResponse
+  rpc UnpublishModel(UnpublishModelRequest) returns (UnpublishModelResponse) {
+    option (google.api.http) = {
+      post : "/v1alpha/{name=models/*}:unpublish"
+      body : "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
   // ListModelInstance method receives a ListModelInstanceRequest message and
   // returns a ListModelInstanceResponse
   rpc ListModelInstance(ListModelInstanceRequest)


### PR DESCRIPTION
Because

-  Support publish and unpublish a model

This commit

- Add publish and unpublish method
