### PR TITLE
fix(model): add optional view param for GET operation

### DIFF
--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -270,6 +270,10 @@ message LookUpModelRequest {
   // Permalink of a model. For example:
   // "models/{uid}"
   string permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Model view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // LookUpModelResponse represents a response for a model instance
@@ -387,6 +391,10 @@ message LookUpModelInstanceRequest {
   // Permalink of a model instance. For example:
   // "models/{model_uid}/instances/{instance_uid}"
   string permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Model instance view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // LookUpModelInstanceResponse represents a response for a model instance

--- a/instill/model/v1alpha/model.proto
+++ b/instill/model/v1alpha/model.proto
@@ -164,8 +164,10 @@ message ListModelRequest {
   int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
   // Page token
   string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
-  //  Definition view (default is VIEW_BASIC)
-  View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
+  // Model view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // ListModelResponse represents a response for a list of models
@@ -219,6 +221,10 @@ message GetModelRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
+  // Model view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // GetModelResponse represents a response for a model
@@ -339,8 +345,10 @@ message ListModelInstanceRequest {
   int64 page_size = 2 [ (google.api.field_behavior) = OPTIONAL ];
   // Page token
   string page_token = 3 [ (google.api.field_behavior) = OPTIONAL ];
-  //  Definition view (default is VIEW_BASIC)
-  View view = 4 [ (google.api.field_behavior) = OPTIONAL ];
+  // Model instance view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 4 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // ListModelInstanceResponse represents a response for a list of model instances
@@ -361,6 +369,10 @@ message GetModelInstanceRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
   ];
+  // Model instance view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // GetModelInstanceResponse represents a response for a model instance

--- a/instill/model/v1alpha/model_definition.proto
+++ b/instill/model/v1alpha/model_definition.proto
@@ -81,7 +81,10 @@ message ListModelDefinitionRequest {
   // Page token
   string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
   // Definition view (default is VIEW_BASIC)
-  View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
+  // `ModelDefinition.model_instance_spec`
+  // VIEW_FULL: show full information
+  optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // ListModelDefinitionResponse represents a response to list all supported model
@@ -103,6 +106,11 @@ message GetModelDefinitionRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/ModelDefinition"
   ];
+  // Definition view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
+  // `ModelDefinition.model_instance_spec`
+  // VIEW_FULL: show full information
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // GetModelDefinitionResponse represents a response for a model definition

--- a/instill/model/v1alpha/model_service.swagger.json
+++ b/instill/model/v1alpha/model_service.swagger.json
@@ -148,7 +148,7 @@
           },
           {
             "name": "view",
-            "description": "Definition view (default is VIEW_BASIC).\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
+            "description": "Definition view (default is VIEW_BASIC)\nVIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and\n`ModelDefinition.model_instance_spec`\nVIEW_FULL: show full information.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
             "in": "query",
             "required": false,
             "type": "string",
@@ -201,7 +201,7 @@
           },
           {
             "name": "view",
-            "description": "Definition view (default is VIEW_BASIC).\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
+            "description": "Model view (default is VIEW_BASIC)\nVIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`\nVIEW_FULL: show full information.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
             "in": "query",
             "required": false,
             "type": "string",
@@ -325,6 +325,19 @@
             "required": true,
             "type": "string",
             "pattern": "models/[^/]+"
+          },
+          {
+            "name": "view",
+            "description": "Model view (default is VIEW_BASIC)\nVIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`\nVIEW_FULL: show full information.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "VIEW_UNSPECIFIED",
+              "VIEW_BASIC",
+              "VIEW_FULL"
+            ],
+            "default": "VIEW_UNSPECIFIED"
           }
         ],
         "tags": [
@@ -358,6 +371,19 @@
             "required": true,
             "type": "string",
             "pattern": "models/[^/]+/instances/[^/]+"
+          },
+          {
+            "name": "view",
+            "description": "Model instance view (default is VIEW_BASIC)\nVIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`\nVIEW_FULL: show full information.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "VIEW_UNSPECIFIED",
+              "VIEW_BASIC",
+              "VIEW_FULL"
+            ],
+            "default": "VIEW_UNSPECIFIED"
           }
         ],
         "tags": [
@@ -486,6 +512,19 @@
             "required": true,
             "type": "string",
             "pattern": "model-definitions/[^/]+"
+          },
+          {
+            "name": "view",
+            "description": "Definition view (default is VIEW_BASIC)\nVIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and\n`ModelDefinition.model_instance_spec`\nVIEW_FULL: show full information.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "VIEW_UNSPECIFIED",
+              "VIEW_BASIC",
+              "VIEW_FULL"
+            ],
+            "default": "VIEW_UNSPECIFIED"
           }
         ],
         "tags": [
@@ -848,7 +887,7 @@
           },
           {
             "name": "view",
-            "description": "Definition view (default is VIEW_BASIC).\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
+            "description": "Model instance view (default is VIEW_BASIC)\nVIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`\nVIEW_FULL: show full information.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
             "in": "query",
             "required": false,
             "type": "string",

--- a/instill/model/v1alpha/model_service.swagger.json
+++ b/instill/model/v1alpha/model_service.swagger.json
@@ -930,6 +930,19 @@
             "required": true,
             "type": "string",
             "pattern": "models/[^/]+/instances/[^/]+"
+          },
+          {
+            "name": "view",
+            "description": "Model instance view (default is VIEW_BASIC)\nVIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`\nVIEW_FULL: show full information.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "VIEW_UNSPECIFIED",
+              "VIEW_BASIC",
+              "VIEW_FULL"
+            ],
+            "default": "VIEW_UNSPECIFIED"
           }
         ],
         "tags": [
@@ -963,6 +976,19 @@
             "required": true,
             "type": "string",
             "pattern": "models/[^/]+"
+          },
+          {
+            "name": "view",
+            "description": "Model view (default is VIEW_BASIC)\nVIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`\nVIEW_FULL: show full information.\n\n - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.\n - VIEW_BASIC: View: BASIC, server response only include basic information of the resource\n - VIEW_FULL: View: FULL, full representation of the resource",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "VIEW_UNSPECIFIED",
+              "VIEW_BASIC",
+              "VIEW_FULL"
+            ],
+            "default": "VIEW_UNSPECIFIED"
           }
         ],
         "tags": [


### PR DESCRIPTION
Because

- in GET operation, it is desirable to return results that the user is interested in 

This commit

- make `view` parameter optional
- add `view` parameter to `GET /model-definitions/*`
- add `view` parameter to `GET /models/*`
- add `view` parameter to `GET /models/*/instances/*`
- add `view` parameter to `lookUp` custom methods