### PR TITLE
refactor(usage):  define service enum

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2542,6 +2542,21 @@ definitions:
        - MODE_SYNC: Mode: SYNC
        - MODE_ASYNC: Mode: ASYNC
     title: Mode enumerates the pipeline modes
+  SessionDataService:
+    type: string
+    enum:
+    - SERVICE_UNSPECIFIED
+    - SERVICE_MGMT
+    - SERVICE_CONNECTOR
+    - SERVICE_MODEL
+    - SERVICE_PIPELINE
+    default: SERVICE_UNSPECIFIED
+    title: |-
+      - SERVICE_UNSPECIFIED: Service: UNSPECIFIED
+       - SERVICE_MGMT: Service: MGMT
+       - SERVICE_CONNECTOR: Service: CONNECTOR
+       - SERVICE_MODEL: Service: MODEL
+       - SERVICE_PIPELINE: Service: Pipeline
   SpecSupportedDestinationSyncModes:
     type: string
     enum:
@@ -3975,11 +3990,9 @@ definitions:
         title: Session UUID
         required:
         - session_uid
-      service_id:
-        type: string
-        title: Service ID, e.g., 'mgmt', 'connector', 'model', 'pipeline'
-        required:
-        - service_id
+      service:
+        $ref: '#/definitions/SessionDataService'
+        title: name of the service to collect data from
       version:
         type: string
         title: Version of the service
@@ -4007,10 +4020,9 @@ definitions:
         title: Report time
         required:
         - report_time
-    title: SessionData represents the usage data collected from a session
+    title: SessionData represents the session data collected from a session
     required:
     - session_uid
-    - service_id
     - version
     - arch
     - os

--- a/vdp/usage/v1alpha/usage.proto
+++ b/vdp/usage/v1alpha/usage.proto
@@ -38,12 +38,26 @@ message Session {
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
-// SessionData represents the usage data collected from a session
+// SessionData represents the session data collected from a session
 message SessionData {
+  enum Service {
+    // Service: UNSPECIFIED
+    SERVICE_UNSPECIFIED = 0;
+    // Service: MGMT
+    SERVICE_MGMT = 1;
+    // Service: CONNECTOR
+    SERVICE_CONNECTOR = 2;
+    // Service: MODEL
+    SERVICE_MODEL = 3;
+    // Service: PIPELINE
+    SERVICE_PIPELINE = 4;
+  }
+
   // Session UUID
   string session_uid = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // Service ID, e.g., 'mgmt', 'connector', 'model', 'pipeline'
-  string service_id = 2 [ (google.api.field_behavior) = REQUIRED ];
+  // name of the service to collect data from
+  Service service = 2 [ (google.api.field_behavior) = REQUIRED ];
+
   // Version of the service
   string version = 3 [ (google.api.field_behavior) = REQUIRED ];
   // Architecture of the system


### PR DESCRIPTION
Because

- to constrain the service session data, define service enum type

This commit

- define `service` enum to represent session service
