### PR TITLE
chore: update name of keypoint message to plural for consistency

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -521,10 +521,9 @@ message KeypointObject {
 }
 
 // KeypointOutput represents the output of keypoint detection task
-// The keypoint detection model do not support batch, so output is singular
-message KeypointOutput {
+message KeypointOutputs {
   // Keypoint Objects
-  repeated KeypointObject keypoint_output = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  repeated KeypointObject keypoint_outputs = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // BoundingBox represents the bounding box data structure


### PR DESCRIPTION
Because

- change keypoint message name with plural to make consistency

This commit

- change keypoint message name with plural
