### PR TITLE
chore: add test model instance method

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -581,6 +581,25 @@ message TriggerModelInstanceResponse {
   google.protobuf.Struct output = 1;
 }
 
+// TestModelInstanceRequest represents a request to test a model instance
+message TestModelInstanceRequest {
+  // The resource name of the model instance to trigger.
+  // For example "models/{model}/instances/{instance}"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
+  ];
+  // Input to trigger the model instance
+  repeated Input inputs = 2 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// TestModelInstanceResponse represents a response for the output for
+// testing a model instance
+message TestModelInstanceResponse {
+  // Output from a model
+  google.protobuf.Struct output = 1;
+}
+
 // TriggerModelInstanceBinaryFileUploadRequest represents a request to trigger a
 // model instance by uploading binary file
 message TriggerModelInstanceBinaryFileUploadRequest {

--- a/vdp/model/v1alpha/model_service.proto
+++ b/vdp/model/v1alpha/model_service.proto
@@ -222,11 +222,22 @@ service ModelService {
     option (google.api.method_signature) = "name,inputs";
   }
 
+  // TestModelInstance method receives a TestModelInstanceRequest message
+  // and returns a TestModelInstanceResponse message.
+  rpc TestModelInstance(TestModelInstanceRequest)
+      returns (TestModelInstanceResponse) {
+    option (google.api.http) = {
+      post : "/v1alpha/{name=models/*/instances/*}:test"
+      body : "*"
+    };
+    option (google.api.method_signature) = "name,inputs";
+  }
+
   // TriggerModelInstanceBinaryFileUpload method receives a
   // TriggerModelInstanceBinaryFileUploadRequest message and returns a
   // TriggerModelInstanceBinaryFileUploadResponse message.
   //
-  // Endpoint: "POST/v1alpha/{name=models/*/instances/*}:trigger-multipart"
+  // Endpoint: "POST/v1alpha/{name=models/*/instances/*}:test-multipart"
   rpc TriggerModelInstanceBinaryFileUpload(
       stream TriggerModelInstanceBinaryFileUploadRequest)
       returns (TriggerModelInstanceBinaryFileUploadResponse) {


### PR DESCRIPTION
Because

- Add external endpoints for users to test an given online model instance

This commit

- Add TestModelInstance method
