### PR TITLE
chore: add trigger model instance binary endpoint

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -581,6 +581,28 @@ message TriggerModelInstanceResponse {
   google.protobuf.Struct output = 1;
 }
 
+// TriggerModelInstanceBinaryFileUploadRequest represents a request to test a
+// model instance by uploading binary file
+message TriggerModelInstanceBinaryFileUploadRequest {
+  // The resource name of the model instance to trigger.
+  // For example "models/{model}/instances/{instance}"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
+  ];
+  // The list of file length for each uploaded binary file
+  repeated uint64 file_lengths = 2 [ (google.api.field_behavior) = REQUIRED ];
+  // Content of images in bytes
+  bytes bytes = 3 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// TriggerModelInstanceBinaryFileUploadResponse represents a response for the
+// output for testing a model instance
+message TriggerModelInstanceBinaryFileUploadResponse {
+  // Output from a model
+  google.protobuf.Struct output = 1;
+}
+
 // TestModelInstanceRequest represents a request to test a model instance
 message TestModelInstanceRequest {
   // The resource name of the model instance to trigger.

--- a/vdp/model/v1alpha/model_service.proto
+++ b/vdp/model/v1alpha/model_service.proto
@@ -222,6 +222,17 @@ service ModelService {
     option (google.api.method_signature) = "name,inputs";
   }
 
+  // TriggerModelInstanceBinaryFileUpload method receives a
+  // TriggerModelInstanceBinaryFileUploadRequest message and returns a
+  // TriggerModelInstanceBinaryFileUploadResponse message.
+  //
+  // Endpoint: "POST/v1alpha/{name=models/*/instances/*}:trigger-multipart"
+  rpc TriggerModelInstanceBinaryFileUpload(
+      stream TriggerModelInstanceBinaryFileUploadRequest)
+      returns (TriggerModelInstanceBinaryFileUploadResponse) {
+    option (google.api.method_signature) = "name,file";
+  }
+
   // TestModelInstance method receives a TestModelInstanceRequest message
   // and returns a TestModelInstanceResponse message.
   rpc TestModelInstance(TestModelInstanceRequest)


### PR DESCRIPTION
Because

- Add endpoint TriggerModelInstanceBinaryFileUploadResponse for pipeline-backend's usage

This commit

- Add endpoint TriggerModelInstanceBinaryFileUploadResponse
