### PR TITLE
chore(model): add release stage in model definition

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2372,6 +2372,11 @@ paths:
         - VIEW_BASIC
         - VIEW_FULL
         default: VIEW_UNSPECIFIED
+      - name: filter
+        description: Filter expression to list pipelines
+        in: query
+        required: false
+        type: string
       tags:
       - PipelineService
     post:
@@ -2944,7 +2949,7 @@ definitions:
           connector definition
         readOnly: true
       release_stage:
-        $ref: '#/definitions/v1alphaReleaseStage'
+        $ref: '#/definitions/vdpconnectorv1alphaReleaseStage'
         title: ConnectorDefinition release stage
       release_date:
         $ref: '#/definitions/typeDate'
@@ -3590,6 +3595,9 @@ definitions:
         type: string
         title: ModelDefinition icon
         readOnly: true
+      release_stage:
+        $ref: '#/definitions/vdpmodelv1alphaReleaseStage'
+        title: ModelDefinition release stage
       model_spec:
         type: object
         description: |-
@@ -4057,22 +4065,6 @@ definitions:
           type: string
         title: A list of model instance resources
     title: Pipeline represents a pipeline recipe
-  v1alphaReleaseStage:
-    type: string
-    enum:
-    - RELEASE_STAGE_UNSPECIFIED
-    - RELEASE_STAGE_ALPHA
-    - RELEASE_STAGE_BETA
-    - RELEASE_STAGE_GENERALLY_AVAILABLE
-    - RELEASE_STAGE_CUSTOM
-    default: RELEASE_STAGE_UNSPECIFIED
-    description: |-
-      - RELEASE_STAGE_UNSPECIFIED: ReleaseStage: UNSPECIFIED
-       - RELEASE_STAGE_ALPHA: ReleaseStage: ALPHA
-       - RELEASE_STAGE_BETA: ReleaseStage: BETA
-       - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
-       - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
-    title: ReleaseStage enumerates the release stages
   v1alphaRenameDestinationConnectorResponse:
     type: object
     properties:
@@ -4334,6 +4326,15 @@ definitions:
     title: |-
       TestModelInstanceResponse represents a response for the output for
       testing a model instance
+  v1alphaTriggerModelInstanceBinaryFileUploadResponse:
+    type: object
+    properties:
+      output:
+        type: object
+        title: Output from a model
+    title: |-
+      TriggerModelInstanceBinaryFileUploadResponse represents a response for the
+      output for testing a model instance
   v1alphaTriggerModelInstanceResponse:
     type: object
     properties:
@@ -4347,7 +4348,9 @@ definitions:
     type: object
     properties:
       output:
-        type: object
+        type: array
+        items:
+          type: object
         title: Output from a pipeline
     title: |-
       TriggerPipelineBinaryFileUploadResponse represents a response for the output
@@ -4356,7 +4359,9 @@ definitions:
     type: object
     properties:
       output:
-        type: object
+        type: array
+        items:
+          type: object
         title: Output from a pipeline
     title: TriggerPipelineResponse represents a response for the output of a pipeline
   v1alphaUndeployModelInstanceResponse:
@@ -4494,6 +4499,22 @@ definitions:
         $ref: '#/definitions/v1alphaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
+  vdpconnectorv1alphaReleaseStage:
+    type: string
+    enum:
+    - RELEASE_STAGE_UNSPECIFIED
+    - RELEASE_STAGE_ALPHA
+    - RELEASE_STAGE_BETA
+    - RELEASE_STAGE_GENERALLY_AVAILABLE
+    - RELEASE_STAGE_CUSTOM
+    default: RELEASE_STAGE_UNSPECIFIED
+    description: |-
+      - RELEASE_STAGE_UNSPECIFIED: ReleaseStage: UNSPECIFIED
+       - RELEASE_STAGE_ALPHA: ReleaseStage: ALPHA
+       - RELEASE_STAGE_BETA: ReleaseStage: BETA
+       - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
+       - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
+    title: ReleaseStage enumerates the release stages
   vdpconnectorv1alphaView:
     type: string
     enum:
@@ -4544,6 +4565,22 @@ definitions:
         $ref: '#/definitions/v1alphaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
+  vdpmodelv1alphaReleaseStage:
+    type: string
+    enum:
+    - RELEASE_STAGE_UNSPECIFIED
+    - RELEASE_STAGE_ALPHA
+    - RELEASE_STAGE_BETA
+    - RELEASE_STAGE_GENERALLY_AVAILABLE
+    - RELEASE_STAGE_CUSTOM
+    default: RELEASE_STAGE_UNSPECIFIED
+    description: |-
+      - RELEASE_STAGE_UNSPECIFIED: ReleaseStage: UNSPECIFIED
+       - RELEASE_STAGE_ALPHA: ReleaseStage: ALPHA
+       - RELEASE_STAGE_BETA: ReleaseStage: BETA
+       - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
+       - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
+    title: ReleaseStage enumerates the release stages
   vdpmodelv1alphaView:
     type: string
     enum:

--- a/vdp/model/v1alpha/model_definition.proto
+++ b/vdp/model/v1alpha/model_definition.proto
@@ -13,6 +13,20 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
 
+// ReleaseStage enumerates the release stages
+enum ReleaseStage {
+  // ReleaseStage: UNSPECIFIED
+  RELEASE_STAGE_UNSPECIFIED = 0;
+  // ReleaseStage: ALPHA
+  RELEASE_STAGE_ALPHA = 1;
+  // ReleaseStage: BETA
+  RELEASE_STAGE_BETA = 2;
+  // ReleaseStage: GENERALLY_AVAILABLE
+  RELEASE_STAGE_GENERALLY_AVAILABLE = 3;
+  // ReleaseStage: CUSTOM
+  RELEASE_STAGE_CUSTOM = 4;
+}
+
 ///////////////////////////////////////////////////////////////////
 // ModelDefinition represents the definition of a model
 message ModelDefinition {
@@ -36,26 +50,28 @@ message ModelDefinition {
   string documentation_url = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition icon
   string icon = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // ModelDefinition release stage
+  ReleaseStage release_stage = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 
   // ModelDefinition model specification represents the JSON schema used to
   // validate the JSON configurations of a model created from a specific model
   // source. Must be a valid JSON that includes what fields are needed to
   // create/display a model.
-  google.protobuf.Struct model_spec = 7
+  google.protobuf.Struct model_spec = 8
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 
   // ModelDefinition model instance specification represents the JSON schema
   // used to validate the JSON configurations of a model instance from a
   // specific model source. Must be a valid JSON that includes what fields are
   // needed to display a model instance.
-  google.protobuf.Struct model_instance_spec = 8
+  google.protobuf.Struct model_instance_spec = 9
       [ (google.api.field_behavior) = REQUIRED ];
 
   // ModelDefinition create time
-  google.protobuf.Timestamp create_time = 9
+  google.protobuf.Timestamp create_time = 10
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition update time
-  google.protobuf.Timestamp update_time = 10
+  google.protobuf.Timestamp update_time = 11
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 


### PR DESCRIPTION
Because

- we need a grading system to represent the readiness level of a model definition 

This commit

- adopt the release stage used in connector definition to model definition
