### PR TITLE
chore(model): update naming

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -150,9 +150,9 @@ message ModelInstanceCard {
   int32 size = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Type of the resource. Fixed to "file".
   string type = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Contents of the README file in bytes and base64 format
-  bytes contents = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Encoding type of the contents. Fixed to "base64".
+  // Content of the README file in bytes and base64 format
+  bytes content = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Encoding type of the content. Fixed to "base64".
   string encoding = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
@@ -204,7 +204,7 @@ message CreateModelBinaryFileUploadRequest {
   // Format: models/{model}
   Model model = 1 [ (google.api.field_behavior) = REQUIRED ];
   // Model content in bytes
-  bytes bytes = 2 [ (google.api.field_behavior) = REQUIRED ];
+  bytes content = 2 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // CreateModelBinaryFileUploadResponse represents a response for a model
@@ -593,7 +593,7 @@ message TriggerModelInstanceBinaryFileUploadRequest {
   // The list of file length for each uploaded binary file
   repeated uint64 file_lengths = 2 [ (google.api.field_behavior) = REQUIRED ];
   // Content of images in bytes
-  bytes bytes = 3 [ (google.api.field_behavior) = REQUIRED ];
+  bytes content = 3 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // TriggerModelInstanceBinaryFileUploadResponse represents a response for the
@@ -634,7 +634,7 @@ message TestModelInstanceBinaryFileUploadRequest {
   // The list of file length for each uploaded binary file
   repeated uint64 file_lengths = 2 [ (google.api.field_behavior) = REQUIRED ];
   // Content of images in bytes
-  bytes bytes = 3 [ (google.api.field_behavior) = REQUIRED ];
+  bytes content = 3 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // TestModelInstanceBinaryFileUploadResponse represents a response for the


### PR DESCRIPTION
Because

-  naming consistence

This commit

- change name from `bytes` to `content`
