### PR TITLE
chore(model): change model configuration from string to protobuf struct

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -48,9 +48,9 @@ message Model {
     (google.api.field_behavior) = IMMUTABLE,
     (google.api.resource_reference).type = "api.instill.tech/ModelDefinition"
   ];
-  // Model configuration represents the configuration JSON string that has been
+  // Model configuration represents the configuration JSON that has been
   // validated using the `model_spec` JSON schema of a ModelDefinition
-  string configuration = 6 [ (google.api.field_behavior) = IMMUTABLE ];
+  google.protobuf.Struct configuration = 6 [ (google.api.field_behavior) = IMMUTABLE ];
   // Model visibility including public or private
   Visibility visibility = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Model owner
@@ -123,10 +123,10 @@ message ModelInstance {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.resource_reference).type = "api.instill.tech/ModelDefinition"
   ];
-  // Model instance configuration represents the configuration JSON string that
+  // Model instance configuration represents the configuration JSON that
   // has been validated using the `model_instance_spec` JSON schema of a
   // ModelDefinition
-  string configuration = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.Struct configuration = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Model instance create time
   google.protobuf.Timestamp create_time = 8
       [ (google.api.field_behavior) = OUTPUT_ONLY ];


### PR DESCRIPTION
Because

- configuration should represent in the struct, refer to [issue](https://github.com/instill-ai/protobufs/issues/85)

This commit

- change model configuration from string to protobuf struct
