### PR TITLE
chore(model): add unspecified task outputs

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -487,6 +487,13 @@ message Input {
   }
 }
 
+// UnspecifiedTaskOutputs represents a list of unspecified task outputs
+message UnspecifiedTaskOutputs {
+  // A list of unspecified task outputs
+  repeated google.protobuf.Struct RawOutputs = 1
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
 // ClassificationOutput represents the output of classification task
 message ClassificationOutput {
   // Classification category


### PR DESCRIPTION
Because

- infer model response should be JSON object

This commit

- add output structure of the unspecified task