### PR TITLE
chore(mode): update task to enum ModelInstance.Task

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -570,7 +570,7 @@ message TestModelInstanceBinaryFileUploadRequest {
 // output for inference a model instance
 message ModelInstanceInferenceResponse {
     // The task type
-    string task = 1 [ (google.api.field_behavior) = REQUIRED ];
+    ModelInstance.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
     // The inference task output
     oneof output {
         // The classification output


### PR DESCRIPTION
Because

- task type should enum

This commit

- update task type of outputs to enum ModelInstance.Task
