### PR TITLE
chore: use wrapper for scalar value in response message

### DIFF
--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -4,6 +4,7 @@ package vdp.connector.v1alpha;
 
 // Protocol Buffers Well-Known Types
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/field_mask.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -39,7 +40,7 @@ message Connector {
   // Connector state
   State state = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Connector tombstone
-  bool tombstone = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.BoolValue tombstone = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Connector owner
   oneof owner {
     // The resource name of a user, e.g., "users/local-user".
@@ -157,9 +158,9 @@ message ListSourceConnectorResponse {
   // A list of SourceConnector resources
   repeated SourceConnector source_connectors = 1;
   // Next page token
-  string next_page_token = 2;
+  google.protobuf.StringValue next_page_token = 2;
   // Total count of connector resources
-  int64 total_size = 3;
+  google.protobuf.Int64Value total_size = 3;
 }
 
 // GetSourceConnectorRequest represents a request to query a
@@ -357,9 +358,9 @@ message ListDestinationConnectorResponse {
   // A list of DestinationConnector resources
   repeated DestinationConnector destination_connectors = 1;
   // Next page token
-  string next_page_token = 2;
+  google.protobuf.StringValue next_page_token = 2;
   // Total count of connector resources
-  int64 total_size = 3;
+  google.protobuf.Int64Value total_size = 3;
 }
 
 // GetDestinationConnectorRequest represents a request to query a

--- a/vdp/connector/v1alpha/connector_definition.proto
+++ b/vdp/connector/v1alpha/connector_definition.proto
@@ -4,6 +4,7 @@ package vdp.connector.v1alpha;
 
 // Protocol Buffers Well-Known Types
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -174,9 +175,9 @@ message ListSourceConnectorDefinitionResponse {
   // A list of SourceConnectorDefinition resources
   repeated SourceConnectorDefinition source_connector_definitions = 1;
   // Next page token
-  string next_page_token = 2;
-  // Total count of SourceConnectorDefinition resources
-  int64 total_size = 3;
+  google.protobuf.StringValue next_page_token = 2;
+  // Total count of connector resources
+  google.protobuf.Int64Value total_size = 3;
 }
 
 // GetSourceConnectorDefinitionRequest represents a request to query a
@@ -229,9 +230,9 @@ message ListDestinationConnectorDefinitionResponse {
   // A list of DestinationConnectorDefinition resources
   repeated DestinationConnectorDefinition destination_connector_definitions = 1;
   // Next page token
-  string next_page_token = 2;
-  // Total count of DestinationConnectorDefinition resources
-  int64 total_size = 3;
+  google.protobuf.StringValue next_page_token = 2;
+  // Total count of connector resources
+  google.protobuf.Int64Value total_size = 3;
 }
 
 // GetDestinationConnectorDefinitionRequest represents a request to query a

--- a/vdp/model/v1alpha/classification_output.proto
+++ b/vdp/model/v1alpha/classification_output.proto
@@ -2,13 +2,16 @@ syntax = "proto3";
 
 package vdp.model.v1alpha;
 
+// Protocol Buffers Well-Known Types
+import "google/protobuf/wrappers.proto";
+
 // Google api
 import "google/api/field_behavior.proto";
 
 // ClassificationOutput represents the output of classification task
 message ClassificationOutput {
   // Classification category
-  string category = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.StringValue category = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Classification score
-  float score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }

--- a/vdp/model/v1alpha/common.proto
+++ b/vdp/model/v1alpha/common.proto
@@ -2,17 +2,20 @@ syntax = "proto3";
 
 package vdp.model.v1alpha;
 
+// Protocol Buffers Well-Known Types
+import "google/protobuf/wrappers.proto";
+
 // Google api
 import "google/api/field_behavior.proto";
 
 // BoundingBox represents the bounding box data structure
 message BoundingBox {
   // Bounding box top y-axis value
-  float top = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue top = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Bounding box left x-axis value
-  float left = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue left = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Bounding box width value
-  float width = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue width = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Bounding box height value
-  float height = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue height = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }

--- a/vdp/model/v1alpha/detection_output.proto
+++ b/vdp/model/v1alpha/detection_output.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package vdp.model.v1alpha;
 
+// Protocol Buffers Well-Known Types
+import "google/protobuf/wrappers.proto";
+
 // Google api
 import "google/api/field_behavior.proto";
 
@@ -10,9 +13,9 @@ import "vdp/model/v1alpha/common.proto";
 // BoundingBoxObject represents a predicted bounding box object
 message BoundingBoxObject {
   // Bounding box object category
-  string category = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.StringValue category = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Bounding box object score
-  float score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Bounding box
   BoundingBox bounding_box = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }

--- a/vdp/model/v1alpha/keypoint_output.proto
+++ b/vdp/model/v1alpha/keypoint_output.proto
@@ -2,17 +2,20 @@ syntax = "proto3";
 
 package vdp.model.v1alpha;
 
+// Protocol Buffers Well-Known Types
+import "google/protobuf/wrappers.proto";
+
 // Google api
 import "google/api/field_behavior.proto";
 
 // Keypoint structure which include coordinate and keypoint visibility
 message Keypoint {
   // x coordinate
-  float x = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue x = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // y coordinate
-  float y = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue y = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // visibility
-  float v = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue v = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // List of keypoints and a score corresponding to a person object
@@ -20,7 +23,7 @@ message KeypointObject {
   // Keypoints
   repeated Keypoint keypoint_group = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Keypoint score
-  float score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.protobuf.FloatValue score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // KeypointOutput represents the output of keypoint detection task

--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -6,6 +6,7 @@ package vdp.model.v1alpha;
 import "google/protobuf/struct.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 // Google api
@@ -186,9 +187,9 @@ message ListModelResponse {
   // a list of Models
   repeated Model models = 1;
   // Next page token
-  string next_page_token = 2;
+  google.protobuf.StringValue next_page_token = 2;
   // Total count of models
-  int64 total_size = 3;
+  google.protobuf.Int64Value total_size = 3;
 }
 
 // CreateModelRequest represents a request to create a model
@@ -377,9 +378,9 @@ message ListModelInstanceResponse {
   // a list of Model instances
   repeated ModelInstance instances = 1;
   // Next page token
-  string next_page_token = 2;
+  google.protobuf.StringValue next_page_token = 2;
   // Total count of model instances
-  int64 total_size = 3;
+  google.protobuf.Int64Value total_size = 3;
 }
 
 // GetModelInstanceRequest represents a request to query a model instance

--- a/vdp/model/v1alpha/model_definition.proto
+++ b/vdp/model/v1alpha/model_definition.proto
@@ -4,8 +4,7 @@ package vdp.model.v1alpha;
 
 // Protocol Buffers Well-Known Types
 import "google/protobuf/struct.proto";
-
-// Protobuf standard
+import "google/protobuf/wrappers.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -110,9 +109,9 @@ message ListModelDefinitionResponse {
   // a list of ModelDefinition instances
   repeated ModelDefinition model_definitions = 1;
   // Next page token
-  string next_page_token = 2;
+  google.protobuf.StringValue next_page_token = 2;
   // Total count of model definitions
-  int64 total_size = 3;
+  google.protobuf.Int64Value total_size = 3;
 }
 
 // GetModelDefinitionRequest represents a request to query a model definition

--- a/vdp/model/v1alpha/ocr_output.proto
+++ b/vdp/model/v1alpha/ocr_output.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package vdp.model.v1alpha;
 
+// Protocol Buffers Well-Known Types
+import "google/protobuf/wrappers.proto";
+
 import "vdp/model/v1alpha/common.proto";
 
 // Google api
@@ -13,7 +16,7 @@ message OcrOutput {
   repeated BoundingBox bounding_boxes = 1
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // A list of ocr texts
-  repeated string texts = 2
+  repeated google.protobuf.StringValue texts = 2
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -4,6 +4,7 @@ package vdp.pipeline.v1alpha;
 
 // Protocol Buffers Well-Known Types
 import "google/protobuf/field_mask.proto";
+import "google/protobuf/wrappers.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -142,9 +143,9 @@ message ListPipelineResponse {
   // A list of pipeline resources
   repeated Pipeline pipelines = 1;
   // Next page token
-  string next_page_token = 2;
-  // Total count of pipeline resources
-  int64 total_size = 3;
+  google.protobuf.StringValue next_page_token = 2;
+  // Total count of connector resources
+  google.protobuf.Int64Value total_size = 3;
 }
 
 // GetPipelineRequest represents a request to query a pipeline


### PR DESCRIPTION
Because

- Disable EmitUnpopulated in backends to make response consistency.

This commit

- Use wrapper for scalar value which allow empty value response
