### PR TITLE
chore: update buf deps version

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 868034942d3c4d24b722f6a834dd7bb2
+    commit: 8d7204855ec14631a499bd7393ce1970
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: 00116f302b12478b85deb33b734e026c
+    commit: bc28b723cd774c32b6fbc77621518765


### PR DESCRIPTION
Because

- old version of googleapis do not exist and error in ci/cd

This commit

- update buf mod deps
