### PR TITLE
refactor(model): change BatchOutput to TaskOutput

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -484,8 +484,8 @@ message GetModelInstanceCardResponse {
 //  Trigger methods
 ////////////////////////////////////
 
-// BatchOutput represents the output of a CV Task result from a model instance
-message BatchOutput {
+// TaskOutput represents the output of a CV Task result from a model instance
+message TaskOutput {
   // The inference task output
   oneof output {
     // The classification output
@@ -531,8 +531,8 @@ message TriggerModelInstanceRequest {
 message TriggerModelInstanceResponse {
   // The task type
   ModelInstance.Task task = 1;
-  // The batch output from a model instance
-  repeated BatchOutput batch_outputs = 2;
+  // The task output from a model instance
+  repeated TaskOutput task_outputs = 2;
 }
 
 // TriggerModelInstanceBinaryFileUploadRequest represents a request to test a
@@ -555,8 +555,8 @@ message TriggerModelInstanceBinaryFileUploadRequest {
 message TriggerModelInstanceBinaryFileUploadResponse {
   // The task type
   ModelInstance.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // The batch output from a model instance
-  repeated BatchOutput batch_outputs = 2
+  // The task output from a model instance
+  repeated TaskOutput task_outputs = 2
       [ (google.api.field_behavior) = REQUIRED ];
 }
 
@@ -577,8 +577,8 @@ message TestModelInstanceRequest {
 message TestModelInstanceResponse {
   // The task type
   ModelInstance.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // The batch output from a model instance
-  repeated BatchOutput batch_outputs = 2
+  // The task output from a model instance
+  repeated TaskOutput task_outputs = 2
       [ (google.api.field_behavior) = REQUIRED ];
 }
 
@@ -602,7 +602,7 @@ message TestModelInstanceBinaryFileUploadRequest {
 message TestModelInstanceBinaryFileUploadResponse {
   // The task type
   ModelInstance.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // The batch output from a model instance
-  repeated BatchOutput batch_outputs = 2
+  // The task output from a model instance
+  repeated TaskOutput task_outputs = 2
       [ (google.api.field_behavior) = REQUIRED ];
 }

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -268,12 +268,12 @@ message RenamePipelineResponse {
 //  Trigger methods
 ////////////////////////////////////
 
-// BatchOutput represents the output of a CV Task result from a
-// model instance, extended from model.v1alpha.BatchOutput.
-// Here we don't use a model.v1alpha.BatchOutput type field but explicitly use the
+// TaskOutput represents the output of a CV Task result from a
+// model instance, extended from model.v1alpha.TaskOutput.
+// Here we don't use a model.v1alpha.TaskOutput type field but explicitly use the
 // replicated oneof field because we want the CV Task output to be at the same message
 // layer like the trigger output of model instance.
-message BatchOutput {
+message TaskOutput {
   // The index of input data in a batch
   string index = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // The inference task output
@@ -306,9 +306,9 @@ message ModelInstanceOutput {
   // The task type
   model.v1alpha.ModelInstance.Task task = 2
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // The extended batch outputs based on the model instance inference (i.e.,
+  // The extended task outputs based on the model instance inference (i.e.,
   // from a trigger endpoint of model-backend)
-  repeated BatchOutput batch_outputs = 3
+  repeated TaskOutput task_outputs = 3
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 


### PR DESCRIPTION
Because

- naming consistency

This commit

- change BatchOutput to TaskOutput
