### PR TITLE
feat(model): add instance segmentation task output

### DIFF
--- a/vdp/model/v1alpha/instance_segmentation_output.proto
+++ b/vdp/model/v1alpha/instance_segmentation_output.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package vdp.model.v1alpha;
+
+// Google api
+import "google/api/field_behavior.proto";
+
+import "vdp/model/v1alpha/common.proto";
+
+
+// InstanceSegmentationObject corresponding to a instance segmentation object
+message InstanceSegmentationObject {
+  // RLE
+  repeated int32 rle = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Keypoint score
+  float score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Bounding box object
+  BoundingBox bounding_box = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Object label
+  string label = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+// InstanceSegmentationOutput represents the output of instance segmentation task
+message InstanceSegmentationOutput {
+  // A list of instance segmentation objects
+  repeated InstanceSegmentationObject objects = 1
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}

--- a/vdp/model/v1alpha/instance_segmentation_output.proto
+++ b/vdp/model/v1alpha/instance_segmentation_output.proto
@@ -11,7 +11,7 @@ import "vdp/model/v1alpha/common.proto";
 // InstanceSegmentationObject corresponding to a instance segmentation object
 message InstanceSegmentationObject {
   // RLE
-  repeated int32 rle = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  string rle = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Keypoint score
   float score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Bounding box object

--- a/vdp/model/v1alpha/instance_segmentation_output.proto
+++ b/vdp/model/v1alpha/instance_segmentation_output.proto
@@ -12,7 +12,7 @@ import "vdp/model/v1alpha/common.proto";
 message InstanceSegmentationObject {
   // RLE
   string rle = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Keypoint score
+  // Instance score
   float score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Bounding box object
   BoundingBox bounding_box = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];

--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -17,6 +17,7 @@ import "vdp/model/v1alpha/classification_output.proto";
 import "vdp/model/v1alpha/detection_output.proto";
 import "vdp/model/v1alpha/keypoint_output.proto";
 import "vdp/model/v1alpha/ocr_output.proto";
+import "vdp/model/v1alpha/instance_segmentation_output.proto";
 import "vdp/model/v1alpha/unspecified_output.proto";
 
 // Model represents a model
@@ -99,6 +100,8 @@ message ModelInstance {
     TASK_KEYPOINT = 3;
     // Task: OCR
     TASK_OCR = 4;
+    // Task: INSTANCE SEGMENTATION
+    TASK_INSTANCE_SEGMENTATION = 5;
   }
 
   // State enumerates a model instance state
@@ -499,8 +502,10 @@ message TaskOutput {
     KeypointOutput keypoint = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The ocr output
     OcrOutput ocr = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // The instance segmentation output
+    InstanceSegmentationOutput instance_segmentation = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The unspecified task output
-    UnspecifiedOutput unspecified = 5
+    UnspecifiedOutput unspecified = 6
         [ (google.api.field_behavior) = OUTPUT_ONLY ];
   }
 }


### PR DESCRIPTION
Because

- VDP support instance segmentation task

This commit

- add instance segmentation output task
