### PR TITLE
refactor(model): fix field name inconsistency

### DIFF
--- a/vdp/model/v1alpha/instance_segmentation_output.proto
+++ b/vdp/model/v1alpha/instance_segmentation_output.proto
@@ -7,20 +7,20 @@ import "google/api/field_behavior.proto";
 
 import "vdp/model/v1alpha/common.proto";
 
-
 // InstanceSegmentationObject corresponding to a instance segmentation object
 message InstanceSegmentationObject {
-  // RLE
+  // Instance RLE segmentation mask
   string rle = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Instance category
+  string category = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Instance score
-  float score = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Bounding box object
-  BoundingBox bounding_box = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Object label
-  string label = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  float score = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Instance bounding box
+  BoundingBox bounding_box = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
-// InstanceSegmentationOutput represents the output of instance segmentation task
+// InstanceSegmentationOutput represents the output of instance segmentation
+// task
 message InstanceSegmentationOutput {
   // A list of instance segmentation objects
   repeated InstanceSegmentationObject objects = 1


### PR DESCRIPTION
Because

- we need to keep naming convention strict in protobuf

This commit

- change `InstanceSegmentationObject.label` to `InstanceSegmentationObject.category` in `vdp.model.v1alpha`
