### PR TITLE
feat(model): add semantic segmentation output

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -18,6 +18,7 @@ import "vdp/model/v1alpha/detection_output.proto";
 import "vdp/model/v1alpha/keypoint_output.proto";
 import "vdp/model/v1alpha/ocr_output.proto";
 import "vdp/model/v1alpha/instance_segmentation_output.proto";
+import "vdp/model/v1alpha/semantic_segmentation_output.proto";
 import "vdp/model/v1alpha/unspecified_output.proto";
 
 // Model represents a model
@@ -102,6 +103,8 @@ message ModelInstance {
     TASK_OCR = 4;
     // Task: INSTANCE SEGMENTATION
     TASK_INSTANCE_SEGMENTATION = 5;
+    // Task: SEMANTIC SEGMENTATION
+    TASK_SEMANTIC_SEGMENTATION = 6;
   }
 
   // State enumerates a model instance state
@@ -504,8 +507,10 @@ message TaskOutput {
     OcrOutput ocr = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The instance segmentation output
     InstanceSegmentationOutput instance_segmentation = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // The semantic segmentation output
+    SemanticSegmentationOutput semantic_segmentation = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The unspecified task output
-    UnspecifiedOutput unspecified = 6
+    UnspecifiedOutput unspecified = 7
         [ (google.api.field_behavior) = OUTPUT_ONLY ];
   }
 }

--- a/vdp/model/v1alpha/semantic_segmentation_output.proto
+++ b/vdp/model/v1alpha/semantic_segmentation_output.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package vdp.model.v1alpha;
+
+// Google api
+import "google/api/field_behavior.proto";
+
+// SemanticSegmentationStuff corresponding to a semantic segmentation stuff
+message SemanticSegmentationStuff {
+  // RLE segmentation mask
+  string rle = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Stuff category
+  string category = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+// SemanticSegmentationOutput represents the output of semantic segmentation
+// task
+message SemanticSegmentationOutput {
+  // A list of semantic segmentation stuffs
+  repeated SemanticSegmentationStuff stuffs = 1
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}


### PR DESCRIPTION
Because

- support semantic segmentation in VDP

This commit

- add semantic segmentation in model service
