### PR TITLE
chore(pipeline): add semantic segmentation inference task output

### DIFF
--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -17,6 +17,7 @@ import "vdp/model/v1alpha/detection_output.proto";
 import "vdp/model/v1alpha/keypoint_output.proto";
 import "vdp/model/v1alpha/ocr_output.proto";
 import "vdp/model/v1alpha/instance_segmentation_output.proto";
+import "vdp/model/v1alpha/semantic_segmentation_output.proto";
 import "vdp/model/v1alpha/unspecified_output.proto";
 
 // Pipeline represents a pipeline recipe
@@ -296,8 +297,11 @@ message TaskOutput {
     // The instance segmentation output
     model.v1alpha.InstanceSegmentationOutput instance_segmentation = 6
         [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // The semantic segmentation output
+    model.v1alpha.SemanticSegmentationOutput semantic_segmentation = 7
+        [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The unspecified task output
-    model.v1alpha.UnspecifiedOutput unspecified = 7
+    model.v1alpha.UnspecifiedOutput unspecified = 8
         [ (google.api.field_behavior) = OUTPUT_ONLY ];
   }
 }


### PR DESCRIPTION
Because

- support semantic segmentation in VDP

This commit

- add semantic segmentation inference output in pipeline backend
