### PR TITLE
chore: update Visual Data Preparation to Versatile Data Pipeline

### DIFF
--- a/.github/workflows/add-issue-to-prj.yml
+++ b/.github/workflows/add-issue-to-prj.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.botGitHubToken }}
           ORGANIZATION: instill-ai
-          PROJECT_NUMBER: 5 # Visual Data Preparation (VDP) project
+          PROJECT_NUMBER: 5 # Versatile Data Pipeline (VDP) project
         run: |
           gh api graphql -f query='
             query($org: String!, $number: Int!) {

--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -15,7 +15,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.botGitHubToken }}
           ORGANIZATION: instill-ai
-          PROJECT_NUMBER: 5 # Visual Data Preparation (VDP) project
+          PROJECT_NUMBER: 5 # Versatile Data Pipeline (VDP) project
         run: |
           gh api graphql -f query='
             query($org: String!, $number: Int!) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Visual Data Preparation (VDP) Protobufs
+# Versatile Data Pipeline (VDP) Protobufs
 
-This repository is the interface definitions of [Visual Data Preparation (VDP) APIs](https://github.com/instill-ai/vdp) that support both REST and gRPC protocols. You can also use these definitions with open source tools to generate client libraries, documentation, and other artifacts.
+This repository is the interface definitions of [Versatile Data Pipeline (VDP) APIs](https://github.com/instill-ai/vdp) that support both REST and gRPC protocols. You can also use these definitions with open source tools to generate client libraries, documentation, and other artifacts.
 
 ## Overview
 

--- a/buf.md
+++ b/buf.md
@@ -1,6 +1,6 @@
-# Visual Data Preparation (VDP) Protobufs
+# Versatile Data Pipeline (VDP) Protobufs
 
-This repository is the interface definitions of [Visual Data Preparation (VDP) APIs](https://github.com/instill-ai/vdp) that support both REST and gRPC protocols. You can also use these definitions with open source tools to generate client libraries, documentation, and other artifacts.
+This repository is the interface definitions of [Versatile Data Pipeline (VDP) APIs](https://github.com/instill-ai/vdp) that support both REST and gRPC protocols. You can also use these definitions with open source tools to generate client libraries, documentation, and other artifacts.
 
 ## Overview
 


### PR DESCRIPTION
Because

- instead of Visual Data Preparation, VDP is Versatile Data Pipeline now. We realise that as a general ETL infrastructure, VDP is capable of processing all kinds of unstructured data, and we should not limit its usage to only visual data. That's why we replace the word Visual with Versatile. Besides, the term Data Preparation is a bit misleading, users often think it has something to do with data labelling or cleaning. The term Data Pipeline is definitely more precise to capture the core concept of VDP.
 
This commit

- update to Versatile Data Pipeline
