### PR TITLE
chore: add view in get/list operation methods

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -624,6 +624,10 @@ message GetModelOperationRequest {
   string name = 1 [
     (google.api.field_behavior) = REQUIRED
   ];
+  // View (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`, `ModelInstance.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // GetModelOperationResponse represents a response for a model operation
@@ -643,6 +647,10 @@ message ListModelOperationRequest {
   string page_token = 2;
   // Filter expression to list operations
   optional string filter = 3 [ (google.api.field_behavior) = OPTIONAL ];
+  // View (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`, `ModelInstance.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 4 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // ListModelOperationResponse represents a response for a list of model operations including deploy and undeploy


### PR DESCRIPTION
Because

- `view` is a standard field in the Get/List method in Google AIP

This commit

- add view in the request of Get/List operation methods
