### PR TITLE
chore(model): update ready method with additional binding

### DIFF
--- a/vdp/model/v1alpha/model_service.proto
+++ b/vdp/model/v1alpha/model_service.proto
@@ -30,6 +30,7 @@ service ModelService {
   rpc Readiness(ReadinessRequest) returns (ReadinessResponse) {
     option (google.api.http) = {
       get : "/v1alpha/__readiness"
+      additional_bindings : [ {get : "/v1alpha/ready/model"} ]
     };
   }
 


### PR DESCRIPTION
Because

- check model service ready

This commit

- add additional binding to ready method of model-backend
