### PR TITLE
chore(model): fix typo in TaskInput

### DIFF
--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -496,7 +496,7 @@ message TaskInput {
   // Input type
   oneof input {
     // The classification input
-    ClassificationInput classiciation = 1;
+    ClassificationInput classification = 1;
     // The detection input
     DetectionInput detection = 2;
     // The keypoint input


### PR DESCRIPTION
Because

- typo in TaskInput

This commit

- fix typo
