### PR TITLE
refactor: auto-format protobuf files

### DIFF
--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -532,7 +532,8 @@ message WriteDestinationConnectorRequest {
   // Pipeline recipe
   pipeline.v1alpha.Recipe recipe = 5 [ (google.api.field_behavior) = REQUIRED ];
   // Indices corresponds to each JSON data element
-  repeated string data_mapping_indices = 6 [ (google.api.field_behavior) = REQUIRED ];
+  repeated string data_mapping_indices = 6
+      [ (google.api.field_behavior) = REQUIRED ];
   // JSON data to write
   repeated pipeline.v1alpha.ModelInstanceOutput model_instance_outputs = 7
       [ (google.api.field_behavior) = REQUIRED ];

--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -213,7 +213,8 @@ message CreateModelRequest {
 // CreateModelResponse represents a response for a model
 message CreateModelResponse {
   // Create model operation message
-  google.longrunning.Operation operation = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.longrunning.Operation operation = 1
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // CreateModelBinaryFileUploadRequest represents a request to create a model
@@ -231,7 +232,8 @@ message CreateModelBinaryFileUploadRequest {
 // instance
 message CreateModelBinaryFileUploadResponse {
   // Create model operation message
-  google.longrunning.Operation operation = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  google.longrunning.Operation operation = 1
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // GetModelRequest represents a request to query a model
@@ -531,11 +533,14 @@ message TaskOutput {
     // The ocr output
     OcrOutput ocr = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The instance segmentation output
-    InstanceSegmentationOutput instance_segmentation = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    InstanceSegmentationOutput instance_segmentation = 5
+        [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The semantic segmentation output
-    SemanticSegmentationOutput semantic_segmentation = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    SemanticSegmentationOutput semantic_segmentation = 6
+        [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The text to image output
-    TextToImageOutput text_to_image = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    TextToImageOutput text_to_image = 7
+        [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The unspecified task output
     UnspecifiedOutput unspecified = 8
         [ (google.api.field_behavior) = OUTPUT_ONLY ];
@@ -638,12 +643,10 @@ message TestModelInstanceBinaryFileUploadResponse {
 // GetModelOperationRequest represents a request to query a model operation
 message GetModelOperationRequest {
   // The name of the operation resource.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED
-  ];
+  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
   // View (default is VIEW_BASIC)
-  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`, `ModelInstance.configuration`
-  // VIEW_FULL: show full information
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
+  // `ModelInstance.configuration` VIEW_FULL: show full information
   optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
@@ -653,7 +656,8 @@ message GetModelOperationResponse {
   google.longrunning.Operation operation = 1;
 }
 
-// ListModelOperationRequest represents a request to list all model operations including deploy and undeploy
+// ListModelOperationRequest represents a request to list all model operations
+// including deploy and undeploy
 message ListModelOperationRequest {
   // Page size: the maximum number of resources to return. The service may
   // return fewer than this value. If unspecified, at most 10 operations will be
@@ -665,12 +669,13 @@ message ListModelOperationRequest {
   // Filter expression to list operations
   optional string filter = 3 [ (google.api.field_behavior) = OPTIONAL ];
   // View (default is VIEW_BASIC)
-  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`, `ModelInstance.configuration`
-  // VIEW_FULL: show full information
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
+  // `ModelInstance.configuration` VIEW_FULL: show full information
   optional View view = 4 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
-// ListModelOperationResponse represents a response for a list of model operations including deploy and undeploy
+// ListModelOperationResponse represents a response for a list of model
+// operations including deploy and undeploy
 message ListModelOperationResponse {
   // a list of model operations
   repeated google.longrunning.Operation operations = 1;
@@ -683,10 +688,9 @@ message ListModelOperationResponse {
 // CancelModelOperationRequest represents a request to cancel a model operation
 message CancelModelOperationRequest {
   // The name of the operation resource.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED
-  ];
+  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// CancelModelOperationResponse represents a response for canceling a model operation
+// CancelModelOperationResponse represents a response for canceling a model
+// operation
 message CancelModelOperationResponse {}

--- a/vdp/model/v1alpha/task_instance_segmentation.proto
+++ b/vdp/model/v1alpha/task_instance_segmentation.proto
@@ -30,7 +30,8 @@ message InstanceSegmentationInput {
   }
 }
 
-// InstanceSegmentationOutput represents the output of instance segmentation task
+// InstanceSegmentationOutput represents the output of instance segmentation
+// task
 message InstanceSegmentationOutput {
   // A list of instance segmentation objects
   repeated InstanceSegmentationObject objects = 1

--- a/vdp/model/v1alpha/task_semantic_segmentation.proto
+++ b/vdp/model/v1alpha/task_semantic_segmentation.proto
@@ -24,7 +24,8 @@ message SemanticSegmentationInput {
   }
 }
 
-// SemanticSegmentationOutput represents the output of semantic segmentation task
+// SemanticSegmentationOutput represents the output of semantic segmentation
+// task
 message SemanticSegmentationOutput {
   // A list of semantic segmentation stuffs
   repeated SemanticSegmentationStuff stuffs = 1

--- a/vdp/model/v1alpha/task_unspecified.proto
+++ b/vdp/model/v1alpha/task_unspecified.proto
@@ -16,5 +16,6 @@ message UnspecifiedInput {
 // UnspecifiedOutput represents the output of unspecified task
 message UnspecifiedOutput {
   // A list of unspecified task outputs
-  repeated google.protobuf.Struct raw_outputs = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  repeated google.protobuf.Struct raw_outputs = 1
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -274,9 +274,9 @@ message RenamePipelineResponse {
 
 // TaskOutput represents the output of a CV Task result from a
 // model instance, extended from model.v1alpha.TaskOutput.
-// Here we don't use a model.v1alpha.TaskOutput type field but explicitly use the
-// replicated oneof field because we want the CV Task output to be at the same message
-// layer like the trigger output of model instance.
+// Here we don't use a model.v1alpha.TaskOutput type field but explicitly use
+// the replicated oneof field because we want the CV Task output to be at the
+// same message layer like the trigger output of model instance.
 message TaskOutput {
   // The index of input data in a batch
   string index = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
@@ -333,7 +333,8 @@ message TriggerPipelineRequest {
     (google.api.resource_reference) = {type : "api.instill.tech/Pipeline"}
   ];
   // Input to the pipeline
-  repeated model.v1alpha.TaskInput inputs = 2 [ (google.api.field_behavior) = REQUIRED ];
+  repeated model.v1alpha.TaskInput inputs = 2
+      [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // TriggerPipelineResponse represents a response for the output

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -300,8 +300,11 @@ message TaskOutput {
     // The semantic segmentation output
     model.v1alpha.SemanticSegmentationOutput semantic_segmentation = 7
         [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // The text to image output
+    model.v1alpha.TextToImageOutput text_to_image = 8
+        [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // The unspecified task output
-    model.v1alpha.UnspecifiedOutput unspecified = 8
+    model.v1alpha.UnspecifiedOutput unspecified = 9
         [ (google.api.field_behavior) = OUTPUT_ONLY ];
   }
 }


### PR DESCRIPTION
Because

- the format across files are not consistent

This commit

- reformat all files
- add mixing task input in pipeline
