### PR TITLE
fix(mgmt,billing): refactor mgmt message, endpoints and add billing service

### DIFF
--- a/.github/workflows/buf-check.yaml
+++ b/.github/workflows/buf-check.yaml
@@ -2,9 +2,6 @@ name: Check buf
 
 on:
   pull_request:
-    paths:
-      - instill/**
-      - buf.*
 
 jobs:
   check-buf:
@@ -15,5 +12,4 @@ jobs:
       - uses: bufbuild/buf-lint-action@v1
       - uses: bufbuild/buf-breaking-action@v1
         with:
-          # The 'main' branch of the GitHub repository that defines the module.
-          against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main'
+          against: "https://github.com/instill-ai/protobufs.git#branch=main,ref=HEAD~1"

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -7,9 +7,9 @@ managed:
       - buf.build/googleapis/googleapis
       - buf.build/grpc-ecosystem/grpc-gateway
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/python:v3.19.3-1
+  - remote: buf.build/protocolbuffers/plugins/python:v21.10.0-1
     out: gen/python
-  - remote: buf.build/grpc/plugins/python:v1.45.0-1
+  - remote: buf.build/grpc/plugins/python:v1.51.1-1
     out: gen/python
   - remote: buf.build/library/plugins/go:v1.27.1-1
     out: gen/go
@@ -20,19 +20,19 @@ plugins:
     opt:
       - paths=source_relative
       - require_unimplemented_servers=false
-  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.10.3-1
+  - remote: buf.build/grpc-ecosystem/plugins/grpc-gateway:v2.15.0-1
     out: gen/go
     opt:
       - paths=source_relative
       - generate_unbound_methods=true
-  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.10.3-1
+  - remote: buf.build/grpc-ecosystem/plugins/openapiv2:v2.15.0-1
     out: gen/openapiv2
     opt:
       - output_format=yaml
       - json_names_for_fields=false
       - allow_merge=true,merge_file_name=gen/openapiv2
       - version=true
-  - remote: buf.build/sawadashota/plugins/protoc-gen-doc:v1.5.0
+  - remote: buf.build/sawadashota/plugins/protoc-gen-doc:v1.5.1
     out: gen/grpc-doc
     opt:
       - markdown,README.md,source_relative

--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 8d7204855ec14631a499bd7393ce1970
+    commit: 75b4300737fb4efca0831636be94e517
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: bc28b723cd774c32b6fbc77621518765
+    commit: a1ecdc58eccd49aa8bea2a7a9022dc27

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1,6133 +1,6103 @@
 swagger: "2.0"
 info:
-    title: vdp/healthcheck/v1alpha/healthcheck.proto
-    version: version not set
+  title: vdp/healthcheck/v1alpha/healthcheck.proto
+  version: version not set
 tags:
-    - name: PlanService
-    - name: ConnectorService
-    - name: UserService
-    - name: ModelService
-    - name: PipelineService
-    - name: UsageService
+  - name: PlanService
+  - name: ConnectorService
+  - name: UserService
+  - name: ModelService
+  - name: PipelineService
+  - name: UsageService
 consumes:
-    - application/json
+  - application/json
 produces:
-    - application/json
+  - application/json
 paths:
-    /v1alpha/__liveness:
-        get:
-            summary: |-
-                Liveness method receives a LivenessRequest message and returns a
-                LivenessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: UsageService_Liveness
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpusagev1alphaLivenessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - UsageService
-    /v1alpha/__readiness:
-        get:
-            summary: |-
-                Readiness method receives a ReadinessRequest message and returns a
-                ReadinessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: UsageService_Readiness
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpusagev1alphaReadinessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - UsageService
-    /v1alpha/{destination_connector.name}:
-        get:
-            summary: |-
-                GetDestinationConnector method receives a GetDestinationConnectorRequest
-                message and returns a GetDestinationConnectorResponse message.
-            operationId: ConnectorService_GetDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: destination_connector.name
-                  description: |-
-                      DestinationConnectorConnector resource name. It must have the format of
-                      "destination-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: destination-connectors/[^/]+
-                - name: view
-                  description: |-
-                      DestinationConnector view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-        delete:
-            summary: |-
-                DeleteDestinationConnector method receives a
-                DeleteDestinationConnectorRequest message and returns a
-                DeleteDestinationConnectorResponse message.
-            operationId: ConnectorService_DeleteDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDeleteDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: destination_connector.name
-                  description: |-
-                      DestinationConnector resource name. It must have the format of
-                      "destination-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: destination-connectors/[^/]+
-            tags:
-                - ConnectorService
-        patch:
-            summary: |-
-                UpdateDestinationConnector method receives a
-                UpdateDestinationConnectorRequest message and returns a
-                UpdateDestinationConnectorResponse message.
-            operationId: ConnectorService_UpdateDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaUpdateDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: destination_connector.name
-                  description: |-
-                      DestinationConnector resource name. It must have the format of
-                      "destination-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: destination-connectors/[^/]+
-                - name: destination_connector
-                  description: DestinationConnector resource
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          connector:
-                              $ref: "#/definitions/v1alphaConnector"
-                              title: DestinationConnector's connector data structure
-                          destination_connector_definition:
-                              type: string
-                              title: DestinationConnectorDefinition resource
-                          id:
-                              type: string
-                              description: |-
-                                  DestinationConnector resource ID (the last segment of the resource name)
-                                  used to construct the resource name. This conforms to RFC-1034, which
-                                  restricts to letters, numbers, and hyphen, with the first character a
-                                  letter, the last a letter or a number, and a 63 character maximum.
-                          uid:
-                              type: string
-                              title: DestinationConnector UUID
-                              readOnly: true
-                      title: DestinationConnector resource
-                - name: update_mask
-                  description: Update mask for a DestinationConnector resource
-                  in: query
-                  required: true
-                  type: string
-            tags:
-                - ConnectorService
-    /v1alpha/{destination_connector_definition.name}:
-        get:
-            summary: |-
-                GetDestinationConnectorDefinition method receives a
-                GetDestinationConnectorDefinitionRequest message and returns a
-                GetGetDestinationConnectorDefinitionResponse message.
-            operationId: ConnectorService_GetDestinationConnectorDefinition
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetDestinationConnectorDefinitionResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: destination_connector_definition.name
-                  description: |-
-                      DestinationConnectorDefinition resource name. It must have the format of
-                      "source-connector-definitions/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: destination-connector-definitions/[^/]+
-                - name: view
-                  description: |-
-                      DestinationConnectorDefinition resource view (default is
-                      DEFINITION_VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-    /v1alpha/{model.name}:
-        get:
-            summary: |-
-                GetModel method receives a GetModelRequest message and returns a
-                GetModelResponse
-            operationId: ModelService_GetModel
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetModelResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: model.name
-                  description: |-
-                      Resource name of the model.
-                      For example "models/{model}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+
-                - name: view
-                  description: |-
-                      Model view (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
-                      VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-        delete:
-            summary: |-
-                DeleteModel method receives a DeleteModelRequest message and returns a
-                DeleteModelResponse
-            operationId: ModelService_DeleteModel
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDeleteModelResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: model.name
-                  description: |-
-                      Resource name of the model.
-                      For example "models/{model}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+
-            tags:
-                - ModelService
-        patch:
-            summary: |-
-                UpdateModel method receives a UpdateModelRequest message and returns a
-                UpdateModelResponse
-            operationId: ModelService_UpdateModel
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaUpdateModelResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: model.name
-                  description: |-
-                      Resource name. It must have the format of "models/{model}".
-                      For example: "models/yolov4"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+
-                - name: model
-                  description: |-
-                      The model to update
-
-                      The model `name` field is used to identify the model to update.
-                      Format: models/{model}
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          configuration:
-                              type: object
-                              title: |-
-                                  Model configuration represents the configuration JSON that has been
-                                  validated using the `model_spec` JSON schema of a ModelDefinition
-                          create_time:
-                              type: string
-                              format: date-time
-                              title: Model create time
-                              readOnly: true
-                          description:
-                              type: string
-                              title: Model description
-                          id:
-                              type: string
-                              description: |-
-                                  Resource ID (the last segment of the resource name) used to construct the
-                                  resource name. This conforms to RFC-1034, which restricts to letters,
-                                  numbers, and hyphen, with the first character a letter, the last a letter
-                                  or a number, and a 63 character maximum.
-                          model_definition:
-                              type: string
-                              title: Model definition resource name
-                          org:
-                              type: string
-                              title: The resource name of an organization
-                              readOnly: true
-                          uid:
-                              type: string
-                              title: Model ID in UUIDv4
-                              readOnly: true
-                          update_time:
-                              type: string
-                              format: date-time
-                              title: Model update time
-                              readOnly: true
-                          user:
-                              type: string
-                              description: The resource name of a user, e.g., "users/local-user".
-                              readOnly: true
-                          visibility:
-                              $ref: "#/definitions/v1alphaModelVisibility"
-                              title: Model visibility including public or private
-                      description: |-
-                          The model `name` field is used to identify the model to update.
-                          Format: models/{model}
-                      title: The model to update
-                - name: update_mask
-                  description: Mask of fields to update.
-                  in: query
-                  required: true
-                  type: string
-            tags:
-                - ModelService
-    /v1alpha/{model_definition.name}:
-        get:
-            summary: |-
-                GetModelDefinition method receives a GetModelDefinitionRequest message and
-                returns a GetModelDefinitionResponse
-            operationId: ModelService_GetModelDefinition
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetModelDefinitionResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: model_definition.name
-                  description: |-
-                      Resource name of the model definition.
-                      For example "model-definitions/{uuid}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: model-definitions/[^/]+
-                - name: view
-                  description: |-
-                      Definition view (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
-                      `ModelDefinition.model_instance_spec`
-                      VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-    /v1alpha/{model_instance.name/readme}:
-        get:
-            summary: |-
-                GetModelInstanceCard method receives a GetModelInstanceCardRequest message
-                and returns a GetModelInstanceCardResponse
-            operationId: ModelService_GetModelInstanceCard
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetModelInstanceCardResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: model_instance.name/readme
-                  description: |-
-                      Resource name of the model instance card.
-                      For example "models/{model}/instances/{instance}/readme"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+/instances/[^/]+/readme
-            tags:
-                - ModelService
-    /v1alpha/{model_instance.name}:
-        get:
-            summary: |-
-                GetModelInstance method receives a GetModelInstanceRequest message and
-                returns a GetModelInstanceResponse
-            operationId: ModelService_GetModelInstance
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetModelInstanceResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: model_instance.name
-                  description: |-
-                      Resource name of the model instance.
-                      For example "models/{model}/instances/{instance}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+/instances/[^/]+
-                - name: view
-                  description: |-
-                      Model instance view (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-                      VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-    /v1alpha/{name_1}/connect:
-        post:
-            summary: |-
-                Connect a destination connector.
-                The "state" of the connector after connecting is "CONNECTED".
-                ConnectDestinationConnector can be called on DestinationConnector in the
-                state `DISCONNECTED`; DestinationConnector in a different state (including
-                `CONNECTED`) returns an error.
-            operationId: ConnectorService_ConnectDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaConnectDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name_1
-                  description: |-
-                      DestinationConnector resource name. It must have the format of
-                      "destination-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: destination-connectors/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: |-
-                          ConnectDestinationConnectorRequest represents a request to connect a
-                          destination connector
-            tags:
-                - ConnectorService
-    /v1alpha/{name_1}/disconnect:
-        post:
-            summary: |-
-                Disconnect a destination connector.
-                The "state" of the connector after disconnecting is "DISCONNECTED".
-                DisconnectDestinationConnector can be called on DestinationConnector in the
-                state `CONNECTED`; DestinationConnector in a different state (including
-                `DISCONNECTED`) returns an error.
-            operationId: ConnectorService_DisconnectDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDisconnectDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name_1
-                  description: |-
-                      DestinationConnector resource name. It must have the format of
-                      "destination-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: destination-connectors/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: |-
-                          DisconnectDestinationConnectorRequest represents a request to disconnect a
-                          destination connector
-            tags:
-                - ConnectorService
-    /v1alpha/{name_1}/rename:
-        post:
-            summary: |-
-                RenameDestinationConnector method receives a
-                RenameDestinationConnectorRequest message and returns a
-                RenameDestinationConnectorResponse message.
-            operationId: ConnectorService_RenameDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaRenameDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name_1
-                  description: |-
-                      DestinationConnector resource name. It must have the format of
-                      "destination-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: destination-connectors/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          new_destination_connector_id:
-                              type: string
-                              title: |-
-                                  DestinationConnector new resource id to replace with the
-                                  DestinationConnector resource name to be
-                                  "destination-connectors/{new_destination_connector_id}"
-                              required:
-                                  - new_destination_connector_id
-                      title: |-
-                          RenameDestinationConnectorRequest represents a request to rename the
-                          DestinationConnector resource name
-                      required:
-                          - new_destination_connector_id
-            tags:
-                - ConnectorService
-    /v1alpha/{name_1}/trigger:
-        post:
-            summary: |-
-                TriggerPipeline method receives a TriggerPipelineRequest message and
-                returns a TriggerPipelineResponse.
-            operationId: PipelineService_TriggerPipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaTriggerPipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name_1
-                  description: Pipeline resource name. It must have the format of "pipelines/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: pipelines/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          task_inputs:
-                              type: array
-                              items:
-                                  $ref: "#/definitions/v1alphaTaskInput"
-                              title: Input to the pipeline
-                              required:
-                                  - task_inputs
-                      title: TriggerPipelineRequest represents a request to trigger a pipeline
-                      required:
-                          - task_inputs
-            tags:
-                - PipelineService
-    /v1alpha/{name_2}/rename:
-        post:
-            summary: RenameModel method rename a model
-            operationId: ModelService_RenameModel
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaRenameModelResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name_2
-                  description: Resource name for the model to be renamed.
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          new_model_id:
-                              type: string
-                              title: New ID of this model
-                              required:
-                                  - new_model_id
-                      title: RenameModelRequest represents a request to rename a model
-                      required:
-                          - new_model_id
-            tags:
-                - ModelService
-    /v1alpha/{name_3}/rename:
-        post:
-            summary: |-
-                RenamePipeline method receives a RenamePipelineRequest message and returns
-                a RenamePipelineResponse message.
-            operationId: PipelineService_RenamePipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaRenamePipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name_3
-                  description: Pipeline resource name. It must have the format of "pipelines/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: pipelines/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          new_pipeline_id:
-                              type: string
-                              title: |-
-                                  Pipeline new resource id to replace with the pipeline resource name to be
-                                  "pipelines/{new_pipeline_id}"
-                              required:
-                                  - new_pipeline_id
-                      title: |-
-                          RenamePipelineRequest represents a request to rename the pipeline resource
-                          name
-                      required:
-                          - new_pipeline_id
-            tags:
-                - PipelineService
-    /v1alpha/{name}:
-        get:
-            summary: |-
-                GetModelOperation method receives a
-                GetModelOperationRequest message and returns a
-                GetModelOperationResponse message.
-            operationId: ModelService_GetModelOperation
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetModelOperationResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: The name of the operation resource.
-                  in: path
-                  required: true
-                  type: string
-                  pattern: operations/[^/]+
-                - name: view
-                  description: |-
-                      View (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-                      `ModelInstance.configuration` VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-    /v1alpha/{name}/activate:
-        post:
-            summary: |-
-                Activate a pipeline.
-                The "state" of the pipeline after activating is "ACTIVE".
-                ActivatePipeline can be called on Pipelines in the state "INACTIVE";
-                Pipelines in a different state (including "ACTIVE") returns an error.
-            operationId: PipelineService_ActivatePipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaActivatePipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: Pipeline resource name. It must have the format of "pipelines/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: pipelines/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: ActivatePipelineRequest represents a request to activate a pipeline
-            tags:
-                - PipelineService
-    /v1alpha/{name}/cancel:
-        post:
-            summary: |-
-                CancelModelOperation method receives a CancelModelOperationRequest message
-                and returns a CancelModelOperationResponse
-            operationId: ModelService_CancelModelOperation
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaCancelModelOperationResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: The name of the operation resource.
-                  in: path
-                  required: true
-                  type: string
-                  pattern: operations/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: CancelModelOperationRequest represents a request to cancel a model operation
-            tags:
-                - ModelService
-    /v1alpha/{name}/connect:
-        post:
-            summary: |-
-                Connect a source connector.
-                The "state" of the connector after connecting is "CONNECTED".
-                ConnectSourceConnector can be called on SourceConnector in the state
-                `DISCONNECTED`; SourceConnector in a different state (including
-                `CONNECTED`) returns an error.
-            operationId: ConnectorService_ConnectSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaConnectSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      SourceConnector resource name. It must have the format of
-                      "source-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: source-connectors/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: |-
-                          ConnectSourceConnectorRequest represents a request to connect a
-                          source connector
-            tags:
-                - ConnectorService
-    /v1alpha/{name}/deactivate:
-        post:
-            summary: |-
-                Deactivate a pipeline.
-                The "state" of the pipeline after inactivating is "INACTIVE".
-                DeactivatePipeline can be called on Pipelines in the state "ACTIVE";
-                Pipelines in a different state (including "INACTIVE") returns an error.
-            operationId: PipelineService_DeactivatePipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDeactivatePipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: Pipeline resource name. It must have the format of "pipelines/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: pipelines/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: DeactivatePipelineRequest represents a request to deactivate a pipeline
-            tags:
-                - PipelineService
-    /v1alpha/{name}/deploy:
-        post:
-            summary: DeployModelInstance deploy a model instance to online state
-            operationId: ModelService_DeployModelInstance
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDeployModelInstanceResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      Resource name for the model instance to be deployed.
-                      Format: models/{model}/instances/{instance}
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+/instances/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: |-
-                          DeployModelInstanceRequest represents a request to deploy a model instance to
-                          online state
-            tags:
-                - ModelService
-    /v1alpha/{name}/disconnect:
-        post:
-            summary: |-
-                Disconnect a source connector.
-                The "state" of the connector after disconnecting is "DISCONNECTED".
-                DisconnectSourceConnector can be called on SourceConnector in the state
-                `CONNECTED`; SourceConnector in a different state (including
-                `DISCONNECTED`) returns an error.
-            operationId: ConnectorService_DisconnectSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDisconnectSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      SourceConnector resource name. It must have the format of
-                      "source-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: source-connectors/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: |-
-                          DisconnectSourceConnectorRequest represents a request to disconnect a
-                          source connector
-            tags:
-                - ConnectorService
-    /v1alpha/{name}/publish:
-        post:
-            summary: |-
-                PublishModel method receives a PublishModelRequest message and returns a
-                PublishModelResponse
-            operationId: ModelService_PublishModel
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaPublishModelResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      Resource name of the model.
-                      For example "models/{model}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: PublishModelRequest represents a request to publish a model
-            tags:
-                - ModelService
-    /v1alpha/{name}/read:
-        post:
-            summary: |-
-                ReadSourceConnector method receives a ReadSourceConnectorRequest
-                message and returns a ReadSourceConnectorResponse message.
-            operationId: ConnectorService_ReadSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaReadSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      SourceConnector resource name. It must have the format of
-                      "source-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: source-connectors/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: |-
-                          ReadSourceConnectorRequest represents a request to perform read operation of
-                          a SourceConnector given the resource name
-            tags:
-                - ConnectorService
-    /v1alpha/{name}/rename:
-        post:
-            summary: |-
-                RenameSourceConnector method receives a RenameSourceConnectorRequest
-                message and returns a RenameSourceConnectorResponse message.
-            operationId: ConnectorService_RenameSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaRenameSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      SourceConnector resource name. It must have the format of
-                      "source-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: source-connectors/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          new_source_connector_id:
-                              type: string
-                              title: |-
-                                  SourceConnector new resource id to replace with the
-                                  SourceConnector resource name to be
-                                  "source-connectors/{new_source_connector_id}"
-                              required:
-                                  - new_source_connector_id
-                      title: |-
-                          RenameSourceConnectorRequest represents a request to rename the
-                          SourceConnector resource name
-                      required:
-                          - new_source_connector_id
-            tags:
-                - ConnectorService
-    /v1alpha/{name}/test:
-        post:
-            summary: |-
-                TestModelInstance method receives a TestModelInstanceRequest message
-                and returns a TestModelInstanceResponse message.
-            operationId: ModelService_TestModelInstance
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaTestModelInstanceResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      The resource name of the model instance to trigger.
-                      For example "models/{model}/instances/{instance}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+/instances/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          task_inputs:
-                              type: array
-                              items:
-                                  $ref: "#/definitions/v1alphaTaskInput"
-                              title: Input to trigger the model instance
-                              required:
-                                  - task_inputs
-                      title: TestModelInstanceRequest represents a request to test a model instance
-                      required:
-                          - task_inputs
-            tags:
-                - ModelService
-    /v1alpha/{name}/trigger:
-        post:
-            summary: /////////////////////////////////////////////////////
-            description: |-
-                TriggerModelInstance method receives a TriggerModelInstanceRequest message
-                and returns a TriggerModelInstanceResponse message.
-            operationId: ModelService_TriggerModelInstance
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaTriggerModelInstanceResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      The resource name of the model instance to trigger.
-                      For example "models/{model}/instances/{instance}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+/instances/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          task_inputs:
-                              type: array
-                              items:
-                                  $ref: "#/definitions/v1alphaTaskInput"
-                              title: Input to trigger the model instance
-                              required:
-                                  - task_inputs
-                      title: TriggerModelInstanceRequest represents a request to trigger a model instance
-                      required:
-                          - task_inputs
-            tags:
-                - ModelService
-    /v1alpha/{name}/undeploy:
-        post:
-            summary: UndeployModelInstance undeploy a model instance to offline state
-            operationId: ModelService_UndeployModelInstance
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaUndeployModelInstanceResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      Resource name for the model instance to be undeployed.
-                      Format: models/{model}/instances/{instance}
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+/instances/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: |-
-                          UndeployModelInstanceRequest represents a request to undeploy a model
-                          instance to offline state
-            tags:
-                - ModelService
-    /v1alpha/{name}/unpublish:
-        post:
-            summary: |-
-                UnpublishModel method receives a UnpublishModelRequest message and returns
-                a UnpublishModelResponse
-            operationId: ModelService_UnpublishModel
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaUnpublishModelResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      Resource name of the model.
-                      For example "models/{model}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      title: UnpublishModelRequest represents a request to unpublish a model
-            tags:
-                - ModelService
-    /v1alpha/{name}/write:
-        post:
-            summary: |-
-                WriteDestinationConnector method receives a
-                WriteDestinationConnectorRequest message and returns a
-                WriteDestinationConnectorResponse message.
-            operationId: ConnectorService_WriteDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaWriteDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: name
-                  description: |-
-                      DestinationConnector resource name. It must have the format of
-                      "destination-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: destination-connectors/[^/]+
-                - name: body
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          data_mapping_indices:
-                              type: array
-                              items:
-                                  type: string
-                              title: Indices corresponds to each JSON data element
-                              required:
-                                  - data_mapping_indices
-                          destination_sync_mode:
-                              $ref: "#/definitions/v1alphaSupportedDestinationSyncModes"
-                              title: |-
-                                  Destination sync mode:
-                                  https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
-                          model_instance_outputs:
-                              type: array
-                              items:
-                                  $ref: "#/definitions/v1alphaModelInstanceOutput"
-                              title: JSON data to write
-                              required:
-                                  - model_instance_outputs
-                          pipeline:
-                              type: string
-                              title: Pipeline resource name
-                              required:
-                                  - pipeline
-                          recipe:
-                              $ref: "#/definitions/v1alphaRecipe"
-                              title: Pipeline recipe
-                          sync_mode:
-                              $ref: "#/definitions/v1alphaSupportedSyncModes"
-                              title: |-
-                                  Sync mode:
-                                  https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
-                      title: |-
-                          WriteDestinationConnectorRequest represents a request to perform write
-                          operation of a DestinationConnector given the resource name
-                      required:
-                          - pipeline
-                          - data_mapping_indices
-                          - model_instance_outputs
-            tags:
-                - ConnectorService
-    /v1alpha/{parent}/instances:
-        get:
-            summary: |-
-                ListModelInstance method receives a ListModelInstanceRequest message and
-                returns a ListModelInstanceResponse
-            operationId: ModelService_ListModelInstance
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListModelInstanceResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: parent
-                  description: |-
-                      The name of the model whose instances we'd like to list.
-                      e.g., "models/yolov4"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+
-                - name: page_size
-                  description: |-
-                      Page size: the maximum number of resources to return. The service may
-                      return fewer than this value. If unspecified, at most 10 model instances
-                      will be returned. The maximum value is 100; values above 100 will be
-                      coereced to 100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      Model instance view (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-                      VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-    /v1alpha/{permalink_1}/lookUp:
-        get:
-            summary: |-
-                LookUpDestinationConnector method receives a
-                LookUpDestinationConnectorRequest message and returns a
-                LookUpDestinationConnectorResponse
-            operationId: ConnectorService_LookUpDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaLookUpDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: permalink_1
-                  description: |-
-                      Permalink of a destination connector. For example:
-                      "destination-connectors/{uid}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: destination-connectors/[^/]+
-                - name: view
-                  description: |-
-                      SourceConnector view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-    /v1alpha/{permalink_2}/lookUp:
-        get:
-            summary: |-
-                LookUpModel method receives a LookUpModelRequest message and returns a
-                LookUpModelResponse
-            operationId: ModelService_LookUpModel
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaLookUpModelResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: permalink_2
-                  description: |-
-                      Permalink of a model. For example:
-                      "models/{uid}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+
-                - name: view
-                  description: |-
-                      Model view (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
-                      VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-    /v1alpha/{permalink_3}/lookUp:
-        get:
-            summary: |-
-                LookUpModelInstance method receives a LookUpModelInstanceRequest message
-                and returns a
-                LookUpModelInstanceResponse
-            operationId: ModelService_LookUpModelInstance
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaLookUpModelInstanceResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: permalink_3
-                  description: |-
-                      Permalink of a model instance. For example:
-                      "models/{model_uid}/instances/{instance_uid}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: models/[^/]+/instances/[^/]+
-                - name: view
-                  description: |-
-                      Model instance view (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-                      VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-    /v1alpha/{permalink_4}/lookUp:
-        get:
-            summary: |-
-                LookUpPipeline method receives a LookUpPipelineRequest message and returns
-                a LookUpPipelineResponse
-            operationId: PipelineService_LookUpPipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaLookUpPipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: permalink_4
-                  description: |-
-                      Permalink of a pipeline. For example:
-                      "pipelines/{uid}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: pipelines/[^/]+
-                - name: view
-                  description: |-
-                      View view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - PipelineService
-    /v1alpha/{permalink}/lookUp:
-        get:
-            summary: |-
-                LookUpSourceConnector method receives a LookUpSourceConnectorRequest
-                message and returns a LookUpSourceConnectorResponse
-            operationId: ConnectorService_LookUpSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaLookUpSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: permalink
-                  description: |-
-                      Permalink of a source connector. For example:
-                      "source-connectors/{uid}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: source-connectors/[^/]+
-                - name: view
-                  description: |-
-                      SourceConnector view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-    /v1alpha/{pipeline.name}:
-        get:
-            summary: |-
-                GetPipeline method receives a GetPipelineRequest message and returns a
-                GetPipelineResponse message.
-            operationId: PipelineService_GetPipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetPipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: pipeline.name
-                  description: Pipeline resource name. It must have the format of "pipelines/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: pipelines/[^/]+
-                - name: view
-                  description: |-
-                      Pipeline resource view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - PipelineService
-        delete:
-            summary: |-
-                DeletePipeline method receives a DeletePipelineRequest message and returns
-                a DeletePipelineResponse message.
-            operationId: PipelineService_DeletePipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDeletePipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: pipeline.name
-                  description: Pipeline resource name. It must have the format of "pipelines/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: pipelines/[^/]+
-            tags:
-                - PipelineService
-        patch:
-            summary: |-
-                UpdatePipeline method receives a UpdatePipelineRequest message and returns
-                a UpdatePipelineResponse message.
-            operationId: PipelineService_UpdatePipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaUpdatePipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: pipeline.name
-                  description: Pipeline resource name. It must have the format of "pipelines/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: pipelines/[^/]+
-                - name: pipeline
-                  description: A pipeline resource to update
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          create_time:
-                              type: string
-                              format: date-time
-                              title: Pipeline creation time
-                              readOnly: true
-                          description:
-                              type: string
-                              title: Pipeline description
-                          id:
-                              type: string
-                              description: |-
-                                  Pipeline resource ID (the last segment of the resource name) used to
-                                  construct the resource name. This conforms to RFC-1034, which restricts to
-                                  letters, numbers, and hyphen, with the first character a letter, the last a
-                                  letter or a number, and a 63 character maximum.
-                          mode:
-                              $ref: "#/definitions/PipelineMode"
-                              title: Pipeline mode
-                          org:
-                              type: string
-                              title: The resource name of an organization
-                              readOnly: true
-                          recipe:
-                              $ref: "#/definitions/v1alphaRecipe"
-                              title: Pipeline recipe
-                          state:
-                              $ref: "#/definitions/v1alphaPipelineState"
-                              title: Pipeline state
-                          uid:
-                              type: string
-                              title: Pipeline UUID
-                              readOnly: true
-                          update_time:
-                              type: string
-                              format: date-time
-                              title: Pipeline update time
-                              readOnly: true
-                          user:
-                              type: string
-                              description: The resource name of a user, e.g., "users/local-user".
-                              readOnly: true
-                      title: A pipeline resource to update
-                - name: update_mask
-                  description: Update mask for a pipeline resource
-                  in: query
-                  required: true
-                  type: string
-            tags:
-                - PipelineService
-    /v1alpha/{source_connector.name}:
-        get:
-            summary: |-
-                GetSourceConnector method receives a GetSourceConnectorRequest message and
-                returns a GetSourceConnectorResponse message.
-            operationId: ConnectorService_GetSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: source_connector.name
-                  description: |-
-                      SourceConnectorConnector resource name. It must have the format of
-                      "source-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: source-connectors/[^/]+
-                - name: view
-                  description: |-
-                      SourceConnector view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-        delete:
-            summary: |-
-                DeleteSourceConnector method receives a DeleteSourceConnectorRequest
-                message and returns a DeleteSourceConnectorResponse message.
-            operationId: ConnectorService_DeleteSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDeleteSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: source_connector.name
-                  description: |-
-                      SourceConnector resource name. It must have the format of
-                      "source-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: source-connectors/[^/]+
-            tags:
-                - ConnectorService
-        patch:
-            summary: |-
-                UpdateSourceConnector method receives a UpdateSourceConnectorRequest
-                message and returns a UpdateSourceConnectorResponse message.
-            operationId: ConnectorService_UpdateSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaUpdateSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: source_connector.name
-                  description: |-
-                      SourceConnector resource name. It must have the format of
-                      "source-connectors/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: source-connectors/[^/]+
-                - name: source_connector
-                  description: SourceConnector resource
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          connector:
-                              $ref: "#/definitions/v1alphaConnector"
-                              title: SourceConnector's connector data structure
-                          id:
-                              type: string
-                              description: |-
-                                  SourceConnector resource ID (the last segment of the resource name) used to
-                                  construct the resource name. This conforms to RFC-1034, which restricts to
-                                  letters, numbers, and hyphen, with the first character a letter, the last a
-                                  letter or a number, and a 63 character maximum.
-                          source_connector_definition:
-                              type: string
-                              title: SourceConnectorDefinition resource
-                          uid:
-                              type: string
-                              title: SourceConnector UUID
-                              readOnly: true
-                      title: SourceConnector resource
-                - name: update_mask
-                  description: Update mask for a SourceConnector resource
-                  in: query
-                  required: true
-                  type: string
-            tags:
-                - ConnectorService
-    /v1alpha/{source_connector_definition.name}:
-        get:
-            summary: |-
-                GetSourceConnectorDefinition method receives a
-                GetSourceConnectorDefinitionRequest message and returns a
-                GetGetSourceConnectorDefinitionResponse message.
-            operationId: ConnectorService_GetSourceConnectorDefinition
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetSourceConnectorDefinitionResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: source_connector_definition.name
-                  description: |-
-                      SourceConnectorDefinition resource name. It must have the format of
-                      "source-connector-definitions/*"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: source-connector-definitions/[^/]+
-                - name: view
-                  description: |-
-                      SourceConnectorDefinition resource view (default is DEFINITION_VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-    /v1alpha/{user.name}/exists:
-        get:
-            summary: |-
-                ExistUsername method receives a ExistUsernameRequest message and returns a
-                ExistUsernameResponse
-            operationId: UserService_ExistUsername
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaExistUsernameResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: user.name
-                  description: |-
-                      The resource name of the user to be deleted,
-                      for example: "users/local-user"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: users/[^/]+
-            tags:
-                - UserService
-    /v1alpha/admin/{permalink_1}/lookUp:
-        get:
-            summary: |-
-                LookUpUser method receives a LookUpUserRequest message and returns a
-                LookUpUserResponse
-            operationId: UserService_LookUpUser
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaLookUpUserResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: permalink_1
-                  description: |-
-                      Permalink of a user. For example:
-                      "users/{uid}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: users/[^/]+
-                - name: view
-                  description: |-
-                      View view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - UserService
-    /v1alpha/admin/{permalink}/lookUp:
-        get:
-            summary: |-
-                LookUpPlan method receives a LookUpPlanRequest message and returns a
-                LookUpPlanResponse
-            operationId: PlanService_LookUpPlan
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaLookUpPlanResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: permalink
-                  description: |-
-                      Permalink of a plan. For example:
-                      "plans/{uid}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: plans/[^/]+
-                - name: view
-                  description: |-
-                      Plan resource view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - PlanService
-    /v1alpha/admin/{plan.name}:
-        get:
-            summary: |-
-                GetPlan method receives a GetPlanRequest message and returns
-                a GetPlanResponse message.
-            operationId: PlanService_GetPlan
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetPlanResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: plan.name
-                  description: |-
-                      Resource name of a plan. For example:
-                      "plans/free"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: plans/[^/]+
-                - name: view
-                  description: |-
-                      Plan resource view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - PlanService
-        delete:
-            summary: |-
-                DeletePlan method receives a DeletePlanRequest message and returns a
-                DeletePlanResponse
-            operationId: PlanService_DeletePlan
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDeletePlanResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: plan.name
-                  description: |-
-                      The resource name of the plan to be deleted,
-                      for example: "plans/free"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: plans/[^/]+
-            tags:
-                - PlanService
-        patch:
-            summary: |-
-                UpdatePlan method receives a UpdatePlanRequest message and returns
-                a UpdatePlanResponse
-            operationId: PlanService_UpdatePlan
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaUpdatePlanResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: plan.name
-                  description: |-
-                      Resource name. It must have the format of "plans/*".
-                      For example: "plans/free".
-                  in: path
-                  required: true
-                  type: string
-                  pattern: plans/[^/]+
-                - name: plan
-                  description: |-
-                      The plan to update
-
-                      The plan's `name` field is used to identify the plan to update.
-                      Format: plans/{plan}
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          create_time:
-                              type: string
-                              format: date-time
-                              title: Plan creation time
-                              readOnly: true
-                          id:
-                              type: string
-                              description: |-
-                                  Plan resource ID (the last segment of the resource name) used to
-                                  construct the resource name. This conforms to RFC-1034, which restricts to
-                                  letters, numbers, and hyphen, with the first character a letter, the last a
-                                  letter or a number, and a 63 character maximum.
-                          spec:
-                              type: object
-                              title: Plan specification in JSON format
-                              required:
-                                  - spec
-                          tier:
-                              $ref: "#/definitions/PlanTier"
-                              title: Plan tier
-                          uid:
-                              type: string
-                              title: Plan UUID
-                              readOnly: true
-                          update_time:
-                              type: string
-                              format: date-time
-                              title: Plan update time
-                              readOnly: true
-                          visibility:
-                              $ref: "#/definitions/v1alphaPlanVisibility"
-                              title: Plan visibility
-                      description: |-
-                          The plan's `name` field is used to identify the plan to update.
-                          Format: plans/{plan}
-                      title: The plan to update
-                      required:
-                          - spec
-                - name: update_mask
-                  description: Update mask for a plan resource
-                  in: query
-                  required: true
-                  type: string
-            tags:
-                - PlanService
-    /v1alpha/admin/{user.name}:
-        get:
-            summary: |-
-                GetUser method receives a GetUserRequest message and returns
-                a GetUserResponse message.
-            operationId: UserService_GetUser
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetUserResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: user.name
-                  description: |-
-                      Resource name of a user. For example:
-                      "users/instill"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: users/[^/]+
-                - name: view
-                  description: |-
-                      View view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - UserService
-        delete:
-            summary: |-
-                DeleteUser method receives a DeleteUserRequest message and returns a
-                DeleteUserResponse
-            operationId: UserService_DeleteUser
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaDeleteUserResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: user.name
-                  description: |-
-                      The resource name of the user to be deleted,
-                      for example: "users/local-user"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: users/[^/]+
-            tags:
-                - UserService
-        patch:
-            summary: |-
-                UpdateUser method receives a UpdateUserRequest message and returns
-                a UpdateUserResponse
-            operationId: UserService_UpdateUser
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaUpdateUserResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: user.name
-                  description: |-
-                      Resource name. It must have the format of "users/*".
-                      For example: "users/local-user".
-                  in: path
-                  required: true
-                  type: string
-                  pattern: users/[^/]+
-                - name: user
-                  description: |-
-                      The user to update
-
-                      The user's `name` field is used to identify the user to update.
-                      Format: users/{user}
-                  in: body
-                  required: true
-                  schema:
-                      type: object
-                      properties:
-                          cookie_token:
-                              type: string
-                              title: User console cookie token
-                          create_time:
-                              type: string
-                              format: date-time
-                              title: User creation time
-                              readOnly: true
-                          email:
-                              type: string
-                              title: User email
-                              required:
-                                  - email
-                          first_name:
-                              type: string
-                              title: User first name
-                          id:
-                              type: string
-                              description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
-                              required:
-                                  - id
-                          last_name:
-                              type: string
-                              title: User last name
-                          newsletter_subscription:
-                              type: boolean
-                              title: User newsletter subscription
-                              required:
-                                  - newsletter_subscription
-                          org_name:
-                              type: string
-                              title: User company or institution name
-                          plan:
-                              type: string
-                              description: User plan. This field is not used in open-source VDP.
-                          role:
-                              type: string
-                              title: |-
-                                  User role. Allowed roles:
-                                   - "manager"
-                                   - "ai-researcher"
-                                   - "ai-engineer"
-                                   - "data-engineer",
-                                   - "data-scientist",
-                                   - "analytics-engineer"
-                                   - "hobbyist"
-                          type:
-                              $ref: "#/definitions/v1alphaOwnerType"
-                              title: "Owner type: fixed to `OWNER_TYPE_USER`"
-                          uid:
-                              type: string
-                              title: User ID in UUIDv4
-                              required:
-                                  - uid
-                          update_time:
-                              type: string
-                              format: date-time
-                              title: User update time
-                              readOnly: true
-                      description: |-
-                          The user's `name` field is used to identify the user to update.
-                          Format: users/{user}
-                      title: The user to update
-                      required:
-                          - uid
-                          - id
-                          - email
-                          - newsletter_subscription
-                - name: update_mask
-                  description: Update mask for a user resource
-                  in: query
-                  required: true
-                  type: string
-            tags:
-                - UserService
-    /v1alpha/admin/plans:
-        get:
-            summary: |-
-                ListPlan method receives a ListPlanRequest message and returns a
-                ListPlanResponse message.
-            operationId: PlanService_ListPlan
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListPlanResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      Page size: the maximum number of resources to return. The service may
-                      return fewer than this value. If unspecified, at most 10 plans will be
-                      returned. The maximum value is 100; values above 100 will be coereced to
-                      100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      View view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-                - name: filter
-                  description: Filter expression to list plans
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - PlanService
-        post:
-            summary: |-
-                CreatePlan receives a CreatePlanRequest message and returns a
-                aGetPlanResponses
-            operationId: PlanService_CreatePlan
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaCreatePlanResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: plan
-                  description: |-
-                      The plan to be created
-
-                      The plan's `name` field is used to identify the plan to create.
-                      Format: plans/{plan}
-                  in: body
-                  required: true
-                  schema:
-                      $ref: "#/definitions/v1alphaPlan"
-            tags:
-                - PlanService
-    /v1alpha/admin/users:
-        get:
-            summary: |-
-                ListUser method receives a ListUserRequest message and returns a
-                ListUserResponse message.
-            operationId: UserService_ListUser
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListUserResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      Page size: the maximum number of resources to return. The service may
-                      return fewer than this value. If unspecified, at most 10 users will be
-                      returned. The maximum value is 100; values above 100 will be coereced to
-                      100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      View view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-                - name: filter
-                  description: Filter expression to list users
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - UserService
-        post:
-            summary: |-
-                CreateUser receives a CreateUserRequest message and returns a
-                aGetUserResponse
-            operationId: UserService_CreateUser
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaCreateUserResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: user
-                  description: |-
-                      The user to be created
-
-                      The user's `name` field is used to identify the user to create.
-                      Format: users/{user}
-                  in: body
-                  required: true
-                  schema:
-                      $ref: "#/definitions/v1alphaUser"
-            tags:
-                - UserService
-    /v1alpha/destination-connector-definitions:
-        get:
-            summary: |-
-                ListDestinationConnectorDefinition method receives a
-                ListDestinationConnectorDefinitionRequest message and returns a
-                ListDestinationConnectorDefinitionResponse message.
-            operationId: ConnectorService_ListDestinationConnectorDefinition
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListDestinationConnectorDefinitionResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      The maximum number of DestinationConnectorDefinitions to return. The
-                      service may return fewer than this value. If unspecified, at most 10
-                      DestinationConnectorDefinitions will be returned. The maximum value is 100;
-                      values above 100 will be coerced to 100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      Definition view (default is DEFINITION_VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-    /v1alpha/destination-connectors:
-        get:
-            summary: |-
-                ListDestinationConnector method receives a ListDestinationConnectorRequest
-                message and returns a ListDestinationConnectorResponse message.
-            operationId: ConnectorService_ListDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      The maximum number of connectors to return. The service may return fewer
-                      than this value. If unspecified, at most 10 connectors will be returned.
-                      The maximum value is 100; values above 100 will be coerced to 100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      DestinationConnector view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-        post:
-            summary: |-
-                CreateDestinationConnector method receives a
-                CreateDestinationConnectorRequest message and returns a
-                CreateDestinationConnectorResponse message.
-            operationId: ConnectorService_CreateDestinationConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaCreateDestinationConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: destination_connector
-                  description: DestinationConnector resource
-                  in: body
-                  required: true
-                  schema:
-                      $ref: "#/definitions/v1alphaDestinationConnector"
-            tags:
-                - ConnectorService
-    /v1alpha/health/billing:
-        get:
-            summary: |-
-                Liveness method receives a LivenessRequest message and returns a
-                LivenessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: PlanService_Liveness2
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpbillingv1alphaLivenessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - PlanService
-    /v1alpha/health/connector:
-        get:
-            summary: |-
-                Liveness method receives a LivenessRequest message and returns a
-                LivenessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: ConnectorService_Liveness2
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpconnectorv1alphaLivenessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - ConnectorService
-    /v1alpha/health/mgmt:
-        get:
-            summary: |-
-                Liveness method receives a LivenessRequest message and returns a
-                LivenessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: UserService_Liveness2
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpmgmtv1alphaLivenessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - UserService
-    /v1alpha/health/model:
-        get:
-            summary: |-
-                Liveness method receives a LivenessRequest message and returns a
-                LivenessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: ModelService_Liveness2
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpmodelv1alphaLivenessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - ModelService
-    /v1alpha/health/pipeline:
-        get:
-            summary: |-
-                Liveness method receives a LivenessRequest message and returns a
-                LivenessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: PipelineService_Liveness2
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdppipelinev1alphaLivenessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - PipelineService
-    /v1alpha/health/usage:
-        get:
-            summary: |-
-                Liveness method receives a LivenessRequest message and returns a
-                LivenessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: UsageService_Liveness2
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpusagev1alphaLivenessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - UsageService
-    /v1alpha/model-definitions:
-        get:
-            summary: |-
-                ListModelDefinition method receives a ListModelDefinitionRequest message
-                and returns a ListModelDefinitionResponse
-            operationId: ModelService_ListModelDefinition
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListModelDefinitionResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      Page size: the maximum number of resources to return. The service may
-                      return fewer than this value. If unspecified, at most 10 ModelDefinitions
-                      will be returned. The maximum value is 100; values above 100 will be
-                      coereced to 100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      Definition view (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
-                      `ModelDefinition.model_instance_spec`
-                      VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-    /v1alpha/models:
-        get:
-            summary: |-
-                ListModel method receives a ListModelRequest message and returns a
-                ListModelResponse
-            operationId: ModelService_ListModel
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListModelResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      Page size: the maximum number of resources to return. The service may
-                      return fewer than this value. If unspecified, at most 10 models will be
-                      returned. The maximum value is 100; values above 100 will be coereced to
-                      100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      Model view (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
-                      VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-        post:
-            summary: |-
-                CreateModel method receives a CreateModelRequest message and returns a
-                CreateModelResponse
-            operationId: ModelService_CreateModel
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaCreateModelResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: model
-                  description: |-
-                      The model to be created
-
-                      The model `name` field is used to identify the model to create.
-                      Format: models/{model}
-                  in: body
-                  required: true
-                  schema:
-                      $ref: "#/definitions/v1alphaModel"
-            tags:
-                - ModelService
-    /v1alpha/operations:
-        get:
-            summary: |-
-                ListModelOperation method receives a ListModelOperationRequest message
-                and returns a ListModelOperationResponse
-            operationId: ModelService_ListModelOperation
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListModelOperationResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      Page size: the maximum number of resources to return. The service may
-                      return fewer than this value. If unspecified, at most 10 operations will be
-                      returned. The maximum value is 100; values above 100 will be coereced to
-                      100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: filter
-                  description: Filter expression to list operations
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      View (default is VIEW_BASIC)
-                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-                      `ModelInstance.configuration` VIEW_FULL: show full information
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                       - VIEW_FULL: View: FULL, full representation of the resource
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ModelService
-    /v1alpha/pipelines:
-        get:
-            summary: |-
-                ListPipeline method receives a ListPipelineRequest message and returns a
-                ListPipelineResponse message.
-            operationId: PipelineService_ListPipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListPipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      The maximum number of pipelines to return. The service may return fewer
-                      than this value. If unspecified, at most 10 pipelines will be returned. The
-                      maximum value is 100; values above 100 will be coerced to 100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      View view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-                - name: filter
-                  description: Filter expression to list pipelines
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - PipelineService
-        post:
-            summary: |-
-                CreatePipeline method receives a CreatePipelineRequest message and returns
-                a CreatePipelineResponse message.
-            operationId: PipelineService_CreatePipeline
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaCreatePipelineResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: pipeline
-                  description: A pipeline resource to create
-                  in: body
-                  required: true
-                  schema:
-                      $ref: "#/definitions/v1alphaPipeline"
-            tags:
-                - PipelineService
-    /v1alpha/ready/billing:
-        get:
-            summary: |-
-                Readiness method receives a ReadinessRequest message and returns a
-                ReadinessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: PlanService_Readiness2
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpbillingv1alphaReadinessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - PlanService
-    /v1alpha/ready/mgmt:
-        get:
-            summary: |-
-                Readiness method receives a ReadinessRequest message and returns a
-                ReadinessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: UserService_Readiness2
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpmgmtv1alphaReadinessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - UserService
-    /v1alpha/ready/model:
-        get:
-            summary: |-
-                Readiness method receives a ReadinessRequest message and returns a
-                ReadinessResponse message.
-                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-            operationId: ModelService_Readiness2
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/vdpmodelv1alphaReadinessResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: health_check_request.service
-                  description: Service name to check for its readiness status
-                  in: query
-                  required: false
-                  type: string
-            tags:
-                - ModelService
-    /v1alpha/reports:
-        post:
-            summary: |-
-                SendSessionReport method receives a SendSessionReportRequest message and
-                returns a SendSessionReportResponse message.
-            operationId: UsageService_SendSessionReport
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaSendSessionReportResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: report
-                  description: A report resource to create
-                  in: body
-                  required: true
-                  schema:
-                      $ref: "#/definitions/v1alphaSessionReport"
-            tags:
-                - UsageService
-    /v1alpha/sessions:
-        post:
-            summary: |-
-                CreateSession method receives a CreateSessionRequest message and returns
-                a CreateSessionResponse message.
-            operationId: UsageService_CreateSession
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaCreateSessionResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: session
-                  description: A session resource to create
-                  in: body
-                  required: true
-                  schema:
-                      $ref: "#/definitions/v1alphaSession"
-            tags:
-                - UsageService
-    /v1alpha/source-connector-definitions:
-        get:
-            summary: |-
-                ListSourceConnectorDefinition method receives a
-                ListSourceConnectorDefinitionRequest message and returns a
-                ListSourceConnectorDefinitionResponse message.
-            operationId: ConnectorService_ListSourceConnectorDefinition
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListSourceConnectorDefinitionResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      The maximum number of SourceConnectorDefinitions to return. The service may
-                      return fewer than this value. If unspecified, at most 10
-                      SourceConnectorDefinitions will be returned. The maximum value is 100;
-                      values above 100 will be coerced to 100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      Definition view (default is DEFINITION_VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-    /v1alpha/source-connectors:
-        get:
-            summary: |-
-                ListSourceConnector method receives a ListSourceConnectorRequest message
-                and returns a ListSourceConnectorResponse message.
-            operationId: ConnectorService_ListSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaListSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: page_size
-                  description: |-
-                      The maximum number of connectors to return. The service may return fewer
-                      than this value. If unspecified, at most 10 connectors will be returned.
-                      The maximum value is 100; values above 100 will be coerced to 100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
-                - name: view
-                  description: |-
-                      SourceConnector view (default is VIEW_BASIC)
-
-                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                       - VIEW_BASIC: View: BASIC
-                       - VIEW_FULL: View: FULL
-                  in: query
-                  required: false
-                  type: string
-                  enum:
-                      - VIEW_UNSPECIFIED
-                      - VIEW_BASIC
-                      - VIEW_FULL
-                  default: VIEW_UNSPECIFIED
-            tags:
-                - ConnectorService
-        post:
-            summary: |-
-                CreateSourceConnector method receives a CreateSourceConnectorRequest
-                message and returns a CreateSourceConnectorResponse message.
-            operationId: ConnectorService_CreateSourceConnector
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaCreateSourceConnectorResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: source_connector
-                  description: SourceConnector resource
-                  in: body
-                  required: true
-                  schema:
-                      $ref: "#/definitions/v1alphaSourceConnector"
-            tags:
-                - ConnectorService
-    /v1alpha/user:
-        get:
-            summary: |-
-                GetAuthenticatedUser method receives a GetAuthenticatedUserRequest message and returns
-                a GetAuthenticatedUserResponse message.
-            operationId: UserService_GetAuthenticatedUser
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaGetAuthenticatedUserResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            tags:
-                - UserService
-        patch:
-            summary: "UpdateAuthenticatedUser method receives a UpdateAuthenticatedUserRequest message and returns \na UpdateAuthenticatedUserResponse message."
-            operationId: UserService_UpdateAuthenticatedUser
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: "#/definitions/v1alphaUpdateAuthenticatedUserResponse"
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: "#/definitions/rpcStatus"
-            parameters:
-                - name: user
-                  description: The user to update
-                  in: body
-                  required: true
-                  schema:
-                      $ref: "#/definitions/v1alphaUser"
-                - name: update_mask
-                  description: Update mask for a user resource
-                  in: query
-                  required: true
-                  type: string
-            tags:
-                - UserService
-definitions:
-    AdvancedAuthAuthFlowType:
-        type: string
-        enum:
-            - AUTH_FLOW_TYPE_UNSPECIFIED
-            - AUTH_FLOW_TYPE_OAUTH2_0
-            - AUTH_FLOW_TYPE_OAUTH1_0
-        default: AUTH_FLOW_TYPE_UNSPECIFIED
-        description: |-
-            - AUTH_FLOW_TYPE_UNSPECIFIED: AuthFlowType: AUTH_TYPE_UNSPECIFIED
-             - AUTH_FLOW_TYPE_OAUTH2_0: AuthFlowType: AUTH_TYPE_OAUTH2_0
-             - AUTH_FLOW_TYPE_OAUTH1_0: AuthFlowType: AUTH_TYPE_OAUTH1_0
-        title: AuthFlowType enumerates the type of auth
-    HealthCheckResponseServingStatus:
-        type: string
-        enum:
-            - SERVING_STATUS_UNSPECIFIED
-            - SERVING_STATUS_SERVING
-            - SERVING_STATUS_NOT_SERVING
-        default: SERVING_STATUS_UNSPECIFIED
-        description: |-
-            - SERVING_STATUS_UNSPECIFIED: Serving status: UNSPECIFIED
-             - SERVING_STATUS_SERVING: Serving status: SERVING
-             - SERVING_STATUS_NOT_SERVING: Serving status: NOT SERVING
-        title: ServingStatus enumerates the status of a queried service
-    ModelInstanceTask:
-        type: string
-        enum:
-            - TASK_UNSPECIFIED
-            - TASK_CLASSIFICATION
-            - TASK_DETECTION
-            - TASK_KEYPOINT
-            - TASK_OCR
-            - TASK_INSTANCE_SEGMENTATION
-            - TASK_SEMANTIC_SEGMENTATION
-            - TASK_TEXT_TO_IMAGE
-        default: TASK_UNSPECIFIED
-        description: |-
-            - TASK_UNSPECIFIED: Task: UNSPECIFIED
-             - TASK_CLASSIFICATION: Task: CLASSIFICATION
-             - TASK_DETECTION: Task: DETECTION
-             - TASK_KEYPOINT: Task: KEYPOINT
-             - TASK_OCR: Task: OCR
-             - TASK_INSTANCE_SEGMENTATION: Task: INSTANCE SEGMENTATION
-             - TASK_SEMANTIC_SEGMENTATION: Task: SEMANTIC SEGMENTATION
-             - TASK_TEXT_TO_IMAGE: Task: TEXT TO IMAGE
-        title: Task enumerates the task type of a model instance
-    PipelineMode:
-        type: string
-        enum:
-            - MODE_UNSPECIFIED
-            - MODE_SYNC
-            - MODE_ASYNC
-        default: MODE_UNSPECIFIED
-        description: |-
-            - MODE_UNSPECIFIED: Mode: UNSPECIFIED
-             - MODE_SYNC: Mode: SYNC
-             - MODE_ASYNC: Mode: ASYNC
-        title: Mode enumerates the pipeline modes
-    PlanTier:
-        type: string
-        enum:
-            - TIER_UNSPECIFIED
-            - TIER_FREE
-            - TIER_CUSTOM
-        default: TIER_UNSPECIFIED
-        description: |-
-            - TIER_UNSPECIFIED: PlanType: UNSPECIFIED, equivalent to FREE.
-             - TIER_FREE: PlanType: FREE
-             - TIER_CUSTOM: PlanType: CUSTOM
-        title: Tier enumerates the billing plan tier type
-    SessionService:
-        type: string
-        enum:
-            - SERVICE_UNSPECIFIED
-            - SERVICE_MGMT
-            - SERVICE_CONNECTOR
-            - SERVICE_MODEL
-            - SERVICE_PIPELINE
-        default: SERVICE_UNSPECIFIED
-        description: |-
-            - SERVICE_UNSPECIFIED: Service: UNSPECIFIED
-             - SERVICE_MGMT: Service: MGMT
-             - SERVICE_CONNECTOR: Service: CONNECTOR
-             - SERVICE_MODEL: Service: MODEL
-             - SERVICE_PIPELINE: Service: PIPELINE
-        title: Service enumerates the services to collect data from
-    googlelongrunningOperation:
-        type: object
-        properties:
-            done:
-                type: boolean
-                description: |-
-                    If the value is `false`, it means the operation is still in progress.
-                    If `true`, the operation is completed, and either `error` or `response` is
-                    available.
-            error:
-                $ref: "#/definitions/rpcStatus"
-                description: The error result of the operation in case of failure or cancellation.
-            metadata:
-                $ref: "#/definitions/protobufAny"
-                description: |-
-                    Service-specific metadata associated with the operation.  It typically
-                    contains progress information and common metadata such as create time.
-                    Some services might not provide such metadata.  Any method that returns a
-                    long-running operation should document the metadata type, if any.
-            name:
-                type: string
-                description: |-
-                    The server-assigned name, which is only unique within the same service that
-                    originally returns it. If you use the default HTTP mapping, the
-                    `name` should be a resource name ending with `operations/{unique_id}`.
-            response:
-                $ref: "#/definitions/protobufAny"
-                description: |-
-                    The normal response of the operation in case of success.  If the original
-                    method returns no data on success, such as `Delete`, the response is
-                    `google.protobuf.Empty`.  If the original method is standard
-                    `Get`/`Create`/`Update`, the response should be the resource.  For other
-                    methods, the response should have the type `XxxResponse`, where `Xxx`
-                    is the original method name.  For example, if the original method name
-                    is `TakeSnapshot()`, the inferred response type is
-                    `TakeSnapshotResponse`.
-        description: |-
-            This resource represents a long-running operation that is the result of a
-            network API call.
-    protobufAny:
-        type: object
-        properties:
-            "@type":
-                type: string
-                description: |-
-                    A URL/resource name that uniquely identifies the type of the serialized
-                    protocol buffer message. This string must contain at least
-                    one "/" character. The last segment of the URL's path must represent
-                    the fully qualified name of the type (as in
-                    `path/google.protobuf.Duration`). The name should be in a canonical form
-                    (e.g., leading "." is not accepted).
-
-                    In practice, teams usually precompile into the binary all types that they
-                    expect it to use in the context of Any. However, for URLs which use the
-                    scheme `http`, `https`, or no scheme, one can optionally set up a type
-                    server that maps type URLs to message definitions as follows:
-
-                    * If no scheme is provided, `https` is assumed.
-                    * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-                      value in binary format, or produce an error.
-                    * Applications are allowed to cache lookup results based on the
-                      URL, or have them precompiled into a binary to avoid any
-                      lookup. Therefore, binary compatibility needs to be preserved
-                      on changes to types. (Use versioned type names to manage
-                      breaking changes.)
-
-                    Note: this functionality is not currently available in the official
-                    protobuf release, and it is not used for type URLs beginning with
-                    type.googleapis.com.
-
-                    Schemes other than `http`, `https` (or the empty scheme) might be
-                    used with implementation specific semantics.
-        additionalProperties: {}
-        description: |-
-            `Any` contains an arbitrary serialized protocol buffer message along with a
-            URL that describes the type of the serialized message.
-
-            Protobuf library provides support to pack/unpack Any values in the form
-            of utility functions or additional generated methods of the Any type.
-
-            Example 1: Pack and unpack a message in C++.
-
-                Foo foo = ...;
-                Any any;
-                any.PackFrom(foo);
-                ...
-                if (any.UnpackTo(&foo)) {
-                  ...
-                }
-
-            Example 2: Pack and unpack a message in Java.
-
-                Foo foo = ...;
-                Any any = Any.pack(foo);
-                ...
-                if (any.is(Foo.class)) {
-                  foo = any.unpack(Foo.class);
-                }
-
-            Example 3: Pack and unpack a message in Python.
-
-                foo = Foo(...)
-                any = Any()
-                any.Pack(foo)
-                ...
-                if any.Is(Foo.DESCRIPTOR):
-                  any.Unpack(foo)
-                  ...
-
-            Example 4: Pack and unpack a message in Go
-
-                 foo := &pb.Foo{...}
-                 any, err := anypb.New(foo)
-                 if err != nil {
-                   ...
-                 }
-                 ...
-                 foo := &pb.Foo{}
-                 if err := any.UnmarshalTo(foo); err != nil {
-                   ...
-                 }
-
-            The pack methods provided by protobuf library will by default use
-            'type.googleapis.com/full.type.name' as the type URL and the unpack
-            methods only use the fully qualified type name after the last '/'
-            in the type URL, for example "foo.bar.com/x/y.z" will yield type
-            name "y.z".
-
-
-            JSON
-
-            The JSON representation of an `Any` value uses the regular
-            representation of the deserialized, embedded message, with an
-            additional field `@type` which contains the type URL. Example:
-
-                package google.profile;
-                message Person {
-                  string first_name = 1;
-                  string last_name = 2;
-                }
-
-                {
-                  "@type": "type.googleapis.com/google.profile.Person",
-                  "firstName": <string>,
-                  "lastName": <string>
-                }
-
-            If the embedded message type is well-known and has a custom JSON
-            representation, that representation will be embedded adding a field
-            `value` which holds the custom JSON in addition to the `@type`
-            field. Example (for message [google.protobuf.Duration][]):
-
-                {
-                  "@type": "type.googleapis.com/google.protobuf.Duration",
-                  "value": "1.212s"
-                }
-    protobufNullValue:
-        type: string
-        enum:
-            - NULL_VALUE
-        default: NULL_VALUE
-        description: |-
-            `NullValue` is a singleton enumeration to represent the null value for the
-            `Value` type union.
-
-             The JSON representation for `NullValue` is JSON `null`.
-
-             - NULL_VALUE: Null value.
-    rpcStatus:
-        type: object
-        properties:
-            code:
-                type: integer
-                format: int32
-                description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
-            details:
-                type: array
-                items:
-                    $ref: "#/definitions/protobufAny"
-                description: |-
-                    A list of messages that carry the error details.  There is a common set of
-                    message types for APIs to use.
-            message:
-                type: string
-                description: |-
-                    A developer-facing error message, which should be in English. Any
-                    user-facing error message should be localized and sent in the
-                    [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
-        description: |-
-            The `Status` type defines a logical error model that is suitable for
-            different programming environments, including REST APIs and RPC APIs. It is
-            used by [gRPC](https://github.com/grpc). Each `Status` message contains
-            three pieces of data: error code, error message, and error details.
-
-            You can find out more about this error model and how to work with it in the
-            [API Design Guide](https://cloud.google.com/apis/design/errors).
-    typeDate:
-        type: object
-        properties:
-            day:
-                type: integer
-                format: int32
-                description: |-
-                    Day of a month. Must be from 1 to 31 and valid for the year and month, or 0
-                    to specify a year by itself or a year and month where the day isn't
-                    significant.
-            month:
-                type: integer
-                format: int32
-                description: |-
-                    Month of a year. Must be from 1 to 12, or 0 to specify a year without a
-                    month and day.
-            year:
-                type: integer
-                format: int32
-                description: |-
-                    Year of the date. Must be from 1 to 9999, or 0 to specify a date without
-                    a year.
-        description: |-
-            * A full date, with non-zero year, month, and day values
-            * A month and day value, with a zero year, such as an anniversary
-            * A year on its own, with zero month and day values
-            * A year and month value, with a zero day, such as a credit card expiration
-            date
-
-            Related types are [google.type.TimeOfDay][google.type.TimeOfDay] and
-            `google.protobuf.Timestamp`.
-        title: |-
-            Represents a whole or partial calendar date, such as a birthday. The time of
-            day and time zone are either specified elsewhere or are insignificant. The
-            date is relative to the Gregorian Calendar. This can represent one of the
-            following:
-    v1alphaActivatePipelineResponse:
-        type: object
-        properties:
-            pipeline:
-                $ref: "#/definitions/v1alphaPipeline"
-                title: A pipeline resource
-        title: ActivatePipelineResponse represents an activated pipeline
-    v1alphaAdvancedAuth:
-        type: object
-        properties:
-            auth_flow_type:
-                $ref: "#/definitions/AdvancedAuthAuthFlowType"
-                title: AdvancedAuth auth flow type
-            oauth_config_specification:
-                $ref: "#/definitions/v1alphaOauthConfigSpecification"
-                title: OauthConfigSpecification represents OAuth config specification
-            predicate_key:
-                type: array
-                items:
-                    type: string
-                title: |-
-                    AdvancedAuth predicate key, i.e., the JSON Path to a field in the
-                    connectorSpecification that should exist for the advanced auth to be
-                    applicable
-            predicate_value:
-                type: string
-                title: |-
-                    AdvancedAuth predicate value, i.e., the value of the predicate key fields
-                    for the advanced auth to be applicable
-        description: |-
-            Additional and optional specification object to describe what an 'advanced'
-            Auth flow would need to function.
-            - A connector should be able to fully function with the configuration as
-            described by the ConnectorSpecification in a 'basic' mode.
-            - The 'advanced' mode provides easier UX for the user with UI improvements
-            and automations. However, this requires further setup on the server side by
-            instance or workspace admins beforehand. The trade-off is that the user does
-            not have to provide as many technical inputs anymore and the auth process is
-            faster and easier to complete.
-    v1alphaBoundingBox:
-        type: object
-        properties:
-            height:
-                type: number
-                format: float
-                title: Bounding box height value
-                readOnly: true
-            left:
-                type: number
-                format: float
-                title: Bounding box left x-axis value
-                readOnly: true
-            top:
-                type: number
-                format: float
-                title: Bounding box top y-axis value
-                readOnly: true
-            width:
-                type: number
-                format: float
-                title: Bounding box width value
-                readOnly: true
-        title: BoundingBox represents the bounding box data structure
-    v1alphaCancelModelOperationResponse:
-        type: object
-        title: |-
-            CancelModelOperationResponse represents a response for canceling a model
-            operation
-    v1alphaClassificationInput:
-        type: object
-        properties:
-            image_base64:
-                type: string
-                title: Image type base64
-            image_url:
-                type: string
-                title: Image type URL
-        title: ClassificationInput represents the input of classification task
-    v1alphaClassificationOutput:
-        type: object
-        properties:
-            category:
-                type: string
-                title: Classification category
-                readOnly: true
-            score:
-                type: number
-                format: float
-                title: Classification score
-                readOnly: true
-        title: ClassificationOutput represents the output of classification task
-    v1alphaConnectDestinationConnectorResponse:
-        type: object
-        properties:
-            destination_connector:
-                $ref: "#/definitions/v1alphaDestinationConnector"
-                title: A DestinationConnector resource
-        title: |-
-            ConnectDestinationConnectorResponse represents a connected destination
-            connector
-    v1alphaConnectSourceConnectorResponse:
-        type: object
-        properties:
-            source_connector:
-                $ref: "#/definitions/v1alphaSourceConnector"
-                title: A SourceConnector resource
-        title: ConnectSourceConnectorResponse represents a connected source connector
-    v1alphaConnector:
-        type: object
-        properties:
-            configuration:
-                type: object
-                title: Connector configuration in JSON format
-                required:
-                    - configuration
-            create_time:
-                type: string
-                format: date-time
-                title: Connector creation time
-                readOnly: true
-            description:
-                type: string
-                title: Connector description
-            org:
-                type: string
-                title: The resource name of an organization
-                readOnly: true
-            state:
-                $ref: "#/definitions/v1alphaConnectorState"
-                title: Connector state
-            tombstone:
-                type: boolean
-                title: Connector tombstone
-                readOnly: true
-            update_time:
-                type: string
-                format: date-time
-                title: Connector update time
-                readOnly: true
-            user:
-                type: string
-                description: The resource name of a user, e.g., "users/local-user".
-                readOnly: true
-        title: Connector represents a connector data model
-        required:
-            - configuration
-    v1alphaConnectorDefinition:
-        type: object
-        properties:
-            create_time:
-                type: string
-                format: date-time
-                title: ConnectorDefinition creation time
-                readOnly: true
-            custom:
-                type: boolean
-                title: |-
-                    ConnectorDefinition custom flag, i.e., whether this is a custom
-                    connector definition
-                readOnly: true
-            docker_image_tag:
-                type: string
-                title: ConnectorDefinition Docker image tag
-                readOnly: true
-            docker_repository:
-                type: string
-                title: ConnectorDefinition Docker repository
-                readOnly: true
-            documentation_url:
-                type: string
-                title: ConnectorDefinition documentation URL
-                readOnly: true
-            icon:
-                type: string
-                title: ConnectorDefinition icon
-                readOnly: true
-            public:
-                type: boolean
-                title: |-
-                    ConnectorDefinition public flag, i.e., true if this connector
-                    definition is available to all workspaces
-                readOnly: true
-            release_date:
-                $ref: "#/definitions/typeDate"
-                description: |-
-                    ConnectorDefinition release date, i.e., the date when this connector
-                    was first released, in yyyy-mm-dd format.
-            release_stage:
-                $ref: "#/definitions/vdpconnectorv1alphaReleaseStage"
-                title: ConnectorDefinition release stage
-            resource_requirements:
-                type: object
-                title: ConnectorDefinition resource requirements
-                readOnly: true
-            spec:
-                $ref: "#/definitions/v1alphaSpec"
-                title: ConnectorDefinition spec
-            title:
-                type: string
-                title: ConnectorDefinition title
-                readOnly: true
-            tombstone:
-                type: boolean
-                title: |-
-                    ConnectorDefinition tombstone, i.e., if not set or false, the
-                    configuration is active, or otherwise, if true, this configuration is
-                    permanently off
-                readOnly: true
-            update_time:
-                type: string
-                format: date-time
-                title: ConnectorDefinition update time
-                readOnly: true
-        title: ConnectorDefinition represents the connector definition data model
-    v1alphaConnectorState:
-        type: string
-        enum:
-            - STATE_UNSPECIFIED
-            - STATE_DISCONNECTED
-            - STATE_CONNECTED
-            - STATE_ERROR
-        default: STATE_UNSPECIFIED
-        description: |-
-            - STATE_UNSPECIFIED: State: UNSPECIFIED
-             - STATE_DISCONNECTED: State: DISCONNECTED
-             - STATE_CONNECTED: State: CONNECTED
-             - STATE_ERROR: State: ERROR
-        title: State enumerates the connector state
-    v1alphaConnectorUsageData:
-        type: object
-        properties:
-            usages:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaConnectorUsageDataUserUsageData"
-                title: Usage data of all users in the connector service
-        title: Connector service usage data
-    v1alphaConnectorUsageDataUserUsageData:
-        type: object
-        properties:
-            destination_connector_connected_state_num:
-                type: string
-                format: int64
-                title: Number of destination connectors with 'connected' state
-                required:
-                    - destination_connector_connected_state_num
-            destination_connector_definition_ids:
-                type: array
-                items:
-                    type: string
-                description: |-
-                    Definition IDs of the destination connectors. Element in the
-                    list should not be duplicated.
-                required:
-                    - destination_connector_definition_ids
-            destination_connector_disconnected_state_num:
-                type: string
-                format: int64
-                title: Number of destination connectors with 'disconnected' state
-                required:
-                    - destination_connector_disconnected_state_num
-            source_connector_connected_state_num:
-                type: string
-                format: int64
-                title: Number of source connectors with 'connected' state
-                required:
-                    - source_connector_connected_state_num
-            source_connector_definition_ids:
-                type: array
-                items:
-                    type: string
-                description: |-
-                    Definition IDs of the source connectors. Element in the list
-                    should not be duplicated.
-                required:
-                    - source_connector_definition_ids
-            source_connector_disconnected_state_num:
-                type: string
-                format: int64
-                title: Number of source connectors with 'disconneceted' state
-                required:
-                    - source_connector_disconnected_state_num
-            user_uid:
-                type: string
-                title: User UUID
-                required:
-                    - user_uid
-        title: Per user usage data in the connector service
-        required:
-            - user_uid
-            - source_connector_connected_state_num
-            - source_connector_disconnected_state_num
-            - source_connector_definition_ids
-            - destination_connector_connected_state_num
-            - destination_connector_disconnected_state_num
-            - destination_connector_definition_ids
-    v1alphaCreateDestinationConnectorResponse:
-        type: object
-        properties:
-            destination_connector:
-                $ref: "#/definitions/v1alphaDestinationConnector"
-                title: DestinationConnector resource
-        title: |-
-            CreateDestinationConnectorResponse represents a response for a
-            DestinationConnector resource
-    v1alphaCreateModelBinaryFileUploadResponse:
-        type: object
-        properties:
-            operation:
-                $ref: "#/definitions/googlelongrunningOperation"
-                title: Create model operation message
-        title: |-
-            CreateModelBinaryFileUploadResponse represents a response for a model
-            instance
-    v1alphaCreateModelResponse:
-        type: object
-        properties:
-            operation:
-                $ref: "#/definitions/googlelongrunningOperation"
-                title: Create model operation message
-        title: CreateModelResponse represents a response for a model
-    v1alphaCreatePipelineResponse:
-        type: object
-        properties:
-            pipeline:
-                $ref: "#/definitions/v1alphaPipeline"
-                title: The created pipeline resource
-        title: CreatePipelineResponse represents a response for a pipeline resource
-    v1alphaCreatePlanResponse:
-        type: object
-        properties:
-            plan:
-                $ref: "#/definitions/v1alphaPlan"
-                title: A plan resource
-        title: CreatePlanResponse represents a response for a plan response
-    v1alphaCreateSessionResponse:
-        type: object
-        properties:
-            session:
-                $ref: "#/definitions/v1alphaSession"
-                title: A session resource
-        title: CreateSessionResponse represents a response for a session response
-    v1alphaCreateSourceConnectorResponse:
-        type: object
-        properties:
-            source_connector:
-                $ref: "#/definitions/v1alphaSourceConnector"
-                title: SourceConnector resource
-        title: |-
-            CreateSourceConnectorResponse represents a response for a
-            SourceConnector resource
-    v1alphaCreateUserResponse:
-        type: object
-        properties:
-            user:
-                $ref: "#/definitions/v1alphaUser"
-                title: A user resource
-        title: CreateUserResponse represents a response for a user response
-    v1alphaDeactivatePipelineResponse:
-        type: object
-        properties:
-            pipeline:
-                $ref: "#/definitions/v1alphaPipeline"
-                title: A pipeline resource
-        title: DeactivatePipelineResponse represents an inactivated pipeline
-    v1alphaDeleteDestinationConnectorResponse:
-        type: object
-        title: DeleteDestinationConnectorResponse represents an empty response
-    v1alphaDeleteModelResponse:
-        type: object
-        title: DeleteModelResponse represents an empty response
-    v1alphaDeletePipelineResponse:
-        type: object
-        title: DeletePipelineResponse represents an empty response
-    v1alphaDeletePlanResponse:
-        type: object
-        title: DeletePlanResponse represents an empty response
-    v1alphaDeleteSourceConnectorResponse:
-        type: object
-        title: DeleteSourceConnectorResponse represents an empty response
-    v1alphaDeleteUserResponse:
-        type: object
-        title: DeleteUserResponse represents an empty response
-    v1alphaDeployModelInstanceResponse:
-        type: object
-        properties:
-            operation:
-                $ref: "#/definitions/googlelongrunningOperation"
-                title: Deploy operation message
-        title: |-
-            DeployModelInstanceResponse represents a response for a deployed model
-            instance
-    v1alphaDestinationConnector:
-        type: object
-        properties:
-            connector:
-                $ref: "#/definitions/v1alphaConnector"
-                title: DestinationConnector's connector data structure
-            destination_connector_definition:
-                type: string
-                title: DestinationConnectorDefinition resource
-            id:
-                type: string
-                description: |-
-                    DestinationConnector resource ID (the last segment of the resource name)
-                    used to construct the resource name. This conforms to RFC-1034, which
-                    restricts to letters, numbers, and hyphen, with the first character a
-                    letter, the last a letter or a number, and a 63 character maximum.
-            name:
-                type: string
-                title: |-
-                    DestinationConnector resource name. It must have the format of
-                    "destination-connectors/*"
-                readOnly: true
-            uid:
-                type: string
-                title: DestinationConnector UUID
-                readOnly: true
-        title: DestinationConnector represents a destination connector resource
-    v1alphaDestinationConnectorDefinition:
-        type: object
-        properties:
-            connector_definition:
-                $ref: "#/definitions/v1alphaConnectorDefinition"
-                title: DestinationConnectorDefinition connector definition
-            id:
-                type: string
-                description: |-
-                    DestinationConnectorDefinition resource ID (the last segment of the
-                    resource name) used to construct the resource name. This conforms to
-                    RFC-1034, which restricts to letters, numbers, and hyphen, with the first
-                    character a letter, the last a letter or a number, and a 63 character
-                    maximum.
-            name:
-                type: string
-                title: |-
-                    DestinationConnectorDefinition resource name. It must have the format of
-                    "connector-definitions/*"
-                readOnly: true
-            uid:
-                type: string
-                title: DestinationConnectorDefinition UUID
-                readOnly: true
-        title: |-
-            DestinationConnectorDefinition represents the destination connector
-            definition resource
-    v1alphaDetectionInput:
-        type: object
-        properties:
-            image_base64:
-                type: string
-                title: Image type base64
-            image_url:
-                type: string
-                title: Image type URL
-        title: DetectionInput represents the input of detection task
-    v1alphaDetectionObject:
-        type: object
-        properties:
-            bounding_box:
-                $ref: "#/definitions/v1alphaBoundingBox"
-                title: Detection bounding box
-            category:
-                type: string
-                title: Detection object category
-                readOnly: true
-            score:
-                type: number
-                format: float
-                title: Detection object score
-                readOnly: true
-        title: DetectionObject represents a predicted object
-    v1alphaDetectionOutput:
-        type: object
-        properties:
-            objects:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaDetectionObject"
-                title: A list of detection objects
-                readOnly: true
-        title: DetectionOutput represents the output of detection task
-    v1alphaDisconnectDestinationConnectorResponse:
-        type: object
-        properties:
-            destination_connector:
-                $ref: "#/definitions/v1alphaDestinationConnector"
-                title: A DestinationConnector resource
-        title: |-
-            DisconnectDestinationConnectorResponse represents a disconnected destination
-            connector
-    v1alphaDisconnectSourceConnectorResponse:
-        type: object
-        properties:
-            source_connector:
-                $ref: "#/definitions/v1alphaSourceConnector"
-                title: A SourceConnector resource
-        title: DisconnectSourceConnectorResponse represents a disconnected source connector
-    v1alphaExistUsernameResponse:
-        type: object
-        properties:
-            exists:
-                type: boolean
-                title: A boolean value indicating whether the username has been occupied
-        title: |-
-            ExistUsernameResponse represents a response about whether
-            the queried username has been occupied
-    v1alphaGetAuthenticatedUserResponse:
-        type: object
-        properties:
-            user:
-                $ref: "#/definitions/v1alphaUser"
-                title: A user resource
-        title: |-
-            GetAuthenticatedUserResponse represents a response for
-            the authenticated user resource
-    v1alphaGetDestinationConnectorDefinitionResponse:
-        type: object
-        properties:
-            destination_connector_definition:
-                $ref: "#/definitions/v1alphaDestinationConnectorDefinition"
-                title: A DestinationConnectorDefinition resource
-        title: |-
-            GetDestinationConnectorDefinitionResponse represents a
-            DestinationConnectorDefinition response
-    v1alphaGetDestinationConnectorResponse:
-        type: object
-        properties:
-            destination_connector:
-                $ref: "#/definitions/v1alphaDestinationConnector"
-                title: DestinationConnector resource
-        title: |-
-            GetDestinationConnectorResponse represents a response for a
-            DestinationConnector resource
-    v1alphaGetModelDefinitionResponse:
-        type: object
-        properties:
-            model_definition:
-                $ref: "#/definitions/v1alphaModelDefinition"
-                title: A model definition instance
-        title: GetModelDefinitionResponse represents a response for a model definition
-    v1alphaGetModelInstanceCardResponse:
-        type: object
-        properties:
-            readme:
-                $ref: "#/definitions/v1alphaModelInstanceCard"
-                title: Retrieved model instance card
-        title: |-
-            GetModelInstanceCardResponse represents a response to fetch a model
-            instance's README card
-    v1alphaGetModelInstanceResponse:
-        type: object
-        properties:
-            instance:
-                $ref: "#/definitions/v1alphaModelInstance"
-                title: Retrieved model instance
-        title: GetModelInstanceResponse represents a response for a model instance
-    v1alphaGetModelOperationResponse:
-        type: object
-        properties:
-            operation:
-                $ref: "#/definitions/googlelongrunningOperation"
-                title: The retrieved model operation
-        title: GetModelOperationResponse represents a response for a model operation
-    v1alphaGetModelResponse:
-        type: object
-        properties:
-            model:
-                $ref: "#/definitions/v1alphaModel"
-                title: The retrieved model
-        title: GetModelResponse represents a response for a model
-    v1alphaGetPipelineResponse:
-        type: object
-        properties:
-            pipeline:
-                $ref: "#/definitions/v1alphaPipeline"
-                title: A pipeline resource
-        title: GetPipelineResponse represents a response for a pipeline resource
-    v1alphaGetPlanResponse:
-        type: object
-        properties:
-            plan:
-                $ref: "#/definitions/v1alphaPlan"
-                title: A plan resource
-        title: GetPlanResponse represents a response for a plan resource
-    v1alphaGetSourceConnectorDefinitionResponse:
-        type: object
-        properties:
-            source_connector_definition:
-                $ref: "#/definitions/v1alphaSourceConnectorDefinition"
-                title: A SourceConnectorDefinition resource
-        title: |-
-            GetSourceConnectorDefinitionResponse represents a SourceConnectorDefinition
-            response
-    v1alphaGetSourceConnectorResponse:
-        type: object
-        properties:
-            source_connector:
-                $ref: "#/definitions/v1alphaSourceConnector"
-                title: SourceConnector resource
-        title: |-
-            GetSourceConnectorResponse represents a response for a
-            SourceConnector resource
-    v1alphaGetUserResponse:
-        type: object
-        properties:
-            user:
-                $ref: "#/definitions/v1alphaUser"
-                title: A user resource
-        title: GetUserResponse represents a response for a user resource
-    v1alphaHealthCheckRequest:
-        type: object
-        properties:
-            service:
-                type: string
-                title: Service name to check for its readiness status
-        title: HealthCheckRequest represents a request to health check a service
-    v1alphaHealthCheckResponse:
-        type: object
-        properties:
-            status:
-                $ref: "#/definitions/HealthCheckResponseServingStatus"
-                title: Status is the instance of the enum type ServingStatus
-        title: HealthCheckResponse represents a response for a service heath status
-    v1alphaInstanceSegmentationInput:
-        type: object
-        properties:
-            image_base64:
-                type: string
-                title: Image type base64
-            image_url:
-                type: string
-                title: Image type URL
-        title: InstanceSegmentationInput represents the input of instance segmentation task
-    v1alphaInstanceSegmentationObject:
-        type: object
-        properties:
-            bounding_box:
-                $ref: "#/definitions/v1alphaBoundingBox"
-                title: Instance bounding box
-            category:
-                type: string
-                title: Instance category
-                readOnly: true
-            rle:
-                type: string
-                title: Instance RLE segmentation mask
-                readOnly: true
-            score:
-                type: number
-                format: float
-                title: Instance score
-                readOnly: true
-        title: InstanceSegmentationObject corresponding to a instance segmentation object
-    v1alphaInstanceSegmentationOutput:
-        type: object
-        properties:
-            objects:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaInstanceSegmentationObject"
-                title: A list of instance segmentation objects
-                readOnly: true
-        title: |-
-            InstanceSegmentationOutput represents the output of instance segmentation
-            task
-    v1alphaKeypoint:
-        type: object
-        properties:
-            v:
-                type: number
-                format: float
-                title: visibility
-                readOnly: true
-            x:
-                type: number
-                format: float
-                title: x coordinate
-                readOnly: true
-            "y":
-                type: number
-                format: float
-                title: y coordinate
-                readOnly: true
-        title: Keypoint structure which include coordinate and keypoint visibility
-    v1alphaKeypointInput:
-        type: object
-        properties:
-            image_base64:
-                type: string
-                title: Image type base64
-            image_url:
-                type: string
-                title: Image type URL
-        title: KeypointInput represents the input of keypoint detection task
-    v1alphaKeypointObject:
-        type: object
-        properties:
-            bounding_box:
-                $ref: "#/definitions/v1alphaBoundingBox"
-                title: Bounding box object
-            keypoints:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaKeypoint"
-                title: Keypoints
-                readOnly: true
-            score:
-                type: number
-                format: float
-                title: Keypoint score
-                readOnly: true
-        title: KeypointObject corresponding to a person object
-    v1alphaKeypointOutput:
-        type: object
-        properties:
-            objects:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaKeypointObject"
-                title: A list of keypoint objects
-                readOnly: true
-        title: KeypointOutput represents the output of keypoint detection task
-    v1alphaListDestinationConnectorDefinitionResponse:
-        type: object
-        properties:
-            destination_connector_definitions:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaDestinationConnectorDefinition"
-                title: A list of DestinationConnectorDefinition resources
-            next_page_token:
-                type: string
-                title: Next page token
-            total_size:
-                type: string
-                format: int64
-                title: Total count of DestinationConnectorDefinition resources
-        title: |-
-            ListDestinationConnectorDefinitionResponse represents a response for a list
-            of DestinationConnectorDefinitions
-    v1alphaListDestinationConnectorResponse:
-        type: object
-        properties:
-            destination_connectors:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaDestinationConnector"
-                title: A list of DestinationConnector resources
-            next_page_token:
-                type: string
-                title: Next page token
-            total_size:
-                type: string
-                format: int64
-                title: Total count of connector resources
-        title: |-
-            ListDestinationConnectorResponse represents a response for a list of
-            DestinationConnector resources
-    v1alphaListModelDefinitionResponse:
-        type: object
-        properties:
-            model_definitions:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaModelDefinition"
-                title: a list of ModelDefinition instances
-            next_page_token:
-                type: string
-                title: Next page token
-            total_size:
-                type: string
-                format: int64
-                title: Total count of model definitions
-        title: |-
-            ListModelDefinitionResponse represents a response to list all supported model
-            definitions
-    v1alphaListModelInstanceResponse:
-        type: object
-        properties:
-            instances:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaModelInstance"
-                title: a list of Model instances
-            next_page_token:
-                type: string
-                title: Next page token
-            total_size:
-                type: string
-                format: int64
-                title: Total count of model instances
-        title: ListModelInstanceResponse represents a response for a list of model instances
-    v1alphaListModelOperationResponse:
-        type: object
-        properties:
-            next_page_token:
-                type: string
-                title: Next page token
-            operations:
-                type: array
-                items:
-                    $ref: "#/definitions/googlelongrunningOperation"
-                title: a list of model operations
-            total_size:
-                type: string
-                format: int64
-                title: Total count of operations
-        title: |-
-            ListModelOperationResponse represents a response for a list of model
-            operations including deploy and undeploy
-    v1alphaListModelResponse:
-        type: object
-        properties:
-            models:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaModel"
-                title: a list of Models
-            next_page_token:
-                type: string
-                title: Next page token
-            total_size:
-                type: string
-                format: int64
-                title: Total count of models
-        title: ListModelResponse represents a response for a list of models
-    v1alphaListPipelineResponse:
-        type: object
-        properties:
-            next_page_token:
-                type: string
-                title: Next page token
-            pipelines:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaPipeline"
-                title: A list of pipeline resources
-            total_size:
-                type: string
-                format: int64
-                title: Total count of pipeline resources
-        title: ListPipelineResponse represents a response for a list of pipelines
-    v1alphaListPlanResponse:
-        type: object
-        properties:
-            next_page_token:
-                type: string
-                title: Next page token
-            plans:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaPlan"
-                title: A list of plans
-            total_size:
-                type: string
-                format: int64
-                title: Total count of plans
-        title: ListPlanResponse represents a response for a list of plans
-    v1alphaListSourceConnectorDefinitionResponse:
-        type: object
-        properties:
-            next_page_token:
-                type: string
-                title: Next page token
-            source_connector_definitions:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaSourceConnectorDefinition"
-                title: A list of SourceConnectorDefinition resources
-            total_size:
-                type: string
-                format: int64
-                title: Total count of SourceConnectorDefinition resources
-        title: |-
-            ListSourceConnectorDefinitionResponse represents a response for a list of
-            SourceConnectorDefinitions
-    v1alphaListSourceConnectorResponse:
-        type: object
-        properties:
-            next_page_token:
-                type: string
-                title: Next page token
-            source_connectors:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaSourceConnector"
-                title: A list of SourceConnector resources
-            total_size:
-                type: string
-                format: int64
-                title: Total count of connector resources
-        title: |-
-            ListSourceConnectorResponse represents a response for a list of
-            SourceConnector resources
-    v1alphaListUserResponse:
-        type: object
-        properties:
-            next_page_token:
-                type: string
-                title: Next page token
-            total_size:
-                type: string
-                format: int64
-                title: Total count of users
-            users:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaUser"
-                title: A list of users
-        title: ListUserResponse represents a response for a list of users
-    v1alphaLookUpDestinationConnectorResponse:
-        type: object
-        properties:
-            destination_connector:
-                $ref: "#/definitions/v1alphaDestinationConnector"
-                title: DestinationConnector resource
-        title: |-
-            LookUpDestinationConnectorResponse represents a response for a destination
-            connector
-    v1alphaLookUpModelInstanceResponse:
-        type: object
-        properties:
-            instance:
-                $ref: "#/definitions/v1alphaModelInstance"
-                title: A model instance
-        title: LookUpModelInstanceResponse represents a response for a model instance
-    v1alphaLookUpModelResponse:
-        type: object
-        properties:
-            model:
-                $ref: "#/definitions/v1alphaModel"
-                title: A model resource
-        title: LookUpModelResponse represents a response for a model instance
-    v1alphaLookUpPipelineResponse:
-        type: object
-        properties:
-            pipeline:
-                $ref: "#/definitions/v1alphaPipeline"
-                title: A pipeline resource
-        title: LookUpPipelineResponse represents a response for a pipeline resource
-    v1alphaLookUpPlanResponse:
-        type: object
-        properties:
-            plan:
-                $ref: "#/definitions/v1alphaPlan"
-                title: A plan resource
-        title: LookUpPlanResponse represents a response for a plan resource
-    v1alphaLookUpSourceConnectorResponse:
-        type: object
-        properties:
-            source_connector:
-                $ref: "#/definitions/v1alphaSourceConnector"
-                title: SourceConnector resource
-        title: LookUpSourceConnectorResponse represents a response for a source connector
-    v1alphaLookUpUserResponse:
-        type: object
-        properties:
-            user:
-                $ref: "#/definitions/v1alphaUser"
-                title: A user resource
-        title: LookUpUserResponse represents a response for a user resource
-    v1alphaMgmtUsageData:
-        type: object
-        properties:
-            usages:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaUser"
-                title: Repeated user usage data
-        title: Management service usage data
-    v1alphaModel:
-        type: object
-        properties:
-            configuration:
-                type: object
-                title: |-
-                    Model configuration represents the configuration JSON that has been
-                    validated using the `model_spec` JSON schema of a ModelDefinition
-            create_time:
-                type: string
-                format: date-time
-                title: Model create time
-                readOnly: true
-            description:
-                type: string
-                title: Model description
-            id:
-                type: string
-                description: |-
-                    Resource ID (the last segment of the resource name) used to construct the
-                    resource name. This conforms to RFC-1034, which restricts to letters,
-                    numbers, and hyphen, with the first character a letter, the last a letter
-                    or a number, and a 63 character maximum.
-            model_definition:
-                type: string
-                title: Model definition resource name
-            name:
-                type: string
-                title: |-
-                    Resource name. It must have the format of "models/{model}".
-                    For example: "models/yolov4"
-                readOnly: true
-            org:
-                type: string
-                title: The resource name of an organization
-                readOnly: true
-            uid:
-                type: string
-                title: Model ID in UUIDv4
-                readOnly: true
-            update_time:
-                type: string
-                format: date-time
-                title: Model update time
-                readOnly: true
-            user:
-                type: string
-                description: The resource name of a user, e.g., "users/local-user".
-                readOnly: true
-            visibility:
-                $ref: "#/definitions/v1alphaModelVisibility"
-                title: Model visibility including public or private
-        title: Model represents a model
-    v1alphaModelDefinition:
-        type: object
-        properties:
-            create_time:
-                type: string
-                format: date-time
-                title: ModelDefinition create time
-                readOnly: true
-            documentation_url:
-                type: string
-                title: ModelDefinition documentation url
-                readOnly: true
-            icon:
-                type: string
-                title: ModelDefinition icon
-                readOnly: true
-            id:
-                type: string
-                description: |-
-                    ModelDefinition resource ID (the last segment of the resource name) used to
-                    construct the resource name.
-                readOnly: true
-            model_instance_spec:
-                type: object
-                description: |-
-                    ModelDefinition model instance specification represents the JSON schema
-                    used to validate the JSON configurations of a model instance from a
-                    specific model source. Must be a valid JSON that includes what fields are
-                    needed to display a model instance.
-                required:
-                    - model_instance_spec
-            model_spec:
-                type: object
-                description: |-
-                    ModelDefinition model specification represents the JSON schema used to
-                    validate the JSON configurations of a model created from a specific model
-                    source. Must be a valid JSON that includes what fields are needed to
-                    create/display a model.
-                readOnly: true
-            name:
-                type: string
-                title: |-
-                    ModelDefinition resource name. It must have the format of
-                    "model-definitions/{model-definition}"
-                readOnly: true
-            release_stage:
-                $ref: "#/definitions/vdpmodelv1alphaReleaseStage"
-                title: ModelDefinition release stage
-            title:
-                type: string
-                title: ModelDefinition display official title
-                readOnly: true
-            uid:
-                type: string
-                title: ModelDefinition ID in UUIDv4
-                readOnly: true
-            update_time:
-                type: string
-                format: date-time
-                title: ModelDefinition update time
-                readOnly: true
-        title: |-
-            /////////////////////////////////////////////////////////////////
-            ModelDefinition represents the definition of a model
-        required:
-            - model_instance_spec
-    v1alphaModelInstance:
-        type: object
-        properties:
-            configuration:
-                type: object
-                title: |-
-                    Model instance configuration represents the configuration JSON that
-                    has been validated using the `model_instance_spec` JSON schema of a
-                    ModelDefinition
-                readOnly: true
-            create_time:
-                type: string
-                format: date-time
-                title: Model instance create time
-                readOnly: true
-            id:
-                type: string
-                description: |-
-                    Model instance ID (the last segment of the resource name), used to
-                    construct the resource name. This conforms to RFC-1034, which restricts to
-                    letters, numbers, and hyphen, with the first character a letter, the last a
-                    letter or a number, and a 63 character maximum.
-                readOnly: true
-            model_definition:
-                type: string
-                title: Model definition resource name
-                readOnly: true
-            name:
-                type: string
-                title: |-
-                    Resource name. It must have the format of
-                    "models/{model}/instances/{instance}"
-                readOnly: true
-            state:
-                $ref: "#/definitions/v1alphaModelInstanceState"
-                title: Model instance state
-            task:
-                $ref: "#/definitions/ModelInstanceTask"
-                title: Model instance task
-            uid:
-                type: string
-                title: Model instance ID in UUIDv4
-                readOnly: true
-            update_time:
-                type: string
-                format: date-time
-                title: Model instance update time
-                readOnly: true
-        title: ModelVersion represents one deployable instance of a model
-    v1alphaModelInstanceCard:
-        type: object
-        properties:
-            content:
-                type: string
-                format: byte
-                title: Content of the README file in bytes and base64 format
-                readOnly: true
-            encoding:
-                type: string
-                description: Encoding type of the content. Fixed to "base64".
-                readOnly: true
-            name:
-                type: string
-                title: |-
-                    Resource name. It must have the format of
-                    "models/{model}/instances/{instance}/readme"
-                readOnly: true
-            size:
-                type: integer
-                format: int32
-                title: Size of the file
-                readOnly: true
-            type:
-                type: string
-                description: Type of the resource. Fixed to "file".
-                readOnly: true
-        description: |-
-            ModelInstanceCard represents the README card for a model instance. There
-            exists one and exactly one README card per model instance.
-    v1alphaModelInstanceOutput:
-        type: object
-        properties:
-            model_instance:
-                type: string
-                title: The model instance
-                readOnly: true
-            task:
-                $ref: "#/definitions/ModelInstanceTask"
-                title: The task type
-            task_outputs:
-                type: array
-                items:
-                    $ref: "#/definitions/vdppipelinev1alphaTaskOutput"
-                title: |-
-                    The extended task outputs based on the model instance inference (i.e.,
-                    from a trigger endpoint of model-backend)
-                readOnly: true
-        title: ModelInstanceOutput represents one model instance inference result
-    v1alphaModelInstanceState:
-        type: string
-        enum:
-            - STATE_UNSPECIFIED
-            - STATE_OFFLINE
-            - STATE_ONLINE
-            - STATE_ERROR
-        default: STATE_UNSPECIFIED
-        description: |-
-            - STATE_UNSPECIFIED: State: UNSPECIFIED
-             - STATE_OFFLINE: State: OFFLINE
-             - STATE_ONLINE: State: ONLINE
-             - STATE_ERROR: State: ERROR
-        title: State enumerates a model instance state
-    v1alphaModelUsageData:
-        type: object
-        properties:
-            usages:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaModelUsageDataUserUsageData"
-                title: Usage data of all users in the model service
-        title: Model service usage data
-    v1alphaModelUsageDataUserUsageData:
-        type: object
-        properties:
-            instance_offline_state_num:
-                type: string
-                format: int64
-                title: Number of model instances with 'offline' state
-                required:
-                    - instance_offline_state_num
-            instance_online_state_num:
-                type: string
-                format: int64
-                title: Number of model instances with 'online' state
-                required:
-                    - instance_online_state_num
-            model_definition_ids:
-                type: array
-                items:
-                    type: string
-                description: |-
-                    Definition IDs of the model instances. Element in the list
-                    should not be duplicated.
-                required:
-                    - model_definition_ids
-            model_offline_state_num:
-                type: string
-                format: int64
-                title: Number of models that have no 'online' instances
-                required:
-                    - model_offline_state_num
-            model_online_state_num:
-                type: string
-                format: int64
-                title: Number of models that have at least one 'online' instance
-                required:
-                    - model_online_state_num
-            tasks:
-                type: array
-                items:
-                    $ref: "#/definitions/ModelInstanceTask"
-                description: |-
-                    Tasks of the model instances. Element in the list should not be
-                    duplicated.
-                required:
-                    - tasks
-            test_num:
-                type: string
-                format: int64
-                title: Number of model instance testing operations
-                required:
-                    - test_num
-            user_uid:
-                type: string
-                title: User UUID
-                required:
-                    - user_uid
-        title: Per user usage data in the model service
-        required:
-            - user_uid
-            - model_online_state_num
-            - model_offline_state_num
-            - instance_online_state_num
-            - instance_offline_state_num
-            - model_definition_ids
-            - tasks
-            - test_num
-    v1alphaModelVisibility:
-        type: string
-        enum:
-            - VISIBILITY_UNSPECIFIED
-            - VISIBILITY_PRIVATE
-            - VISIBILITY_PUBLIC
-        default: VISIBILITY_UNSPECIFIED
-        description: |-
-            - VISIBILITY_UNSPECIFIED: Visibility: UNSPECIFIED, equivalent to PRIVATE.
-             - VISIBILITY_PRIVATE: Visibility: PRIVATE
-             - VISIBILITY_PUBLIC: Visibility: PUBLIC
-        title: Model visibility including public or private
-    v1alphaOauthConfigSpecification:
-        type: object
-        properties:
-            complete_oauth_output_specification:
-                type: object
-                description: |-
-                    Examples:
-
-                        complete_oauth_output_specification={
-                          refresh_token: {
-                            type: string,
-                            path_in_connector_config: ['credentials', 'refresh_token']
-                          }
-                        }
-                title: |-
-                    OAuth specific blob. This is a Json Schema used to validate Json
-                    configurations produced by the OAuth flows as they are returned by the
-                    distant OAuth APIs. Must be a valid JSON describing the fields to merge
-                    back to `ConnectorSpecification.connectionSpecification`. For each field, a
-                    special annotation `path_in_connector_config` can be specified to determine
-                    where to merge it,
-                readOnly: true
-            complete_oauth_server_input_specification:
-                type: object
-                description: |-
-                    OAuth specific blob. This is a Json Schema used to validate Json
-                    configurations persisted as Airbyte Server configurations. Must be a valid
-                    non-nested JSON describing additional fields configured by the Airbyte
-                    Instance or Workspace Admins to be used by the server when completing an
-                    OAuth flow (typically exchanging an auth code for refresh token).
-
-                    Examples:
-
-                        complete_oauth_server_input_specification={
-                          client_id: {
-                            type: string
-                          },
-                          client_secret: {
-                            type: string
-                          }
-                        }
-                readOnly: true
-            complete_oauth_server_output_specification:
-                type: object
-                description: |-
-                    Examples:
-
-                          complete_oauth_server_output_specification={
-                            client_id: {
-                              type: string,
-                              path_in_connector_config: ['credentials', 'client_id']
-                            },
-                            client_secret: {
-                              type: string,
-                              path_in_connector_config: ['credentials', 'client_secret']
-                            }
-                          }
-                title: |-
-                    OAuth specific blob. This is a Json Schema used to validate Json
-                    configurations persisted as Airbyte Server configurations that also need to
-                    be merged back into the connector configuration at runtime. This is a
-                    subset configuration of `complete_oauth_server_input_specification` that
-                    filters fields out to retain only the ones that are necessary for the
-                    connector to function with OAuth. (some fields could be used during oauth
-                    flows but not needed afterwards, therefore they would be listed in the
-                    `complete_oauth_server_input_specification` but not
-                    `complete_oauth_server_output_specification`) Must be a valid non-nested
-                    JSON describing additional fields configured by the Airbyte Instance or
-                    Workspace Admins to be used by the connector when using OAuth flow APIs.
-                    These fields are to be merged back to
-                    `ConnectorSpecification.connectionSpecification`. For each field, a special
-                    annotation `path_in_connector_config` can be specified to determine where
-                    to merge it,
-                readOnly: true
-            oauth_user_input_from_connector_config_specification:
-                type: object
-                description: |-
-                    OAuth specific blob. This is a Json Schema used to validate Json
-                    configurations used as input to OAuth. Must be a valid non-nested JSON that
-                    refers to properties from ConnectorSpecification.connectionSpecification
-                    using special annotation 'path_in_connector_config'.
-                    These are input values the user is entering through the UI to authenticate
-                    to the connector, that might also shared as inputs for syncing data via the
-                    connector.
-
-                    Examples:
-
-                    if no connector values is shared during oauth flow,
-                    oauth_user_input_from_connector_config_specification=[] if connector values
-                    such as 'app_id' inside the top level are used to generate the API url for
-                    the oauth flow,
-                      oauth_user_input_from_connector_config_specification={
-                        app_id: {
-                          type: string
-                          path_in_connector_config: ['app_id']
-                        }
-                      }
-                    if connector values such as 'info.app_id' nested inside another object are
-                    used to generate the API url for the oauth flow,
-                     oauth_user_input_from_connector_config_specification={
-                       app_id: {
-                         type: string
-                         path_in_connector_config: ['info', 'app_id']
-                       }
-                     }
-                readOnly: true
-        title: OauthConfigSpecification represents oauth config specification
-    v1alphaOcrInput:
-        type: object
-        properties:
-            image_base64:
-                type: string
-                title: Image type base64
-            image_url:
-                type: string
-                title: Image type URL
-        title: OcrInput represents the input of ocr task
-    v1alphaOcrObject:
-        type: object
-        properties:
-            bounding_box:
-                $ref: "#/definitions/v1alphaBoundingBox"
-                title: OCR bounding box
-            score:
-                type: number
-                format: float
-                title: OCR text score
-                readOnly: true
-            text:
-                type: string
-                title: OCR text
-                readOnly: true
-        title: OcrObject represents a predicted ocr object
-    v1alphaOcrOutput:
-        type: object
-        properties:
-            objects:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaOcrObject"
-                title: A list of OCR objects
-                readOnly: true
-        title: OcrOutput represents the output of ocr task
-    v1alphaOwnerType:
-        type: string
-        enum:
-            - OWNER_TYPE_UNSPECIFIED
-            - OWNER_TYPE_USER
-            - OWNER_TYPE_ORGANIZATION
-        default: OWNER_TYPE_UNSPECIFIED
-        description: |-
-            - OWNER_TYPE_UNSPECIFIED: OwnerType: UNSPECIFIED
-             - OWNER_TYPE_USER: OwnerType: USER
-             - OWNER_TYPE_ORGANIZATION: OwnerType: ORGANIZATION
-        title: OwnerType enumerates the owner type of any resource
-    v1alphaPipeline:
-        type: object
-        properties:
-            create_time:
-                type: string
-                format: date-time
-                title: Pipeline creation time
-                readOnly: true
-            description:
-                type: string
-                title: Pipeline description
-            id:
-                type: string
-                description: |-
-                    Pipeline resource ID (the last segment of the resource name) used to
-                    construct the resource name. This conforms to RFC-1034, which restricts to
-                    letters, numbers, and hyphen, with the first character a letter, the last a
-                    letter or a number, and a 63 character maximum.
-            mode:
-                $ref: "#/definitions/PipelineMode"
-                title: Pipeline mode
-            name:
-                type: string
-                title: Pipeline resource name. It must have the format of "pipelines/*"
-                readOnly: true
-            org:
-                type: string
-                title: The resource name of an organization
-                readOnly: true
-            recipe:
-                $ref: "#/definitions/v1alphaRecipe"
-                title: Pipeline recipe
-            state:
-                $ref: "#/definitions/v1alphaPipelineState"
-                title: Pipeline state
-            uid:
-                type: string
-                title: Pipeline UUID
-                readOnly: true
-            update_time:
-                type: string
-                format: date-time
-                title: Pipeline update time
-                readOnly: true
-            user:
-                type: string
-                description: The resource name of a user, e.g., "users/local-user".
-                readOnly: true
-        title: Pipeline represents the content of a pipeline
-    v1alphaPipelineState:
-        type: string
-        enum:
-            - STATE_UNSPECIFIED
-            - STATE_INACTIVE
-            - STATE_ACTIVE
-            - STATE_ERROR
-        default: STATE_UNSPECIFIED
-        description: |-
-            - STATE_UNSPECIFIED: State: UNSPECIFIED
-             - STATE_INACTIVE: State INACTIVE indicates the pipeline is inactive
-             - STATE_ACTIVE: State ACTIVE indicates the pipeline is active
-             - STATE_ERROR: State ERROR indicates the pipeline has error
-        title: State enumerates the state of a pipeline
-    v1alphaPipelineUsageData:
-        type: object
-        properties:
-            usages:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaPipelineUsageDataUserUsageData"
-                title: Usage data of all users in the pipeline service
-        title: Pipeline service usage data
-    v1alphaPipelineUsageDataUserUsageData:
-        type: object
-        properties:
-            pipeline_active_state_num:
-                type: string
-                format: int64
-                title: Number of pipelines with 'active' state
-                required:
-                    - pipeline_active_state_num
-            pipeline_async_mode_num:
-                type: string
-                format: int64
-                title: Number of pipelines with 'async' mode
-                required:
-                    - pipeline_async_mode_num
-            pipeline_inactive_state_num:
-                type: string
-                format: int64
-                title: Number of pipelines with 'inactive' state
-                required:
-                    - pipeline_inactive_state_num
-            pipeline_sync_mode_num:
-                type: string
-                format: int64
-                title: Number of pipelines with 'sync' mode
-                required:
-                    - pipeline_sync_mode_num
-            trigger_num:
-                type: string
-                format: int64
-                title: Number of pipeline triggering operations
-                required:
-                    - trigger_num
-            user_uid:
-                type: string
-                title: User UUID
-                required:
-                    - user_uid
-        title: Per user usage data in the pipeline service
-        required:
-            - user_uid
-            - pipeline_active_state_num
-            - pipeline_inactive_state_num
-            - pipeline_async_mode_num
-            - pipeline_sync_mode_num
-            - trigger_num
-    v1alphaPlan:
-        type: object
-        properties:
-            create_time:
-                type: string
-                format: date-time
-                title: Plan creation time
-                readOnly: true
-            id:
-                type: string
-                description: |-
-                    Plan resource ID (the last segment of the resource name) used to
-                    construct the resource name. This conforms to RFC-1034, which restricts to
-                    letters, numbers, and hyphen, with the first character a letter, the last a
-                    letter or a number, and a 63 character maximum.
-            name:
-                type: string
-                description: |-
-                    Resource name. It must have the format of "plans/*".
-                    For example: "plans/free".
-                readOnly: true
-            spec:
-                type: object
-                title: Plan specification in JSON format
-                required:
-                    - spec
-            tier:
-                $ref: "#/definitions/PlanTier"
-                title: Plan tier
-            uid:
-                type: string
-                title: Plan UUID
-                readOnly: true
-            update_time:
-                type: string
-                format: date-time
-                title: Plan update time
-                readOnly: true
-            visibility:
-                $ref: "#/definitions/v1alphaPlanVisibility"
-                title: Plan visibility
-        title: Plan represents the content of a billing plan
-        required:
-            - spec
-    v1alphaPlanVisibility:
-        type: string
-        enum:
-            - VISIBILITY_UNSPECIFIED
-            - VISIBILITY_PRIVATE
-            - VISIBILITY_PUBLIC
-        default: VISIBILITY_UNSPECIFIED
-        description: |-
-            - VISIBILITY_UNSPECIFIED: Visibility: UNSPECIFIED, equivalent to PRIVATE.
-             - VISIBILITY_PRIVATE: Visibility: PRIVATE
-             - VISIBILITY_PUBLIC: Visibility: PUBLIC
-        title: Plan visibility including public or private
-    v1alphaPublishModelResponse:
-        type: object
-        properties:
-            model:
-                $ref: "#/definitions/v1alphaModel"
-                title: Published model
-        title: PublishModelResponse represents a response for the published model
-    v1alphaReadSourceConnectorResponse:
-        type: object
-        properties:
-            data:
-                type: string
-                format: byte
-                title: Read data in bytes
-        title: |-
-            ReadSourceConnectorResponse represents the read data from a SourceConnector
-            resource
-    v1alphaRecipe:
-        type: object
-        properties:
-            destination:
-                type: string
-                title: A destination connector resource
-            model_instances:
-                type: array
-                items:
-                    type: string
-                title: A list of model instance resources
-            source:
-                type: string
-                title: A source connector resource
-        title: Pipeline represents a pipeline recipe
-    v1alphaRenameDestinationConnectorResponse:
-        type: object
-        properties:
-            destination_connector:
-                $ref: "#/definitions/v1alphaDestinationConnector"
-                title: A DestinationConnector resource
-        title: |-
-            RenameDestinationConnectorResponse represents a renamed DestinationConnector
-            resource
-    v1alphaRenameModelResponse:
-        type: object
-        properties:
-            model:
-                $ref: "#/definitions/v1alphaModel"
-                title: Renamed model
-        title: RenameModelResponse represents a response for a model
-    v1alphaRenamePipelineResponse:
-        type: object
-        properties:
-            pipeline:
-                $ref: "#/definitions/v1alphaPipeline"
-                title: A pipeline resource
-        title: RenamePipelineResponse represents a renamed pipeline resource
-    v1alphaRenameSourceConnectorResponse:
-        type: object
-        properties:
-            source_connector:
-                $ref: "#/definitions/v1alphaSourceConnector"
-                title: A SourceConnector resource
-        title: RenameSourceConnectorResponse represents a renamed SourceConnector resource
-    v1alphaSemanticSegmentationInput:
-        type: object
-        properties:
-            image_base64:
-                type: string
-                title: Image type base64
-            image_url:
-                type: string
-                title: Image type URL
-        title: SemanticSegmentationInput represents the input of semantic segmentation task
-    v1alphaSemanticSegmentationOutput:
-        type: object
-        properties:
-            stuffs:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaSemanticSegmentationStuff"
-                title: A list of semantic segmentation stuffs
-                readOnly: true
-        title: |-
-            SemanticSegmentationOutput represents the output of semantic segmentation
-            task
-    v1alphaSemanticSegmentationStuff:
-        type: object
-        properties:
-            category:
-                type: string
-                title: Stuff category
-                readOnly: true
-            rle:
-                type: string
-                title: RLE segmentation mask
-                readOnly: true
-        title: SemanticSegmentationStuff corresponding to a semantic segmentation stuff
-    v1alphaSendSessionReportResponse:
-        type: object
-        title: SendReportResponse represents an empty response
-    v1alphaSession:
-        type: object
-        properties:
-            arch:
-                type: string
-                title: Architecture of the system
-                required:
-                    - arch
-            create_time:
-                type: string
-                format: date-time
-                title: Session creation time
-                readOnly: true
-            edition:
-                type: string
-                title: "Session edition, allowed values include: 'local-ce' and 'local-ce:dev'"
-                required:
-                    - edition
-            name:
-                type: string
-                title: Resource name in the format of 'sessions/uid'
-                readOnly: true
-            os:
-                type: string
-                title: Operating system
-                required:
-                    - os
-            report_time:
-                type: string
-                format: date-time
-                title: Report time
-                required:
-                    - report_time
-            service:
-                $ref: "#/definitions/SessionService"
-                title: name of the service to collect data from
-            token:
-                type: string
-                description: |-
-                    Token to send report. The token is generated by the server and sent to
-                    the client. Client needs to use the token to send report to the server.
-                readOnly: true
-            uid:
-                type: string
-                title: Resource UUID
-                readOnly: true
-            update_time:
-                type: string
-                format: date-time
-                title: Session update time
-                readOnly: true
-            uptime:
-                type: string
-                format: int64
-                title: Session service uptime
-                required:
-                    - uptime
-            version:
-                type: string
-                title: Version of the service
-                required:
-                    - version
-        title: |-
-            Session represents a unique session whenever a new instance of VDP service
-            gets started. The usage server returns a token that should be used as part of
-            the challenge when sending a report with data collected from this session
-        required:
-            - edition
-            - version
-            - arch
-            - os
-            - uptime
-            - report_time
-    v1alphaSessionReport:
-        type: object
-        properties:
-            connector_usage_data:
-                $ref: "#/definitions/v1alphaConnectorUsageData"
-                title: Connector service usage data
-            mgmt_usage_data:
-                $ref: "#/definitions/v1alphaMgmtUsageData"
-                title: Management service usage data
-            model_usage_data:
-                $ref: "#/definitions/v1alphaModelUsageData"
-                title: Model service usage data
-            pipeline_usage_data:
-                $ref: "#/definitions/v1alphaPipelineUsageData"
-                title: Pipeline service usage data
-            pow:
-                type: string
-                title: Proof-of-work See https://en.wikipedia.org/wiki/Proof_of_work
-                required:
-                    - pow
-            session:
-                $ref: "#/definitions/v1alphaSession"
-                title: Session
-            session_uid:
-                type: string
-                title: Session uid
-                required:
-                    - session_uid
-            token:
-                type: string
-                title: Session token
-                required:
-                    - token
-        title: |-
-            SessionReport represents a report to be sent to the server that includes the
-            usage data of a session
-        required:
-            - session_uid
-            - token
-            - pow
-    v1alphaSourceConnector:
-        type: object
-        properties:
-            connector:
-                $ref: "#/definitions/v1alphaConnector"
-                title: SourceConnector's connector data structure
-            id:
-                type: string
-                description: |-
-                    SourceConnector resource ID (the last segment of the resource name) used to
-                    construct the resource name. This conforms to RFC-1034, which restricts to
-                    letters, numbers, and hyphen, with the first character a letter, the last a
-                    letter or a number, and a 63 character maximum.
-            name:
-                type: string
-                title: |-
-                    SourceConnector resource name. It must have the format of
-                    "source-connectors/*"
-                readOnly: true
-            source_connector_definition:
-                type: string
-                title: SourceConnectorDefinition resource
-            uid:
-                type: string
-                title: SourceConnector UUID
-                readOnly: true
-        title: SourceConnector represents a source connector resource
-    v1alphaSourceConnectorDefinition:
-        type: object
-        properties:
-            connector_definition:
-                $ref: "#/definitions/v1alphaConnectorDefinition"
-                title: SourceConnectorDefinition connector definition
-            id:
-                type: string
-                description: |-
-                    SourceConnectorDefinition resource ID (the last segment of the resource
-                    name) used to construct the resource name. This conforms to RFC-1034, which
-                    restricts to letters, numbers, and hyphen, with the first character a
-                    letter, the last a letter or a number, and a 63 character maximum.
-            name:
-                type: string
-                title: |-
-                    SourceConnectorDefinition resource name. It must have the format of
-                    "connector-definitions/*"
-                readOnly: true
-            uid:
-                type: string
-                title: SourceConnectorDefinition UUID
-                readOnly: true
-        title: SourceConnectorDefinition represents the source connector definition resource
-    v1alphaSpec:
-        type: object
-        properties:
-            advanced_auth:
-                $ref: "#/definitions/v1alphaAdvancedAuth"
-                title: |-
-                    Spec advanced auth, i.e., additional and optional specification object to
-                    describe what an 'advanced' Auth flow would need to function
-            connection_specification:
-                type: object
-                title: Spec connection specification
-                required:
-                    - connection_specification
-            documentation_url:
-                type: string
-                title: Spec documentation URL
-                readOnly: true
-            supported_destination_sync_modes:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaSupportedDestinationSyncModes"
-                title: |-
-                    Spec destination sync mode, i.e., a list of destination sync modes
-                    supported by the connector
-                readOnly: true
-            supports_dbt:
-                type: boolean
-                title: Spec supports dbt flag, i.e., if the connector supports DBT or not
-                readOnly: true
-            supports_incremental:
-                type: boolean
-                title: |-
-                    Spec supports incremental flag, i.e., if the connector supports incremental
-                    mode or not
-                readOnly: true
-            supports_normalization:
-                type: boolean
-                title: |-
-                    Spec supports normalization flag, i.e., if the connector supports
-                    normalization or not
-                readOnly: true
-        title: |-
-            //////////////////////////////////
-            Spec represents a spec data model
-        required:
-            - connection_specification
-    v1alphaSupportedDestinationSyncModes:
-        type: string
-        enum:
-            - SUPPORTED_DESTINATION_SYNC_MODES_UNSPECIFIED
-            - SUPPORTED_DESTINATION_SYNC_MODES_APPEND
-            - SUPPORTED_DESTINATION_SYNC_MODES_OVERWRITE
-            - SUPPORTED_DESTINATION_SYNC_MODES_APPEND_DEDUP
-        default: SUPPORTED_DESTINATION_SYNC_MODES_UNSPECIFIED
-        description: |-
-            - SUPPORTED_DESTINATION_SYNC_MODES_UNSPECIFIED: SupportedDestinationSyncModes: DESTINATION_SYNC_MODES_UNSPECIFIED
-             - SUPPORTED_DESTINATION_SYNC_MODES_APPEND: SupportedDestinationSyncModes: DESTINATION_SYNC_MODES_APPEND
-             - SUPPORTED_DESTINATION_SYNC_MODES_OVERWRITE: SupportedDestinationSyncModes: DESTINATION_SYNC_MODES_OVERWRITE
-             - SUPPORTED_DESTINATION_SYNC_MODES_APPEND_DEDUP: SupportedDestinationSyncModes: DESTINATION_SYNC_MODES_APPEND_DEDUP
-        title: |-
-            SupportedDestinationSyncModes enumerates destination sync mode (this needs to
-            be in plural form to match with Airbyte protocol)
-    v1alphaSupportedSyncModes:
-        type: string
-        enum:
-            - SUPPORTED_SYNC_MODES_UNSPECIFIED
-            - SUPPORTED_SYNC_MODES_FULL_REFRESH
-            - SUPPORTED_SYNC_MODES_INCREMENTAL
-        default: SUPPORTED_SYNC_MODES_UNSPECIFIED
-        description: |-
-            - SUPPORTED_SYNC_MODES_UNSPECIFIED: SupportedSyncModes: SUPPORTED_SYNC_MODES_UNSPECIFIED
-             - SUPPORTED_SYNC_MODES_FULL_REFRESH: SupportedSyncModes: SUPPORTED_SYNC_MODES_FULL_REFRESH
-             - SUPPORTED_SYNC_MODES_INCREMENTAL: SupportedSyncModes: SUPPORTED_SYNC_MODES_INCREMENTAL
-        title: |-
-            SupportedSyncModes enumerates sync mode (this needs to be in plural form to
-            match with Airbyte protocol)
-    v1alphaTaskInput:
-        type: object
-        properties:
-            classification:
-                $ref: "#/definitions/v1alphaClassificationInput"
-                title: The classification input
-            detection:
-                $ref: "#/definitions/v1alphaDetectionInput"
-                title: The detection input
-            instance_segmentation:
-                $ref: "#/definitions/v1alphaInstanceSegmentationInput"
-                title: The instance segmentation input
-            keypoint:
-                $ref: "#/definitions/v1alphaKeypointInput"
-                title: The keypoint input
-            ocr:
-                $ref: "#/definitions/v1alphaOcrInput"
-                title: The ocr input
-            semantic_segmentation:
-                $ref: "#/definitions/v1alphaSemanticSegmentationInput"
-                title: The semantic segmentation input
-            text_to_image:
-                $ref: "#/definitions/v1alphaTextToImageInput"
-                title: The text to image input
-            unspecified:
-                $ref: "#/definitions/v1alphaUnspecifiedInput"
-                title: The unspecified task input
-        title: Input represents the input to trigger a model instance
-    v1alphaTestModelInstanceBinaryFileUploadResponse:
-        type: object
-        properties:
-            task:
-                $ref: "#/definitions/ModelInstanceTask"
-                title: The task type
-            task_outputs:
-                type: array
-                items:
-                    $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
-                title: The task output from a model instance
-                required:
-                    - task_outputs
-        title: |-
-            TestModelInstanceBinaryFileUploadResponse represents a response for the
-            output for testing a model instance
-        required:
-            - task_outputs
-    v1alphaTestModelInstanceResponse:
-        type: object
-        properties:
-            task:
-                $ref: "#/definitions/ModelInstanceTask"
-                title: The task type
-            task_outputs:
-                type: array
-                items:
-                    $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
-                title: The task output from a model instance
-                required:
-                    - task_outputs
-        title: |-
-            TestModelInstanceResponse represents a response for the output for
-            testing a model instance
-        required:
-            - task_outputs
-    v1alphaTextToImageInput:
-        type: object
-        properties:
-            cfg_scale:
-                type: string
-                format: int64
-                title: The guidance scale
-                readOnly: true
-            prompt:
-                type: string
-                title: The prompt text
-                readOnly: true
-            seed:
-                type: string
-                format: int64
-                title: The seed
-                readOnly: true
-            steps:
-                type: string
-                format: int64
-                title: The steps
-                readOnly: true
-        title: TextToImageInput represents the input of text to image task
-    v1alphaTextToImageOutput:
-        type: object
-        properties:
-            images:
-                type: array
-                items:
-                    type: string
-                title: List of generated images
-                readOnly: true
-        title: TextToImageOutput represents the output of text to image task
-    v1alphaTriggerModelInstanceBinaryFileUploadResponse:
-        type: object
-        properties:
-            task:
-                $ref: "#/definitions/ModelInstanceTask"
-                title: The task type
-            task_outputs:
-                type: array
-                items:
-                    $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
-                title: The task output from a model instance
-                required:
-                    - task_outputs
-        title: |-
-            TriggerModelInstanceBinaryFileUploadResponse represents a response for the
-            output for testing a model instance
-        required:
-            - task_outputs
-    v1alphaTriggerModelInstanceResponse:
-        type: object
-        properties:
-            task:
-                $ref: "#/definitions/ModelInstanceTask"
-                title: The task type
-            task_outputs:
-                type: array
-                items:
-                    $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
-                title: The task output from a model instance
-        title: |-
-            TriggerModelInstanceResponse represents a response for the output for
-            triggering a model instance
-    v1alphaTriggerPipelineBinaryFileUploadResponse:
-        type: object
-        properties:
-            data_mapping_indices:
-                type: array
-                items:
-                    type: string
-                title: The data mapping indices stores UUID for each input
-            model_instance_outputs:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaModelInstanceOutput"
-                title: The multiple model instance inference outputs
-        title: |-
-            TriggerPipelineBinaryFileUploadResponse represents a response for the output
-            of a pipeline, i.e., the multiple model instance inference outputs
-    v1alphaTriggerPipelineResponse:
-        type: object
-        properties:
-            data_mapping_indices:
-                type: array
-                items:
-                    type: string
-                title: The data mapping indices stores UUID for each input
-            model_instance_outputs:
-                type: array
-                items:
-                    $ref: "#/definitions/v1alphaModelInstanceOutput"
-                title: The multiple model instance inference outputs
-        title: |-
-            TriggerPipelineResponse represents a response for the output
-            of a pipeline, i.e., the multiple model instance inference outputs
-    v1alphaUndeployModelInstanceResponse:
-        type: object
-        properties:
-            operation:
-                $ref: "#/definitions/googlelongrunningOperation"
-                title: Undeploy operation message
-        title: |-
-            UndeployModelInstanceResponse represents a response for a undeployed model
-            instance
-    v1alphaUnpublishModelResponse:
-        type: object
-        properties:
-            model:
-                $ref: "#/definitions/v1alphaModel"
-                title: Unpublished model
-        title: UnpublishModelResponse represents a response for the unpublished model
-    v1alphaUnspecifiedInput:
-        type: object
-        properties:
-            raw_inputs:
-                type: array
-                items:
-                    type: object
-                title: A list of unspecified task inputs
-        title: UnspecifiedInput represents the input of unspecified task
-    v1alphaUnspecifiedOutput:
-        type: object
-        properties:
-            raw_outputs:
-                type: array
-                items:
-                    type: object
-                title: A list of unspecified task outputs
-                readOnly: true
-        title: UnspecifiedOutput represents the output of unspecified task
-    v1alphaUpdateAuthenticatedUserResponse:
-        type: object
-        properties:
-            user:
-                $ref: "#/definitions/v1alphaUser"
-                title: A user resource
-        title: |-
-            UpdateAuthenticatedUserResponse represents a response for
-            the authenticated user resource
-    v1alphaUpdateDestinationConnectorResponse:
-        type: object
-        properties:
-            destination_connector:
-                $ref: "#/definitions/v1alphaDestinationConnector"
-                title: DestinationConnector resource
-        title: |-
-            UpdateDestinationConnectorResponse represents a response for a
-            DestinationConnector resource
-    v1alphaUpdateModelResponse:
-        type: object
-        properties:
-            model:
-                $ref: "#/definitions/v1alphaModel"
-                title: The updated model
-        title: UpdateModelResponse represents a response for a model
-    v1alphaUpdatePipelineResponse:
-        type: object
-        properties:
-            pipeline:
-                $ref: "#/definitions/v1alphaPipeline"
-                title: An updated pipeline resource
-        title: UpdatePipelineResponse represents a response for a pipeline resource
-    v1alphaUpdatePlanResponse:
-        type: object
-        properties:
-            plan:
-                $ref: "#/definitions/v1alphaPlan"
-                title: A plan resource
-        title: UpdatePlanResponse represents a response for a plan resource
-    v1alphaUpdateSourceConnectorResponse:
-        type: object
-        properties:
-            source_connector:
-                $ref: "#/definitions/v1alphaSourceConnector"
-                title: SourceConnector resource
-        title: |-
-            UpdateSourceConnectorResponse represents a response for a
-            SourceConnector resource
-    v1alphaUpdateUserResponse:
-        type: object
-        properties:
-            user:
-                $ref: "#/definitions/v1alphaUser"
-                title: A user resource
-        title: UpdateUserResponse represents a response for a user resource
-    v1alphaUser:
-        type: object
-        properties:
-            cookie_token:
-                type: string
-                title: User console cookie token
-            create_time:
-                type: string
-                format: date-time
-                title: User creation time
-                readOnly: true
-            email:
-                type: string
-                title: User email
-                required:
-                    - email
-            first_name:
-                type: string
-                title: User first name
-            id:
-                type: string
-                description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
-                required:
-                    - id
-            last_name:
-                type: string
-                title: User last name
-            name:
-                type: string
-                description: |-
-                    Resource name. It must have the format of "users/*".
-                    For example: "users/local-user".
-                readOnly: true
-            newsletter_subscription:
-                type: boolean
-                title: User newsletter subscription
-                required:
-                    - newsletter_subscription
-            org_name:
-                type: string
-                title: User company or institution name
-            plan:
-                type: string
-                description: User plan. This field is not used in open-source VDP.
-            role:
-                type: string
-                title: |-
-                    User role. Allowed roles:
-                     - "manager"
-                     - "ai-researcher"
-                     - "ai-engineer"
-                     - "data-engineer",
-                     - "data-scientist",
-                     - "analytics-engineer"
-                     - "hobbyist"
-            type:
-                $ref: "#/definitions/v1alphaOwnerType"
-                title: "Owner type: fixed to `OWNER_TYPE_USER`"
-            uid:
-                type: string
-                title: User ID in UUIDv4
-                required:
-                    - uid
-            update_time:
-                type: string
-                format: date-time
-                title: User update time
-                readOnly: true
-        title: User represents the content of a user
-        required:
-            - uid
-            - id
-            - email
-            - newsletter_subscription
-    v1alphaWriteDestinationConnectorResponse:
-        type: object
-        title: |-
-            WriteDestinationConnectorResponse represents the read data from a
-            DestinationConnector resource
-    vdpbillingv1alphaLivenessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: LivenessResponse represents a response for a service liveness status
-    vdpbillingv1alphaReadinessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: ReadinessResponse represents a response for a service readiness status
-    vdpbillingv1alphaView:
-        type: string
-        enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-        default: VIEW_UNSPECIFIED
-        description: |-
-            View represents a view of any resource. The resource view is implemented by
-            adding a parameter to the method request which allows the client to specify
-            which view of the resource it wants to receive in the response.
+  /v1alpha/__liveness:
+    get:
+      summary: |-
+        Liveness method receives a LivenessRequest message and returns a
+        LivenessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: UsageService_Liveness
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpusagev1alphaLivenessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - UsageService
+  /v1alpha/__readiness:
+    get:
+      summary: |-
+        Readiness method receives a ReadinessRequest message and returns a
+        ReadinessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: UsageService_Readiness
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpusagev1alphaReadinessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - UsageService
+  /v1alpha/{destination_connector.name}:
+    get:
+      summary: |-
+        GetDestinationConnector method receives a GetDestinationConnectorRequest
+        message and returns a GetDestinationConnectorResponse message.
+      operationId: ConnectorService_GetDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: destination_connector.name
+          description: |-
+            DestinationConnectorConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+        - name: view
+          description: |-
+            DestinationConnector view (default is VIEW_BASIC)
 
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
-    vdpconnectorv1alphaLivenessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: LivenessResponse represents a response for a service liveness status
-    vdpconnectorv1alphaReadinessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: ReadinessResponse represents a response for a service readiness status
-    vdpconnectorv1alphaReleaseStage:
-        type: string
-        enum:
-            - RELEASE_STAGE_UNSPECIFIED
-            - RELEASE_STAGE_ALPHA
-            - RELEASE_STAGE_BETA
-            - RELEASE_STAGE_GENERALLY_AVAILABLE
-            - RELEASE_STAGE_CUSTOM
-        default: RELEASE_STAGE_UNSPECIFIED
-        description: |-
-            - RELEASE_STAGE_UNSPECIFIED: ReleaseStage: UNSPECIFIED
-             - RELEASE_STAGE_ALPHA: ReleaseStage: ALPHA
-             - RELEASE_STAGE_BETA: ReleaseStage: BETA
-             - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
-             - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
-        title: ReleaseStage enumerates the release stages
-    vdpconnectorv1alphaView:
-        type: string
-        enum:
+          in: query
+          required: false
+          type: string
+          enum:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
-        default: VIEW_UNSPECIFIED
-        description: |-
-            - VIEW_UNSPECIFIED: View: UNSPECIFIED
-             - VIEW_BASIC: View: BASIC
-             - VIEW_FULL: View: FULL
-        title: View enumerates the definition views
-    vdpmgmtv1alphaLivenessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: LivenessResponse represents a response for a service liveness status
-    vdpmgmtv1alphaReadinessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: ReadinessResponse represents a response for a service readiness status
-    vdpmgmtv1alphaView:
-        type: string
-        enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-        default: VIEW_UNSPECIFIED
-        description: |-
-            View represents a view of any resource. The resource view is implemented by
-            adding a parameter to the method request which allows the client to specify
-            which view of the resource it wants to receive in the response.
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+    delete:
+      summary: |-
+        DeleteDestinationConnector method receives a
+        DeleteDestinationConnectorRequest message and returns a
+        DeleteDestinationConnectorResponse message.
+      operationId: ConnectorService_DeleteDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: destination_connector.name
+          description: |-
+            DestinationConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+      tags:
+        - ConnectorService
+    patch:
+      summary: |-
+        UpdateDestinationConnector method receives a
+        UpdateDestinationConnectorRequest message and returns a
+        UpdateDestinationConnectorResponse message.
+      operationId: ConnectorService_UpdateDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: destination_connector.name
+          description: |-
+            DestinationConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+        - name: destination_connector
+          description: DestinationConnector resource
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: DestinationConnector UUID
+                readOnly: true
+              id:
+                type: string
+                description: |-
+                  DestinationConnector resource ID (the last segment of the resource name)
+                  used to construct the resource name. This conforms to RFC-1034, which
+                  restricts to letters, numbers, and hyphen, with the first character a
+                  letter, the last a letter or a number, and a 63 character maximum.
+              destination_connector_definition:
+                type: string
+                title: DestinationConnectorDefinition resource
+              connector:
+                $ref: '#/definitions/v1alphaConnector'
+                title: DestinationConnector's connector data structure
+            title: DestinationConnector resource
+            required:
+              - connector
+        - name: update_mask
+          description: Update mask for a DestinationConnector resource
+          in: query
+          required: true
+          type: string
+      tags:
+        - ConnectorService
+  /v1alpha/{destination_connector_definition.name}:
+    get:
+      summary: |-
+        GetDestinationConnectorDefinition method receives a
+        GetDestinationConnectorDefinitionRequest message and returns a
+        GetGetDestinationConnectorDefinitionResponse message.
+      operationId: ConnectorService_GetDestinationConnectorDefinition
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetDestinationConnectorDefinitionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: destination_connector_definition.name
+          description: |-
+            DestinationConnectorDefinition resource name. It must have the format of
+            "source-connector-definitions/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connector-definitions/[^/]+
+        - name: view
+          description: |-
+            DestinationConnectorDefinition resource view (default is
+            DEFINITION_VIEW_BASIC)
 
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
-    vdpmodelv1alphaLivenessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: LivenessResponse represents a response for a service liveness status
-    vdpmodelv1alphaReadinessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: ReadinessResponse represents a response for a service readiness status
-    vdpmodelv1alphaReleaseStage:
-        type: string
-        enum:
-            - RELEASE_STAGE_UNSPECIFIED
-            - RELEASE_STAGE_ALPHA
-            - RELEASE_STAGE_BETA
-            - RELEASE_STAGE_GENERALLY_AVAILABLE
-            - RELEASE_STAGE_CUSTOM
-        default: RELEASE_STAGE_UNSPECIFIED
-        description: |-
-            - RELEASE_STAGE_UNSPECIFIED: ReleaseStage: UNSPECIFIED
-             - RELEASE_STAGE_ALPHA: ReleaseStage: ALPHA
-             - RELEASE_STAGE_BETA: ReleaseStage: BETA
-             - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
-             - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
-        title: ReleaseStage enumerates the release stages
-    vdpmodelv1alphaTaskOutput:
-        type: object
-        properties:
-            classification:
-                $ref: "#/definitions/v1alphaClassificationOutput"
-                title: The classification output
-            detection:
-                $ref: "#/definitions/v1alphaDetectionOutput"
-                title: The detection output
-            instance_segmentation:
-                $ref: "#/definitions/v1alphaInstanceSegmentationOutput"
-                title: The instance segmentation output
-            keypoint:
-                $ref: "#/definitions/v1alphaKeypointOutput"
-                title: The keypoint output
-            ocr:
-                $ref: "#/definitions/v1alphaOcrOutput"
-                title: The ocr output
-            semantic_segmentation:
-                $ref: "#/definitions/v1alphaSemanticSegmentationOutput"
-                title: The semantic segmentation output
-            text_to_image:
-                $ref: "#/definitions/v1alphaTextToImageOutput"
-                title: The text to image output
-            unspecified:
-                $ref: "#/definitions/v1alphaUnspecifiedOutput"
-                title: The unspecified task output
-        title: TaskOutput represents the output of a CV Task result from a model instance
-    vdpmodelv1alphaView:
-        type: string
-        enum:
+          in: query
+          required: false
+          type: string
+          enum:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
-        default: VIEW_UNSPECIFIED
-        description: |-
-            View represents a view of any resource. The resource view is implemented by
-            adding a parameter to the method request which allows the client to specify
-            which view of the resource it wants to receive in the response.
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+  /v1alpha/{model.name}:
+    get:
+      summary: |-
+        GetModel method receives a GetModelRequest message and returns a
+        GetModelResponse
+      operationId: ModelService_GetModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: model.name
+          description: |-
+            Resource name of the model.
+            For example "models/{model}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+
+        - name: view
+          description: |-
+            Model view (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+            VIEW_FULL: show full information
 
              - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
              - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
              - VIEW_FULL: View: FULL, full representation of the resource
-    vdppipelinev1alphaLivenessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: LivenessResponse represents a response for a service liveness status
-    vdppipelinev1alphaReadinessResponse:
-        type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: ReadinessResponse represents a response for a service readiness status
-    vdppipelinev1alphaTaskOutput:
-        type: object
-        properties:
-            classification:
-                $ref: "#/definitions/v1alphaClassificationOutput"
-                title: The classification output
-            detection:
-                $ref: "#/definitions/v1alphaDetectionOutput"
-                title: The detection output
-            index:
-                type: string
-                title: The index of input data in a batch
-                readOnly: true
-            instance_segmentation:
-                $ref: "#/definitions/v1alphaInstanceSegmentationOutput"
-                title: The instance segmentation output
-            keypoint:
-                $ref: "#/definitions/v1alphaKeypointOutput"
-                title: The keypoint output
-            ocr:
-                $ref: "#/definitions/v1alphaOcrOutput"
-                title: The ocr output
-            semantic_segmentation:
-                $ref: "#/definitions/v1alphaSemanticSegmentationOutput"
-                title: The semantic segmentation output
-            text_to_image:
-                $ref: "#/definitions/v1alphaTextToImageOutput"
-                title: The text to image output
-            unspecified:
-                $ref: "#/definitions/v1alphaUnspecifiedOutput"
-                title: The unspecified task output
-        description: |-
-            TaskOutput represents the output of a CV Task result from a
-            model instance, extended from model.v1alpha.TaskOutput.
-            Here we don't use a model.v1alpha.TaskOutput type field but explicitly use
-            the replicated oneof field because we want the CV Task output to be at the
-            same message layer like the trigger output of model instance.
-    vdppipelinev1alphaView:
-        type: string
-        enum:
+          in: query
+          required: false
+          type: string
+          enum:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
-        default: VIEW_UNSPECIFIED
-        description: |-
-            View represents a view of any resource. The resource view is implemented by
-            adding a parameter to the method request which allows the client to specify
-            which view of the resource it wants to receive in the response.
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+    delete:
+      summary: |-
+        DeleteModel method receives a DeleteModelRequest message and returns a
+        DeleteModelResponse
+      operationId: ModelService_DeleteModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: model.name
+          description: |-
+            Resource name of the model.
+            For example "models/{model}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+
+      tags:
+        - ModelService
+    patch:
+      summary: |-
+        UpdateModel method receives a UpdateModelRequest message and returns a
+        UpdateModelResponse
+      operationId: ModelService_UpdateModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: model.name
+          description: |-
+            Resource name. It must have the format of "models/{model}".
+            For example: "models/yolov4"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+
+        - name: model
+          description: |-
+            The model to update
+
+            The model `name` field is used to identify the model to update.
+            Format: models/{model}
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: Model ID in UUIDv4
+                readOnly: true
+              id:
+                type: string
+                description: |-
+                  Resource ID (the last segment of the resource name) used to construct the
+                  resource name. This conforms to RFC-1034, which restricts to letters,
+                  numbers, and hyphen, with the first character a letter, the last a letter
+                  or a number, and a 63 character maximum.
+              description:
+                type: string
+                title: Model description
+              model_definition:
+                type: string
+                title: Model definition resource name
+              configuration:
+                type: object
+                title: |-
+                  Model configuration represents the configuration JSON that has been
+                  validated using the `model_spec` JSON schema of a ModelDefinition
+              visibility:
+                $ref: '#/definitions/v1alphaModelVisibility'
+                title: Model visibility including public or private
+                readOnly: true
+              user:
+                type: string
+                description: The resource name of a user, e.g., "users/local-user".
+                readOnly: true
+              org:
+                type: string
+                title: The resource name of an organization
+                readOnly: true
+              create_time:
+                type: string
+                format: date-time
+                title: Model create time
+                readOnly: true
+              update_time:
+                type: string
+                format: date-time
+                title: Model update time
+                readOnly: true
+            description: |-
+              The model `name` field is used to identify the model to update.
+              Format: models/{model}
+            title: The model to update
+        - name: update_mask
+          description: Mask of fields to update.
+          in: query
+          required: true
+          type: string
+      tags:
+        - ModelService
+  /v1alpha/{model_definition.name}:
+    get:
+      summary: |-
+        GetModelDefinition method receives a GetModelDefinitionRequest message and
+        returns a GetModelDefinitionResponse
+      operationId: ModelService_GetModelDefinition
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetModelDefinitionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: model_definition.name
+          description: |-
+            Resource name of the model definition.
+            For example "model-definitions/{uuid}"
+          in: path
+          required: true
+          type: string
+          pattern: model-definitions/[^/]+
+        - name: view
+          description: |-
+            Definition view (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
+            `ModelDefinition.model_instance_spec`
+            VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+  /v1alpha/{model_instance.name/readme}:
+    get:
+      summary: |-
+        GetModelInstanceCard method receives a GetModelInstanceCardRequest message
+        and returns a GetModelInstanceCardResponse
+      operationId: ModelService_GetModelInstanceCard
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetModelInstanceCardResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: model_instance.name/readme
+          description: |-
+            Resource name of the model instance card.
+            For example "models/{model}/instances/{instance}/readme"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+/instances/[^/]+/readme
+      tags:
+        - ModelService
+  /v1alpha/{model_instance.name}:
+    get:
+      summary: |-
+        GetModelInstance method receives a GetModelInstanceRequest message and
+        returns a GetModelInstanceResponse
+      operationId: ModelService_GetModelInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetModelInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: model_instance.name
+          description: |-
+            Resource name of the model instance.
+            For example "models/{model}/instances/{instance}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+/instances/[^/]+
+        - name: view
+          description: |-
+            Model instance view (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+            VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+  /v1alpha/{name_1}/connect:
+    post:
+      summary: |-
+        Connect a destination connector.
+        The "state" of the connector after connecting is "CONNECTED".
+        ConnectDestinationConnector can be called on DestinationConnector in the
+        state `DISCONNECTED`; DestinationConnector in a different state (including
+        `CONNECTED`) returns an error.
+      operationId: ConnectorService_ConnectDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaConnectDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_1
+          description: |-
+            DestinationConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              ConnectDestinationConnectorRequest represents a request to connect a
+              destination connector
+      tags:
+        - ConnectorService
+  /v1alpha/{name_1}/disconnect:
+    post:
+      summary: |-
+        Disconnect a destination connector.
+        The "state" of the connector after disconnecting is "DISCONNECTED".
+        DisconnectDestinationConnector can be called on DestinationConnector in the
+        state `CONNECTED`; DestinationConnector in a different state (including
+        `DISCONNECTED`) returns an error.
+      operationId: ConnectorService_DisconnectDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDisconnectDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_1
+          description: |-
+            DestinationConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              DisconnectDestinationConnectorRequest represents a request to disconnect a
+              destination connector
+      tags:
+        - ConnectorService
+  /v1alpha/{name_1}/rename:
+    post:
+      summary: |-
+        RenameDestinationConnector method receives a
+        RenameDestinationConnectorRequest message and returns a
+        RenameDestinationConnectorResponse message.
+      operationId: ConnectorService_RenameDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRenameDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_1
+          description: |-
+            DestinationConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_destination_connector_id:
+                type: string
+                title: |-
+                  DestinationConnector new resource id to replace with the
+                  DestinationConnector resource name to be
+                  "destination-connectors/{new_destination_connector_id}"
+            title: |-
+              RenameDestinationConnectorRequest represents a request to rename the
+              DestinationConnector resource name
+            required:
+              - new_destination_connector_id
+      tags:
+        - ConnectorService
+  /v1alpha/{name_1}/trigger:
+    post:
+      summary: |-
+        TriggerPipeline method receives a TriggerPipelineRequest message and
+        returns a TriggerPipelineResponse.
+      operationId: PipelineService_TriggerPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_1
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              task_inputs:
+                type: array
+                items:
+                  $ref: '#/definitions/v1alphaTaskInput'
+                title: Input to the pipeline
+            title: TriggerPipelineRequest represents a request to trigger a pipeline
+            required:
+              - task_inputs
+      tags:
+        - PipelineService
+  /v1alpha/{name_2}/rename:
+    post:
+      summary: RenameModel method rename a model
+      operationId: ModelService_RenameModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRenameModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_2
+          description: Resource name for the model to be renamed.
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_model_id:
+                type: string
+                title: New ID of this model
+            title: RenameModelRequest represents a request to rename a model
+            required:
+              - new_model_id
+      tags:
+        - ModelService
+  /v1alpha/{name_3}/rename:
+    post:
+      summary: |-
+        RenamePipeline method receives a RenamePipelineRequest message and returns
+        a RenamePipelineResponse message.
+      operationId: PipelineService_RenamePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRenamePipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_3
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_pipeline_id:
+                type: string
+                title: |-
+                  Pipeline new resource id to replace with the pipeline resource name to be
+                  "pipelines/{new_pipeline_id}"
+            title: |-
+              RenamePipelineRequest represents a request to rename the pipeline resource
+              name
+            required:
+              - new_pipeline_id
+      tags:
+        - PipelineService
+  /v1alpha/{name}:
+    get:
+      summary: |-
+        GetModelOperation method receives a
+        GetModelOperationRequest message and returns a
+        GetModelOperationResponse message.
+      operationId: ModelService_GetModelOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetModelOperationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: The name of the operation resource.
+          in: path
+          required: true
+          type: string
+          pattern: operations/[^/]+
+        - name: view
+          description: |-
+            View (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
+            `ModelInstance.configuration` VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+  /v1alpha/{name}/activate:
+    post:
+      summary: |-
+        Activate a pipeline.
+        The "state" of the pipeline after activating is "ACTIVE".
+        ActivatePipeline can be called on Pipelines in the state "INACTIVE";
+        Pipelines in a different state (including "ACTIVE") returns an error.
+      operationId: PipelineService_ActivatePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaActivatePipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: ActivatePipelineRequest represents a request to activate a pipeline
+      tags:
+        - PipelineService
+  /v1alpha/{name}/cancel:
+    post:
+      summary: |-
+        CancelModelOperation method receives a CancelModelOperationRequest message
+        and returns a CancelModelOperationResponse
+      operationId: ModelService_CancelModelOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCancelModelOperationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: The name of the operation resource.
+          in: path
+          required: true
+          type: string
+          pattern: operations/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: CancelModelOperationRequest represents a request to cancel a model operation
+      tags:
+        - ModelService
+  /v1alpha/{name}/connect:
+    post:
+      summary: |-
+        Connect a source connector.
+        The "state" of the connector after connecting is "CONNECTED".
+        ConnectSourceConnector can be called on SourceConnector in the state
+        `DISCONNECTED`; SourceConnector in a different state (including
+        `CONNECTED`) returns an error.
+      operationId: ConnectorService_ConnectSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaConnectSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              ConnectSourceConnectorRequest represents a request to connect a
+              source connector
+      tags:
+        - ConnectorService
+  /v1alpha/{name}/deactivate:
+    post:
+      summary: |-
+        Deactivate a pipeline.
+        The "state" of the pipeline after inactivating is "INACTIVE".
+        DeactivatePipeline can be called on Pipelines in the state "ACTIVE";
+        Pipelines in a different state (including "INACTIVE") returns an error.
+      operationId: PipelineService_DeactivatePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeactivatePipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: DeactivatePipelineRequest represents a request to deactivate a pipeline
+      tags:
+        - PipelineService
+  /v1alpha/{name}/deploy:
+    post:
+      summary: DeployModelInstance deploy a model instance to online state
+      operationId: ModelService_DeployModelInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeployModelInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            Resource name for the model instance to be deployed.
+            Format: models/{model}/instances/{instance}
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+/instances/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              DeployModelInstanceRequest represents a request to deploy a model instance to
+              online state
+      tags:
+        - ModelService
+  /v1alpha/{name}/disconnect:
+    post:
+      summary: |-
+        Disconnect a source connector.
+        The "state" of the connector after disconnecting is "DISCONNECTED".
+        DisconnectSourceConnector can be called on SourceConnector in the state
+        `CONNECTED`; SourceConnector in a different state (including
+        `DISCONNECTED`) returns an error.
+      operationId: ConnectorService_DisconnectSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDisconnectSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              DisconnectSourceConnectorRequest represents a request to disconnect a
+              source connector
+      tags:
+        - ConnectorService
+  /v1alpha/{name}/publish:
+    post:
+      summary: |-
+        PublishModel method receives a PublishModelRequest message and returns a
+        PublishModelResponse
+      operationId: ModelService_PublishModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaPublishModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            Resource name of the model.
+            For example "models/{model}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: PublishModelRequest represents a request to publish a model
+      tags:
+        - ModelService
+  /v1alpha/{name}/read:
+    post:
+      summary: |-
+        ReadSourceConnector method receives a ReadSourceConnectorRequest
+        message and returns a ReadSourceConnectorResponse message.
+      operationId: ConnectorService_ReadSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaReadSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              ReadSourceConnectorRequest represents a request to perform read operation of
+              a SourceConnector given the resource name
+      tags:
+        - ConnectorService
+  /v1alpha/{name}/rename:
+    post:
+      summary: |-
+        RenameSourceConnector method receives a RenameSourceConnectorRequest
+        message and returns a RenameSourceConnectorResponse message.
+      operationId: ConnectorService_RenameSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRenameSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_source_connector_id:
+                type: string
+                title: |-
+                  SourceConnector new resource id to replace with the
+                  SourceConnector resource name to be
+                  "source-connectors/{new_source_connector_id}"
+            title: |-
+              RenameSourceConnectorRequest represents a request to rename the
+              SourceConnector resource name
+            required:
+              - new_source_connector_id
+      tags:
+        - ConnectorService
+  /v1alpha/{name}/test:
+    post:
+      summary: |-
+        TestModelInstance method receives a TestModelInstanceRequest message
+        and returns a TestModelInstanceResponse message.
+      operationId: ModelService_TestModelInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTestModelInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            The resource name of the model instance to trigger.
+            For example "models/{model}/instances/{instance}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+/instances/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              task_inputs:
+                type: array
+                items:
+                  $ref: '#/definitions/v1alphaTaskInput'
+                title: Input to trigger the model instance
+            title: TestModelInstanceRequest represents a request to test a model instance
+            required:
+              - task_inputs
+      tags:
+        - ModelService
+  /v1alpha/{name}/trigger:
+    post:
+      summary: /////////////////////////////////////////////////////
+      description: |-
+        TriggerModelInstance method receives a TriggerModelInstanceRequest message
+        and returns a TriggerModelInstanceResponse message.
+      operationId: ModelService_TriggerModelInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerModelInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            The resource name of the model instance to trigger.
+            For example "models/{model}/instances/{instance}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+/instances/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              task_inputs:
+                type: array
+                items:
+                  $ref: '#/definitions/v1alphaTaskInput'
+                title: Input to trigger the model instance
+            title: TriggerModelInstanceRequest represents a request to trigger a model instance
+            required:
+              - task_inputs
+      tags:
+        - ModelService
+  /v1alpha/{name}/undeploy:
+    post:
+      summary: UndeployModelInstance undeploy a model instance to offline state
+      operationId: ModelService_UndeployModelInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUndeployModelInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            Resource name for the model instance to be undeployed.
+            Format: models/{model}/instances/{instance}
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+/instances/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              UndeployModelInstanceRequest represents a request to undeploy a model
+              instance to offline state
+      tags:
+        - ModelService
+  /v1alpha/{name}/unpublish:
+    post:
+      summary: |-
+        UnpublishModel method receives a UnpublishModelRequest message and returns
+        a UnpublishModelResponse
+      operationId: ModelService_UnpublishModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUnpublishModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            Resource name of the model.
+            For example "models/{model}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: UnpublishModelRequest represents a request to unpublish a model
+      tags:
+        - ModelService
+  /v1alpha/{name}/write:
+    post:
+      summary: |-
+        WriteDestinationConnector method receives a
+        WriteDestinationConnectorRequest message and returns a
+        WriteDestinationConnectorResponse message.
+      operationId: ConnectorService_WriteDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWriteDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            DestinationConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              sync_mode:
+                $ref: '#/definitions/v1alphaSupportedSyncModes'
+                title: |-
+                  Sync mode:
+                  https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
+              destination_sync_mode:
+                $ref: '#/definitions/v1alphaSupportedDestinationSyncModes'
+                title: |-
+                  Destination sync mode:
+                  https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
+              pipeline:
+                type: string
+                title: Pipeline resource name
+              recipe:
+                $ref: '#/definitions/v1alphaRecipe'
+                title: Pipeline recipe
+              data_mapping_indices:
+                type: array
+                items:
+                  type: string
+                title: Indices corresponds to each JSON data element
+              model_instance_outputs:
+                type: array
+                items:
+                  $ref: '#/definitions/v1alphaModelInstanceOutput'
+                title: JSON data to write
+            title: |-
+              WriteDestinationConnectorRequest represents a request to perform write
+              operation of a DestinationConnector given the resource name
+            required:
+              - sync_mode
+              - destination_sync_mode
+              - pipeline
+              - recipe
+              - data_mapping_indices
+              - model_instance_outputs
+      tags:
+        - ConnectorService
+  /v1alpha/{parent}/instances:
+    get:
+      summary: |-
+        ListModelInstance method receives a ListModelInstanceRequest message and
+        returns a ListModelInstanceResponse
+      operationId: ModelService_ListModelInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListModelInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: parent
+          description: |-
+            The name of the model whose instances we'd like to list.
+            e.g., "models/yolov4"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+
+        - name: page_size
+          description: |-
+            Page size: the maximum number of resources to return. The service may
+            return fewer than this value. If unspecified, at most 10 model instances
+            will be returned. The maximum value is 100; values above 100 will be
+            coereced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            Model instance view (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+            VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+  /v1alpha/{permalink_1}/lookUp:
+    get:
+      summary: |-
+        LookUpDestinationConnector method receives a
+        LookUpDestinationConnectorRequest message and returns a
+        LookUpDestinationConnectorResponse
+      operationId: ConnectorService_LookUpDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaLookUpDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: permalink_1
+          description: |-
+            Permalink of a destination connector. For example:
+            "destination-connectors/{uid}"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+        - name: view
+          description: |-
+            SourceConnector view (default is VIEW_BASIC)
 
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
-    vdpusagev1alphaLivenessResponse:
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+  /v1alpha/{permalink_2}/lookUp:
+    get:
+      summary: |-
+        LookUpModel method receives a LookUpModelRequest message and returns a
+        LookUpModelResponse
+      operationId: ModelService_LookUpModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaLookUpModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: permalink_2
+          description: |-
+            Permalink of a model. For example:
+            "models/{uid}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+
+        - name: view
+          description: |-
+            Model view (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+            VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+  /v1alpha/{permalink_3}/lookUp:
+    get:
+      summary: |-
+        LookUpModelInstance method receives a LookUpModelInstanceRequest message
+        and returns a
+        LookUpModelInstanceResponse
+      operationId: ModelService_LookUpModelInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaLookUpModelInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: permalink_3
+          description: |-
+            Permalink of a model instance. For example:
+            "models/{model_uid}/instances/{instance_uid}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+/instances/[^/]+
+        - name: view
+          description: |-
+            Model instance view (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+            VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+  /v1alpha/{permalink_4}/lookUp:
+    get:
+      summary: |-
+        LookUpPipeline method receives a LookUpPipelineRequest message and returns
+        a LookUpPipelineResponse
+      operationId: PipelineService_LookUpPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaLookUpPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: permalink_4
+          description: |-
+            Permalink of a pipeline. For example:
+            "pipelines/{uid}"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - PipelineService
+  /v1alpha/{permalink}/lookUp:
+    get:
+      summary: |-
+        LookUpSourceConnector method receives a LookUpSourceConnectorRequest
+        message and returns a LookUpSourceConnectorResponse
+      operationId: ConnectorService_LookUpSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaLookUpSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: permalink
+          description: |-
+            Permalink of a source connector. For example:
+            "source-connectors/{uid}"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+        - name: view
+          description: |-
+            SourceConnector view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+  /v1alpha/{pipeline.name}:
+    get:
+      summary: |-
+        GetPipeline method receives a GetPipelineRequest message and returns a
+        GetPipelineResponse message.
+      operationId: PipelineService_GetPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: pipeline.name
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: view
+          description: |-
+            Pipeline resource view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - PipelineService
+    delete:
+      summary: |-
+        DeletePipeline method receives a DeletePipelineRequest message and returns
+        a DeletePipelineResponse message.
+      operationId: PipelineService_DeletePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeletePipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: pipeline.name
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+      tags:
+        - PipelineService
+    patch:
+      summary: |-
+        UpdatePipeline method receives a UpdatePipelineRequest message and returns
+        a UpdatePipelineResponse message.
+      operationId: PipelineService_UpdatePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdatePipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: pipeline.name
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: pipeline
+          description: A pipeline resource to update
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: Pipeline UUID
+                readOnly: true
+              id:
+                type: string
+                description: |-
+                  Pipeline resource ID (the last segment of the resource name) used to
+                  construct the resource name. This conforms to RFC-1034, which restricts to
+                  letters, numbers, and hyphen, with the first character a letter, the last a
+                  letter or a number, and a 63 character maximum.
+              description:
+                type: string
+                title: Pipeline description
+              recipe:
+                $ref: '#/definitions/v1alphaRecipe'
+                title: Pipeline recipe
+              mode:
+                $ref: '#/definitions/PipelineMode'
+                title: Pipeline mode
+                readOnly: true
+              state:
+                $ref: '#/definitions/v1alphaPipelineState'
+                title: Pipeline state
+                readOnly: true
+              user:
+                type: string
+                description: The resource name of a user, e.g., "users/local-user".
+                readOnly: true
+              org:
+                type: string
+                title: The resource name of an organization
+                readOnly: true
+              create_time:
+                type: string
+                format: date-time
+                title: Pipeline creation time
+                readOnly: true
+              update_time:
+                type: string
+                format: date-time
+                title: Pipeline update time
+                readOnly: true
+            title: A pipeline resource to update
+        - name: update_mask
+          description: Update mask for a pipeline resource
+          in: query
+          required: true
+          type: string
+      tags:
+        - PipelineService
+  /v1alpha/{source_connector.name}:
+    get:
+      summary: |-
+        GetSourceConnector method receives a GetSourceConnectorRequest message and
+        returns a GetSourceConnectorResponse message.
+      operationId: ConnectorService_GetSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: source_connector.name
+          description: |-
+            SourceConnectorConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+        - name: view
+          description: |-
+            SourceConnector view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+    delete:
+      summary: |-
+        DeleteSourceConnector method receives a DeleteSourceConnectorRequest
+        message and returns a DeleteSourceConnectorResponse message.
+      operationId: ConnectorService_DeleteSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: source_connector.name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+      tags:
+        - ConnectorService
+    patch:
+      summary: |-
+        UpdateSourceConnector method receives a UpdateSourceConnectorRequest
+        message and returns a UpdateSourceConnectorResponse message.
+      operationId: ConnectorService_UpdateSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: source_connector.name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+        - name: source_connector
+          description: SourceConnector resource
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: SourceConnector UUID
+                readOnly: true
+              id:
+                type: string
+                description: |-
+                  SourceConnector resource ID (the last segment of the resource name) used to
+                  construct the resource name. This conforms to RFC-1034, which restricts to
+                  letters, numbers, and hyphen, with the first character a letter, the last a
+                  letter or a number, and a 63 character maximum.
+              source_connector_definition:
+                type: string
+                title: SourceConnectorDefinition resource
+              connector:
+                $ref: '#/definitions/v1alphaConnector'
+                title: SourceConnector's connector data structure
+            title: SourceConnector resource
+            required:
+              - connector
+        - name: update_mask
+          description: Update mask for a SourceConnector resource
+          in: query
+          required: true
+          type: string
+      tags:
+        - ConnectorService
+  /v1alpha/{source_connector_definition.name}:
+    get:
+      summary: |-
+        GetSourceConnectorDefinition method receives a
+        GetSourceConnectorDefinitionRequest message and returns a
+        GetGetSourceConnectorDefinitionResponse message.
+      operationId: ConnectorService_GetSourceConnectorDefinition
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetSourceConnectorDefinitionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: source_connector_definition.name
+          description: |-
+            SourceConnectorDefinition resource name. It must have the format of
+            "source-connector-definitions/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connector-definitions/[^/]+
+        - name: view
+          description: |-
+            SourceConnectorDefinition resource view (default is DEFINITION_VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+  /v1alpha/{user.name}/exists:
+    get:
+      summary: |-
+        ExistUsername method receives a ExistUsernameRequest message and returns a
+        ExistUsernameResponse
+      operationId: UserService_ExistUsername
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaExistUsernameResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: user.name
+          description: |-
+            The resource name of the user to be deleted,
+            for example: "users/local-user"
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+      tags:
+        - UserService
+  /v1alpha/admin/{permalink_1}/lookUp:
+    get:
+      summary: |-
+        LookUpUser method receives a LookUpUserRequest message and returns a
+        LookUpUserResponse
+      operationId: UserService_LookUpUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaLookUpUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: permalink_1
+          description: |-
+            Permalink of a user. For example:
+            "users/{uid}"
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - UserService
+  /v1alpha/admin/{permalink}/lookUp:
+    get:
+      summary: |-
+        LookUpPlan method receives a LookUpPlanRequest message and returns a
+        LookUpPlanResponse
+      operationId: PlanService_LookUpPlan
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaLookUpPlanResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: permalink
+          description: |-
+            Permalink of a plan. For example:
+            "plans/{uid}"
+          in: path
+          required: true
+          type: string
+          pattern: plans/[^/]+
+        - name: view
+          description: |-
+            Plan resource view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - PlanService
+  /v1alpha/admin/{plan.name}:
+    get:
+      summary: |-
+        GetPlan method receives a GetPlanRequest message and returns
+        a GetPlanResponse message.
+      operationId: PlanService_GetPlan
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetPlanResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: plan.name
+          description: |-
+            Resource name of a plan. For example:
+            "plans/free"
+          in: path
+          required: true
+          type: string
+          pattern: plans/[^/]+
+        - name: view
+          description: |-
+            Plan resource view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - PlanService
+    delete:
+      summary: |-
+        DeletePlan method receives a DeletePlanRequest message and returns a
+        DeletePlanResponse
+      operationId: PlanService_DeletePlan
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeletePlanResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: plan.name
+          description: |-
+            The resource name of the plan to be deleted,
+            for example: "plans/free"
+          in: path
+          required: true
+          type: string
+          pattern: plans/[^/]+
+      tags:
+        - PlanService
+    patch:
+      summary: |-
+        UpdatePlan method receives a UpdatePlanRequest message and returns
+        a UpdatePlanResponse
+      operationId: PlanService_UpdatePlan
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdatePlanResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: plan.name
+          description: |-
+            Resource name. It must have the format of "plans/*".
+            For example: "plans/free".
+          in: path
+          required: true
+          type: string
+          pattern: plans/[^/]+
+        - name: plan
+          description: |-
+            The plan to update
+
+            The plan's `name` field is used to identify the plan to update.
+            Format: plans/{plan}
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: Plan UUID
+                readOnly: true
+              id:
+                type: string
+                description: |-
+                  Plan resource ID (the last segment of the resource name) used to
+                  construct the resource name. This conforms to RFC-1034, which restricts to
+                  letters, numbers, and hyphen, with the first character a letter, the last a
+                  letter or a number, and a 63 character maximum.
+              create_time:
+                type: string
+                format: date-time
+                title: Plan creation time
+                readOnly: true
+              update_time:
+                type: string
+                format: date-time
+                title: Plan update time
+                readOnly: true
+              tier:
+                $ref: '#/definitions/PlanTier'
+                title: Plan tier
+              visibility:
+                $ref: '#/definitions/v1alphaPlanVisibility'
+                title: Plan visibility
+              spec:
+                type: object
+                title: Plan specification in JSON format
+            description: |-
+              The plan's `name` field is used to identify the plan to update.
+              Format: plans/{plan}
+            title: The plan to update
+            required:
+              - tier
+              - visibility
+              - spec
+        - name: update_mask
+          description: Update mask for a plan resource
+          in: query
+          required: true
+          type: string
+      tags:
+        - PlanService
+  /v1alpha/admin/{user.name}:
+    get:
+      summary: |-
+        GetUser method receives a GetUserRequest message and returns
+        a GetUserResponse message.
+      operationId: UserService_GetUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: user.name
+          description: |-
+            Resource name of a user. For example:
+            "users/instill"
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - UserService
+    delete:
+      summary: |-
+        DeleteUser method receives a DeleteUserRequest message and returns a
+        DeleteUserResponse
+      operationId: UserService_DeleteUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: user.name
+          description: |-
+            The resource name of the user to be deleted,
+            for example: "users/local-user"
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+      tags:
+        - UserService
+    patch:
+      summary: |-
+        UpdateUser method receives a UpdateUserRequest message and returns
+        a UpdateUserResponse
+      operationId: UserService_UpdateUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: user.name
+          description: |-
+            Resource name. It must have the format of "users/*".
+            For example: "users/local-user".
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: user
+          description: |-
+            The user to update
+
+            The user's `name` field is used to identify the user to update.
+            Format: users/{user}
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: User ID in UUIDv4
+              id:
+                type: string
+                description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
+              type:
+                $ref: '#/definitions/v1alphaOwnerType'
+                title: 'Owner type: fixed to `OWNER_TYPE_USER`'
+                readOnly: true
+              create_time:
+                type: string
+                format: date-time
+                title: User creation time
+                readOnly: true
+              update_time:
+                type: string
+                format: date-time
+                title: User update time
+                readOnly: true
+              email:
+                type: string
+                title: User email
+              plan:
+                type: string
+                description: User plan. This field is not used in open-source VDP.
+              first_name:
+                type: string
+                title: User first name
+              last_name:
+                type: string
+                title: User last name
+              org_name:
+                type: string
+                title: User company or institution name
+              role:
+                type: string
+                title: |-
+                  User role. Allowed roles:
+                   - "manager"
+                   - "ai-researcher"
+                   - "ai-engineer"
+                   - "data-engineer",
+                   - "data-scientist",
+                   - "analytics-engineer"
+                   - "hobbyist"
+              newsletter_subscription:
+                type: boolean
+                title: User newsletter subscription
+              cookie_token:
+                type: string
+                title: User console cookie token
+            description: |-
+              The user's `name` field is used to identify the user to update.
+              Format: users/{user}
+            title: The user to update
+            required:
+              - uid
+              - id
+              - email
+              - newsletter_subscription
+        - name: update_mask
+          description: Update mask for a user resource
+          in: query
+          required: true
+          type: string
+      tags:
+        - UserService
+  /v1alpha/admin/plans:
+    get:
+      summary: |-
+        ListPlan method receives a ListPlanRequest message and returns a
+        ListPlanResponse message.
+      operationId: PlanService_ListPlan
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListPlanResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            Page size: the maximum number of resources to return. The service may
+            return fewer than this value. If unspecified, at most 10 plans will be
+            returned. The maximum value is 100; values above 100 will be coereced to
+            100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list plans
+          in: query
+          required: false
+          type: string
+      tags:
+        - PlanService
+    post:
+      summary: |-
+        CreatePlan receives a CreatePlanRequest message and returns a
+        aGetPlanResponses
+      operationId: PlanService_CreatePlan
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreatePlanResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: plan
+          description: |-
+            The plan to be created
+
+            The plan's `name` field is used to identify the plan to create.
+            Format: plans/{plan}
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaPlan'
+            required:
+              - plan
+      tags:
+        - PlanService
+  /v1alpha/admin/users:
+    get:
+      summary: |-
+        ListUser method receives a ListUserRequest message and returns a
+        ListUserResponse message.
+      operationId: UserService_ListUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            Page size: the maximum number of resources to return. The service may
+            return fewer than this value. If unspecified, at most 10 users will be
+            returned. The maximum value is 100; values above 100 will be coereced to
+            100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list users
+          in: query
+          required: false
+          type: string
+      tags:
+        - UserService
+    post:
+      summary: |-
+        CreateUser receives a CreateUserRequest message and returns a
+        aGetUserResponse
+      operationId: UserService_CreateUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: user
+          description: |-
+            The user to be created
+
+            The user's `name` field is used to identify the user to create.
+            Format: users/{user}
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaUser'
+            required:
+              - user
+      tags:
+        - UserService
+  /v1alpha/destination-connector-definitions:
+    get:
+      summary: |-
+        ListDestinationConnectorDefinition method receives a
+        ListDestinationConnectorDefinitionRequest message and returns a
+        ListDestinationConnectorDefinitionResponse message.
+      operationId: ConnectorService_ListDestinationConnectorDefinition
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListDestinationConnectorDefinitionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of DestinationConnectorDefinitions to return. The
+            service may return fewer than this value. If unspecified, at most 10
+            DestinationConnectorDefinitions will be returned. The maximum value is 100;
+            values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            Definition view (default is DEFINITION_VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+  /v1alpha/destination-connectors:
+    get:
+      summary: |-
+        ListDestinationConnector method receives a ListDestinationConnectorRequest
+        message and returns a ListDestinationConnectorResponse message.
+      operationId: ConnectorService_ListDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of connectors to return. The service may return fewer
+            than this value. If unspecified, at most 10 connectors will be returned.
+            The maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            DestinationConnector view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+    post:
+      summary: |-
+        CreateDestinationConnector method receives a
+        CreateDestinationConnectorRequest message and returns a
+        CreateDestinationConnectorResponse message.
+      operationId: ConnectorService_CreateDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: destination_connector
+          description: DestinationConnector resource
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaDestinationConnector'
+            required:
+              - destination_connector
+      tags:
+        - ConnectorService
+  /v1alpha/health/billing:
+    get:
+      summary: |-
+        Liveness method receives a LivenessRequest message and returns a
+        LivenessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: PlanService_Liveness2
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpbillingv1alphaLivenessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - PlanService
+  /v1alpha/health/connector:
+    get:
+      summary: |-
+        Liveness method receives a LivenessRequest message and returns a
+        LivenessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: ConnectorService_Liveness2
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpconnectorv1alphaLivenessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1alpha/health/mgmt:
+    get:
+      summary: |-
+        Liveness method receives a LivenessRequest message and returns a
+        LivenessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: UserService_Liveness2
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpmgmtv1alphaLivenessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - UserService
+  /v1alpha/health/model:
+    get:
+      summary: |-
+        Liveness method receives a LivenessRequest message and returns a
+        LivenessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: ModelService_Liveness2
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpmodelv1alphaLivenessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - ModelService
+  /v1alpha/health/pipeline:
+    get:
+      summary: |-
+        Liveness method receives a LivenessRequest message and returns a
+        LivenessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: PipelineService_Liveness2
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdppipelinev1alphaLivenessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - PipelineService
+  /v1alpha/health/usage:
+    get:
+      summary: |-
+        Liveness method receives a LivenessRequest message and returns a
+        LivenessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: UsageService_Liveness2
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpusagev1alphaLivenessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - UsageService
+  /v1alpha/model-definitions:
+    get:
+      summary: |-
+        ListModelDefinition method receives a ListModelDefinitionRequest message
+        and returns a ListModelDefinitionResponse
+      operationId: ModelService_ListModelDefinition
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListModelDefinitionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            Page size: the maximum number of resources to return. The service may
+            return fewer than this value. If unspecified, at most 10 ModelDefinitions
+            will be returned. The maximum value is 100; values above 100 will be
+            coereced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            Definition view (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
+            `ModelDefinition.model_instance_spec`
+            VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+  /v1alpha/models:
+    get:
+      summary: |-
+        ListModel method receives a ListModelRequest message and returns a
+        ListModelResponse
+      operationId: ModelService_ListModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            Page size: the maximum number of resources to return. The service may
+            return fewer than this value. If unspecified, at most 10 models will be
+            returned. The maximum value is 100; values above 100 will be coereced to
+            100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            Model view (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+            VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+    post:
+      summary: |-
+        CreateModel method receives a CreateModelRequest message and returns a
+        CreateModelResponse
+      operationId: ModelService_CreateModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: model
+          description: |-
+            The model to be created
+
+            The model `name` field is used to identify the model to create.
+            Format: models/{model}
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaModel'
+            required:
+              - model
+      tags:
+        - ModelService
+  /v1alpha/operations:
+    get:
+      summary: |-
+        ListModelOperation method receives a ListModelOperationRequest message
+        and returns a ListModelOperationResponse
+      operationId: ModelService_ListModelOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListModelOperationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            Page size: the maximum number of resources to return. The service may
+            return fewer than this value. If unspecified, at most 10 operations will be
+            returned. The maximum value is 100; values above 100 will be coereced to
+            100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: filter
+          description: Filter expression to list operations
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
+            `ModelInstance.configuration` VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelService
+  /v1alpha/pipelines:
+    get:
+      summary: |-
+        ListPipeline method receives a ListPipelineRequest message and returns a
+        ListPipelineResponse message.
+      operationId: PipelineService_ListPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of pipelines to return. The service may return fewer
+            than this value. If unspecified, at most 10 pipelines will be returned. The
+            maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list pipelines
+          in: query
+          required: false
+          type: string
+      tags:
+        - PipelineService
+    post:
+      summary: |-
+        CreatePipeline method receives a CreatePipelineRequest message and returns
+        a CreatePipelineResponse message.
+      operationId: PipelineService_CreatePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreatePipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: pipeline
+          description: A pipeline resource to create
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaPipeline'
+            required:
+              - pipeline
+      tags:
+        - PipelineService
+  /v1alpha/ready/billing:
+    get:
+      summary: |-
+        Readiness method receives a ReadinessRequest message and returns a
+        ReadinessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: PlanService_Readiness2
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpbillingv1alphaReadinessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - PlanService
+  /v1alpha/ready/mgmt:
+    get:
+      summary: |-
+        Readiness method receives a ReadinessRequest message and returns a
+        ReadinessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: UserService_Readiness2
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpmgmtv1alphaReadinessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - UserService
+  /v1alpha/ready/model:
+    get:
+      summary: |-
+        Readiness method receives a ReadinessRequest message and returns a
+        ReadinessResponse message.
+        See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+      operationId: ModelService_Readiness2
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/vdpmodelv1alphaReadinessResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: health_check_request.service
+          description: Service name to check for its readiness status
+          in: query
+          required: false
+          type: string
+      tags:
+        - ModelService
+  /v1alpha/reports:
+    post:
+      summary: |-
+        SendSessionReport method receives a SendSessionReportRequest message and
+        returns a SendSessionReportResponse message.
+      operationId: UsageService_SendSessionReport
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaSendSessionReportResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: report
+          description: A report resource to create
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaSessionReport'
+            required:
+              - report
+      tags:
+        - UsageService
+  /v1alpha/sessions:
+    post:
+      summary: |-
+        CreateSession method receives a CreateSessionRequest message and returns
+        a CreateSessionResponse message.
+      operationId: UsageService_CreateSession
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateSessionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: session
+          description: A session resource to create
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaSession'
+            required:
+              - session
+      tags:
+        - UsageService
+  /v1alpha/source-connector-definitions:
+    get:
+      summary: |-
+        ListSourceConnectorDefinition method receives a
+        ListSourceConnectorDefinitionRequest message and returns a
+        ListSourceConnectorDefinitionResponse message.
+      operationId: ConnectorService_ListSourceConnectorDefinition
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListSourceConnectorDefinitionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of SourceConnectorDefinitions to return. The service may
+            return fewer than this value. If unspecified, at most 10
+            SourceConnectorDefinitions will be returned. The maximum value is 100;
+            values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            Definition view (default is DEFINITION_VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+  /v1alpha/source-connectors:
+    get:
+      summary: |-
+        ListSourceConnector method receives a ListSourceConnectorRequest message
+        and returns a ListSourceConnectorResponse message.
+      operationId: ConnectorService_ListSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of connectors to return. The service may return fewer
+            than this value. If unspecified, at most 10 connectors will be returned.
+            The maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            SourceConnector view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ConnectorService
+    post:
+      summary: |-
+        CreateSourceConnector method receives a CreateSourceConnectorRequest
+        message and returns a CreateSourceConnectorResponse message.
+      operationId: ConnectorService_CreateSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: source_connector
+          description: SourceConnector resource
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaSourceConnector'
+            required:
+              - source_connector
+      tags:
+        - ConnectorService
+  /v1alpha/user:
+    get:
+      summary: |-
+        GetAuthenticatedUser method receives a GetAuthenticatedUserRequest message and returns
+        a GetAuthenticatedUserResponse message.
+      operationId: UserService_GetAuthenticatedUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetAuthenticatedUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      tags:
+        - UserService
+    patch:
+      summary: "UpdateAuthenticatedUser method receives a UpdateAuthenticatedUserRequest message and returns \na UpdateAuthenticatedUserResponse message."
+      operationId: UserService_UpdateAuthenticatedUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateAuthenticatedUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: user
+          description: The user to update
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaUser'
+            required:
+              - user
+        - name: update_mask
+          description: Update mask for a user resource
+          in: query
+          required: true
+          type: string
+      tags:
+        - UserService
+definitions:
+  AdvancedAuthAuthFlowType:
+    type: string
+    enum:
+      - AUTH_FLOW_TYPE_UNSPECIFIED
+      - AUTH_FLOW_TYPE_OAUTH2_0
+      - AUTH_FLOW_TYPE_OAUTH1_0
+    default: AUTH_FLOW_TYPE_UNSPECIFIED
+    description: |-
+      - AUTH_FLOW_TYPE_UNSPECIFIED: AuthFlowType: AUTH_TYPE_UNSPECIFIED
+       - AUTH_FLOW_TYPE_OAUTH2_0: AuthFlowType: AUTH_TYPE_OAUTH2_0
+       - AUTH_FLOW_TYPE_OAUTH1_0: AuthFlowType: AUTH_TYPE_OAUTH1_0
+    title: AuthFlowType enumerates the type of auth
+  HealthCheckResponseServingStatus:
+    type: string
+    enum:
+      - SERVING_STATUS_UNSPECIFIED
+      - SERVING_STATUS_SERVING
+      - SERVING_STATUS_NOT_SERVING
+    default: SERVING_STATUS_UNSPECIFIED
+    description: |-
+      - SERVING_STATUS_UNSPECIFIED: Serving status: UNSPECIFIED
+       - SERVING_STATUS_SERVING: Serving status: SERVING
+       - SERVING_STATUS_NOT_SERVING: Serving status: NOT SERVING
+    title: ServingStatus enumerates the status of a queried service
+  ModelInstanceTask:
+    type: string
+    enum:
+      - TASK_UNSPECIFIED
+      - TASK_CLASSIFICATION
+      - TASK_DETECTION
+      - TASK_KEYPOINT
+      - TASK_OCR
+      - TASK_INSTANCE_SEGMENTATION
+      - TASK_SEMANTIC_SEGMENTATION
+      - TASK_TEXT_TO_IMAGE
+    default: TASK_UNSPECIFIED
+    description: |-
+      - TASK_UNSPECIFIED: Task: UNSPECIFIED
+       - TASK_CLASSIFICATION: Task: CLASSIFICATION
+       - TASK_DETECTION: Task: DETECTION
+       - TASK_KEYPOINT: Task: KEYPOINT
+       - TASK_OCR: Task: OCR
+       - TASK_INSTANCE_SEGMENTATION: Task: INSTANCE SEGMENTATION
+       - TASK_SEMANTIC_SEGMENTATION: Task: SEMANTIC SEGMENTATION
+       - TASK_TEXT_TO_IMAGE: Task: TEXT TO IMAGE
+    title: Task enumerates the task type of a model instance
+  PipelineMode:
+    type: string
+    enum:
+      - MODE_UNSPECIFIED
+      - MODE_SYNC
+      - MODE_ASYNC
+    default: MODE_UNSPECIFIED
+    description: |-
+      - MODE_UNSPECIFIED: Mode: UNSPECIFIED
+       - MODE_SYNC: Mode: SYNC
+       - MODE_ASYNC: Mode: ASYNC
+    title: Mode enumerates the pipeline modes
+  PlanTier:
+    type: string
+    enum:
+      - TIER_UNSPECIFIED
+      - TIER_FREE
+      - TIER_CUSTOM
+    default: TIER_UNSPECIFIED
+    description: |-
+      - TIER_UNSPECIFIED: PlanType: UNSPECIFIED, equivalent to FREE.
+       - TIER_FREE: PlanType: FREE
+       - TIER_CUSTOM: PlanType: CUSTOM
+    title: Tier enumerates the billing plan tier type
+  SessionService:
+    type: string
+    enum:
+      - SERVICE_UNSPECIFIED
+      - SERVICE_MGMT
+      - SERVICE_CONNECTOR
+      - SERVICE_MODEL
+      - SERVICE_PIPELINE
+    default: SERVICE_UNSPECIFIED
+    description: |-
+      - SERVICE_UNSPECIFIED: Service: UNSPECIFIED
+       - SERVICE_MGMT: Service: MGMT
+       - SERVICE_CONNECTOR: Service: CONNECTOR
+       - SERVICE_MODEL: Service: MODEL
+       - SERVICE_PIPELINE: Service: PIPELINE
+    title: Service enumerates the services to collect data from
+  googlelongrunningOperation:
+    type: object
+    properties:
+      name:
+        type: string
+        description: |-
+          The server-assigned name, which is only unique within the same service that
+          originally returns it. If you use the default HTTP mapping, the
+          `name` should be a resource name ending with `operations/{unique_id}`.
+      metadata:
+        $ref: '#/definitions/protobufAny'
+        description: |-
+          Service-specific metadata associated with the operation.  It typically
+          contains progress information and common metadata such as create time.
+          Some services might not provide such metadata.  Any method that returns a
+          long-running operation should document the metadata type, if any.
+      done:
+        type: boolean
+        description: |-
+          If the value is `false`, it means the operation is still in progress.
+          If `true`, the operation is completed, and either `error` or `response` is
+          available.
+      error:
+        $ref: '#/definitions/rpcStatus'
+        description: The error result of the operation in case of failure or cancellation.
+      response:
+        $ref: '#/definitions/protobufAny'
+        description: |-
+          The normal response of the operation in case of success.  If the original
+          method returns no data on success, such as `Delete`, the response is
+          `google.protobuf.Empty`.  If the original method is standard
+          `Get`/`Create`/`Update`, the response should be the resource.  For other
+          methods, the response should have the type `XxxResponse`, where `Xxx`
+          is the original method name.  For example, if the original method name
+          is `TakeSnapshot()`, the inferred response type is
+          `TakeSnapshotResponse`.
+    description: |-
+      This resource represents a long-running operation that is the result of a
+      network API call.
+  protobufAny:
+    type: object
+    properties:
+      '@type':
+        type: string
+        description: |-
+          A URL/resource name that uniquely identifies the type of the serialized
+          protocol buffer message. This string must contain at least
+          one "/" character. The last segment of the URL's path must represent
+          the fully qualified name of the type (as in
+          `path/google.protobuf.Duration`). The name should be in a canonical form
+          (e.g., leading "." is not accepted).
+
+          In practice, teams usually precompile into the binary all types that they
+          expect it to use in the context of Any. However, for URLs which use the
+          scheme `http`, `https`, or no scheme, one can optionally set up a type
+          server that maps type URLs to message definitions as follows:
+
+          * If no scheme is provided, `https` is assumed.
+          * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+            value in binary format, or produce an error.
+          * Applications are allowed to cache lookup results based on the
+            URL, or have them precompiled into a binary to avoid any
+            lookup. Therefore, binary compatibility needs to be preserved
+            on changes to types. (Use versioned type names to manage
+            breaking changes.)
+
+          Note: this functionality is not currently available in the official
+          protobuf release, and it is not used for type URLs beginning with
+          type.googleapis.com.
+
+          Schemes other than `http`, `https` (or the empty scheme) might be
+          used with implementation specific semantics.
+    additionalProperties: {}
+    description: |-
+      `Any` contains an arbitrary serialized protocol buffer message along with a
+      URL that describes the type of the serialized message.
+
+      Protobuf library provides support to pack/unpack Any values in the form
+      of utility functions or additional generated methods of the Any type.
+
+      Example 1: Pack and unpack a message in C++.
+
+          Foo foo = ...;
+          Any any;
+          any.PackFrom(foo);
+          ...
+          if (any.UnpackTo(&foo)) {
+            ...
+          }
+
+      Example 2: Pack and unpack a message in Java.
+
+          Foo foo = ...;
+          Any any = Any.pack(foo);
+          ...
+          if (any.is(Foo.class)) {
+            foo = any.unpack(Foo.class);
+          }
+
+       Example 3: Pack and unpack a message in Python.
+
+          foo = Foo(...)
+          any = Any()
+          any.Pack(foo)
+          ...
+          if any.Is(Foo.DESCRIPTOR):
+            any.Unpack(foo)
+            ...
+
+       Example 4: Pack and unpack a message in Go
+
+           foo := &pb.Foo{...}
+           any, err := anypb.New(foo)
+           if err != nil {
+             ...
+           }
+           ...
+           foo := &pb.Foo{}
+           if err := any.UnmarshalTo(foo); err != nil {
+             ...
+           }
+
+      The pack methods provided by protobuf library will by default use
+      'type.googleapis.com/full.type.name' as the type URL and the unpack
+      methods only use the fully qualified type name after the last '/'
+      in the type URL, for example "foo.bar.com/x/y.z" will yield type
+      name "y.z".
+
+
+      JSON
+      ====
+      The JSON representation of an `Any` value uses the regular
+      representation of the deserialized, embedded message, with an
+      additional field `@type` which contains the type URL. Example:
+
+          package google.profile;
+          message Person {
+            string first_name = 1;
+            string last_name = 2;
+          }
+
+          {
+            "@type": "type.googleapis.com/google.profile.Person",
+            "firstName": <string>,
+            "lastName": <string>
+          }
+
+      If the embedded message type is well-known and has a custom JSON
+      representation, that representation will be embedded adding a field
+      `value` which holds the custom JSON in addition to the `@type`
+      field. Example (for message [google.protobuf.Duration][]):
+
+          {
+            "@type": "type.googleapis.com/google.protobuf.Duration",
+            "value": "1.212s"
+          }
+  protobufNullValue:
+    type: string
+    enum:
+      - NULL_VALUE
+    default: NULL_VALUE
+    description: |-
+      `NullValue` is a singleton enumeration to represent the null value for the
+      `Value` type union.
+
+       The JSON representation for `NullValue` is JSON `null`.
+
+       - NULL_VALUE: Null value.
+  rpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+        description: |-
+          The status code, which should be an enum value of
+          [google.rpc.Code][google.rpc.Code].
+      message:
+        type: string
+        description: |-
+          A developer-facing error message, which should be in English. Any
+          user-facing error message should be localized and sent in the
+          [google.rpc.Status.details][google.rpc.Status.details] field, or localized
+          by the client.
+      details:
+        type: array
+        items:
+          $ref: '#/definitions/protobufAny'
+        description: |-
+          A list of messages that carry the error details.  There is a common set of
+          message types for APIs to use.
+    description: |-
+      The `Status` type defines a logical error model that is suitable for
+      different programming environments, including REST APIs and RPC APIs. It is
+      used by [gRPC](https://github.com/grpc). Each `Status` message contains
+      three pieces of data: error code, error message, and error details.
+
+      You can find out more about this error model and how to work with it in the
+      [API Design Guide](https://cloud.google.com/apis/design/errors).
+  typeDate:
+    type: object
+    properties:
+      year:
+        type: integer
+        format: int32
+        description: |-
+          Year of the date. Must be from 1 to 9999, or 0 to specify a date without
+          a year.
+      month:
+        type: integer
+        format: int32
+        description: |-
+          Month of a year. Must be from 1 to 12, or 0 to specify a year without a
+          month and day.
+      day:
+        type: integer
+        format: int32
+        description: |-
+          Day of a month. Must be from 1 to 31 and valid for the year and month, or 0
+          to specify a year by itself or a year and month where the day isn't
+          significant.
+    description: |-
+      * A full date, with non-zero year, month, and day values
+      * A month and day value, with a zero year, such as an anniversary
+      * A year on its own, with zero month and day values
+      * A year and month value, with a zero day, such as a credit card expiration
+      date
+
+      Related types are [google.type.TimeOfDay][google.type.TimeOfDay] and
+      `google.protobuf.Timestamp`.
+    title: |-
+      Represents a whole or partial calendar date, such as a birthday. The time of
+      day and time zone are either specified elsewhere or are insignificant. The
+      date is relative to the Gregorian Calendar. This can represent one of the
+      following:
+  v1alphaActivatePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: ActivatePipelineResponse represents an activated pipeline
+  v1alphaAdvancedAuth:
+    type: object
+    properties:
+      auth_flow_type:
+        $ref: '#/definitions/AdvancedAuthAuthFlowType'
+        title: AdvancedAuth auth flow type
+      predicate_key:
+        type: array
+        items:
+          type: string
+        title: |-
+          AdvancedAuth predicate key, i.e., the JSON Path to a field in the
+          connectorSpecification that should exist for the advanced auth to be
+          applicable
+      predicate_value:
+        type: string
+        title: |-
+          AdvancedAuth predicate value, i.e., the value of the predicate key fields
+          for the advanced auth to be applicable
+      oauth_config_specification:
+        $ref: '#/definitions/v1alphaOauthConfigSpecification'
+        title: OauthConfigSpecification represents OAuth config specification
+    description: |-
+      Additional and optional specification object to describe what an 'advanced'
+      Auth flow would need to function.
+      - A connector should be able to fully function with the configuration as
+      described by the ConnectorSpecification in a 'basic' mode.
+      - The 'advanced' mode provides easier UX for the user with UI improvements
+      and automations. However, this requires further setup on the server side by
+      instance or workspace admins beforehand. The trade-off is that the user does
+      not have to provide as many technical inputs anymore and the auth process is
+      faster and easier to complete.
+  v1alphaBoundingBox:
+    type: object
+    properties:
+      top:
+        type: number
+        format: float
+        title: Bounding box top y-axis value
+        readOnly: true
+      left:
+        type: number
+        format: float
+        title: Bounding box left x-axis value
+        readOnly: true
+      width:
+        type: number
+        format: float
+        title: Bounding box width value
+        readOnly: true
+      height:
+        type: number
+        format: float
+        title: Bounding box height value
+        readOnly: true
+    title: BoundingBox represents the bounding box data structure
+  v1alphaCancelModelOperationResponse:
+    type: object
+    title: |-
+      CancelModelOperationResponse represents a response for canceling a model
+      operation
+  v1alphaClassificationInput:
+    type: object
+    properties:
+      image_url:
+        type: string
+        title: Image type URL
+      image_base64:
+        type: string
+        title: Image type base64
+    title: ClassificationInput represents the input of classification task
+  v1alphaClassificationOutput:
+    type: object
+    properties:
+      category:
+        type: string
+        title: Classification category
+        readOnly: true
+      score:
+        type: number
+        format: float
+        title: Classification score
+        readOnly: true
+    title: ClassificationOutput represents the output of classification task
+  v1alphaConnectDestinationConnectorResponse:
+    type: object
+    properties:
+      destination_connector:
+        $ref: '#/definitions/v1alphaDestinationConnector'
+        title: A DestinationConnector resource
+    title: |-
+      ConnectDestinationConnectorResponse represents a connected destination
+      connector
+  v1alphaConnectSourceConnectorResponse:
+    type: object
+    properties:
+      source_connector:
+        $ref: '#/definitions/v1alphaSourceConnector'
+        title: A SourceConnector resource
+    title: ConnectSourceConnectorResponse represents a connected source connector
+  v1alphaConnector:
+    type: object
+    properties:
+      description:
+        type: string
+        title: Connector description
+      configuration:
         type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: LivenessResponse represents a response for a service liveness status
-    vdpusagev1alphaReadinessResponse:
+        title: Connector configuration in JSON format
+      state:
+        $ref: '#/definitions/v1alphaConnectorState'
+        title: Connector state
+        readOnly: true
+      tombstone:
+        type: boolean
+        title: Connector tombstone
+        readOnly: true
+      user:
+        type: string
+        description: The resource name of a user, e.g., "users/local-user".
+        readOnly: true
+      org:
+        type: string
+        title: The resource name of an organization
+        readOnly: true
+      create_time:
+        type: string
+        format: date-time
+        title: Connector creation time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: Connector update time
+        readOnly: true
+    title: Connector represents a connector data model
+    required:
+      - configuration
+  v1alphaConnectorDefinition:
+    type: object
+    properties:
+      title:
+        type: string
+        title: ConnectorDefinition title
+        readOnly: true
+      docker_repository:
+        type: string
+        title: ConnectorDefinition Docker repository
+        readOnly: true
+      docker_image_tag:
+        type: string
+        title: ConnectorDefinition Docker image tag
+        readOnly: true
+      documentation_url:
+        type: string
+        title: ConnectorDefinition documentation URL
+        readOnly: true
+      icon:
+        type: string
+        title: ConnectorDefinition icon
+        readOnly: true
+      spec:
+        $ref: '#/definitions/v1alphaSpec'
+        title: ConnectorDefinition spec
+        readOnly: true
+      tombstone:
+        type: boolean
+        title: |-
+          ConnectorDefinition tombstone, i.e., if not set or false, the
+          configuration is active, or otherwise, if true, this configuration is
+          permanently off
+        readOnly: true
+      public:
+        type: boolean
+        title: |-
+          ConnectorDefinition public flag, i.e., true if this connector
+          definition is available to all workspaces
+        readOnly: true
+      custom:
+        type: boolean
+        title: |-
+          ConnectorDefinition custom flag, i.e., whether this is a custom
+          connector definition
+        readOnly: true
+      release_stage:
+        $ref: '#/definitions/vdpconnectorv1alphaReleaseStage'
+        title: ConnectorDefinition release stage
+        readOnly: true
+      release_date:
+        $ref: '#/definitions/typeDate'
+        description: |-
+          ConnectorDefinition release date, i.e., the date when this connector
+          was first released, in yyyy-mm-dd format.
+        readOnly: true
+      resource_requirements:
         type: object
-        properties:
-            health_check_response:
-                $ref: "#/definitions/v1alphaHealthCheckResponse"
-                title: HealthCheckResponse message
-        title: ReadinessResponse represents a response for a service readiness status
+        title: ConnectorDefinition resource requirements
+        readOnly: true
+      create_time:
+        type: string
+        format: date-time
+        title: ConnectorDefinition creation time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: ConnectorDefinition update time
+        readOnly: true
+    title: ConnectorDefinition represents the connector definition data model
+  v1alphaConnectorState:
+    type: string
+    enum:
+      - STATE_UNSPECIFIED
+      - STATE_DISCONNECTED
+      - STATE_CONNECTED
+      - STATE_ERROR
+    default: STATE_UNSPECIFIED
+    description: |-
+      - STATE_UNSPECIFIED: State: UNSPECIFIED
+       - STATE_DISCONNECTED: State: DISCONNECTED
+       - STATE_CONNECTED: State: CONNECTED
+       - STATE_ERROR: State: ERROR
+    title: State enumerates the connector state
+  v1alphaConnectorUsageData:
+    type: object
+    properties:
+      usages:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaConnectorUsageDataUserUsageData'
+        title: Usage data of all users in the connector service
+    title: Connector service usage data
+  v1alphaConnectorUsageDataUserUsageData:
+    type: object
+    properties:
+      user_uid:
+        type: string
+        title: User UUID
+      source_connector_connected_state_num:
+        type: string
+        format: int64
+        title: Number of source connectors with 'connected' state
+      source_connector_disconnected_state_num:
+        type: string
+        format: int64
+        title: Number of source connectors with 'disconneceted' state
+      source_connector_definition_ids:
+        type: array
+        items:
+          type: string
+        description: |-
+          Definition IDs of the source connectors. Element in the list
+          should not be duplicated.
+      destination_connector_connected_state_num:
+        type: string
+        format: int64
+        title: Number of destination connectors with 'connected' state
+      destination_connector_disconnected_state_num:
+        type: string
+        format: int64
+        title: Number of destination connectors with 'disconnected' state
+      destination_connector_definition_ids:
+        type: array
+        items:
+          type: string
+        description: |-
+          Definition IDs of the destination connectors. Element in the
+          list should not be duplicated.
+    title: Per user usage data in the connector service
+    required:
+      - user_uid
+      - source_connector_connected_state_num
+      - source_connector_disconnected_state_num
+      - source_connector_definition_ids
+      - destination_connector_connected_state_num
+      - destination_connector_disconnected_state_num
+      - destination_connector_definition_ids
+  v1alphaCreateDestinationConnectorResponse:
+    type: object
+    properties:
+      destination_connector:
+        $ref: '#/definitions/v1alphaDestinationConnector'
+        title: DestinationConnector resource
+    title: |-
+      CreateDestinationConnectorResponse represents a response for a
+      DestinationConnector resource
+  v1alphaCreateModelBinaryFileUploadResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Create model operation message
+        readOnly: true
+    title: |-
+      CreateModelBinaryFileUploadResponse represents a response for a model
+      instance
+  v1alphaCreateModelResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Create model operation message
+        readOnly: true
+    title: CreateModelResponse represents a response for a model
+  v1alphaCreatePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: The created pipeline resource
+    title: CreatePipelineResponse represents a response for a pipeline resource
+  v1alphaCreatePlanResponse:
+    type: object
+    properties:
+      plan:
+        $ref: '#/definitions/v1alphaPlan'
+        title: A plan resource
+    title: CreatePlanResponse represents a response for a plan response
+  v1alphaCreateSessionResponse:
+    type: object
+    properties:
+      session:
+        $ref: '#/definitions/v1alphaSession'
+        title: A session resource
+    title: CreateSessionResponse represents a response for a session response
+  v1alphaCreateSourceConnectorResponse:
+    type: object
+    properties:
+      source_connector:
+        $ref: '#/definitions/v1alphaSourceConnector'
+        title: SourceConnector resource
+    title: |-
+      CreateSourceConnectorResponse represents a response for a
+      SourceConnector resource
+  v1alphaCreateUserResponse:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/v1alphaUser'
+        title: A user resource
+    title: CreateUserResponse represents a response for a user response
+  v1alphaDeactivatePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: DeactivatePipelineResponse represents an inactivated pipeline
+  v1alphaDeleteDestinationConnectorResponse:
+    type: object
+    title: DeleteDestinationConnectorResponse represents an empty response
+  v1alphaDeleteModelResponse:
+    type: object
+    title: DeleteModelResponse represents an empty response
+  v1alphaDeletePipelineResponse:
+    type: object
+    title: DeletePipelineResponse represents an empty response
+  v1alphaDeletePlanResponse:
+    type: object
+    title: DeletePlanResponse represents an empty response
+  v1alphaDeleteSourceConnectorResponse:
+    type: object
+    title: DeleteSourceConnectorResponse represents an empty response
+  v1alphaDeleteUserResponse:
+    type: object
+    title: DeleteUserResponse represents an empty response
+  v1alphaDeployModelInstanceResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Deploy operation message
+    title: |-
+      DeployModelInstanceResponse represents a response for a deployed model
+      instance
+  v1alphaDestinationConnector:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          DestinationConnector resource name. It must have the format of
+          "destination-connectors/*"
+        readOnly: true
+      uid:
+        type: string
+        title: DestinationConnector UUID
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          DestinationConnector resource ID (the last segment of the resource name)
+          used to construct the resource name. This conforms to RFC-1034, which
+          restricts to letters, numbers, and hyphen, with the first character a
+          letter, the last a letter or a number, and a 63 character maximum.
+      destination_connector_definition:
+        type: string
+        title: DestinationConnectorDefinition resource
+      connector:
+        $ref: '#/definitions/v1alphaConnector'
+        title: DestinationConnector's connector data structure
+    title: DestinationConnector represents a destination connector resource
+    required:
+      - connector
+  v1alphaDestinationConnectorDefinition:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          DestinationConnectorDefinition resource name. It must have the format of
+          "connector-definitions/*"
+        readOnly: true
+      uid:
+        type: string
+        title: DestinationConnectorDefinition UUID
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          DestinationConnectorDefinition resource ID (the last segment of the
+          resource name) used to construct the resource name. This conforms to
+          RFC-1034, which restricts to letters, numbers, and hyphen, with the first
+          character a letter, the last a letter or a number, and a 63 character
+          maximum.
+      connector_definition:
+        $ref: '#/definitions/v1alphaConnectorDefinition'
+        title: DestinationConnectorDefinition connector definition
+        readOnly: true
+    title: |-
+      DestinationConnectorDefinition represents the destination connector
+      definition resource
+  v1alphaDetectionInput:
+    type: object
+    properties:
+      image_url:
+        type: string
+        title: Image type URL
+      image_base64:
+        type: string
+        title: Image type base64
+    title: DetectionInput represents the input of detection task
+  v1alphaDetectionObject:
+    type: object
+    properties:
+      category:
+        type: string
+        title: Detection object category
+        readOnly: true
+      score:
+        type: number
+        format: float
+        title: Detection object score
+        readOnly: true
+      bounding_box:
+        $ref: '#/definitions/v1alphaBoundingBox'
+        title: Detection bounding box
+        readOnly: true
+    title: DetectionObject represents a predicted object
+  v1alphaDetectionOutput:
+    type: object
+    properties:
+      objects:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaDetectionObject'
+        title: A list of detection objects
+        readOnly: true
+    title: DetectionOutput represents the output of detection task
+  v1alphaDisconnectDestinationConnectorResponse:
+    type: object
+    properties:
+      destination_connector:
+        $ref: '#/definitions/v1alphaDestinationConnector'
+        title: A DestinationConnector resource
+    title: |-
+      DisconnectDestinationConnectorResponse represents a disconnected destination
+      connector
+  v1alphaDisconnectSourceConnectorResponse:
+    type: object
+    properties:
+      source_connector:
+        $ref: '#/definitions/v1alphaSourceConnector'
+        title: A SourceConnector resource
+    title: DisconnectSourceConnectorResponse represents a disconnected source connector
+  v1alphaExistUsernameResponse:
+    type: object
+    properties:
+      exists:
+        type: boolean
+        title: A boolean value indicating whether the username has been occupied
+    title: |-
+      ExistUsernameResponse represents a response about whether
+      the queried username has been occupied
+  v1alphaGetAuthenticatedUserResponse:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/v1alphaUser'
+        title: A user resource
+    title: |-
+      GetAuthenticatedUserResponse represents a response for
+      the authenticated user resource
+  v1alphaGetDestinationConnectorDefinitionResponse:
+    type: object
+    properties:
+      destination_connector_definition:
+        $ref: '#/definitions/v1alphaDestinationConnectorDefinition'
+        title: A DestinationConnectorDefinition resource
+    title: |-
+      GetDestinationConnectorDefinitionResponse represents a
+      DestinationConnectorDefinition response
+  v1alphaGetDestinationConnectorResponse:
+    type: object
+    properties:
+      destination_connector:
+        $ref: '#/definitions/v1alphaDestinationConnector'
+        title: DestinationConnector resource
+    title: |-
+      GetDestinationConnectorResponse represents a response for a
+      DestinationConnector resource
+  v1alphaGetModelDefinitionResponse:
+    type: object
+    properties:
+      model_definition:
+        $ref: '#/definitions/v1alphaModelDefinition'
+        title: A model definition instance
+    title: GetModelDefinitionResponse represents a response for a model definition
+  v1alphaGetModelInstanceCardResponse:
+    type: object
+    properties:
+      readme:
+        $ref: '#/definitions/v1alphaModelInstanceCard'
+        title: Retrieved model instance card
+    title: |-
+      GetModelInstanceCardResponse represents a response to fetch a model
+      instance's README card
+  v1alphaGetModelInstanceResponse:
+    type: object
+    properties:
+      instance:
+        $ref: '#/definitions/v1alphaModelInstance'
+        title: Retrieved model instance
+    title: GetModelInstanceResponse represents a response for a model instance
+  v1alphaGetModelOperationResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: The retrieved model operation
+    title: GetModelOperationResponse represents a response for a model operation
+  v1alphaGetModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: The retrieved model
+    title: GetModelResponse represents a response for a model
+  v1alphaGetPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: GetPipelineResponse represents a response for a pipeline resource
+  v1alphaGetPlanResponse:
+    type: object
+    properties:
+      plan:
+        $ref: '#/definitions/v1alphaPlan'
+        title: A plan resource
+    title: GetPlanResponse represents a response for a plan resource
+  v1alphaGetSourceConnectorDefinitionResponse:
+    type: object
+    properties:
+      source_connector_definition:
+        $ref: '#/definitions/v1alphaSourceConnectorDefinition'
+        title: A SourceConnectorDefinition resource
+    title: |-
+      GetSourceConnectorDefinitionResponse represents a SourceConnectorDefinition
+      response
+  v1alphaGetSourceConnectorResponse:
+    type: object
+    properties:
+      source_connector:
+        $ref: '#/definitions/v1alphaSourceConnector'
+        title: SourceConnector resource
+    title: |-
+      GetSourceConnectorResponse represents a response for a
+      SourceConnector resource
+  v1alphaGetUserResponse:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/v1alphaUser'
+        title: A user resource
+    title: GetUserResponse represents a response for a user resource
+  v1alphaHealthCheckRequest:
+    type: object
+    properties:
+      service:
+        type: string
+        title: Service name to check for its readiness status
+    title: HealthCheckRequest represents a request to health check a service
+  v1alphaHealthCheckResponse:
+    type: object
+    properties:
+      status:
+        $ref: '#/definitions/HealthCheckResponseServingStatus'
+        title: Status is the instance of the enum type ServingStatus
+    title: HealthCheckResponse represents a response for a service heath status
+  v1alphaInstanceSegmentationInput:
+    type: object
+    properties:
+      image_url:
+        type: string
+        title: Image type URL
+      image_base64:
+        type: string
+        title: Image type base64
+    title: InstanceSegmentationInput represents the input of instance segmentation task
+  v1alphaInstanceSegmentationObject:
+    type: object
+    properties:
+      rle:
+        type: string
+        title: Instance RLE segmentation mask
+        readOnly: true
+      category:
+        type: string
+        title: Instance category
+        readOnly: true
+      score:
+        type: number
+        format: float
+        title: Instance score
+        readOnly: true
+      bounding_box:
+        $ref: '#/definitions/v1alphaBoundingBox'
+        title: Instance bounding box
+        readOnly: true
+    title: InstanceSegmentationObject corresponding to a instance segmentation object
+  v1alphaInstanceSegmentationOutput:
+    type: object
+    properties:
+      objects:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaInstanceSegmentationObject'
+        title: A list of instance segmentation objects
+        readOnly: true
+    title: |-
+      InstanceSegmentationOutput represents the output of instance segmentation
+      task
+  v1alphaKeypoint:
+    type: object
+    properties:
+      x:
+        type: number
+        format: float
+        title: x coordinate
+        readOnly: true
+      "y":
+        type: number
+        format: float
+        title: y coordinate
+        readOnly: true
+      v:
+        type: number
+        format: float
+        title: visibility
+        readOnly: true
+    title: Keypoint structure which include coordinate and keypoint visibility
+  v1alphaKeypointInput:
+    type: object
+    properties:
+      image_url:
+        type: string
+        title: Image type URL
+      image_base64:
+        type: string
+        title: Image type base64
+    title: KeypointInput represents the input of keypoint detection task
+  v1alphaKeypointObject:
+    type: object
+    properties:
+      keypoints:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaKeypoint'
+        title: Keypoints
+        readOnly: true
+      score:
+        type: number
+        format: float
+        title: Keypoint score
+        readOnly: true
+      bounding_box:
+        $ref: '#/definitions/v1alphaBoundingBox'
+        title: Bounding box object
+        readOnly: true
+    title: KeypointObject corresponding to a person object
+  v1alphaKeypointOutput:
+    type: object
+    properties:
+      objects:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaKeypointObject'
+        title: A list of keypoint objects
+        readOnly: true
+    title: KeypointOutput represents the output of keypoint detection task
+  v1alphaListDestinationConnectorDefinitionResponse:
+    type: object
+    properties:
+      destination_connector_definitions:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaDestinationConnectorDefinition'
+        title: A list of DestinationConnectorDefinition resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of DestinationConnectorDefinition resources
+    title: |-
+      ListDestinationConnectorDefinitionResponse represents a response for a list
+      of DestinationConnectorDefinitions
+  v1alphaListDestinationConnectorResponse:
+    type: object
+    properties:
+      destination_connectors:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaDestinationConnector'
+        title: A list of DestinationConnector resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of connector resources
+    title: |-
+      ListDestinationConnectorResponse represents a response for a list of
+      DestinationConnector resources
+  v1alphaListModelDefinitionResponse:
+    type: object
+    properties:
+      model_definitions:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaModelDefinition'
+        title: a list of ModelDefinition instances
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of model definitions
+    title: |-
+      ListModelDefinitionResponse represents a response to list all supported model
+      definitions
+  v1alphaListModelInstanceResponse:
+    type: object
+    properties:
+      instances:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaModelInstance'
+        title: a list of Model instances
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of model instances
+    title: ListModelInstanceResponse represents a response for a list of model instances
+  v1alphaListModelOperationResponse:
+    type: object
+    properties:
+      operations:
+        type: array
+        items:
+          $ref: '#/definitions/googlelongrunningOperation'
+        title: a list of model operations
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of operations
+    title: |-
+      ListModelOperationResponse represents a response for a list of model
+      operations including deploy and undeploy
+  v1alphaListModelResponse:
+    type: object
+    properties:
+      models:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaModel'
+        title: a list of Models
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of models
+    title: ListModelResponse represents a response for a list of models
+  v1alphaListPipelineResponse:
+    type: object
+    properties:
+      pipelines:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaPipeline'
+        title: A list of pipeline resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of pipeline resources
+    title: ListPipelineResponse represents a response for a list of pipelines
+  v1alphaListPlanResponse:
+    type: object
+    properties:
+      plans:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaPlan'
+        title: A list of plans
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of plans
+    title: ListPlanResponse represents a response for a list of plans
+  v1alphaListSourceConnectorDefinitionResponse:
+    type: object
+    properties:
+      source_connector_definitions:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaSourceConnectorDefinition'
+        title: A list of SourceConnectorDefinition resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of SourceConnectorDefinition resources
+    title: |-
+      ListSourceConnectorDefinitionResponse represents a response for a list of
+      SourceConnectorDefinitions
+  v1alphaListSourceConnectorResponse:
+    type: object
+    properties:
+      source_connectors:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaSourceConnector'
+        title: A list of SourceConnector resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of connector resources
+    title: |-
+      ListSourceConnectorResponse represents a response for a list of
+      SourceConnector resources
+  v1alphaListUserResponse:
+    type: object
+    properties:
+      users:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaUser'
+        title: A list of users
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of users
+    title: ListUserResponse represents a response for a list of users
+  v1alphaLookUpDestinationConnectorResponse:
+    type: object
+    properties:
+      destination_connector:
+        $ref: '#/definitions/v1alphaDestinationConnector'
+        title: DestinationConnector resource
+    title: |-
+      LookUpDestinationConnectorResponse represents a response for a destination
+      connector
+  v1alphaLookUpModelInstanceResponse:
+    type: object
+    properties:
+      instance:
+        $ref: '#/definitions/v1alphaModelInstance'
+        title: A model instance
+    title: LookUpModelInstanceResponse represents a response for a model instance
+  v1alphaLookUpModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: A model resource
+    title: LookUpModelResponse represents a response for a model instance
+  v1alphaLookUpPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: LookUpPipelineResponse represents a response for a pipeline resource
+  v1alphaLookUpPlanResponse:
+    type: object
+    properties:
+      plan:
+        $ref: '#/definitions/v1alphaPlan'
+        title: A plan resource
+    title: LookUpPlanResponse represents a response for a plan resource
+  v1alphaLookUpSourceConnectorResponse:
+    type: object
+    properties:
+      source_connector:
+        $ref: '#/definitions/v1alphaSourceConnector'
+        title: SourceConnector resource
+    title: LookUpSourceConnectorResponse represents a response for a source connector
+  v1alphaLookUpUserResponse:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/v1alphaUser'
+        title: A user resource
+    title: LookUpUserResponse represents a response for a user resource
+  v1alphaMgmtUsageData:
+    type: object
+    properties:
+      usages:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaUser'
+        title: Repeated user usage data
+    title: Management service usage data
+  v1alphaModel:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          Resource name. It must have the format of "models/{model}".
+          For example: "models/yolov4"
+        readOnly: true
+      uid:
+        type: string
+        title: Model ID in UUIDv4
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          Resource ID (the last segment of the resource name) used to construct the
+          resource name. This conforms to RFC-1034, which restricts to letters,
+          numbers, and hyphen, with the first character a letter, the last a letter
+          or a number, and a 63 character maximum.
+      description:
+        type: string
+        title: Model description
+      model_definition:
+        type: string
+        title: Model definition resource name
+      configuration:
+        type: object
+        title: |-
+          Model configuration represents the configuration JSON that has been
+          validated using the `model_spec` JSON schema of a ModelDefinition
+      visibility:
+        $ref: '#/definitions/v1alphaModelVisibility'
+        title: Model visibility including public or private
+        readOnly: true
+      user:
+        type: string
+        description: The resource name of a user, e.g., "users/local-user".
+        readOnly: true
+      org:
+        type: string
+        title: The resource name of an organization
+        readOnly: true
+      create_time:
+        type: string
+        format: date-time
+        title: Model create time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: Model update time
+        readOnly: true
+    title: Model represents a model
+  v1alphaModelDefinition:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          ModelDefinition resource name. It must have the format of
+          "model-definitions/{model-definition}"
+        readOnly: true
+      uid:
+        type: string
+        title: ModelDefinition ID in UUIDv4
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          ModelDefinition resource ID (the last segment of the resource name) used to
+          construct the resource name.
+        readOnly: true
+      title:
+        type: string
+        title: ModelDefinition display official title
+        readOnly: true
+      documentation_url:
+        type: string
+        title: ModelDefinition documentation url
+        readOnly: true
+      icon:
+        type: string
+        title: ModelDefinition icon
+        readOnly: true
+      release_stage:
+        $ref: '#/definitions/vdpmodelv1alphaReleaseStage'
+        title: ModelDefinition release stage
+        readOnly: true
+      model_spec:
+        type: object
+        description: |-
+          ModelDefinition model specification represents the JSON schema used to
+          validate the JSON configurations of a model created from a specific model
+          source. Must be a valid JSON that includes what fields are needed to
+          create/display a model.
+        readOnly: true
+      model_instance_spec:
+        type: object
+        description: |-
+          ModelDefinition model instance specification represents the JSON schema
+          used to validate the JSON configurations of a model instance from a
+          specific model source. Must be a valid JSON that includes what fields are
+          needed to display a model instance.
+      create_time:
+        type: string
+        format: date-time
+        title: ModelDefinition create time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: ModelDefinition update time
+        readOnly: true
+    title: |-
+      /////////////////////////////////////////////////////////////////
+      ModelDefinition represents the definition of a model
+    required:
+      - model_instance_spec
+  v1alphaModelInstance:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          Resource name. It must have the format of
+          "models/{model}/instances/{instance}"
+        readOnly: true
+      uid:
+        type: string
+        title: Model instance ID in UUIDv4
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          Model instance ID (the last segment of the resource name), used to
+          construct the resource name. This conforms to RFC-1034, which restricts to
+          letters, numbers, and hyphen, with the first character a letter, the last a
+          letter or a number, and a 63 character maximum.
+        readOnly: true
+      state:
+        $ref: '#/definitions/v1alphaModelInstanceState'
+        title: Model instance state
+        readOnly: true
+      task:
+        $ref: '#/definitions/ModelInstanceTask'
+        title: Model instance task
+        readOnly: true
+      model_definition:
+        type: string
+        title: Model definition resource name
+        readOnly: true
+      configuration:
+        type: object
+        title: |-
+          Model instance configuration represents the configuration JSON that
+          has been validated using the `model_instance_spec` JSON schema of a
+          ModelDefinition
+        readOnly: true
+      create_time:
+        type: string
+        format: date-time
+        title: Model instance create time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: Model instance update time
+        readOnly: true
+    title: ModelVersion represents one deployable instance of a model
+  v1alphaModelInstanceCard:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          Resource name. It must have the format of
+          "models/{model}/instances/{instance}/readme"
+        readOnly: true
+      size:
+        type: integer
+        format: int32
+        title: Size of the file
+        readOnly: true
+      type:
+        type: string
+        description: Type of the resource. Fixed to "file".
+        readOnly: true
+      content:
+        type: string
+        format: byte
+        title: Content of the README file in bytes and base64 format
+        readOnly: true
+      encoding:
+        type: string
+        description: Encoding type of the content. Fixed to "base64".
+        readOnly: true
+    description: |-
+      ModelInstanceCard represents the README card for a model instance. There
+      exists one and exactly one README card per model instance.
+  v1alphaModelInstanceOutput:
+    type: object
+    properties:
+      model_instance:
+        type: string
+        title: The model instance
+        readOnly: true
+      task:
+        $ref: '#/definitions/ModelInstanceTask'
+        title: The task type
+        readOnly: true
+      task_outputs:
+        type: array
+        items:
+          $ref: '#/definitions/vdppipelinev1alphaTaskOutput'
+        title: |-
+          The extended task outputs based on the model instance inference (i.e.,
+          from a trigger endpoint of model-backend)
+        readOnly: true
+    title: ModelInstanceOutput represents one model instance inference result
+  v1alphaModelInstanceState:
+    type: string
+    enum:
+      - STATE_UNSPECIFIED
+      - STATE_OFFLINE
+      - STATE_ONLINE
+      - STATE_ERROR
+    default: STATE_UNSPECIFIED
+    description: |-
+      - STATE_UNSPECIFIED: State: UNSPECIFIED
+       - STATE_OFFLINE: State: OFFLINE
+       - STATE_ONLINE: State: ONLINE
+       - STATE_ERROR: State: ERROR
+    title: State enumerates a model instance state
+  v1alphaModelUsageData:
+    type: object
+    properties:
+      usages:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaModelUsageDataUserUsageData'
+        title: Usage data of all users in the model service
+    title: Model service usage data
+  v1alphaModelUsageDataUserUsageData:
+    type: object
+    properties:
+      user_uid:
+        type: string
+        title: User UUID
+      model_online_state_num:
+        type: string
+        format: int64
+        title: Number of models that have at least one 'online' instance
+      model_offline_state_num:
+        type: string
+        format: int64
+        title: Number of models that have no 'online' instances
+      instance_online_state_num:
+        type: string
+        format: int64
+        title: Number of model instances with 'online' state
+      instance_offline_state_num:
+        type: string
+        format: int64
+        title: Number of model instances with 'offline' state
+      model_definition_ids:
+        type: array
+        items:
+          type: string
+        description: |-
+          Definition IDs of the model instances. Element in the list
+          should not be duplicated.
+      tasks:
+        type: array
+        items:
+          $ref: '#/definitions/ModelInstanceTask'
+        description: |-
+          Tasks of the model instances. Element in the list should not be
+          duplicated.
+      test_num:
+        type: string
+        format: int64
+        title: Number of model instance testing operations
+    title: Per user usage data in the model service
+    required:
+      - user_uid
+      - model_online_state_num
+      - model_offline_state_num
+      - instance_online_state_num
+      - instance_offline_state_num
+      - model_definition_ids
+      - tasks
+      - test_num
+  v1alphaModelVisibility:
+    type: string
+    enum:
+      - VISIBILITY_UNSPECIFIED
+      - VISIBILITY_PRIVATE
+      - VISIBILITY_PUBLIC
+    default: VISIBILITY_UNSPECIFIED
+    description: |-
+      - VISIBILITY_UNSPECIFIED: Visibility: UNSPECIFIED, equivalent to PRIVATE.
+       - VISIBILITY_PRIVATE: Visibility: PRIVATE
+       - VISIBILITY_PUBLIC: Visibility: PUBLIC
+    title: Model visibility including public or private
+  v1alphaOauthConfigSpecification:
+    type: object
+    properties:
+      oauth_user_input_from_connector_config_specification:
+        type: object
+        description: |-
+          OAuth specific blob. This is a Json Schema used to validate Json
+          configurations used as input to OAuth. Must be a valid non-nested JSON that
+          refers to properties from ConnectorSpecification.connectionSpecification
+          using special annotation 'path_in_connector_config'.
+          These are input values the user is entering through the UI to authenticate
+          to the connector, that might also shared as inputs for syncing data via the
+          connector.
+
+          Examples:
+
+          if no connector values is shared during oauth flow,
+          oauth_user_input_from_connector_config_specification=[] if connector values
+          such as 'app_id' inside the top level are used to generate the API url for
+          the oauth flow,
+            oauth_user_input_from_connector_config_specification={
+              app_id: {
+                type: string
+                path_in_connector_config: ['app_id']
+              }
+            }
+          if connector values such as 'info.app_id' nested inside another object are
+          used to generate the API url for the oauth flow,
+           oauth_user_input_from_connector_config_specification={
+             app_id: {
+               type: string
+               path_in_connector_config: ['info', 'app_id']
+             }
+           }
+        readOnly: true
+      complete_oauth_output_specification:
+        type: object
+        description: |-
+          Examples:
+
+              complete_oauth_output_specification={
+                refresh_token: {
+                  type: string,
+                  path_in_connector_config: ['credentials', 'refresh_token']
+                }
+              }
+        title: |-
+          OAuth specific blob. This is a Json Schema used to validate Json
+          configurations produced by the OAuth flows as they are returned by the
+          distant OAuth APIs. Must be a valid JSON describing the fields to merge
+          back to `ConnectorSpecification.connectionSpecification`. For each field, a
+          special annotation `path_in_connector_config` can be specified to determine
+          where to merge it,
+        readOnly: true
+      complete_oauth_server_input_specification:
+        type: object
+        description: |-
+          OAuth specific blob. This is a Json Schema used to validate Json
+          configurations persisted as Airbyte Server configurations. Must be a valid
+          non-nested JSON describing additional fields configured by the Airbyte
+          Instance or Workspace Admins to be used by the server when completing an
+          OAuth flow (typically exchanging an auth code for refresh token).
+
+          Examples:
+
+              complete_oauth_server_input_specification={
+                client_id: {
+                  type: string
+                },
+                client_secret: {
+                  type: string
+                }
+              }
+        readOnly: true
+      complete_oauth_server_output_specification:
+        type: object
+        description: |-
+          Examples:
+
+                complete_oauth_server_output_specification={
+                  client_id: {
+                    type: string,
+                    path_in_connector_config: ['credentials', 'client_id']
+                  },
+                  client_secret: {
+                    type: string,
+                    path_in_connector_config: ['credentials', 'client_secret']
+                  }
+                }
+        title: |-
+          OAuth specific blob. This is a Json Schema used to validate Json
+          configurations persisted as Airbyte Server configurations that also need to
+          be merged back into the connector configuration at runtime. This is a
+          subset configuration of `complete_oauth_server_input_specification` that
+          filters fields out to retain only the ones that are necessary for the
+          connector to function with OAuth. (some fields could be used during oauth
+          flows but not needed afterwards, therefore they would be listed in the
+          `complete_oauth_server_input_specification` but not
+          `complete_oauth_server_output_specification`) Must be a valid non-nested
+          JSON describing additional fields configured by the Airbyte Instance or
+          Workspace Admins to be used by the connector when using OAuth flow APIs.
+          These fields are to be merged back to
+          `ConnectorSpecification.connectionSpecification`. For each field, a special
+          annotation `path_in_connector_config` can be specified to determine where
+          to merge it,
+        readOnly: true
+    title: OauthConfigSpecification represents oauth config specification
+  v1alphaOcrInput:
+    type: object
+    properties:
+      image_url:
+        type: string
+        title: Image type URL
+      image_base64:
+        type: string
+        title: Image type base64
+    title: OcrInput represents the input of ocr task
+  v1alphaOcrObject:
+    type: object
+    properties:
+      text:
+        type: string
+        title: OCR text
+        readOnly: true
+      score:
+        type: number
+        format: float
+        title: OCR text score
+        readOnly: true
+      bounding_box:
+        $ref: '#/definitions/v1alphaBoundingBox'
+        title: OCR bounding box
+        readOnly: true
+    title: OcrObject represents a predicted ocr object
+  v1alphaOcrOutput:
+    type: object
+    properties:
+      objects:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaOcrObject'
+        title: A list of OCR objects
+        readOnly: true
+    title: OcrOutput represents the output of ocr task
+  v1alphaOwnerType:
+    type: string
+    enum:
+      - OWNER_TYPE_UNSPECIFIED
+      - OWNER_TYPE_USER
+      - OWNER_TYPE_ORGANIZATION
+    default: OWNER_TYPE_UNSPECIFIED
+    description: |-
+      - OWNER_TYPE_UNSPECIFIED: OwnerType: UNSPECIFIED
+       - OWNER_TYPE_USER: OwnerType: USER
+       - OWNER_TYPE_ORGANIZATION: OwnerType: ORGANIZATION
+    title: OwnerType enumerates the owner type of any resource
+  v1alphaPipeline:
+    type: object
+    properties:
+      name:
+        type: string
+        title: Pipeline resource name. It must have the format of "pipelines/*"
+        readOnly: true
+      uid:
+        type: string
+        title: Pipeline UUID
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          Pipeline resource ID (the last segment of the resource name) used to
+          construct the resource name. This conforms to RFC-1034, which restricts to
+          letters, numbers, and hyphen, with the first character a letter, the last a
+          letter or a number, and a 63 character maximum.
+      description:
+        type: string
+        title: Pipeline description
+      recipe:
+        $ref: '#/definitions/v1alphaRecipe'
+        title: Pipeline recipe
+      mode:
+        $ref: '#/definitions/PipelineMode'
+        title: Pipeline mode
+        readOnly: true
+      state:
+        $ref: '#/definitions/v1alphaPipelineState'
+        title: Pipeline state
+        readOnly: true
+      user:
+        type: string
+        description: The resource name of a user, e.g., "users/local-user".
+        readOnly: true
+      org:
+        type: string
+        title: The resource name of an organization
+        readOnly: true
+      create_time:
+        type: string
+        format: date-time
+        title: Pipeline creation time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: Pipeline update time
+        readOnly: true
+    title: Pipeline represents the content of a pipeline
+  v1alphaPipelineState:
+    type: string
+    enum:
+      - STATE_UNSPECIFIED
+      - STATE_INACTIVE
+      - STATE_ACTIVE
+      - STATE_ERROR
+    default: STATE_UNSPECIFIED
+    description: |-
+      - STATE_UNSPECIFIED: State: UNSPECIFIED
+       - STATE_INACTIVE: State INACTIVE indicates the pipeline is inactive
+       - STATE_ACTIVE: State ACTIVE indicates the pipeline is active
+       - STATE_ERROR: State ERROR indicates the pipeline has error
+    title: State enumerates the state of a pipeline
+  v1alphaPipelineUsageData:
+    type: object
+    properties:
+      usages:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaPipelineUsageDataUserUsageData'
+        title: Usage data of all users in the pipeline service
+    title: Pipeline service usage data
+  v1alphaPipelineUsageDataUserUsageData:
+    type: object
+    properties:
+      user_uid:
+        type: string
+        title: User UUID
+      pipeline_active_state_num:
+        type: string
+        format: int64
+        title: Number of pipelines with 'active' state
+      pipeline_inactive_state_num:
+        type: string
+        format: int64
+        title: Number of pipelines with 'inactive' state
+      pipeline_async_mode_num:
+        type: string
+        format: int64
+        title: Number of pipelines with 'async' mode
+      pipeline_sync_mode_num:
+        type: string
+        format: int64
+        title: Number of pipelines with 'sync' mode
+      trigger_num:
+        type: string
+        format: int64
+        title: Number of pipeline triggering operations
+    title: Per user usage data in the pipeline service
+    required:
+      - user_uid
+      - pipeline_active_state_num
+      - pipeline_inactive_state_num
+      - pipeline_async_mode_num
+      - pipeline_sync_mode_num
+      - trigger_num
+  v1alphaPlan:
+    type: object
+    properties:
+      name:
+        type: string
+        description: |-
+          Resource name. It must have the format of "plans/*".
+          For example: "plans/free".
+        readOnly: true
+      uid:
+        type: string
+        title: Plan UUID
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          Plan resource ID (the last segment of the resource name) used to
+          construct the resource name. This conforms to RFC-1034, which restricts to
+          letters, numbers, and hyphen, with the first character a letter, the last a
+          letter or a number, and a 63 character maximum.
+      create_time:
+        type: string
+        format: date-time
+        title: Plan creation time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: Plan update time
+        readOnly: true
+      tier:
+        $ref: '#/definitions/PlanTier'
+        title: Plan tier
+      visibility:
+        $ref: '#/definitions/v1alphaPlanVisibility'
+        title: Plan visibility
+      spec:
+        type: object
+        title: Plan specification in JSON format
+    title: Plan represents the content of a billing plan
+    required:
+      - tier
+      - visibility
+      - spec
+  v1alphaPlanVisibility:
+    type: string
+    enum:
+      - VISIBILITY_UNSPECIFIED
+      - VISIBILITY_PRIVATE
+      - VISIBILITY_PUBLIC
+    default: VISIBILITY_UNSPECIFIED
+    description: |-
+      - VISIBILITY_UNSPECIFIED: Visibility: UNSPECIFIED, equivalent to PRIVATE.
+       - VISIBILITY_PRIVATE: Visibility: PRIVATE
+       - VISIBILITY_PUBLIC: Visibility: PUBLIC
+    title: Plan visibility including public or private
+  v1alphaPublishModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: Published model
+    title: PublishModelResponse represents a response for the published model
+  v1alphaReadSourceConnectorResponse:
+    type: object
+    properties:
+      data:
+        type: string
+        format: byte
+        title: Read data in bytes
+    title: |-
+      ReadSourceConnectorResponse represents the read data from a SourceConnector
+      resource
+  v1alphaRecipe:
+    type: object
+    properties:
+      source:
+        type: string
+        title: A source connector resource
+      destination:
+        type: string
+        title: A destination connector resource
+      model_instances:
+        type: array
+        items:
+          type: string
+        title: A list of model instance resources
+    title: Pipeline represents a pipeline recipe
+  v1alphaRenameDestinationConnectorResponse:
+    type: object
+    properties:
+      destination_connector:
+        $ref: '#/definitions/v1alphaDestinationConnector'
+        title: A DestinationConnector resource
+    title: |-
+      RenameDestinationConnectorResponse represents a renamed DestinationConnector
+      resource
+  v1alphaRenameModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: Renamed model
+    title: RenameModelResponse represents a response for a model
+  v1alphaRenamePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: RenamePipelineResponse represents a renamed pipeline resource
+  v1alphaRenameSourceConnectorResponse:
+    type: object
+    properties:
+      source_connector:
+        $ref: '#/definitions/v1alphaSourceConnector'
+        title: A SourceConnector resource
+    title: RenameSourceConnectorResponse represents a renamed SourceConnector resource
+  v1alphaSemanticSegmentationInput:
+    type: object
+    properties:
+      image_url:
+        type: string
+        title: Image type URL
+      image_base64:
+        type: string
+        title: Image type base64
+    title: SemanticSegmentationInput represents the input of semantic segmentation task
+  v1alphaSemanticSegmentationOutput:
+    type: object
+    properties:
+      stuffs:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaSemanticSegmentationStuff'
+        title: A list of semantic segmentation stuffs
+        readOnly: true
+    title: |-
+      SemanticSegmentationOutput represents the output of semantic segmentation
+      task
+  v1alphaSemanticSegmentationStuff:
+    type: object
+    properties:
+      rle:
+        type: string
+        title: RLE segmentation mask
+        readOnly: true
+      category:
+        type: string
+        title: Stuff category
+        readOnly: true
+    title: SemanticSegmentationStuff corresponding to a semantic segmentation stuff
+  v1alphaSendSessionReportResponse:
+    type: object
+    title: SendReportResponse represents an empty response
+  v1alphaSession:
+    type: object
+    properties:
+      name:
+        type: string
+        title: Resource name in the format of 'sessions/uid'
+        readOnly: true
+      uid:
+        type: string
+        title: Resource UUID
+        readOnly: true
+      service:
+        $ref: '#/definitions/SessionService'
+        title: name of the service to collect data from
+      edition:
+        type: string
+        title: 'Session edition, allowed values include: ''local-ce'' and ''local-ce:dev'''
+      version:
+        type: string
+        title: Version of the service
+      arch:
+        type: string
+        title: Architecture of the system
+      os:
+        type: string
+        title: Operating system
+      uptime:
+        type: string
+        format: int64
+        title: Session service uptime
+      report_time:
+        type: string
+        format: date-time
+        title: Report time
+      token:
+        type: string
+        description: |-
+          Token to send report. The token is generated by the server and sent to
+          the client. Client needs to use the token to send report to the server.
+        readOnly: true
+      create_time:
+        type: string
+        format: date-time
+        title: Session creation time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: Session update time
+        readOnly: true
+    title: |-
+      Session represents a unique session whenever a new instance of VDP service
+      gets started. The usage server returns a token that should be used as part of
+      the challenge when sending a report with data collected from this session
+    required:
+      - service
+      - edition
+      - version
+      - arch
+      - os
+      - uptime
+      - report_time
+  v1alphaSessionReport:
+    type: object
+    properties:
+      session_uid:
+        type: string
+        title: Session uid
+      token:
+        type: string
+        title: Session token
+      pow:
+        type: string
+        title: Proof-of-work See https://en.wikipedia.org/wiki/Proof_of_work
+      session:
+        $ref: '#/definitions/v1alphaSession'
+        title: Session
+      mgmt_usage_data:
+        $ref: '#/definitions/v1alphaMgmtUsageData'
+        title: Management service usage data
+      connector_usage_data:
+        $ref: '#/definitions/v1alphaConnectorUsageData'
+        title: Connector service usage data
+      model_usage_data:
+        $ref: '#/definitions/v1alphaModelUsageData'
+        title: Model service usage data
+      pipeline_usage_data:
+        $ref: '#/definitions/v1alphaPipelineUsageData'
+        title: Pipeline service usage data
+    title: |-
+      SessionReport represents a report to be sent to the server that includes the
+      usage data of a session
+    required:
+      - session_uid
+      - token
+      - pow
+      - session
+  v1alphaSourceConnector:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          SourceConnector resource name. It must have the format of
+          "source-connectors/*"
+        readOnly: true
+      uid:
+        type: string
+        title: SourceConnector UUID
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          SourceConnector resource ID (the last segment of the resource name) used to
+          construct the resource name. This conforms to RFC-1034, which restricts to
+          letters, numbers, and hyphen, with the first character a letter, the last a
+          letter or a number, and a 63 character maximum.
+      source_connector_definition:
+        type: string
+        title: SourceConnectorDefinition resource
+      connector:
+        $ref: '#/definitions/v1alphaConnector'
+        title: SourceConnector's connector data structure
+    title: SourceConnector represents a source connector resource
+    required:
+      - connector
+  v1alphaSourceConnectorDefinition:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          SourceConnectorDefinition resource name. It must have the format of
+          "connector-definitions/*"
+        readOnly: true
+      uid:
+        type: string
+        title: SourceConnectorDefinition UUID
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          SourceConnectorDefinition resource ID (the last segment of the resource
+          name) used to construct the resource name. This conforms to RFC-1034, which
+          restricts to letters, numbers, and hyphen, with the first character a
+          letter, the last a letter or a number, and a 63 character maximum.
+      connector_definition:
+        $ref: '#/definitions/v1alphaConnectorDefinition'
+        title: SourceConnectorDefinition connector definition
+        readOnly: true
+    title: SourceConnectorDefinition represents the source connector definition resource
+  v1alphaSpec:
+    type: object
+    properties:
+      documentation_url:
+        type: string
+        title: Spec documentation URL
+        readOnly: true
+      connection_specification:
+        type: object
+        title: Spec connection specification
+      supports_incremental:
+        type: boolean
+        title: |-
+          Spec supports incremental flag, i.e., if the connector supports incremental
+          mode or not
+        readOnly: true
+      supports_normalization:
+        type: boolean
+        title: |-
+          Spec supports normalization flag, i.e., if the connector supports
+          normalization or not
+        readOnly: true
+      supports_dbt:
+        type: boolean
+        title: Spec supports dbt flag, i.e., if the connector supports DBT or not
+        readOnly: true
+      supported_destination_sync_modes:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaSupportedDestinationSyncModes'
+        title: |-
+          Spec destination sync mode, i.e., a list of destination sync modes
+          supported by the connector
+        readOnly: true
+      advanced_auth:
+        $ref: '#/definitions/v1alphaAdvancedAuth'
+        title: |-
+          Spec advanced auth, i.e., additional and optional specification object to
+          describe what an 'advanced' Auth flow would need to function
+        readOnly: true
+    title: |-
+      //////////////////////////////////
+      Spec represents a spec data model
+    required:
+      - connection_specification
+  v1alphaSupportedDestinationSyncModes:
+    type: string
+    enum:
+      - SUPPORTED_DESTINATION_SYNC_MODES_UNSPECIFIED
+      - SUPPORTED_DESTINATION_SYNC_MODES_APPEND
+      - SUPPORTED_DESTINATION_SYNC_MODES_OVERWRITE
+      - SUPPORTED_DESTINATION_SYNC_MODES_APPEND_DEDUP
+    default: SUPPORTED_DESTINATION_SYNC_MODES_UNSPECIFIED
+    description: |-
+      - SUPPORTED_DESTINATION_SYNC_MODES_UNSPECIFIED: SupportedDestinationSyncModes: DESTINATION_SYNC_MODES_UNSPECIFIED
+       - SUPPORTED_DESTINATION_SYNC_MODES_APPEND: SupportedDestinationSyncModes: DESTINATION_SYNC_MODES_APPEND
+       - SUPPORTED_DESTINATION_SYNC_MODES_OVERWRITE: SupportedDestinationSyncModes: DESTINATION_SYNC_MODES_OVERWRITE
+       - SUPPORTED_DESTINATION_SYNC_MODES_APPEND_DEDUP: SupportedDestinationSyncModes: DESTINATION_SYNC_MODES_APPEND_DEDUP
+    title: |-
+      SupportedDestinationSyncModes enumerates destination sync mode (this needs to
+      be in plural form to match with Airbyte protocol)
+  v1alphaSupportedSyncModes:
+    type: string
+    enum:
+      - SUPPORTED_SYNC_MODES_UNSPECIFIED
+      - SUPPORTED_SYNC_MODES_FULL_REFRESH
+      - SUPPORTED_SYNC_MODES_INCREMENTAL
+    default: SUPPORTED_SYNC_MODES_UNSPECIFIED
+    description: |-
+      - SUPPORTED_SYNC_MODES_UNSPECIFIED: SupportedSyncModes: SUPPORTED_SYNC_MODES_UNSPECIFIED
+       - SUPPORTED_SYNC_MODES_FULL_REFRESH: SupportedSyncModes: SUPPORTED_SYNC_MODES_FULL_REFRESH
+       - SUPPORTED_SYNC_MODES_INCREMENTAL: SupportedSyncModes: SUPPORTED_SYNC_MODES_INCREMENTAL
+    title: |-
+      SupportedSyncModes enumerates sync mode (this needs to be in plural form to
+      match with Airbyte protocol)
+  v1alphaTaskInput:
+    type: object
+    properties:
+      classification:
+        $ref: '#/definitions/v1alphaClassificationInput'
+        title: The classification input
+      detection:
+        $ref: '#/definitions/v1alphaDetectionInput'
+        title: The detection input
+      keypoint:
+        $ref: '#/definitions/v1alphaKeypointInput'
+        title: The keypoint input
+      ocr:
+        $ref: '#/definitions/v1alphaOcrInput'
+        title: The ocr input
+      instance_segmentation:
+        $ref: '#/definitions/v1alphaInstanceSegmentationInput'
+        title: The instance segmentation input
+      semantic_segmentation:
+        $ref: '#/definitions/v1alphaSemanticSegmentationInput'
+        title: The semantic segmentation input
+      text_to_image:
+        $ref: '#/definitions/v1alphaTextToImageInput'
+        title: The text to image input
+      unspecified:
+        $ref: '#/definitions/v1alphaUnspecifiedInput'
+        title: The unspecified task input
+    title: Input represents the input to trigger a model instance
+  v1alphaTestModelInstanceBinaryFileUploadResponse:
+    type: object
+    properties:
+      task:
+        $ref: '#/definitions/ModelInstanceTask'
+        title: The task type
+      task_outputs:
+        type: array
+        items:
+          $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+        title: The task output from a model instance
+    title: |-
+      TestModelInstanceBinaryFileUploadResponse represents a response for the
+      output for testing a model instance
+    required:
+      - task
+      - task_outputs
+  v1alphaTestModelInstanceResponse:
+    type: object
+    properties:
+      task:
+        $ref: '#/definitions/ModelInstanceTask'
+        title: The task type
+      task_outputs:
+        type: array
+        items:
+          $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+        title: The task output from a model instance
+    title: |-
+      TestModelInstanceResponse represents a response for the output for
+      testing a model instance
+    required:
+      - task
+      - task_outputs
+  v1alphaTextToImageInput:
+    type: object
+    properties:
+      prompt:
+        type: string
+        title: The prompt text
+        readOnly: true
+      steps:
+        type: string
+        format: int64
+        title: The steps
+        readOnly: true
+      cfg_scale:
+        type: string
+        format: int64
+        title: The guidance scale
+        readOnly: true
+      seed:
+        type: string
+        format: int64
+        title: The seed
+        readOnly: true
+    title: TextToImageInput represents the input of text to image task
+  v1alphaTextToImageOutput:
+    type: object
+    properties:
+      images:
+        type: array
+        items:
+          type: string
+        title: List of generated images
+        readOnly: true
+    title: TextToImageOutput represents the output of text to image task
+  v1alphaTriggerModelInstanceBinaryFileUploadResponse:
+    type: object
+    properties:
+      task:
+        $ref: '#/definitions/ModelInstanceTask'
+        title: The task type
+      task_outputs:
+        type: array
+        items:
+          $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+        title: The task output from a model instance
+    title: |-
+      TriggerModelInstanceBinaryFileUploadResponse represents a response for the
+      output for testing a model instance
+    required:
+      - task
+      - task_outputs
+  v1alphaTriggerModelInstanceResponse:
+    type: object
+    properties:
+      task:
+        $ref: '#/definitions/ModelInstanceTask'
+        title: The task type
+      task_outputs:
+        type: array
+        items:
+          $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+        title: The task output from a model instance
+    title: |-
+      TriggerModelInstanceResponse represents a response for the output for
+      triggering a model instance
+  v1alphaTriggerPipelineBinaryFileUploadResponse:
+    type: object
+    properties:
+      data_mapping_indices:
+        type: array
+        items:
+          type: string
+        title: The data mapping indices stores UUID for each input
+      model_instance_outputs:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaModelInstanceOutput'
+        title: The multiple model instance inference outputs
+    title: |-
+      TriggerPipelineBinaryFileUploadResponse represents a response for the output
+      of a pipeline, i.e., the multiple model instance inference outputs
+  v1alphaTriggerPipelineResponse:
+    type: object
+    properties:
+      data_mapping_indices:
+        type: array
+        items:
+          type: string
+        title: The data mapping indices stores UUID for each input
+      model_instance_outputs:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaModelInstanceOutput'
+        title: The multiple model instance inference outputs
+    title: |-
+      TriggerPipelineResponse represents a response for the output
+      of a pipeline, i.e., the multiple model instance inference outputs
+  v1alphaUndeployModelInstanceResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Undeploy operation message
+    title: |-
+      UndeployModelInstanceResponse represents a response for a undeployed model
+      instance
+  v1alphaUnpublishModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: Unpublished model
+    title: UnpublishModelResponse represents a response for the unpublished model
+  v1alphaUnspecifiedInput:
+    type: object
+    properties:
+      raw_inputs:
+        type: array
+        items:
+          type: object
+        title: A list of unspecified task inputs
+    title: UnspecifiedInput represents the input of unspecified task
+  v1alphaUnspecifiedOutput:
+    type: object
+    properties:
+      raw_outputs:
+        type: array
+        items:
+          type: object
+        title: A list of unspecified task outputs
+        readOnly: true
+    title: UnspecifiedOutput represents the output of unspecified task
+  v1alphaUpdateAuthenticatedUserResponse:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/v1alphaUser'
+        title: A user resource
+    title: |-
+      UpdateAuthenticatedUserResponse represents a response for
+      the authenticated user resource
+  v1alphaUpdateDestinationConnectorResponse:
+    type: object
+    properties:
+      destination_connector:
+        $ref: '#/definitions/v1alphaDestinationConnector'
+        title: DestinationConnector resource
+    title: |-
+      UpdateDestinationConnectorResponse represents a response for a
+      DestinationConnector resource
+  v1alphaUpdateModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: The updated model
+    title: UpdateModelResponse represents a response for a model
+  v1alphaUpdatePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: An updated pipeline resource
+    title: UpdatePipelineResponse represents a response for a pipeline resource
+  v1alphaUpdatePlanResponse:
+    type: object
+    properties:
+      plan:
+        $ref: '#/definitions/v1alphaPlan'
+        title: A plan resource
+    title: UpdatePlanResponse represents a response for a plan resource
+  v1alphaUpdateSourceConnectorResponse:
+    type: object
+    properties:
+      source_connector:
+        $ref: '#/definitions/v1alphaSourceConnector'
+        title: SourceConnector resource
+    title: |-
+      UpdateSourceConnectorResponse represents a response for a
+      SourceConnector resource
+  v1alphaUpdateUserResponse:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/v1alphaUser'
+        title: A user resource
+    title: UpdateUserResponse represents a response for a user resource
+  v1alphaUser:
+    type: object
+    properties:
+      name:
+        type: string
+        description: |-
+          Resource name. It must have the format of "users/*".
+          For example: "users/local-user".
+        readOnly: true
+      uid:
+        type: string
+        title: User ID in UUIDv4
+      id:
+        type: string
+        description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
+      type:
+        $ref: '#/definitions/v1alphaOwnerType'
+        title: 'Owner type: fixed to `OWNER_TYPE_USER`'
+        readOnly: true
+      create_time:
+        type: string
+        format: date-time
+        title: User creation time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: User update time
+        readOnly: true
+      email:
+        type: string
+        title: User email
+      plan:
+        type: string
+        description: User plan. This field is not used in open-source VDP.
+      first_name:
+        type: string
+        title: User first name
+      last_name:
+        type: string
+        title: User last name
+      org_name:
+        type: string
+        title: User company or institution name
+      role:
+        type: string
+        title: |-
+          User role. Allowed roles:
+           - "manager"
+           - "ai-researcher"
+           - "ai-engineer"
+           - "data-engineer",
+           - "data-scientist",
+           - "analytics-engineer"
+           - "hobbyist"
+      newsletter_subscription:
+        type: boolean
+        title: User newsletter subscription
+      cookie_token:
+        type: string
+        title: User console cookie token
+    title: User represents the content of a user
+    required:
+      - uid
+      - id
+      - email
+      - newsletter_subscription
+  v1alphaWriteDestinationConnectorResponse:
+    type: object
+    title: |-
+      WriteDestinationConnectorResponse represents the read data from a
+      DestinationConnector resource
+  vdpbillingv1alphaLivenessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: LivenessResponse represents a response for a service liveness status
+  vdpbillingv1alphaReadinessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: ReadinessResponse represents a response for a service readiness status
+  vdpbillingv1alphaView:
+    type: string
+    enum:
+      - VIEW_UNSPECIFIED
+      - VIEW_BASIC
+      - VIEW_FULL
+    default: VIEW_UNSPECIFIED
+    description: |-
+      View represents a view of any resource. The resource view is implemented by
+      adding a parameter to the method request which allows the client to specify
+      which view of the resource it wants to receive in the response.
+
+       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+       - VIEW_BASIC: View: BASIC
+       - VIEW_FULL: View: FULL
+  vdpconnectorv1alphaLivenessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: LivenessResponse represents a response for a service liveness status
+  vdpconnectorv1alphaReadinessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: ReadinessResponse represents a response for a service readiness status
+  vdpconnectorv1alphaReleaseStage:
+    type: string
+    enum:
+      - RELEASE_STAGE_UNSPECIFIED
+      - RELEASE_STAGE_ALPHA
+      - RELEASE_STAGE_BETA
+      - RELEASE_STAGE_GENERALLY_AVAILABLE
+      - RELEASE_STAGE_CUSTOM
+    default: RELEASE_STAGE_UNSPECIFIED
+    description: |-
+      - RELEASE_STAGE_UNSPECIFIED: ReleaseStage: UNSPECIFIED
+       - RELEASE_STAGE_ALPHA: ReleaseStage: ALPHA
+       - RELEASE_STAGE_BETA: ReleaseStage: BETA
+       - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
+       - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
+    title: ReleaseStage enumerates the release stages
+  vdpconnectorv1alphaView:
+    type: string
+    enum:
+      - VIEW_UNSPECIFIED
+      - VIEW_BASIC
+      - VIEW_FULL
+    default: VIEW_UNSPECIFIED
+    description: |-
+      - VIEW_UNSPECIFIED: View: UNSPECIFIED
+       - VIEW_BASIC: View: BASIC
+       - VIEW_FULL: View: FULL
+    title: View enumerates the definition views
+  vdpmgmtv1alphaLivenessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: LivenessResponse represents a response for a service liveness status
+  vdpmgmtv1alphaReadinessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: ReadinessResponse represents a response for a service readiness status
+  vdpmgmtv1alphaView:
+    type: string
+    enum:
+      - VIEW_UNSPECIFIED
+      - VIEW_BASIC
+      - VIEW_FULL
+    default: VIEW_UNSPECIFIED
+    description: |-
+      View represents a view of any resource. The resource view is implemented by
+      adding a parameter to the method request which allows the client to specify
+      which view of the resource it wants to receive in the response.
+
+       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+       - VIEW_BASIC: View: BASIC
+       - VIEW_FULL: View: FULL
+  vdpmodelv1alphaLivenessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: LivenessResponse represents a response for a service liveness status
+  vdpmodelv1alphaReadinessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: ReadinessResponse represents a response for a service readiness status
+  vdpmodelv1alphaReleaseStage:
+    type: string
+    enum:
+      - RELEASE_STAGE_UNSPECIFIED
+      - RELEASE_STAGE_ALPHA
+      - RELEASE_STAGE_BETA
+      - RELEASE_STAGE_GENERALLY_AVAILABLE
+      - RELEASE_STAGE_CUSTOM
+    default: RELEASE_STAGE_UNSPECIFIED
+    description: |-
+      - RELEASE_STAGE_UNSPECIFIED: ReleaseStage: UNSPECIFIED
+       - RELEASE_STAGE_ALPHA: ReleaseStage: ALPHA
+       - RELEASE_STAGE_BETA: ReleaseStage: BETA
+       - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
+       - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
+    title: ReleaseStage enumerates the release stages
+  vdpmodelv1alphaTaskOutput:
+    type: object
+    properties:
+      classification:
+        $ref: '#/definitions/v1alphaClassificationOutput'
+        title: The classification output
+        readOnly: true
+      detection:
+        $ref: '#/definitions/v1alphaDetectionOutput'
+        title: The detection output
+        readOnly: true
+      keypoint:
+        $ref: '#/definitions/v1alphaKeypointOutput'
+        title: The keypoint output
+        readOnly: true
+      ocr:
+        $ref: '#/definitions/v1alphaOcrOutput'
+        title: The ocr output
+        readOnly: true
+      instance_segmentation:
+        $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
+        title: The instance segmentation output
+        readOnly: true
+      semantic_segmentation:
+        $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
+        title: The semantic segmentation output
+        readOnly: true
+      text_to_image:
+        $ref: '#/definitions/v1alphaTextToImageOutput'
+        title: The text to image output
+        readOnly: true
+      unspecified:
+        $ref: '#/definitions/v1alphaUnspecifiedOutput'
+        title: The unspecified task output
+        readOnly: true
+    title: TaskOutput represents the output of a CV Task result from a model instance
+  vdpmodelv1alphaView:
+    type: string
+    enum:
+      - VIEW_UNSPECIFIED
+      - VIEW_BASIC
+      - VIEW_FULL
+    default: VIEW_UNSPECIFIED
+    description: |-
+      View represents a view of any resource. The resource view is implemented by
+      adding a parameter to the method request which allows the client to specify
+      which view of the resource it wants to receive in the response.
+
+       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+       - VIEW_FULL: View: FULL, full representation of the resource
+  vdppipelinev1alphaLivenessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: LivenessResponse represents a response for a service liveness status
+  vdppipelinev1alphaReadinessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: ReadinessResponse represents a response for a service readiness status
+  vdppipelinev1alphaTaskOutput:
+    type: object
+    properties:
+      index:
+        type: string
+        title: The index of input data in a batch
+        readOnly: true
+      classification:
+        $ref: '#/definitions/v1alphaClassificationOutput'
+        title: The classification output
+        readOnly: true
+      detection:
+        $ref: '#/definitions/v1alphaDetectionOutput'
+        title: The detection output
+        readOnly: true
+      keypoint:
+        $ref: '#/definitions/v1alphaKeypointOutput'
+        title: The keypoint output
+        readOnly: true
+      ocr:
+        $ref: '#/definitions/v1alphaOcrOutput'
+        title: The ocr output
+        readOnly: true
+      instance_segmentation:
+        $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
+        title: The instance segmentation output
+        readOnly: true
+      semantic_segmentation:
+        $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
+        title: The semantic segmentation output
+        readOnly: true
+      text_to_image:
+        $ref: '#/definitions/v1alphaTextToImageOutput'
+        title: The text to image output
+        readOnly: true
+      unspecified:
+        $ref: '#/definitions/v1alphaUnspecifiedOutput'
+        title: The unspecified task output
+        readOnly: true
+    description: |-
+      TaskOutput represents the output of a CV Task result from a
+      model instance, extended from model.v1alpha.TaskOutput.
+      Here we don't use a model.v1alpha.TaskOutput type field but explicitly use
+      the replicated oneof field because we want the CV Task output to be at the
+      same message layer like the trigger output of model instance.
+  vdppipelinev1alphaView:
+    type: string
+    enum:
+      - VIEW_UNSPECIFIED
+      - VIEW_BASIC
+      - VIEW_FULL
+    default: VIEW_UNSPECIFIED
+    description: |-
+      View represents a view of any resource. The resource view is implemented by
+      adding a parameter to the method request which allows the client to specify
+      which view of the resource it wants to receive in the response.
+
+       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+       - VIEW_BASIC: View: BASIC
+       - VIEW_FULL: View: FULL
+  vdpusagev1alphaLivenessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: LivenessResponse represents a response for a service liveness status
+  vdpusagev1alphaReadinessResponse:
+    type: object
+    properties:
+      health_check_response:
+        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        title: HealthCheckResponse message
+    title: ReadinessResponse represents a response for a service readiness status

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1,8 +1,9 @@
 swagger: "2.0"
 info:
-    title: vdp/connector/v1alpha/auth.proto
+    title: vdp/healthcheck/v1alpha/healthcheck.proto
     version: version not set
 tags:
+    - name: PlanService
     - name: ConnectorService
     - name: UserService
     - name: ModelService
@@ -370,7 +371,7 @@ paths:
                             description: The resource name of a user, e.g., "users/local-user".
                             readOnly: true
                         visibility:
-                            $ref: '#/definitions/ModelVisibility'
+                            $ref: '#/definitions/v1alphaModelVisibility'
                             title: Model visibility including public or private
                     description: |-
                         The model `name` field is used to identify the model to update.
@@ -1411,32 +1412,6 @@ paths:
     /v1alpha/{permalink_2}/lookUp:
         get:
             summary: |-
-                LookUpUser method receives a LookUpUserRequest message and returns a
-                LookUpUserResponse
-            operationId: UserService_LookUpUser
-            responses:
-                "200":
-                    description: A successful response.
-                    schema:
-                        $ref: '#/definitions/v1alphaLookUpUserResponse'
-                default:
-                    description: An unexpected error response.
-                    schema:
-                        $ref: '#/definitions/rpcStatus'
-            parameters:
-                - name: permalink_2
-                  description: |-
-                    Permalink of a user. For example:
-                    "users/{uid}"
-                  in: path
-                  required: true
-                  type: string
-                  pattern: users/[^/]+
-            tags:
-                - UserService
-    /v1alpha/{permalink_3}/lookUp:
-        get:
-            summary: |-
                 LookUpModel method receives a LookUpModelRequest message and returns a
                 LookUpModelResponse
             operationId: ModelService_LookUpModel
@@ -1450,7 +1425,7 @@ paths:
                     schema:
                         $ref: '#/definitions/rpcStatus'
             parameters:
-                - name: permalink_3
+                - name: permalink_2
                   description: |-
                     Permalink of a model. For example:
                     "models/{uid}"
@@ -1477,7 +1452,7 @@ paths:
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
-    /v1alpha/{permalink_4}/lookUp:
+    /v1alpha/{permalink_3}/lookUp:
         get:
             summary: |-
                 LookUpModelInstance method receives a LookUpModelInstanceRequest message
@@ -1494,7 +1469,7 @@ paths:
                     schema:
                         $ref: '#/definitions/rpcStatus'
             parameters:
-                - name: permalink_4
+                - name: permalink_3
                   description: |-
                     Permalink of a model instance. For example:
                     "models/{model_uid}/instances/{instance_uid}"
@@ -1521,7 +1496,7 @@ paths:
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
-    /v1alpha/{permalink_5}/lookUp:
+    /v1alpha/{permalink_4}/lookUp:
         get:
             summary: |-
                 LookUpPipeline method receives a LookUpPipelineRequest message and returns
@@ -1537,7 +1512,7 @@ paths:
                     schema:
                         $ref: '#/definitions/rpcStatus'
             parameters:
-                - name: permalink_5
+                - name: permalink_4
                   description: |-
                     Permalink of a pipeline. For example:
                     "pipelines/{uid}"
@@ -1905,7 +1880,215 @@ paths:
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
-    /v1alpha/{user.name}:
+    /v1alpha/{user.name}/exists:
+        get:
+            summary: |-
+                ExistUsername method receives a ExistUsernameRequest message and returns a
+                ExistUsernameResponse
+            operationId: UserService_ExistUsername
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaExistUsernameResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: user.name
+                  description: |-
+                    The resource name of the user to be deleted,
+                    for example: "users/local-user"
+                  in: path
+                  required: true
+                  type: string
+                  pattern: users/[^/]+
+            tags:
+                - UserService
+    /v1alpha/admin/{permalink_1}/lookUp:
+        get:
+            summary: |-
+                LookUpUser method receives a LookUpUserRequest message and returns a
+                LookUpUserResponse
+            operationId: UserService_LookUpUser
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaLookUpUserResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: permalink_1
+                  description: |-
+                    Permalink of a user. For example:
+                    "users/{uid}"
+                  in: path
+                  required: true
+                  type: string
+                  pattern: users/[^/]+
+            tags:
+                - UserService
+    /v1alpha/admin/{permalink}/lookUp:
+        get:
+            summary: |-
+                LookUpPlan method receives a LookUpPlanRequest message and returns a
+                LookUpPlanResponse
+            operationId: PlanService_LookUpPlan
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaLookUpPlanResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: permalink
+                  description: |-
+                    Permalink of a plan. For example:
+                    "plans/{uid}"
+                  in: path
+                  required: true
+                  type: string
+                  pattern: plans/[^/]+
+            tags:
+                - PlanService
+    /v1alpha/admin/{plan.name}:
+        get:
+            summary: |-
+                GetPlan method receives a GetPlanRequest message and returns
+                a GetPlanResponse message.
+            operationId: PlanService_GetPlan
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaGetPlanResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: plan.name
+                  description: |-
+                    Resource name of a plan. For example:
+                    "plans/free"
+                  in: path
+                  required: true
+                  type: string
+                  pattern: plans/[^/]+
+            tags:
+                - PlanService
+        delete:
+            summary: |-
+                DeletePlan method receives a DeletePlanRequest message and returns a
+                DeletePlanResponse
+            operationId: PlanService_DeletePlan
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaDeletePlanResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: plan.name
+                  description: |-
+                    The resource name of the plan to be deleted,
+                    for example: "plans/local-plan"
+                  in: path
+                  required: true
+                  type: string
+                  pattern: plans/[^/]+
+            tags:
+                - PlanService
+        patch:
+            summary: |-
+                UpdatePlan method receives a UpdatePlanRequest message and returns
+                a UpdatePlanResponse
+            operationId: PlanService_UpdatePlan
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaUpdatePlanResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: plan.name
+                  description: |-
+                    Resource name. It must have the format of "plans/*".
+                    For example: "plans/free".
+                  in: path
+                  required: true
+                  type: string
+                  pattern: plans/[^/]+
+                - name: plan
+                  description: |-
+                    The plan to update
+
+                    The plan's `name` field is used to identify the plan to update.
+                    Format: plans/{plan}
+                  in: body
+                  required: true
+                  schema:
+                    type: object
+                    properties:
+                        create_time:
+                            type: string
+                            format: date-time
+                            title: Plan creation time
+                            readOnly: true
+                        id:
+                            type: string
+                            description: |-
+                                Pipeline resource ID (the last segment of the resource name) used to
+                                construct the resource name. This conforms to RFC-1034, which restricts to
+                                letters, numbers, and hyphen, with the first character a letter, the last a
+                                letter or a number, and a 63 character maximum.
+                        spec:
+                            type: object
+                            title: Plan specification in JSON format
+                            required:
+                                - spec
+                        tier:
+                            $ref: '#/definitions/PlanTier'
+                            title: Plan tier
+                        uid:
+                            type: string
+                            title: Pipeline UUID
+                            readOnly: true
+                        update_time:
+                            type: string
+                            format: date-time
+                            title: Plan update time
+                            readOnly: true
+                        visibility:
+                            $ref: '#/definitions/v1alphaPlanVisibility'
+                            title: Plan visibility
+                    description: |-
+                        The plan's `name` field is used to identify the plan to update.
+                        Format: plans/{plan}
+                    title: The plan to update
+                    required:
+                        - spec
+                - name: update_mask
+                  description: Update mask for a plan resource
+                  in: query
+                  required: true
+                  type: string
+            tags:
+                - PlanService
+    /v1alpha/admin/{user.name}:
         get:
             summary: |-
                 GetUser method receives a GetUserRequest message and returns
@@ -1990,9 +2173,6 @@ paths:
                   schema:
                     type: object
                     properties:
-                        company_name:
-                            type: string
-                            title: User company name
                         cookie_token:
                             type: string
                             title: User console cookie token
@@ -2004,18 +2184,30 @@ paths:
                         email:
                             type: string
                             title: User email
+                            required:
+                                - email
+                        first_name:
+                            type: string
+                            title: User first name
                         id:
                             type: string
-                            description: |-
-                                Resource ID (the last segment of the resource name), also the user login
-                                username. This conforms to RFC-1034, which restricts to letters, numbers,
-                                and hyphen, with the first character a letter, the last a letter or a
-                                number, and a 63 character maximum.
+                            description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
+                            required:
+                                - id
+                        last_name:
+                            type: string
+                            title: User last name
                         newsletter_subscription:
                             type: boolean
                             title: User newsletter subscription
                             required:
                                 - newsletter_subscription
+                        org_name:
+                            type: string
+                            title: User company or institution name
+                        plan:
+                            $ref: '#/definitions/v1alphaPlan'
+                            title: User plan
                         role:
                             type: string
                             title: |-
@@ -2033,7 +2225,8 @@ paths:
                         uid:
                             type: string
                             title: User ID in UUIDv4
-                            readOnly: true
+                            required:
+                                - uid
                         update_time:
                             type: string
                             format: date-time
@@ -2044,12 +2237,135 @@ paths:
                         Format: users/{user}
                     title: The user to update
                     required:
+                        - uid
+                        - id
+                        - email
                         - newsletter_subscription
                 - name: update_mask
                   description: Update mask for a user resource
                   in: query
                   required: true
                   type: string
+            tags:
+                - UserService
+    /v1alpha/admin/plans:
+        get:
+            summary: |-
+                ListPlan method receives a ListPlanRequest message and returns a
+                ListPlanResponse message.
+            operationId: PlanService_ListPlan
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaListPlanResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: page_size
+                  description: |-
+                    Page size: the maximum number of resources to return. The service may
+                    return fewer than this value. If unspecified, at most 10 plans will be
+                    returned. The maximum value is 100; values above 100 will be coereced to
+                    100.
+                  in: query
+                  required: false
+                  type: string
+                  format: int64
+                - name: page_token
+                  description: Page token
+                  in: query
+                  required: false
+                  type: string
+            tags:
+                - PlanService
+        post:
+            summary: |-
+                CreatePlan receives a CreatePlanRequest message and returns a
+                aGetPlanResponses
+            operationId: PlanService_CreatePlan
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaCreatePlanResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: plan
+                  description: |-
+                    The plan to be created
+
+                    The plan's `name` field is used to identify the plan to create.
+                    Format: plans/{plan}
+                  in: body
+                  required: true
+                  schema:
+                    $ref: '#/definitions/v1alphaPlan'
+            tags:
+                - PlanService
+    /v1alpha/admin/users:
+        get:
+            summary: |-
+                ListUser method receives a ListUserRequest message and returns a
+                ListUserResponse message.
+            operationId: UserService_ListUser
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaListUserResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: page_size
+                  description: |-
+                    Page size: the maximum number of resources to return. The service may
+                    return fewer than this value. If unspecified, at most 10 users will be
+                    returned. The maximum value is 100; values above 100 will be coereced to
+                    100.
+                  in: query
+                  required: false
+                  type: string
+                  format: int64
+                - name: page_token
+                  description: Page token
+                  in: query
+                  required: false
+                  type: string
+            tags:
+                - UserService
+        post:
+            summary: |-
+                CreateUser receives a CreateUserRequest message and returns a
+                aGetUserResponse
+            operationId: UserService_CreateUser
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/v1alphaCreateUserResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: user
+                  description: |-
+                    The user to be created
+
+                    The user's `name` field is used to identify the user to create.
+                    Format: users/{user}
+                  in: body
+                  required: true
+                  schema:
+                    $ref: '#/definitions/v1alphaUser'
             tags:
                 - UserService
     /v1alpha/destination-connector-definitions:
@@ -2172,6 +2488,30 @@ paths:
                     $ref: '#/definitions/v1alphaDestinationConnector'
             tags:
                 - ConnectorService
+    /v1alpha/health/billing:
+        get:
+            summary: |-
+                Liveness method receives a LivenessRequest message and returns a
+                LivenessResponse message.
+                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+            operationId: PlanService_Liveness2
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/vdpbillingv1alphaLivenessResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: health_check_request.service
+                  description: Service name to check for its readiness status
+                  in: query
+                  required: false
+                  type: string
+            tags:
+                - PlanService
     /v1alpha/health/connector:
         get:
             summary: |-
@@ -2550,6 +2890,54 @@ paths:
                     $ref: '#/definitions/v1alphaPipeline'
             tags:
                 - PipelineService
+    /v1alpha/ready/billing:
+        get:
+            summary: |-
+                Readiness method receives a ReadinessRequest message and returns a
+                ReadinessResponse message.
+                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+            operationId: PlanService_Readiness2
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/vdpbillingv1alphaReadinessResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: health_check_request.service
+                  description: Service name to check for its readiness status
+                  in: query
+                  required: false
+                  type: string
+            tags:
+                - PlanService
+    /v1alpha/ready/mgmt:
+        get:
+            summary: |-
+                Readiness method receives a ReadinessRequest message and returns a
+                ReadinessResponse message.
+                See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+            operationId: UserService_Readiness2
+            responses:
+                "200":
+                    description: A successful response.
+                    schema:
+                        $ref: '#/definitions/vdpmgmtv1alphaReadinessResponse'
+                default:
+                    description: An unexpected error response.
+                    schema:
+                        $ref: '#/definitions/rpcStatus'
+            parameters:
+                - name: health_check_request.service
+                  description: Service name to check for its readiness status
+                  in: query
+                  required: false
+                  type: string
+            tags:
+                - UserService
     /v1alpha/ready/model:
         get:
             summary: |-
@@ -2741,64 +3129,47 @@ paths:
                     $ref: '#/definitions/v1alphaSourceConnector'
             tags:
                 - ConnectorService
-    /v1alpha/users:
+    /v1alpha/user:
         get:
             summary: |-
-                ListUser method receives a ListUserRequest message and returns a
-                ListUserResponse message.
-            operationId: UserService_ListUser
+                GetAuthenticatedUser method receives a GetAuthenticatedUserRequest message and returns
+                a GetAuthenticatedUserResponse message.
+            operationId: UserService_GetAuthenticatedUser
             responses:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListUserResponse'
+                        $ref: '#/definitions/v1alphaGetAuthenticatedUserResponse'
                 default:
                     description: An unexpected error response.
                     schema:
                         $ref: '#/definitions/rpcStatus'
-            parameters:
-                - name: page_size
-                  description: |-
-                    Page size: the maximum number of resources to return. The service may
-                    return fewer than this value. If unspecified, at most 10 users will be
-                    returned. The maximum value is 100; values above 100 will be coereced to
-                    100.
-                  in: query
-                  required: false
-                  type: string
-                  format: int64
-                - name: page_token
-                  description: Page token
-                  in: query
-                  required: false
-                  type: string
             tags:
                 - UserService
-        post:
-            summary: |-
-                CreateUser receives a CreateUserRequest message and returns a
-                aGetUserResponse
-            operationId: UserService_CreateUser
+        patch:
+            summary: "UpdateAuthenticatedUser method receives a UpdateAuthenticatedUserRequest message and returns \na UpdateAuthenticatedUserResponse message."
+            operationId: UserService_UpdateAuthenticatedUser
             responses:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaCreateUserResponse'
+                        $ref: '#/definitions/v1alphaUpdateAuthenticatedUserResponse'
                 default:
                     description: An unexpected error response.
                     schema:
                         $ref: '#/definitions/rpcStatus'
             parameters:
                 - name: user
-                  description: |-
-                    The user to be created
-
-                    The user's `name` field is used to identify the user to create.
-                    Format: users/{user}
+                  description: The user to update
                   in: body
                   required: true
                   schema:
                     $ref: '#/definitions/v1alphaUser'
+                - name: update_mask
+                  description: Update mask for a user resource
+                  in: query
+                  required: true
+                  type: string
             tags:
                 - UserService
 definitions:
@@ -2848,18 +3219,6 @@ definitions:
              - TASK_SEMANTIC_SEGMENTATION: Task: SEMANTIC SEGMENTATION
              - TASK_TEXT_TO_IMAGE: Task: TEXT TO IMAGE
         title: Task enumerates the task type of a model instance
-    ModelVisibility:
-        type: string
-        enum:
-            - VISIBILITY_UNSPECIFIED
-            - VISIBILITY_PRIVATE
-            - VISIBILITY_PUBLIC
-        default: VISIBILITY_UNSPECIFIED
-        description: |-
-            - VISIBILITY_UNSPECIFIED: Visibility: UNSPECIFIED, equivalent to PRIVATE.
-             - VISIBILITY_PRIVATE: Visibility: PRIVATE
-             - VISIBILITY_PUBLIC: Visibility: PUBLIC
-        title: Model visibility including public or private
     PipelineMode:
         type: string
         enum:
@@ -2872,6 +3231,18 @@ definitions:
              - MODE_SYNC: Mode: SYNC
              - MODE_ASYNC: Mode: ASYNC
         title: Mode enumerates the pipeline modes
+    PlanTier:
+        type: string
+        enum:
+            - TIER_UNSPECIFIED
+            - TIER_FREE
+            - TIER_CUSTOM
+        default: TIER_UNSPECIFIED
+        description: |-
+            - TIER_UNSPECIFIED: PlanType: UNSPECIFIED, equivalent to FREE.
+             - TIER_FREE: PlanType: FREE
+             - TIER_CUSTOM: PlanType: CUSTOM
+        title: Tier enumerates the billing plan tier type
     SessionService:
         type: string
         enum:
@@ -2987,7 +3358,7 @@ definitions:
                   foo = any.unpack(Foo.class);
                 }
 
-             Example 3: Pack and unpack a message in Python.
+            Example 3: Pack and unpack a message in Python.
 
                 foo = Foo(...)
                 any = Any()
@@ -2997,7 +3368,7 @@ definitions:
                   any.Unpack(foo)
                   ...
 
-             Example 4: Pack and unpack a message in Go
+            Example 4: Pack and unpack a message in Go
 
                  foo := &pb.Foo{...}
                  any, err := anypb.New(foo)
@@ -3018,7 +3389,7 @@ definitions:
 
 
             JSON
-            ====
+
             The JSON representation of an `Any` value uses the regular
             representation of the deserialized, embedded message, with an
             additional field `@type` which contains the type URL. Example:
@@ -3448,6 +3819,13 @@ definitions:
                 $ref: '#/definitions/v1alphaPipeline'
                 title: The created pipeline resource
         title: CreatePipelineResponse represents a response for a pipeline resource
+    v1alphaCreatePlanResponse:
+        type: object
+        properties:
+            plan:
+                $ref: '#/definitions/v1alphaPlan'
+                title: A plan resource
+        title: CreatePlanResponse represents a response for a plan response
     v1alphaCreateSessionResponse:
         type: object
         properties:
@@ -3487,6 +3865,9 @@ definitions:
     v1alphaDeletePipelineResponse:
         type: object
         title: DeletePipelineResponse represents an empty response
+    v1alphaDeletePlanResponse:
+        type: object
+        title: DeletePlanResponse represents an empty response
     v1alphaDeleteSourceConnectorResponse:
         type: object
         title: DeleteSourceConnectorResponse represents an empty response
@@ -3608,6 +3989,24 @@ definitions:
                 $ref: '#/definitions/v1alphaSourceConnector'
                 title: A SourceConnector resource
         title: DisconnectSourceConnectorResponse represents a disconnected source connector
+    v1alphaExistUsernameResponse:
+        type: object
+        properties:
+            exists:
+                type: boolean
+                title: A boolean value indicating whether the username has been occupied
+        title: |-
+            ExistUsernameResponse represents a response about whether
+            the queried username has been occupied
+    v1alphaGetAuthenticatedUserResponse:
+        type: object
+        properties:
+            user:
+                $ref: '#/definitions/v1alphaUser'
+                title: A user resource
+        title: |-
+            GetAuthenticatedUserResponse represents a response for
+            the authenticated user resource
     v1alphaGetDestinationConnectorDefinitionResponse:
         type: object
         properties:
@@ -3670,6 +4069,13 @@ definitions:
                 $ref: '#/definitions/v1alphaPipeline'
                 title: A pipeline resource
         title: GetPipelineResponse represents a response for a pipeline resource
+    v1alphaGetPlanResponse:
+        type: object
+        properties:
+            plan:
+                $ref: '#/definitions/v1alphaPlan'
+                title: A plan resource
+        title: GetPlanResponse represents a response for a plan resource
     v1alphaGetSourceConnectorDefinitionResponse:
         type: object
         properties:
@@ -3928,6 +4334,22 @@ definitions:
                 format: int64
                 title: Total count of pipeline resources
         title: ListPipelineResponse represents a response for a list of pipelines
+    v1alphaListPlanResponse:
+        type: object
+        properties:
+            next_page_token:
+                type: string
+                title: Next page token
+            plans:
+                type: array
+                items:
+                    $ref: '#/definitions/v1alphaPlan'
+                title: A list of plans
+            total_size:
+                type: string
+                format: int64
+                title: Total count of plans
+        title: ListPlanResponse represents a response for a list of plans
     v1alphaListSourceConnectorDefinitionResponse:
         type: object
         properties:
@@ -4010,6 +4432,13 @@ definitions:
                 $ref: '#/definitions/v1alphaPipeline'
                 title: A pipeline resource
         title: LookUpPipelineResponse represents a response for a pipeline resource
+    v1alphaLookUpPlanResponse:
+        type: object
+        properties:
+            plan:
+                $ref: '#/definitions/v1alphaPlan'
+                title: A plan resource
+        title: LookUpPlanResponse represents a response for a plan resource
     v1alphaLookUpSourceConnectorResponse:
         type: object
         properties:
@@ -4083,7 +4512,7 @@ definitions:
                 description: The resource name of a user, e.g., "users/local-user".
                 readOnly: true
             visibility:
-                $ref: '#/definitions/ModelVisibility'
+                $ref: '#/definitions/v1alphaModelVisibility'
                 title: Model visibility including public or private
         title: Model represents a model
     v1alphaModelDefinition:
@@ -4339,6 +4768,18 @@ definitions:
             - model_definition_ids
             - tasks
             - test_num
+    v1alphaModelVisibility:
+        type: string
+        enum:
+            - VISIBILITY_UNSPECIFIED
+            - VISIBILITY_PRIVATE
+            - VISIBILITY_PUBLIC
+        default: VISIBILITY_UNSPECIFIED
+        description: |-
+            - VISIBILITY_UNSPECIFIED: Visibility: UNSPECIFIED, equivalent to PRIVATE.
+             - VISIBILITY_PRIVATE: Visibility: PRIVATE
+             - VISIBILITY_PUBLIC: Visibility: PUBLIC
+        title: Model visibility including public or private
     v1alphaOauthConfigSpecification:
         type: object
         properties:
@@ -4612,6 +5053,62 @@ definitions:
             - pipeline_async_mode_num
             - pipeline_sync_mode_num
             - trigger_num
+    v1alphaPlan:
+        type: object
+        properties:
+            create_time:
+                type: string
+                format: date-time
+                title: Plan creation time
+                readOnly: true
+            id:
+                type: string
+                description: |-
+                    Pipeline resource ID (the last segment of the resource name) used to
+                    construct the resource name. This conforms to RFC-1034, which restricts to
+                    letters, numbers, and hyphen, with the first character a letter, the last a
+                    letter or a number, and a 63 character maximum.
+            name:
+                type: string
+                description: |-
+                    Resource name. It must have the format of "plans/*".
+                    For example: "plans/free".
+                readOnly: true
+            spec:
+                type: object
+                title: Plan specification in JSON format
+                required:
+                    - spec
+            tier:
+                $ref: '#/definitions/PlanTier'
+                title: Plan tier
+            uid:
+                type: string
+                title: Pipeline UUID
+                readOnly: true
+            update_time:
+                type: string
+                format: date-time
+                title: Plan update time
+                readOnly: true
+            visibility:
+                $ref: '#/definitions/v1alphaPlanVisibility'
+                title: Plan visibility
+        title: Plan represents the content of a billing plan
+        required:
+            - spec
+    v1alphaPlanVisibility:
+        type: string
+        enum:
+            - VISIBILITY_UNSPECIFIED
+            - VISIBILITY_PRIVATE
+            - VISIBILITY_PUBLIC
+        default: VISIBILITY_UNSPECIFIED
+        description: |-
+            - VISIBILITY_UNSPECIFIED: Visibility: UNSPECIFIED, equivalent to PRIVATE.
+             - VISIBILITY_PRIVATE: Visibility: PRIVATE
+             - VISIBILITY_PUBLIC: Visibility: PUBLIC
+        title: Plan visibility including public or private
     v1alphaPublishModelResponse:
         type: object
         properties:
@@ -5147,6 +5644,15 @@ definitions:
                 title: A list of unspecified task outputs
                 readOnly: true
         title: UnspecifiedOutput represents the output of unspecified task
+    v1alphaUpdateAuthenticatedUserResponse:
+        type: object
+        properties:
+            user:
+                $ref: '#/definitions/v1alphaUser'
+                title: A user resource
+        title: |-
+            UpdateAuthenticatedUserResponse represents a response for
+            the authenticated user resource
     v1alphaUpdateDestinationConnectorResponse:
         type: object
         properties:
@@ -5170,6 +5676,13 @@ definitions:
                 $ref: '#/definitions/v1alphaPipeline'
                 title: An updated pipeline resource
         title: UpdatePipelineResponse represents a response for a pipeline resource
+    v1alphaUpdatePlanResponse:
+        type: object
+        properties:
+            plan:
+                $ref: '#/definitions/v1alphaPlan'
+                title: A plan resource
+        title: UpdatePlanResponse represents a response for a plan resource
     v1alphaUpdateSourceConnectorResponse:
         type: object
         properties:
@@ -5189,9 +5702,6 @@ definitions:
     v1alphaUser:
         type: object
         properties:
-            company_name:
-                type: string
-                title: User company name
             cookie_token:
                 type: string
                 title: User console cookie token
@@ -5203,13 +5713,19 @@ definitions:
             email:
                 type: string
                 title: User email
+                required:
+                    - email
+            first_name:
+                type: string
+                title: User first name
             id:
                 type: string
-                description: |-
-                    Resource ID (the last segment of the resource name), also the user login
-                    username. This conforms to RFC-1034, which restricts to letters, numbers,
-                    and hyphen, with the first character a letter, the last a letter or a
-                    number, and a 63 character maximum.
+                description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
+                required:
+                    - id
+            last_name:
+                type: string
+                title: User last name
             name:
                 type: string
                 description: |-
@@ -5221,6 +5737,12 @@ definitions:
                 title: User newsletter subscription
                 required:
                     - newsletter_subscription
+            org_name:
+                type: string
+                title: User company or institution name
+            plan:
+                $ref: '#/definitions/v1alphaPlan'
+                title: User plan
             role:
                 type: string
                 title: |-
@@ -5238,7 +5760,8 @@ definitions:
             uid:
                 type: string
                 title: User ID in UUIDv4
-                readOnly: true
+                required:
+                    - uid
             update_time:
                 type: string
                 format: date-time
@@ -5246,12 +5769,29 @@ definitions:
                 readOnly: true
         title: User represents the content of a user
         required:
+            - uid
+            - id
+            - email
             - newsletter_subscription
     v1alphaWriteDestinationConnectorResponse:
         type: object
         title: |-
             WriteDestinationConnectorResponse represents the read data from a
             DestinationConnector resource
+    vdpbillingv1alphaLivenessResponse:
+        type: object
+        properties:
+            health_check_response:
+                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                title: HealthCheckResponse message
+        title: LivenessResponse represents a response for a service liveness status
+    vdpbillingv1alphaReadinessResponse:
+        type: object
+        properties:
+            health_check_response:
+                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                title: HealthCheckResponse message
+        title: ReadinessResponse represents a response for a service readiness status
     vdpconnectorv1alphaLivenessResponse:
         type: object
         properties:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -25,11 +25,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpusagev1alphaLivenessResponse'
+                        $ref: "#/definitions/vdpusagev1alphaLivenessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -49,11 +49,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpusagev1alphaReadinessResponse'
+                        $ref: "#/definitions/vdpusagev1alphaReadinessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -72,34 +72,34 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaGetDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: destination_connector.name
                   description: |-
-                    DestinationConnectorConnector resource name. It must have the format of
-                    "destination-connectors/*"
+                      DestinationConnectorConnector resource name. It must have the format of
+                      "destination-connectors/*"
                   in: path
                   required: true
                   type: string
                   pattern: destination-connectors/[^/]+
                 - name: view
                   description: |-
-                    DestinationConnector view (default is VIEW_BASIC)
+                      DestinationConnector view (default is VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -113,16 +113,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDeleteDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaDeleteDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: destination_connector.name
                   description: |-
-                    DestinationConnector resource name. It must have the format of
-                    "destination-connectors/*"
+                      DestinationConnector resource name. It must have the format of
+                      "destination-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -139,16 +139,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaUpdateDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaUpdateDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: destination_connector.name
                   description: |-
-                    DestinationConnector resource name. It must have the format of
-                    "destination-connectors/*"
+                      DestinationConnector resource name. It must have the format of
+                      "destination-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -158,26 +158,26 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        connector:
-                            $ref: '#/definitions/v1alphaConnector'
-                            title: DestinationConnector's connector data structure
-                        destination_connector_definition:
-                            type: string
-                            title: DestinationConnectorDefinition resource
-                        id:
-                            type: string
-                            description: |-
-                                DestinationConnector resource ID (the last segment of the resource name)
-                                used to construct the resource name. This conforms to RFC-1034, which
-                                restricts to letters, numbers, and hyphen, with the first character a
-                                letter, the last a letter or a number, and a 63 character maximum.
-                        uid:
-                            type: string
-                            title: DestinationConnector UUID
-                            readOnly: true
-                    title: DestinationConnector resource
+                      type: object
+                      properties:
+                          connector:
+                              $ref: "#/definitions/v1alphaConnector"
+                              title: DestinationConnector's connector data structure
+                          destination_connector_definition:
+                              type: string
+                              title: DestinationConnectorDefinition resource
+                          id:
+                              type: string
+                              description: |-
+                                  DestinationConnector resource ID (the last segment of the resource name)
+                                  used to construct the resource name. This conforms to RFC-1034, which
+                                  restricts to letters, numbers, and hyphen, with the first character a
+                                  letter, the last a letter or a number, and a 63 character maximum.
+                          uid:
+                              type: string
+                              title: DestinationConnector UUID
+                              readOnly: true
+                      title: DestinationConnector resource
                 - name: update_mask
                   description: Update mask for a DestinationConnector resource
                   in: query
@@ -196,35 +196,35 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetDestinationConnectorDefinitionResponse'
+                        $ref: "#/definitions/v1alphaGetDestinationConnectorDefinitionResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: destination_connector_definition.name
                   description: |-
-                    DestinationConnectorDefinition resource name. It must have the format of
-                    "source-connector-definitions/*"
+                      DestinationConnectorDefinition resource name. It must have the format of
+                      "source-connector-definitions/*"
                   in: path
                   required: true
                   type: string
                   pattern: destination-connector-definitions/[^/]+
                 - name: view
                   description: |-
-                    DestinationConnectorDefinition resource view (default is
-                    DEFINITION_VIEW_BASIC)
+                      DestinationConnectorDefinition resource view (default is
+                      DEFINITION_VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -238,36 +238,36 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetModelResponse'
+                        $ref: "#/definitions/v1alphaGetModelResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: model.name
                   description: |-
-                    Resource name of the model.
-                    For example "models/{model}"
+                      Resource name of the model.
+                      For example "models/{model}"
                   in: path
                   required: true
                   type: string
                   pattern: models/[^/]+
                 - name: view
                   description: |-
-                    Model view (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
-                    VIEW_FULL: show full information
+                      Model view (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+                      VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -280,16 +280,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDeleteModelResponse'
+                        $ref: "#/definitions/v1alphaDeleteModelResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: model.name
                   description: |-
-                    Resource name of the model.
-                    For example "models/{model}"
+                      Resource name of the model.
+                      For example "models/{model}"
                   in: path
                   required: true
                   type: string
@@ -305,78 +305,78 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaUpdateModelResponse'
+                        $ref: "#/definitions/v1alphaUpdateModelResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: model.name
                   description: |-
-                    Resource name. It must have the format of "models/{model}".
-                    For example: "models/yolov4"
+                      Resource name. It must have the format of "models/{model}".
+                      For example: "models/yolov4"
                   in: path
                   required: true
                   type: string
                   pattern: models/[^/]+
                 - name: model
                   description: |-
-                    The model to update
+                      The model to update
 
-                    The model `name` field is used to identify the model to update.
-                    Format: models/{model}
+                      The model `name` field is used to identify the model to update.
+                      Format: models/{model}
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        configuration:
-                            type: object
-                            title: |-
-                                Model configuration represents the configuration JSON that has been
-                                validated using the `model_spec` JSON schema of a ModelDefinition
-                        create_time:
-                            type: string
-                            format: date-time
-                            title: Model create time
-                            readOnly: true
-                        description:
-                            type: string
-                            title: Model description
-                        id:
-                            type: string
-                            description: |-
-                                Resource ID (the last segment of the resource name) used to construct the
-                                resource name. This conforms to RFC-1034, which restricts to letters,
-                                numbers, and hyphen, with the first character a letter, the last a letter
-                                or a number, and a 63 character maximum.
-                        model_definition:
-                            type: string
-                            title: Model definition resource name
-                        org:
-                            type: string
-                            title: The resource name of an organization
-                            readOnly: true
-                        uid:
-                            type: string
-                            title: Model ID in UUIDv4
-                            readOnly: true
-                        update_time:
-                            type: string
-                            format: date-time
-                            title: Model update time
-                            readOnly: true
-                        user:
-                            type: string
-                            description: The resource name of a user, e.g., "users/local-user".
-                            readOnly: true
-                        visibility:
-                            $ref: '#/definitions/v1alphaModelVisibility'
-                            title: Model visibility including public or private
-                    description: |-
-                        The model `name` field is used to identify the model to update.
-                        Format: models/{model}
-                    title: The model to update
+                      type: object
+                      properties:
+                          configuration:
+                              type: object
+                              title: |-
+                                  Model configuration represents the configuration JSON that has been
+                                  validated using the `model_spec` JSON schema of a ModelDefinition
+                          create_time:
+                              type: string
+                              format: date-time
+                              title: Model create time
+                              readOnly: true
+                          description:
+                              type: string
+                              title: Model description
+                          id:
+                              type: string
+                              description: |-
+                                  Resource ID (the last segment of the resource name) used to construct the
+                                  resource name. This conforms to RFC-1034, which restricts to letters,
+                                  numbers, and hyphen, with the first character a letter, the last a letter
+                                  or a number, and a 63 character maximum.
+                          model_definition:
+                              type: string
+                              title: Model definition resource name
+                          org:
+                              type: string
+                              title: The resource name of an organization
+                              readOnly: true
+                          uid:
+                              type: string
+                              title: Model ID in UUIDv4
+                              readOnly: true
+                          update_time:
+                              type: string
+                              format: date-time
+                              title: Model update time
+                              readOnly: true
+                          user:
+                              type: string
+                              description: The resource name of a user, e.g., "users/local-user".
+                              readOnly: true
+                          visibility:
+                              $ref: "#/definitions/v1alphaModelVisibility"
+                              title: Model visibility including public or private
+                      description: |-
+                          The model `name` field is used to identify the model to update.
+                          Format: models/{model}
+                      title: The model to update
                 - name: update_mask
                   description: Mask of fields to update.
                   in: query
@@ -394,37 +394,37 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetModelDefinitionResponse'
+                        $ref: "#/definitions/v1alphaGetModelDefinitionResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: model_definition.name
                   description: |-
-                    Resource name of the model definition.
-                    For example "model-definitions/{uuid}"
+                      Resource name of the model definition.
+                      For example "model-definitions/{uuid}"
                   in: path
                   required: true
                   type: string
                   pattern: model-definitions/[^/]+
                 - name: view
                   description: |-
-                    Definition view (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
-                    `ModelDefinition.model_instance_spec`
-                    VIEW_FULL: show full information
+                      Definition view (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
+                      `ModelDefinition.model_instance_spec`
+                      VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -438,16 +438,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetModelInstanceCardResponse'
+                        $ref: "#/definitions/v1alphaGetModelInstanceCardResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: model_instance.name/readme
                   description: |-
-                    Resource name of the model instance card.
-                    For example "models/{model}/instances/{instance}/readme"
+                      Resource name of the model instance card.
+                      For example "models/{model}/instances/{instance}/readme"
                   in: path
                   required: true
                   type: string
@@ -464,36 +464,36 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetModelInstanceResponse'
+                        $ref: "#/definitions/v1alphaGetModelInstanceResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: model_instance.name
                   description: |-
-                    Resource name of the model instance.
-                    For example "models/{model}/instances/{instance}"
+                      Resource name of the model instance.
+                      For example "models/{model}/instances/{instance}"
                   in: path
                   required: true
                   type: string
                   pattern: models/[^/]+/instances/[^/]+
                 - name: view
                   description: |-
-                    Model instance view (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-                    VIEW_FULL: show full information
+                      Model instance view (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+                      VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -510,16 +510,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaConnectDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaConnectDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name_1
                   description: |-
-                    DestinationConnector resource name. It must have the format of
-                    "destination-connectors/*"
+                      DestinationConnector resource name. It must have the format of
+                      "destination-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -528,10 +528,10 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: |-
-                        ConnectDestinationConnectorRequest represents a request to connect a
-                        destination connector
+                      type: object
+                      title: |-
+                          ConnectDestinationConnectorRequest represents a request to connect a
+                          destination connector
             tags:
                 - ConnectorService
     /v1alpha/{name_1}/disconnect:
@@ -547,16 +547,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDisconnectDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaDisconnectDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name_1
                   description: |-
-                    DestinationConnector resource name. It must have the format of
-                    "destination-connectors/*"
+                      DestinationConnector resource name. It must have the format of
+                      "destination-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -565,10 +565,10 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: |-
-                        DisconnectDestinationConnectorRequest represents a request to disconnect a
-                        destination connector
+                      type: object
+                      title: |-
+                          DisconnectDestinationConnectorRequest represents a request to disconnect a
+                          destination connector
             tags:
                 - ConnectorService
     /v1alpha/{name_1}/rename:
@@ -582,16 +582,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaRenameDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaRenameDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name_1
                   description: |-
-                    DestinationConnector resource name. It must have the format of
-                    "destination-connectors/*"
+                      DestinationConnector resource name. It must have the format of
+                      "destination-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -600,21 +600,21 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        new_destination_connector_id:
-                            type: string
-                            title: |-
-                                DestinationConnector new resource id to replace with the
-                                DestinationConnector resource name to be
-                                "destination-connectors/{new_destination_connector_id}"
-                            required:
-                                - new_destination_connector_id
-                    title: |-
-                        RenameDestinationConnectorRequest represents a request to rename the
-                        DestinationConnector resource name
-                    required:
-                        - new_destination_connector_id
+                      type: object
+                      properties:
+                          new_destination_connector_id:
+                              type: string
+                              title: |-
+                                  DestinationConnector new resource id to replace with the
+                                  DestinationConnector resource name to be
+                                  "destination-connectors/{new_destination_connector_id}"
+                              required:
+                                  - new_destination_connector_id
+                      title: |-
+                          RenameDestinationConnectorRequest represents a request to rename the
+                          DestinationConnector resource name
+                      required:
+                          - new_destination_connector_id
             tags:
                 - ConnectorService
     /v1alpha/{name_1}/trigger:
@@ -627,11 +627,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaTriggerPipelineResponse'
+                        $ref: "#/definitions/v1alphaTriggerPipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name_1
                   description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -643,18 +643,18 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        task_inputs:
-                            type: array
-                            items:
-                                $ref: '#/definitions/v1alphaTaskInput'
-                            title: Input to the pipeline
-                            required:
-                                - task_inputs
-                    title: TriggerPipelineRequest represents a request to trigger a pipeline
-                    required:
-                        - task_inputs
+                      type: object
+                      properties:
+                          task_inputs:
+                              type: array
+                              items:
+                                  $ref: "#/definitions/v1alphaTaskInput"
+                              title: Input to the pipeline
+                              required:
+                                  - task_inputs
+                      title: TriggerPipelineRequest represents a request to trigger a pipeline
+                      required:
+                          - task_inputs
             tags:
                 - PipelineService
     /v1alpha/{name_2}/rename:
@@ -665,11 +665,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaRenameModelResponse'
+                        $ref: "#/definitions/v1alphaRenameModelResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name_2
                   description: Resource name for the model to be renamed.
@@ -681,16 +681,16 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        new_model_id:
-                            type: string
-                            title: New ID of this model
-                            required:
-                                - new_model_id
-                    title: RenameModelRequest represents a request to rename a model
-                    required:
-                        - new_model_id
+                      type: object
+                      properties:
+                          new_model_id:
+                              type: string
+                              title: New ID of this model
+                              required:
+                                  - new_model_id
+                      title: RenameModelRequest represents a request to rename a model
+                      required:
+                          - new_model_id
             tags:
                 - ModelService
     /v1alpha/{name_3}/rename:
@@ -703,11 +703,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaRenamePipelineResponse'
+                        $ref: "#/definitions/v1alphaRenamePipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name_3
                   description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -719,20 +719,20 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        new_pipeline_id:
-                            type: string
-                            title: |-
-                                Pipeline new resource id to replace with the pipeline resource name to be
-                                "pipelines/{new_pipeline_id}"
-                            required:
-                                - new_pipeline_id
-                    title: |-
-                        RenamePipelineRequest represents a request to rename the pipeline resource
-                        name
-                    required:
-                        - new_pipeline_id
+                      type: object
+                      properties:
+                          new_pipeline_id:
+                              type: string
+                              title: |-
+                                  Pipeline new resource id to replace with the pipeline resource name to be
+                                  "pipelines/{new_pipeline_id}"
+                              required:
+                                  - new_pipeline_id
+                      title: |-
+                          RenamePipelineRequest represents a request to rename the pipeline resource
+                          name
+                      required:
+                          - new_pipeline_id
             tags:
                 - PipelineService
     /v1alpha/{name}:
@@ -746,11 +746,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetModelOperationResponse'
+                        $ref: "#/definitions/v1alphaGetModelOperationResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: The name of the operation resource.
@@ -760,20 +760,20 @@ paths:
                   pattern: operations/[^/]+
                 - name: view
                   description: |-
-                    View (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-                    `ModelInstance.configuration` VIEW_FULL: show full information
+                      View (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
+                      `ModelInstance.configuration` VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -789,11 +789,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaActivatePipelineResponse'
+                        $ref: "#/definitions/v1alphaActivatePipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -805,8 +805,8 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: ActivatePipelineRequest represents a request to activate a pipeline
+                      type: object
+                      title: ActivatePipelineRequest represents a request to activate a pipeline
             tags:
                 - PipelineService
     /v1alpha/{name}/cancel:
@@ -819,11 +819,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaCancelModelOperationResponse'
+                        $ref: "#/definitions/v1alphaCancelModelOperationResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: The name of the operation resource.
@@ -835,8 +835,8 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: CancelModelOperationRequest represents a request to cancel a model operation
+                      type: object
+                      title: CancelModelOperationRequest represents a request to cancel a model operation
             tags:
                 - ModelService
     /v1alpha/{name}/connect:
@@ -852,16 +852,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaConnectSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaConnectSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    SourceConnector resource name. It must have the format of
-                    "source-connectors/*"
+                      SourceConnector resource name. It must have the format of
+                      "source-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -870,10 +870,10 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: |-
-                        ConnectSourceConnectorRequest represents a request to connect a
-                        source connector
+                      type: object
+                      title: |-
+                          ConnectSourceConnectorRequest represents a request to connect a
+                          source connector
             tags:
                 - ConnectorService
     /v1alpha/{name}/deactivate:
@@ -888,11 +888,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDeactivatePipelineResponse'
+                        $ref: "#/definitions/v1alphaDeactivatePipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -904,8 +904,8 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: DeactivatePipelineRequest represents a request to deactivate a pipeline
+                      type: object
+                      title: DeactivatePipelineRequest represents a request to deactivate a pipeline
             tags:
                 - PipelineService
     /v1alpha/{name}/deploy:
@@ -916,16 +916,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDeployModelInstanceResponse'
+                        $ref: "#/definitions/v1alphaDeployModelInstanceResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    Resource name for the model instance to be deployed.
-                    Format: models/{model}/instances/{instance}
+                      Resource name for the model instance to be deployed.
+                      Format: models/{model}/instances/{instance}
                   in: path
                   required: true
                   type: string
@@ -934,10 +934,10 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: |-
-                        DeployModelInstanceRequest represents a request to deploy a model instance to
-                        online state
+                      type: object
+                      title: |-
+                          DeployModelInstanceRequest represents a request to deploy a model instance to
+                          online state
             tags:
                 - ModelService
     /v1alpha/{name}/disconnect:
@@ -953,16 +953,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDisconnectSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaDisconnectSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    SourceConnector resource name. It must have the format of
-                    "source-connectors/*"
+                      SourceConnector resource name. It must have the format of
+                      "source-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -971,10 +971,10 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: |-
-                        DisconnectSourceConnectorRequest represents a request to disconnect a
-                        source connector
+                      type: object
+                      title: |-
+                          DisconnectSourceConnectorRequest represents a request to disconnect a
+                          source connector
             tags:
                 - ConnectorService
     /v1alpha/{name}/publish:
@@ -987,16 +987,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaPublishModelResponse'
+                        $ref: "#/definitions/v1alphaPublishModelResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    Resource name of the model.
-                    For example "models/{model}"
+                      Resource name of the model.
+                      For example "models/{model}"
                   in: path
                   required: true
                   type: string
@@ -1005,8 +1005,8 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: PublishModelRequest represents a request to publish a model
+                      type: object
+                      title: PublishModelRequest represents a request to publish a model
             tags:
                 - ModelService
     /v1alpha/{name}/read:
@@ -1019,16 +1019,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaReadSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaReadSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    SourceConnector resource name. It must have the format of
-                    "source-connectors/*"
+                      SourceConnector resource name. It must have the format of
+                      "source-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -1037,10 +1037,10 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: |-
-                        ReadSourceConnectorRequest represents a request to perform read operation of
-                        a SourceConnector given the resource name
+                      type: object
+                      title: |-
+                          ReadSourceConnectorRequest represents a request to perform read operation of
+                          a SourceConnector given the resource name
             tags:
                 - ConnectorService
     /v1alpha/{name}/rename:
@@ -1053,16 +1053,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaRenameSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaRenameSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    SourceConnector resource name. It must have the format of
-                    "source-connectors/*"
+                      SourceConnector resource name. It must have the format of
+                      "source-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -1071,21 +1071,21 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        new_source_connector_id:
-                            type: string
-                            title: |-
-                                SourceConnector new resource id to replace with the
-                                SourceConnector resource name to be
-                                "source-connectors/{new_source_connector_id}"
-                            required:
-                                - new_source_connector_id
-                    title: |-
-                        RenameSourceConnectorRequest represents a request to rename the
-                        SourceConnector resource name
-                    required:
-                        - new_source_connector_id
+                      type: object
+                      properties:
+                          new_source_connector_id:
+                              type: string
+                              title: |-
+                                  SourceConnector new resource id to replace with the
+                                  SourceConnector resource name to be
+                                  "source-connectors/{new_source_connector_id}"
+                              required:
+                                  - new_source_connector_id
+                      title: |-
+                          RenameSourceConnectorRequest represents a request to rename the
+                          SourceConnector resource name
+                      required:
+                          - new_source_connector_id
             tags:
                 - ConnectorService
     /v1alpha/{name}/test:
@@ -1098,16 +1098,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaTestModelInstanceResponse'
+                        $ref: "#/definitions/v1alphaTestModelInstanceResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    The resource name of the model instance to trigger.
-                    For example "models/{model}/instances/{instance}"
+                      The resource name of the model instance to trigger.
+                      For example "models/{model}/instances/{instance}"
                   in: path
                   required: true
                   type: string
@@ -1116,18 +1116,18 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        task_inputs:
-                            type: array
-                            items:
-                                $ref: '#/definitions/v1alphaTaskInput'
-                            title: Input to trigger the model instance
-                            required:
-                                - task_inputs
-                    title: TestModelInstanceRequest represents a request to test a model instance
-                    required:
-                        - task_inputs
+                      type: object
+                      properties:
+                          task_inputs:
+                              type: array
+                              items:
+                                  $ref: "#/definitions/v1alphaTaskInput"
+                              title: Input to trigger the model instance
+                              required:
+                                  - task_inputs
+                      title: TestModelInstanceRequest represents a request to test a model instance
+                      required:
+                          - task_inputs
             tags:
                 - ModelService
     /v1alpha/{name}/trigger:
@@ -1141,16 +1141,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaTriggerModelInstanceResponse'
+                        $ref: "#/definitions/v1alphaTriggerModelInstanceResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    The resource name of the model instance to trigger.
-                    For example "models/{model}/instances/{instance}"
+                      The resource name of the model instance to trigger.
+                      For example "models/{model}/instances/{instance}"
                   in: path
                   required: true
                   type: string
@@ -1159,18 +1159,18 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        task_inputs:
-                            type: array
-                            items:
-                                $ref: '#/definitions/v1alphaTaskInput'
-                            title: Input to trigger the model instance
-                            required:
-                                - task_inputs
-                    title: TriggerModelInstanceRequest represents a request to trigger a model instance
-                    required:
-                        - task_inputs
+                      type: object
+                      properties:
+                          task_inputs:
+                              type: array
+                              items:
+                                  $ref: "#/definitions/v1alphaTaskInput"
+                              title: Input to trigger the model instance
+                              required:
+                                  - task_inputs
+                      title: TriggerModelInstanceRequest represents a request to trigger a model instance
+                      required:
+                          - task_inputs
             tags:
                 - ModelService
     /v1alpha/{name}/undeploy:
@@ -1181,16 +1181,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaUndeployModelInstanceResponse'
+                        $ref: "#/definitions/v1alphaUndeployModelInstanceResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    Resource name for the model instance to be undeployed.
-                    Format: models/{model}/instances/{instance}
+                      Resource name for the model instance to be undeployed.
+                      Format: models/{model}/instances/{instance}
                   in: path
                   required: true
                   type: string
@@ -1199,10 +1199,10 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: |-
-                        UndeployModelInstanceRequest represents a request to undeploy a model
-                        instance to offline state
+                      type: object
+                      title: |-
+                          UndeployModelInstanceRequest represents a request to undeploy a model
+                          instance to offline state
             tags:
                 - ModelService
     /v1alpha/{name}/unpublish:
@@ -1215,16 +1215,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaUnpublishModelResponse'
+                        $ref: "#/definitions/v1alphaUnpublishModelResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    Resource name of the model.
-                    For example "models/{model}"
+                      Resource name of the model.
+                      For example "models/{model}"
                   in: path
                   required: true
                   type: string
@@ -1233,8 +1233,8 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    title: UnpublishModelRequest represents a request to unpublish a model
+                      type: object
+                      title: UnpublishModelRequest represents a request to unpublish a model
             tags:
                 - ModelService
     /v1alpha/{name}/write:
@@ -1248,16 +1248,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaWriteDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaWriteDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: name
                   description: |-
-                    DestinationConnector resource name. It must have the format of
-                    "destination-connectors/*"
+                      DestinationConnector resource name. It must have the format of
+                      "destination-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -1266,47 +1266,47 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        data_mapping_indices:
-                            type: array
-                            items:
-                                type: string
-                            title: Indices corresponds to each JSON data element
-                            required:
-                                - data_mapping_indices
-                        destination_sync_mode:
-                            $ref: '#/definitions/v1alphaSupportedDestinationSyncModes'
-                            title: |-
-                                Destination sync mode:
-                                https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
-                        model_instance_outputs:
-                            type: array
-                            items:
-                                $ref: '#/definitions/v1alphaModelInstanceOutput'
-                            title: JSON data to write
-                            required:
-                                - model_instance_outputs
-                        pipeline:
-                            type: string
-                            title: Pipeline resource name
-                            required:
-                                - pipeline
-                        recipe:
-                            $ref: '#/definitions/v1alphaRecipe'
-                            title: Pipeline recipe
-                        sync_mode:
-                            $ref: '#/definitions/v1alphaSupportedSyncModes'
-                            title: |-
-                                Sync mode:
-                                https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
-                    title: |-
-                        WriteDestinationConnectorRequest represents a request to perform write
-                        operation of a DestinationConnector given the resource name
-                    required:
-                        - pipeline
-                        - data_mapping_indices
-                        - model_instance_outputs
+                      type: object
+                      properties:
+                          data_mapping_indices:
+                              type: array
+                              items:
+                                  type: string
+                              title: Indices corresponds to each JSON data element
+                              required:
+                                  - data_mapping_indices
+                          destination_sync_mode:
+                              $ref: "#/definitions/v1alphaSupportedDestinationSyncModes"
+                              title: |-
+                                  Destination sync mode:
+                                  https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
+                          model_instance_outputs:
+                              type: array
+                              items:
+                                  $ref: "#/definitions/v1alphaModelInstanceOutput"
+                              title: JSON data to write
+                              required:
+                                  - model_instance_outputs
+                          pipeline:
+                              type: string
+                              title: Pipeline resource name
+                              required:
+                                  - pipeline
+                          recipe:
+                              $ref: "#/definitions/v1alphaRecipe"
+                              title: Pipeline recipe
+                          sync_mode:
+                              $ref: "#/definitions/v1alphaSupportedSyncModes"
+                              title: |-
+                                  Sync mode:
+                                  https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
+                      title: |-
+                          WriteDestinationConnectorRequest represents a request to perform write
+                          operation of a DestinationConnector given the resource name
+                      required:
+                          - pipeline
+                          - data_mapping_indices
+                          - model_instance_outputs
             tags:
                 - ConnectorService
     /v1alpha/{parent}/instances:
@@ -1319,26 +1319,26 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListModelInstanceResponse'
+                        $ref: "#/definitions/v1alphaListModelInstanceResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: parent
                   description: |-
-                    The name of the model whose instances we'd like to list.
-                    e.g., "models/yolov4"
+                      The name of the model whose instances we'd like to list.
+                      e.g., "models/yolov4"
                   in: path
                   required: true
                   type: string
                   pattern: models/[^/]+
                 - name: page_size
                   description: |-
-                    Page size: the maximum number of resources to return. The service may
-                    return fewer than this value. If unspecified, at most 10 model instances
-                    will be returned. The maximum value is 100; values above 100 will be
-                    coereced to 100.
+                      Page size: the maximum number of resources to return. The service may
+                      return fewer than this value. If unspecified, at most 10 model instances
+                      will be returned. The maximum value is 100; values above 100 will be
+                      coereced to 100.
                   in: query
                   required: false
                   type: string
@@ -1350,20 +1350,20 @@ paths:
                   type: string
                 - name: view
                   description: |-
-                    Model instance view (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-                    VIEW_FULL: show full information
+                      Model instance view (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+                      VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -1378,34 +1378,34 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaLookUpDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaLookUpDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: permalink_1
                   description: |-
-                    Permalink of a destination connector. For example:
-                    "destination-connectors/{uid}"
+                      Permalink of a destination connector. For example:
+                      "destination-connectors/{uid}"
                   in: path
                   required: true
                   type: string
                   pattern: destination-connectors/[^/]+
                 - name: view
                   description: |-
-                    SourceConnector view (default is VIEW_BASIC)
+                      SourceConnector view (default is VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -1419,36 +1419,36 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaLookUpModelResponse'
+                        $ref: "#/definitions/v1alphaLookUpModelResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: permalink_2
                   description: |-
-                    Permalink of a model. For example:
-                    "models/{uid}"
+                      Permalink of a model. For example:
+                      "models/{uid}"
                   in: path
                   required: true
                   type: string
                   pattern: models/[^/]+
                 - name: view
                   description: |-
-                    Model view (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
-                    VIEW_FULL: show full information
+                      Model view (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+                      VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -1463,36 +1463,36 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaLookUpModelInstanceResponse'
+                        $ref: "#/definitions/v1alphaLookUpModelInstanceResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: permalink_3
                   description: |-
-                    Permalink of a model instance. For example:
-                    "models/{model_uid}/instances/{instance_uid}"
+                      Permalink of a model instance. For example:
+                      "models/{model_uid}/instances/{instance_uid}"
                   in: path
                   required: true
                   type: string
                   pattern: models/[^/]+/instances/[^/]+
                 - name: view
                   description: |-
-                    Model instance view (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-                    VIEW_FULL: show full information
+                      Model instance view (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+                      VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -1506,34 +1506,34 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaLookUpPipelineResponse'
+                        $ref: "#/definitions/v1alphaLookUpPipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: permalink_4
                   description: |-
-                    Permalink of a pipeline. For example:
-                    "pipelines/{uid}"
+                      Permalink of a pipeline. For example:
+                      "pipelines/{uid}"
                   in: path
                   required: true
                   type: string
                   pattern: pipelines/[^/]+
                 - name: view
                   description: |-
-                    View view (default is VIEW_BASIC)
+                      View view (default is VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - PipelineService
@@ -1547,34 +1547,34 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaLookUpSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaLookUpSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: permalink
                   description: |-
-                    Permalink of a source connector. For example:
-                    "source-connectors/{uid}"
+                      Permalink of a source connector. For example:
+                      "source-connectors/{uid}"
                   in: path
                   required: true
                   type: string
                   pattern: source-connectors/[^/]+
                 - name: view
                   description: |-
-                    SourceConnector view (default is VIEW_BASIC)
+                      SourceConnector view (default is VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -1588,11 +1588,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetPipelineResponse'
+                        $ref: "#/definitions/v1alphaGetPipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: pipeline.name
                   description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1602,18 +1602,18 @@ paths:
                   pattern: pipelines/[^/]+
                 - name: view
                   description: |-
-                    Pipeline resource view (default is VIEW_BASIC)
+                      Pipeline resource view (default is VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - PipelineService
@@ -1626,11 +1626,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDeletePipelineResponse'
+                        $ref: "#/definitions/v1alphaDeletePipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: pipeline.name
                   description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1649,11 +1649,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaUpdatePipelineResponse'
+                        $ref: "#/definitions/v1alphaUpdatePipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: pipeline.name
                   description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1666,50 +1666,50 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        create_time:
-                            type: string
-                            format: date-time
-                            title: Pipeline creation time
-                            readOnly: true
-                        description:
-                            type: string
-                            title: Pipeline description
-                        id:
-                            type: string
-                            description: |-
-                                Pipeline resource ID (the last segment of the resource name) used to
-                                construct the resource name. This conforms to RFC-1034, which restricts to
-                                letters, numbers, and hyphen, with the first character a letter, the last a
-                                letter or a number, and a 63 character maximum.
-                        mode:
-                            $ref: '#/definitions/PipelineMode'
-                            title: Pipeline mode
-                        org:
-                            type: string
-                            title: The resource name of an organization
-                            readOnly: true
-                        recipe:
-                            $ref: '#/definitions/v1alphaRecipe'
-                            title: Pipeline recipe
-                        state:
-                            $ref: '#/definitions/v1alphaPipelineState'
-                            title: Pipeline state
-                        uid:
-                            type: string
-                            title: Pipeline UUID
-                            readOnly: true
-                        update_time:
-                            type: string
-                            format: date-time
-                            title: Pipeline update time
-                            readOnly: true
-                        user:
-                            type: string
-                            description: The resource name of a user, e.g., "users/local-user".
-                            readOnly: true
-                    title: A pipeline resource to update
+                      type: object
+                      properties:
+                          create_time:
+                              type: string
+                              format: date-time
+                              title: Pipeline creation time
+                              readOnly: true
+                          description:
+                              type: string
+                              title: Pipeline description
+                          id:
+                              type: string
+                              description: |-
+                                  Pipeline resource ID (the last segment of the resource name) used to
+                                  construct the resource name. This conforms to RFC-1034, which restricts to
+                                  letters, numbers, and hyphen, with the first character a letter, the last a
+                                  letter or a number, and a 63 character maximum.
+                          mode:
+                              $ref: "#/definitions/PipelineMode"
+                              title: Pipeline mode
+                          org:
+                              type: string
+                              title: The resource name of an organization
+                              readOnly: true
+                          recipe:
+                              $ref: "#/definitions/v1alphaRecipe"
+                              title: Pipeline recipe
+                          state:
+                              $ref: "#/definitions/v1alphaPipelineState"
+                              title: Pipeline state
+                          uid:
+                              type: string
+                              title: Pipeline UUID
+                              readOnly: true
+                          update_time:
+                              type: string
+                              format: date-time
+                              title: Pipeline update time
+                              readOnly: true
+                          user:
+                              type: string
+                              description: The resource name of a user, e.g., "users/local-user".
+                              readOnly: true
+                      title: A pipeline resource to update
                 - name: update_mask
                   description: Update mask for a pipeline resource
                   in: query
@@ -1727,34 +1727,34 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaGetSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: source_connector.name
                   description: |-
-                    SourceConnectorConnector resource name. It must have the format of
-                    "source-connectors/*"
+                      SourceConnectorConnector resource name. It must have the format of
+                      "source-connectors/*"
                   in: path
                   required: true
                   type: string
                   pattern: source-connectors/[^/]+
                 - name: view
                   description: |-
-                    SourceConnector view (default is VIEW_BASIC)
+                      SourceConnector view (default is VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -1767,16 +1767,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDeleteSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaDeleteSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: source_connector.name
                   description: |-
-                    SourceConnector resource name. It must have the format of
-                    "source-connectors/*"
+                      SourceConnector resource name. It must have the format of
+                      "source-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -1792,16 +1792,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaUpdateSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaUpdateSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: source_connector.name
                   description: |-
-                    SourceConnector resource name. It must have the format of
-                    "source-connectors/*"
+                      SourceConnector resource name. It must have the format of
+                      "source-connectors/*"
                   in: path
                   required: true
                   type: string
@@ -1811,26 +1811,26 @@ paths:
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        connector:
-                            $ref: '#/definitions/v1alphaConnector'
-                            title: SourceConnector's connector data structure
-                        id:
-                            type: string
-                            description: |-
-                                SourceConnector resource ID (the last segment of the resource name) used to
-                                construct the resource name. This conforms to RFC-1034, which restricts to
-                                letters, numbers, and hyphen, with the first character a letter, the last a
-                                letter or a number, and a 63 character maximum.
-                        source_connector_definition:
-                            type: string
-                            title: SourceConnectorDefinition resource
-                        uid:
-                            type: string
-                            title: SourceConnector UUID
-                            readOnly: true
-                    title: SourceConnector resource
+                      type: object
+                      properties:
+                          connector:
+                              $ref: "#/definitions/v1alphaConnector"
+                              title: SourceConnector's connector data structure
+                          id:
+                              type: string
+                              description: |-
+                                  SourceConnector resource ID (the last segment of the resource name) used to
+                                  construct the resource name. This conforms to RFC-1034, which restricts to
+                                  letters, numbers, and hyphen, with the first character a letter, the last a
+                                  letter or a number, and a 63 character maximum.
+                          source_connector_definition:
+                              type: string
+                              title: SourceConnectorDefinition resource
+                          uid:
+                              type: string
+                              title: SourceConnector UUID
+                              readOnly: true
+                      title: SourceConnector resource
                 - name: update_mask
                   description: Update mask for a SourceConnector resource
                   in: query
@@ -1849,34 +1849,34 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetSourceConnectorDefinitionResponse'
+                        $ref: "#/definitions/v1alphaGetSourceConnectorDefinitionResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: source_connector_definition.name
                   description: |-
-                    SourceConnectorDefinition resource name. It must have the format of
-                    "source-connector-definitions/*"
+                      SourceConnectorDefinition resource name. It must have the format of
+                      "source-connector-definitions/*"
                   in: path
                   required: true
                   type: string
                   pattern: source-connector-definitions/[^/]+
                 - name: view
                   description: |-
-                    SourceConnectorDefinition resource view (default is DEFINITION_VIEW_BASIC)
+                      SourceConnectorDefinition resource view (default is DEFINITION_VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -1890,16 +1890,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaExistUsernameResponse'
+                        $ref: "#/definitions/v1alphaExistUsernameResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: user.name
                   description: |-
-                    The resource name of the user to be deleted,
-                    for example: "users/local-user"
+                      The resource name of the user to be deleted,
+                      for example: "users/local-user"
                   in: path
                   required: true
                   type: string
@@ -1916,20 +1916,35 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaLookUpUserResponse'
+                        $ref: "#/definitions/v1alphaLookUpUserResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: permalink_1
                   description: |-
-                    Permalink of a user. For example:
-                    "users/{uid}"
+                      Permalink of a user. For example:
+                      "users/{uid}"
                   in: path
                   required: true
                   type: string
                   pattern: users/[^/]+
+                - name: view
+                  description: |-
+                      View view (default is VIEW_BASIC)
+
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
+                  in: query
+                  required: false
+                  type: string
+                  enum:
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
+                  default: VIEW_UNSPECIFIED
             tags:
                 - UserService
     /v1alpha/admin/{permalink}/lookUp:
@@ -1942,20 +1957,35 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaLookUpPlanResponse'
+                        $ref: "#/definitions/v1alphaLookUpPlanResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: permalink
                   description: |-
-                    Permalink of a plan. For example:
-                    "plans/{uid}"
+                      Permalink of a plan. For example:
+                      "plans/{uid}"
                   in: path
                   required: true
                   type: string
                   pattern: plans/[^/]+
+                - name: view
+                  description: |-
+                      Plan resource view (default is VIEW_BASIC)
+
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
+                  in: query
+                  required: false
+                  type: string
+                  enum:
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
+                  default: VIEW_UNSPECIFIED
             tags:
                 - PlanService
     /v1alpha/admin/{plan.name}:
@@ -1968,20 +1998,35 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetPlanResponse'
+                        $ref: "#/definitions/v1alphaGetPlanResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: plan.name
                   description: |-
-                    Resource name of a plan. For example:
-                    "plans/free"
+                      Resource name of a plan. For example:
+                      "plans/free"
                   in: path
                   required: true
                   type: string
                   pattern: plans/[^/]+
+                - name: view
+                  description: |-
+                      Plan resource view (default is VIEW_BASIC)
+
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
+                  in: query
+                  required: false
+                  type: string
+                  enum:
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
+                  default: VIEW_UNSPECIFIED
             tags:
                 - PlanService
         delete:
@@ -1993,16 +2038,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDeletePlanResponse'
+                        $ref: "#/definitions/v1alphaDeletePlanResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: plan.name
                   description: |-
-                    The resource name of the plan to be deleted,
-                    for example: "plans/local-plan"
+                      The resource name of the plan to be deleted,
+                      for example: "plans/free"
                   in: path
                   required: true
                   type: string
@@ -2018,69 +2063,69 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaUpdatePlanResponse'
+                        $ref: "#/definitions/v1alphaUpdatePlanResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: plan.name
                   description: |-
-                    Resource name. It must have the format of "plans/*".
-                    For example: "plans/free".
+                      Resource name. It must have the format of "plans/*".
+                      For example: "plans/free".
                   in: path
                   required: true
                   type: string
                   pattern: plans/[^/]+
                 - name: plan
                   description: |-
-                    The plan to update
+                      The plan to update
 
-                    The plan's `name` field is used to identify the plan to update.
-                    Format: plans/{plan}
+                      The plan's `name` field is used to identify the plan to update.
+                      Format: plans/{plan}
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        create_time:
-                            type: string
-                            format: date-time
-                            title: Plan creation time
-                            readOnly: true
-                        id:
-                            type: string
-                            description: |-
-                                Pipeline resource ID (the last segment of the resource name) used to
-                                construct the resource name. This conforms to RFC-1034, which restricts to
-                                letters, numbers, and hyphen, with the first character a letter, the last a
-                                letter or a number, and a 63 character maximum.
-                        spec:
-                            type: object
-                            title: Plan specification in JSON format
-                            required:
-                                - spec
-                        tier:
-                            $ref: '#/definitions/PlanTier'
-                            title: Plan tier
-                        uid:
-                            type: string
-                            title: Pipeline UUID
-                            readOnly: true
-                        update_time:
-                            type: string
-                            format: date-time
-                            title: Plan update time
-                            readOnly: true
-                        visibility:
-                            $ref: '#/definitions/v1alphaPlanVisibility'
-                            title: Plan visibility
-                    description: |-
-                        The plan's `name` field is used to identify the plan to update.
-                        Format: plans/{plan}
-                    title: The plan to update
-                    required:
-                        - spec
+                      type: object
+                      properties:
+                          create_time:
+                              type: string
+                              format: date-time
+                              title: Plan creation time
+                              readOnly: true
+                          id:
+                              type: string
+                              description: |-
+                                  Plan resource ID (the last segment of the resource name) used to
+                                  construct the resource name. This conforms to RFC-1034, which restricts to
+                                  letters, numbers, and hyphen, with the first character a letter, the last a
+                                  letter or a number, and a 63 character maximum.
+                          spec:
+                              type: object
+                              title: Plan specification in JSON format
+                              required:
+                                  - spec
+                          tier:
+                              $ref: "#/definitions/PlanTier"
+                              title: Plan tier
+                          uid:
+                              type: string
+                              title: Plan UUID
+                              readOnly: true
+                          update_time:
+                              type: string
+                              format: date-time
+                              title: Plan update time
+                              readOnly: true
+                          visibility:
+                              $ref: "#/definitions/v1alphaPlanVisibility"
+                              title: Plan visibility
+                      description: |-
+                          The plan's `name` field is used to identify the plan to update.
+                          Format: plans/{plan}
+                      title: The plan to update
+                      required:
+                          - spec
                 - name: update_mask
                   description: Update mask for a plan resource
                   in: query
@@ -2098,20 +2143,35 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetUserResponse'
+                        $ref: "#/definitions/v1alphaGetUserResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: user.name
                   description: |-
-                    Resource name of a user. For example:
-                    "users/instill"
+                      Resource name of a user. For example:
+                      "users/instill"
                   in: path
                   required: true
                   type: string
                   pattern: users/[^/]+
+                - name: view
+                  description: |-
+                      View view (default is VIEW_BASIC)
+
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
+                  in: query
+                  required: false
+                  type: string
+                  enum:
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
+                  default: VIEW_UNSPECIFIED
             tags:
                 - UserService
         delete:
@@ -2123,16 +2183,16 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaDeleteUserResponse'
+                        $ref: "#/definitions/v1alphaDeleteUserResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: user.name
                   description: |-
-                    The resource name of the user to be deleted,
-                    for example: "users/local-user"
+                      The resource name of the user to be deleted,
+                      for example: "users/local-user"
                   in: path
                   required: true
                   type: string
@@ -2148,99 +2208,99 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaUpdateUserResponse'
+                        $ref: "#/definitions/v1alphaUpdateUserResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: user.name
                   description: |-
-                    Resource name. It must have the format of "users/*".
-                    For example: "users/local-user".
+                      Resource name. It must have the format of "users/*".
+                      For example: "users/local-user".
                   in: path
                   required: true
                   type: string
                   pattern: users/[^/]+
                 - name: user
                   description: |-
-                    The user to update
+                      The user to update
 
-                    The user's `name` field is used to identify the user to update.
-                    Format: users/{user}
+                      The user's `name` field is used to identify the user to update.
+                      Format: users/{user}
                   in: body
                   required: true
                   schema:
-                    type: object
-                    properties:
-                        cookie_token:
-                            type: string
-                            title: User console cookie token
-                        create_time:
-                            type: string
-                            format: date-time
-                            title: User creation time
-                            readOnly: true
-                        email:
-                            type: string
-                            title: User email
-                            required:
-                                - email
-                        first_name:
-                            type: string
-                            title: User first name
-                        id:
-                            type: string
-                            description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
-                            required:
-                                - id
-                        last_name:
-                            type: string
-                            title: User last name
-                        newsletter_subscription:
-                            type: boolean
-                            title: User newsletter subscription
-                            required:
-                                - newsletter_subscription
-                        org_name:
-                            type: string
-                            title: User company or institution name
-                        plan:
-                            type: string
-                            description: User plan. This field is not used in open-source VDP.
-                        role:
-                            type: string
-                            title: |-
-                                User role. Allowed roles:
-                                 - "manager"
-                                 - "ai-researcher"
-                                 - "ai-engineer"
-                                 - "data-engineer",
-                                 - "data-scientist",
-                                 - "analytics-engineer"
-                                 - "hobbyist"
-                        type:
-                            $ref: '#/definitions/v1alphaOwnerType'
-                            title: 'Owner type: fixed to `OWNER_TYPE_USER`'
-                        uid:
-                            type: string
-                            title: User ID in UUIDv4
-                            required:
-                                - uid
-                        update_time:
-                            type: string
-                            format: date-time
-                            title: User update time
-                            readOnly: true
-                    description: |-
-                        The user's `name` field is used to identify the user to update.
-                        Format: users/{user}
-                    title: The user to update
-                    required:
-                        - uid
-                        - id
-                        - email
-                        - newsletter_subscription
+                      type: object
+                      properties:
+                          cookie_token:
+                              type: string
+                              title: User console cookie token
+                          create_time:
+                              type: string
+                              format: date-time
+                              title: User creation time
+                              readOnly: true
+                          email:
+                              type: string
+                              title: User email
+                              required:
+                                  - email
+                          first_name:
+                              type: string
+                              title: User first name
+                          id:
+                              type: string
+                              description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
+                              required:
+                                  - id
+                          last_name:
+                              type: string
+                              title: User last name
+                          newsletter_subscription:
+                              type: boolean
+                              title: User newsletter subscription
+                              required:
+                                  - newsletter_subscription
+                          org_name:
+                              type: string
+                              title: User company or institution name
+                          plan:
+                              type: string
+                              description: User plan. This field is not used in open-source VDP.
+                          role:
+                              type: string
+                              title: |-
+                                  User role. Allowed roles:
+                                   - "manager"
+                                   - "ai-researcher"
+                                   - "ai-engineer"
+                                   - "data-engineer",
+                                   - "data-scientist",
+                                   - "analytics-engineer"
+                                   - "hobbyist"
+                          type:
+                              $ref: "#/definitions/v1alphaOwnerType"
+                              title: "Owner type: fixed to `OWNER_TYPE_USER`"
+                          uid:
+                              type: string
+                              title: User ID in UUIDv4
+                              required:
+                                  - uid
+                          update_time:
+                              type: string
+                              format: date-time
+                              title: User update time
+                              readOnly: true
+                      description: |-
+                          The user's `name` field is used to identify the user to update.
+                          Format: users/{user}
+                      title: The user to update
+                      required:
+                          - uid
+                          - id
+                          - email
+                          - newsletter_subscription
                 - name: update_mask
                   description: Update mask for a user resource
                   in: query
@@ -2258,24 +2318,44 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListPlanResponse'
+                        $ref: "#/definitions/v1alphaListPlanResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    Page size: the maximum number of resources to return. The service may
-                    return fewer than this value. If unspecified, at most 10 plans will be
-                    returned. The maximum value is 100; values above 100 will be coereced to
-                    100.
+                      Page size: the maximum number of resources to return. The service may
+                      return fewer than this value. If unspecified, at most 10 plans will be
+                      returned. The maximum value is 100; values above 100 will be coereced to
+                      100.
                   in: query
                   required: false
                   type: string
                   format: int64
                 - name: page_token
                   description: Page token
+                  in: query
+                  required: false
+                  type: string
+                - name: view
+                  description: |-
+                      View view (default is VIEW_BASIC)
+
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
+                  in: query
+                  required: false
+                  type: string
+                  enum:
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
+                  default: VIEW_UNSPECIFIED
+                - name: filter
+                  description: Filter expression to list plans
                   in: query
                   required: false
                   type: string
@@ -2290,22 +2370,22 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaCreatePlanResponse'
+                        $ref: "#/definitions/v1alphaCreatePlanResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: plan
                   description: |-
-                    The plan to be created
+                      The plan to be created
 
-                    The plan's `name` field is used to identify the plan to create.
-                    Format: plans/{plan}
+                      The plan's `name` field is used to identify the plan to create.
+                      Format: plans/{plan}
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/v1alphaPlan'
+                      $ref: "#/definitions/v1alphaPlan"
             tags:
                 - PlanService
     /v1alpha/admin/users:
@@ -2318,24 +2398,44 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListUserResponse'
+                        $ref: "#/definitions/v1alphaListUserResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    Page size: the maximum number of resources to return. The service may
-                    return fewer than this value. If unspecified, at most 10 users will be
-                    returned. The maximum value is 100; values above 100 will be coereced to
-                    100.
+                      Page size: the maximum number of resources to return. The service may
+                      return fewer than this value. If unspecified, at most 10 users will be
+                      returned. The maximum value is 100; values above 100 will be coereced to
+                      100.
                   in: query
                   required: false
                   type: string
                   format: int64
                 - name: page_token
                   description: Page token
+                  in: query
+                  required: false
+                  type: string
+                - name: view
+                  description: |-
+                      View view (default is VIEW_BASIC)
+
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
+                  in: query
+                  required: false
+                  type: string
+                  enum:
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
+                  default: VIEW_UNSPECIFIED
+                - name: filter
+                  description: Filter expression to list users
                   in: query
                   required: false
                   type: string
@@ -2350,22 +2450,22 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaCreateUserResponse'
+                        $ref: "#/definitions/v1alphaCreateUserResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: user
                   description: |-
-                    The user to be created
+                      The user to be created
 
-                    The user's `name` field is used to identify the user to create.
-                    Format: users/{user}
+                      The user's `name` field is used to identify the user to create.
+                      Format: users/{user}
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/v1alphaUser'
+                      $ref: "#/definitions/v1alphaUser"
             tags:
                 - UserService
     /v1alpha/destination-connector-definitions:
@@ -2379,18 +2479,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListDestinationConnectorDefinitionResponse'
+                        $ref: "#/definitions/v1alphaListDestinationConnectorDefinitionResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    The maximum number of DestinationConnectorDefinitions to return. The
-                    service may return fewer than this value. If unspecified, at most 10
-                    DestinationConnectorDefinitions will be returned. The maximum value is 100;
-                    values above 100 will be coerced to 100.
+                      The maximum number of DestinationConnectorDefinitions to return. The
+                      service may return fewer than this value. If unspecified, at most 10
+                      DestinationConnectorDefinitions will be returned. The maximum value is 100;
+                      values above 100 will be coerced to 100.
                   in: query
                   required: false
                   type: string
@@ -2402,18 +2502,18 @@ paths:
                   type: string
                 - name: view
                   description: |-
-                    Definition view (default is DEFINITION_VIEW_BASIC)
+                      Definition view (default is DEFINITION_VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -2427,17 +2527,17 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaListDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    The maximum number of connectors to return. The service may return fewer
-                    than this value. If unspecified, at most 10 connectors will be returned.
-                    The maximum value is 100; values above 100 will be coerced to 100.
+                      The maximum number of connectors to return. The service may return fewer
+                      than this value. If unspecified, at most 10 connectors will be returned.
+                      The maximum value is 100; values above 100 will be coerced to 100.
                   in: query
                   required: false
                   type: string
@@ -2449,18 +2549,18 @@ paths:
                   type: string
                 - name: view
                   description: |-
-                    DestinationConnector view (default is VIEW_BASIC)
+                      DestinationConnector view (default is VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -2474,18 +2574,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaCreateDestinationConnectorResponse'
+                        $ref: "#/definitions/v1alphaCreateDestinationConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: destination_connector
                   description: DestinationConnector resource
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/v1alphaDestinationConnector'
+                      $ref: "#/definitions/v1alphaDestinationConnector"
             tags:
                 - ConnectorService
     /v1alpha/health/billing:
@@ -2499,11 +2599,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpbillingv1alphaLivenessResponse'
+                        $ref: "#/definitions/vdpbillingv1alphaLivenessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -2523,11 +2623,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpconnectorv1alphaLivenessResponse'
+                        $ref: "#/definitions/vdpconnectorv1alphaLivenessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -2547,11 +2647,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpmgmtv1alphaLivenessResponse'
+                        $ref: "#/definitions/vdpmgmtv1alphaLivenessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -2571,11 +2671,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpmodelv1alphaLivenessResponse'
+                        $ref: "#/definitions/vdpmodelv1alphaLivenessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -2595,11 +2695,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdppipelinev1alphaLivenessResponse'
+                        $ref: "#/definitions/vdppipelinev1alphaLivenessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -2619,11 +2719,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpusagev1alphaLivenessResponse'
+                        $ref: "#/definitions/vdpusagev1alphaLivenessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -2642,18 +2742,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListModelDefinitionResponse'
+                        $ref: "#/definitions/v1alphaListModelDefinitionResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    Page size: the maximum number of resources to return. The service may
-                    return fewer than this value. If unspecified, at most 10 ModelDefinitions
-                    will be returned. The maximum value is 100; values above 100 will be
-                    coereced to 100.
+                      Page size: the maximum number of resources to return. The service may
+                      return fewer than this value. If unspecified, at most 10 ModelDefinitions
+                      will be returned. The maximum value is 100; values above 100 will be
+                      coereced to 100.
                   in: query
                   required: false
                   type: string
@@ -2665,21 +2765,21 @@ paths:
                   type: string
                 - name: view
                   description: |-
-                    Definition view (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
-                    `ModelDefinition.model_instance_spec`
-                    VIEW_FULL: show full information
+                      Definition view (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
+                      `ModelDefinition.model_instance_spec`
+                      VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -2693,18 +2793,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListModelResponse'
+                        $ref: "#/definitions/v1alphaListModelResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    Page size: the maximum number of resources to return. The service may
-                    return fewer than this value. If unspecified, at most 10 models will be
-                    returned. The maximum value is 100; values above 100 will be coereced to
-                    100.
+                      Page size: the maximum number of resources to return. The service may
+                      return fewer than this value. If unspecified, at most 10 models will be
+                      returned. The maximum value is 100; values above 100 will be coereced to
+                      100.
                   in: query
                   required: false
                   type: string
@@ -2716,20 +2816,20 @@ paths:
                   type: string
                 - name: view
                   description: |-
-                    Model view (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
-                    VIEW_FULL: show full information
+                      Model view (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+                      VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -2742,22 +2842,22 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaCreateModelResponse'
+                        $ref: "#/definitions/v1alphaCreateModelResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: model
                   description: |-
-                    The model to be created
+                      The model to be created
 
-                    The model `name` field is used to identify the model to create.
-                    Format: models/{model}
+                      The model `name` field is used to identify the model to create.
+                      Format: models/{model}
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/v1alphaModel'
+                      $ref: "#/definitions/v1alphaModel"
             tags:
                 - ModelService
     /v1alpha/operations:
@@ -2770,18 +2870,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListModelOperationResponse'
+                        $ref: "#/definitions/v1alphaListModelOperationResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    Page size: the maximum number of resources to return. The service may
-                    return fewer than this value. If unspecified, at most 10 operations will be
-                    returned. The maximum value is 100; values above 100 will be coereced to
-                    100.
+                      Page size: the maximum number of resources to return. The service may
+                      return fewer than this value. If unspecified, at most 10 operations will be
+                      returned. The maximum value is 100; values above 100 will be coereced to
+                      100.
                   in: query
                   required: false
                   type: string
@@ -2798,20 +2898,20 @@ paths:
                   type: string
                 - name: view
                   description: |-
-                    View (default is VIEW_BASIC)
-                    VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-                    `ModelInstance.configuration` VIEW_FULL: show full information
+                      View (default is VIEW_BASIC)
+                      VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
+                      `ModelInstance.configuration` VIEW_FULL: show full information
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-                     - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-                     - VIEW_FULL: View: FULL, full representation of the resource
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+                       - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+                       - VIEW_FULL: View: FULL, full representation of the resource
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ModelService
@@ -2825,17 +2925,17 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListPipelineResponse'
+                        $ref: "#/definitions/v1alphaListPipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    The maximum number of pipelines to return. The service may return fewer
-                    than this value. If unspecified, at most 10 pipelines will be returned. The
-                    maximum value is 100; values above 100 will be coerced to 100.
+                      The maximum number of pipelines to return. The service may return fewer
+                      than this value. If unspecified, at most 10 pipelines will be returned. The
+                      maximum value is 100; values above 100 will be coerced to 100.
                   in: query
                   required: false
                   type: string
@@ -2847,18 +2947,18 @@ paths:
                   type: string
                 - name: view
                   description: |-
-                    View view (default is VIEW_BASIC)
+                      View view (default is VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
                 - name: filter
                   description: Filter expression to list pipelines
@@ -2876,18 +2976,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaCreatePipelineResponse'
+                        $ref: "#/definitions/v1alphaCreatePipelineResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: pipeline
                   description: A pipeline resource to create
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/v1alphaPipeline'
+                      $ref: "#/definitions/v1alphaPipeline"
             tags:
                 - PipelineService
     /v1alpha/ready/billing:
@@ -2901,11 +3001,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpbillingv1alphaReadinessResponse'
+                        $ref: "#/definitions/vdpbillingv1alphaReadinessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -2925,11 +3025,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpmgmtv1alphaReadinessResponse'
+                        $ref: "#/definitions/vdpmgmtv1alphaReadinessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -2949,11 +3049,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/vdpmodelv1alphaReadinessResponse'
+                        $ref: "#/definitions/vdpmodelv1alphaReadinessResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: health_check_request.service
                   description: Service name to check for its readiness status
@@ -2972,18 +3072,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaSendSessionReportResponse'
+                        $ref: "#/definitions/v1alphaSendSessionReportResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: report
                   description: A report resource to create
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/v1alphaSessionReport'
+                      $ref: "#/definitions/v1alphaSessionReport"
             tags:
                 - UsageService
     /v1alpha/sessions:
@@ -2996,18 +3096,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaCreateSessionResponse'
+                        $ref: "#/definitions/v1alphaCreateSessionResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: session
                   description: A session resource to create
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/v1alphaSession'
+                      $ref: "#/definitions/v1alphaSession"
             tags:
                 - UsageService
     /v1alpha/source-connector-definitions:
@@ -3021,18 +3121,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListSourceConnectorDefinitionResponse'
+                        $ref: "#/definitions/v1alphaListSourceConnectorDefinitionResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    The maximum number of SourceConnectorDefinitions to return. The service may
-                    return fewer than this value. If unspecified, at most 10
-                    SourceConnectorDefinitions will be returned. The maximum value is 100;
-                    values above 100 will be coerced to 100.
+                      The maximum number of SourceConnectorDefinitions to return. The service may
+                      return fewer than this value. If unspecified, at most 10
+                      SourceConnectorDefinitions will be returned. The maximum value is 100;
+                      values above 100 will be coerced to 100.
                   in: query
                   required: false
                   type: string
@@ -3044,18 +3144,18 @@ paths:
                   type: string
                 - name: view
                   description: |-
-                    Definition view (default is DEFINITION_VIEW_BASIC)
+                      Definition view (default is DEFINITION_VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -3069,17 +3169,17 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaListSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaListSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: page_size
                   description: |-
-                    The maximum number of connectors to return. The service may return fewer
-                    than this value. If unspecified, at most 10 connectors will be returned.
-                    The maximum value is 100; values above 100 will be coerced to 100.
+                      The maximum number of connectors to return. The service may return fewer
+                      than this value. If unspecified, at most 10 connectors will be returned.
+                      The maximum value is 100; values above 100 will be coerced to 100.
                   in: query
                   required: false
                   type: string
@@ -3091,18 +3191,18 @@ paths:
                   type: string
                 - name: view
                   description: |-
-                    SourceConnector view (default is VIEW_BASIC)
+                      SourceConnector view (default is VIEW_BASIC)
 
-                     - VIEW_UNSPECIFIED: View: UNSPECIFIED
-                     - VIEW_BASIC: View: BASIC
-                     - VIEW_FULL: View: FULL
+                       - VIEW_UNSPECIFIED: View: UNSPECIFIED
+                       - VIEW_BASIC: View: BASIC
+                       - VIEW_FULL: View: FULL
                   in: query
                   required: false
                   type: string
                   enum:
-                    - VIEW_UNSPECIFIED
-                    - VIEW_BASIC
-                    - VIEW_FULL
+                      - VIEW_UNSPECIFIED
+                      - VIEW_BASIC
+                      - VIEW_FULL
                   default: VIEW_UNSPECIFIED
             tags:
                 - ConnectorService
@@ -3115,18 +3215,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaCreateSourceConnectorResponse'
+                        $ref: "#/definitions/v1alphaCreateSourceConnectorResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: source_connector
                   description: SourceConnector resource
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/v1alphaSourceConnector'
+                      $ref: "#/definitions/v1alphaSourceConnector"
             tags:
                 - ConnectorService
     /v1alpha/user:
@@ -3139,11 +3239,11 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaGetAuthenticatedUserResponse'
+                        $ref: "#/definitions/v1alphaGetAuthenticatedUserResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             tags:
                 - UserService
         patch:
@@ -3153,18 +3253,18 @@ paths:
                 "200":
                     description: A successful response.
                     schema:
-                        $ref: '#/definitions/v1alphaUpdateAuthenticatedUserResponse'
+                        $ref: "#/definitions/v1alphaUpdateAuthenticatedUserResponse"
                 default:
                     description: An unexpected error response.
                     schema:
-                        $ref: '#/definitions/rpcStatus'
+                        $ref: "#/definitions/rpcStatus"
             parameters:
                 - name: user
                   description: The user to update
                   in: body
                   required: true
                   schema:
-                    $ref: '#/definitions/v1alphaUser'
+                      $ref: "#/definitions/v1alphaUser"
                 - name: update_mask
                   description: Update mask for a user resource
                   in: query
@@ -3269,10 +3369,10 @@ definitions:
                     If `true`, the operation is completed, and either `error` or `response` is
                     available.
             error:
-                $ref: '#/definitions/rpcStatus'
+                $ref: "#/definitions/rpcStatus"
                 description: The error result of the operation in case of failure or cancellation.
             metadata:
-                $ref: '#/definitions/protobufAny'
+                $ref: "#/definitions/protobufAny"
                 description: |-
                     Service-specific metadata associated with the operation.  It typically
                     contains progress information and common metadata such as create time.
@@ -3285,7 +3385,7 @@ definitions:
                     originally returns it. If you use the default HTTP mapping, the
                     `name` should be a resource name ending with `operations/{unique_id}`.
             response:
-                $ref: '#/definitions/protobufAny'
+                $ref: "#/definitions/protobufAny"
                 description: |-
                     The normal response of the operation in case of success.  If the original
                     method returns no data on success, such as `Delete`, the response is
@@ -3301,7 +3401,7 @@ definitions:
     protobufAny:
         type: object
         properties:
-            '@type':
+            "@type":
                 type: string
                 description: |-
                     A URL/resource name that uniquely identifies the type of the serialized
@@ -3437,7 +3537,7 @@ definitions:
             details:
                 type: array
                 items:
-                    $ref: '#/definitions/protobufAny'
+                    $ref: "#/definitions/protobufAny"
                 description: |-
                     A list of messages that carry the error details.  There is a common set of
                     message types for APIs to use.
@@ -3495,17 +3595,17 @@ definitions:
         type: object
         properties:
             pipeline:
-                $ref: '#/definitions/v1alphaPipeline'
+                $ref: "#/definitions/v1alphaPipeline"
                 title: A pipeline resource
         title: ActivatePipelineResponse represents an activated pipeline
     v1alphaAdvancedAuth:
         type: object
         properties:
             auth_flow_type:
-                $ref: '#/definitions/AdvancedAuthAuthFlowType'
+                $ref: "#/definitions/AdvancedAuthAuthFlowType"
                 title: AdvancedAuth auth flow type
             oauth_config_specification:
-                $ref: '#/definitions/v1alphaOauthConfigSpecification'
+                $ref: "#/definitions/v1alphaOauthConfigSpecification"
                 title: OauthConfigSpecification represents OAuth config specification
             predicate_key:
                 type: array
@@ -3586,7 +3686,7 @@ definitions:
         type: object
         properties:
             destination_connector:
-                $ref: '#/definitions/v1alphaDestinationConnector'
+                $ref: "#/definitions/v1alphaDestinationConnector"
                 title: A DestinationConnector resource
         title: |-
             ConnectDestinationConnectorResponse represents a connected destination
@@ -3595,7 +3695,7 @@ definitions:
         type: object
         properties:
             source_connector:
-                $ref: '#/definitions/v1alphaSourceConnector'
+                $ref: "#/definitions/v1alphaSourceConnector"
                 title: A SourceConnector resource
         title: ConnectSourceConnectorResponse represents a connected source connector
     v1alphaConnector:
@@ -3619,7 +3719,7 @@ definitions:
                 title: The resource name of an organization
                 readOnly: true
             state:
-                $ref: '#/definitions/v1alphaConnectorState'
+                $ref: "#/definitions/v1alphaConnectorState"
                 title: Connector state
             tombstone:
                 type: boolean
@@ -3674,19 +3774,19 @@ definitions:
                     definition is available to all workspaces
                 readOnly: true
             release_date:
-                $ref: '#/definitions/typeDate'
+                $ref: "#/definitions/typeDate"
                 description: |-
                     ConnectorDefinition release date, i.e., the date when this connector
                     was first released, in yyyy-mm-dd format.
             release_stage:
-                $ref: '#/definitions/vdpconnectorv1alphaReleaseStage'
+                $ref: "#/definitions/vdpconnectorv1alphaReleaseStage"
                 title: ConnectorDefinition release stage
             resource_requirements:
                 type: object
                 title: ConnectorDefinition resource requirements
                 readOnly: true
             spec:
-                $ref: '#/definitions/v1alphaSpec'
+                $ref: "#/definitions/v1alphaSpec"
                 title: ConnectorDefinition spec
             title:
                 type: string
@@ -3725,7 +3825,7 @@ definitions:
             usages:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaConnectorUsageDataUserUsageData'
+                    $ref: "#/definitions/v1alphaConnectorUsageDataUserUsageData"
                 title: Usage data of all users in the connector service
         title: Connector service usage data
     v1alphaConnectorUsageDataUserUsageData:
@@ -3791,7 +3891,7 @@ definitions:
         type: object
         properties:
             destination_connector:
-                $ref: '#/definitions/v1alphaDestinationConnector'
+                $ref: "#/definitions/v1alphaDestinationConnector"
                 title: DestinationConnector resource
         title: |-
             CreateDestinationConnectorResponse represents a response for a
@@ -3800,7 +3900,7 @@ definitions:
         type: object
         properties:
             operation:
-                $ref: '#/definitions/googlelongrunningOperation'
+                $ref: "#/definitions/googlelongrunningOperation"
                 title: Create model operation message
         title: |-
             CreateModelBinaryFileUploadResponse represents a response for a model
@@ -3809,35 +3909,35 @@ definitions:
         type: object
         properties:
             operation:
-                $ref: '#/definitions/googlelongrunningOperation'
+                $ref: "#/definitions/googlelongrunningOperation"
                 title: Create model operation message
         title: CreateModelResponse represents a response for a model
     v1alphaCreatePipelineResponse:
         type: object
         properties:
             pipeline:
-                $ref: '#/definitions/v1alphaPipeline'
+                $ref: "#/definitions/v1alphaPipeline"
                 title: The created pipeline resource
         title: CreatePipelineResponse represents a response for a pipeline resource
     v1alphaCreatePlanResponse:
         type: object
         properties:
             plan:
-                $ref: '#/definitions/v1alphaPlan'
+                $ref: "#/definitions/v1alphaPlan"
                 title: A plan resource
         title: CreatePlanResponse represents a response for a plan response
     v1alphaCreateSessionResponse:
         type: object
         properties:
             session:
-                $ref: '#/definitions/v1alphaSession'
+                $ref: "#/definitions/v1alphaSession"
                 title: A session resource
         title: CreateSessionResponse represents a response for a session response
     v1alphaCreateSourceConnectorResponse:
         type: object
         properties:
             source_connector:
-                $ref: '#/definitions/v1alphaSourceConnector'
+                $ref: "#/definitions/v1alphaSourceConnector"
                 title: SourceConnector resource
         title: |-
             CreateSourceConnectorResponse represents a response for a
@@ -3846,14 +3946,14 @@ definitions:
         type: object
         properties:
             user:
-                $ref: '#/definitions/v1alphaUser'
+                $ref: "#/definitions/v1alphaUser"
                 title: A user resource
         title: CreateUserResponse represents a response for a user response
     v1alphaDeactivatePipelineResponse:
         type: object
         properties:
             pipeline:
-                $ref: '#/definitions/v1alphaPipeline'
+                $ref: "#/definitions/v1alphaPipeline"
                 title: A pipeline resource
         title: DeactivatePipelineResponse represents an inactivated pipeline
     v1alphaDeleteDestinationConnectorResponse:
@@ -3878,7 +3978,7 @@ definitions:
         type: object
         properties:
             operation:
-                $ref: '#/definitions/googlelongrunningOperation'
+                $ref: "#/definitions/googlelongrunningOperation"
                 title: Deploy operation message
         title: |-
             DeployModelInstanceResponse represents a response for a deployed model
@@ -3887,7 +3987,7 @@ definitions:
         type: object
         properties:
             connector:
-                $ref: '#/definitions/v1alphaConnector'
+                $ref: "#/definitions/v1alphaConnector"
                 title: DestinationConnector's connector data structure
             destination_connector_definition:
                 type: string
@@ -3914,7 +4014,7 @@ definitions:
         type: object
         properties:
             connector_definition:
-                $ref: '#/definitions/v1alphaConnectorDefinition'
+                $ref: "#/definitions/v1alphaConnectorDefinition"
                 title: DestinationConnectorDefinition connector definition
             id:
                 type: string
@@ -3951,7 +4051,7 @@ definitions:
         type: object
         properties:
             bounding_box:
-                $ref: '#/definitions/v1alphaBoundingBox'
+                $ref: "#/definitions/v1alphaBoundingBox"
                 title: Detection bounding box
             category:
                 type: string
@@ -3969,7 +4069,7 @@ definitions:
             objects:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaDetectionObject'
+                    $ref: "#/definitions/v1alphaDetectionObject"
                 title: A list of detection objects
                 readOnly: true
         title: DetectionOutput represents the output of detection task
@@ -3977,7 +4077,7 @@ definitions:
         type: object
         properties:
             destination_connector:
-                $ref: '#/definitions/v1alphaDestinationConnector'
+                $ref: "#/definitions/v1alphaDestinationConnector"
                 title: A DestinationConnector resource
         title: |-
             DisconnectDestinationConnectorResponse represents a disconnected destination
@@ -3986,7 +4086,7 @@ definitions:
         type: object
         properties:
             source_connector:
-                $ref: '#/definitions/v1alphaSourceConnector'
+                $ref: "#/definitions/v1alphaSourceConnector"
                 title: A SourceConnector resource
         title: DisconnectSourceConnectorResponse represents a disconnected source connector
     v1alphaExistUsernameResponse:
@@ -4002,7 +4102,7 @@ definitions:
         type: object
         properties:
             user:
-                $ref: '#/definitions/v1alphaUser'
+                $ref: "#/definitions/v1alphaUser"
                 title: A user resource
         title: |-
             GetAuthenticatedUserResponse represents a response for
@@ -4011,7 +4111,7 @@ definitions:
         type: object
         properties:
             destination_connector_definition:
-                $ref: '#/definitions/v1alphaDestinationConnectorDefinition'
+                $ref: "#/definitions/v1alphaDestinationConnectorDefinition"
                 title: A DestinationConnectorDefinition resource
         title: |-
             GetDestinationConnectorDefinitionResponse represents a
@@ -4020,7 +4120,7 @@ definitions:
         type: object
         properties:
             destination_connector:
-                $ref: '#/definitions/v1alphaDestinationConnector'
+                $ref: "#/definitions/v1alphaDestinationConnector"
                 title: DestinationConnector resource
         title: |-
             GetDestinationConnectorResponse represents a response for a
@@ -4029,14 +4129,14 @@ definitions:
         type: object
         properties:
             model_definition:
-                $ref: '#/definitions/v1alphaModelDefinition'
+                $ref: "#/definitions/v1alphaModelDefinition"
                 title: A model definition instance
         title: GetModelDefinitionResponse represents a response for a model definition
     v1alphaGetModelInstanceCardResponse:
         type: object
         properties:
             readme:
-                $ref: '#/definitions/v1alphaModelInstanceCard'
+                $ref: "#/definitions/v1alphaModelInstanceCard"
                 title: Retrieved model instance card
         title: |-
             GetModelInstanceCardResponse represents a response to fetch a model
@@ -4045,42 +4145,42 @@ definitions:
         type: object
         properties:
             instance:
-                $ref: '#/definitions/v1alphaModelInstance'
+                $ref: "#/definitions/v1alphaModelInstance"
                 title: Retrieved model instance
         title: GetModelInstanceResponse represents a response for a model instance
     v1alphaGetModelOperationResponse:
         type: object
         properties:
             operation:
-                $ref: '#/definitions/googlelongrunningOperation'
+                $ref: "#/definitions/googlelongrunningOperation"
                 title: The retrieved model operation
         title: GetModelOperationResponse represents a response for a model operation
     v1alphaGetModelResponse:
         type: object
         properties:
             model:
-                $ref: '#/definitions/v1alphaModel'
+                $ref: "#/definitions/v1alphaModel"
                 title: The retrieved model
         title: GetModelResponse represents a response for a model
     v1alphaGetPipelineResponse:
         type: object
         properties:
             pipeline:
-                $ref: '#/definitions/v1alphaPipeline'
+                $ref: "#/definitions/v1alphaPipeline"
                 title: A pipeline resource
         title: GetPipelineResponse represents a response for a pipeline resource
     v1alphaGetPlanResponse:
         type: object
         properties:
             plan:
-                $ref: '#/definitions/v1alphaPlan'
+                $ref: "#/definitions/v1alphaPlan"
                 title: A plan resource
         title: GetPlanResponse represents a response for a plan resource
     v1alphaGetSourceConnectorDefinitionResponse:
         type: object
         properties:
             source_connector_definition:
-                $ref: '#/definitions/v1alphaSourceConnectorDefinition'
+                $ref: "#/definitions/v1alphaSourceConnectorDefinition"
                 title: A SourceConnectorDefinition resource
         title: |-
             GetSourceConnectorDefinitionResponse represents a SourceConnectorDefinition
@@ -4089,7 +4189,7 @@ definitions:
         type: object
         properties:
             source_connector:
-                $ref: '#/definitions/v1alphaSourceConnector'
+                $ref: "#/definitions/v1alphaSourceConnector"
                 title: SourceConnector resource
         title: |-
             GetSourceConnectorResponse represents a response for a
@@ -4098,7 +4198,7 @@ definitions:
         type: object
         properties:
             user:
-                $ref: '#/definitions/v1alphaUser'
+                $ref: "#/definitions/v1alphaUser"
                 title: A user resource
         title: GetUserResponse represents a response for a user resource
     v1alphaHealthCheckRequest:
@@ -4112,7 +4212,7 @@ definitions:
         type: object
         properties:
             status:
-                $ref: '#/definitions/HealthCheckResponseServingStatus'
+                $ref: "#/definitions/HealthCheckResponseServingStatus"
                 title: Status is the instance of the enum type ServingStatus
         title: HealthCheckResponse represents a response for a service heath status
     v1alphaInstanceSegmentationInput:
@@ -4129,7 +4229,7 @@ definitions:
         type: object
         properties:
             bounding_box:
-                $ref: '#/definitions/v1alphaBoundingBox'
+                $ref: "#/definitions/v1alphaBoundingBox"
                 title: Instance bounding box
             category:
                 type: string
@@ -4151,7 +4251,7 @@ definitions:
             objects:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaInstanceSegmentationObject'
+                    $ref: "#/definitions/v1alphaInstanceSegmentationObject"
                 title: A list of instance segmentation objects
                 readOnly: true
         title: |-
@@ -4190,12 +4290,12 @@ definitions:
         type: object
         properties:
             bounding_box:
-                $ref: '#/definitions/v1alphaBoundingBox'
+                $ref: "#/definitions/v1alphaBoundingBox"
                 title: Bounding box object
             keypoints:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaKeypoint'
+                    $ref: "#/definitions/v1alphaKeypoint"
                 title: Keypoints
                 readOnly: true
             score:
@@ -4210,7 +4310,7 @@ definitions:
             objects:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaKeypointObject'
+                    $ref: "#/definitions/v1alphaKeypointObject"
                 title: A list of keypoint objects
                 readOnly: true
         title: KeypointOutput represents the output of keypoint detection task
@@ -4220,7 +4320,7 @@ definitions:
             destination_connector_definitions:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaDestinationConnectorDefinition'
+                    $ref: "#/definitions/v1alphaDestinationConnectorDefinition"
                 title: A list of DestinationConnectorDefinition resources
             next_page_token:
                 type: string
@@ -4238,7 +4338,7 @@ definitions:
             destination_connectors:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaDestinationConnector'
+                    $ref: "#/definitions/v1alphaDestinationConnector"
                 title: A list of DestinationConnector resources
             next_page_token:
                 type: string
@@ -4256,7 +4356,7 @@ definitions:
             model_definitions:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaModelDefinition'
+                    $ref: "#/definitions/v1alphaModelDefinition"
                 title: a list of ModelDefinition instances
             next_page_token:
                 type: string
@@ -4274,7 +4374,7 @@ definitions:
             instances:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaModelInstance'
+                    $ref: "#/definitions/v1alphaModelInstance"
                 title: a list of Model instances
             next_page_token:
                 type: string
@@ -4293,7 +4393,7 @@ definitions:
             operations:
                 type: array
                 items:
-                    $ref: '#/definitions/googlelongrunningOperation'
+                    $ref: "#/definitions/googlelongrunningOperation"
                 title: a list of model operations
             total_size:
                 type: string
@@ -4308,7 +4408,7 @@ definitions:
             models:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaModel'
+                    $ref: "#/definitions/v1alphaModel"
                 title: a list of Models
             next_page_token:
                 type: string
@@ -4327,7 +4427,7 @@ definitions:
             pipelines:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaPipeline'
+                    $ref: "#/definitions/v1alphaPipeline"
                 title: A list of pipeline resources
             total_size:
                 type: string
@@ -4343,7 +4443,7 @@ definitions:
             plans:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaPlan'
+                    $ref: "#/definitions/v1alphaPlan"
                 title: A list of plans
             total_size:
                 type: string
@@ -4359,7 +4459,7 @@ definitions:
             source_connector_definitions:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaSourceConnectorDefinition'
+                    $ref: "#/definitions/v1alphaSourceConnectorDefinition"
                 title: A list of SourceConnectorDefinition resources
             total_size:
                 type: string
@@ -4377,7 +4477,7 @@ definitions:
             source_connectors:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaSourceConnector'
+                    $ref: "#/definitions/v1alphaSourceConnector"
                 title: A list of SourceConnector resources
             total_size:
                 type: string
@@ -4399,14 +4499,14 @@ definitions:
             users:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaUser'
+                    $ref: "#/definitions/v1alphaUser"
                 title: A list of users
         title: ListUserResponse represents a response for a list of users
     v1alphaLookUpDestinationConnectorResponse:
         type: object
         properties:
             destination_connector:
-                $ref: '#/definitions/v1alphaDestinationConnector'
+                $ref: "#/definitions/v1alphaDestinationConnector"
                 title: DestinationConnector resource
         title: |-
             LookUpDestinationConnectorResponse represents a response for a destination
@@ -4415,42 +4515,42 @@ definitions:
         type: object
         properties:
             instance:
-                $ref: '#/definitions/v1alphaModelInstance'
+                $ref: "#/definitions/v1alphaModelInstance"
                 title: A model instance
         title: LookUpModelInstanceResponse represents a response for a model instance
     v1alphaLookUpModelResponse:
         type: object
         properties:
             model:
-                $ref: '#/definitions/v1alphaModel'
+                $ref: "#/definitions/v1alphaModel"
                 title: A model resource
         title: LookUpModelResponse represents a response for a model instance
     v1alphaLookUpPipelineResponse:
         type: object
         properties:
             pipeline:
-                $ref: '#/definitions/v1alphaPipeline'
+                $ref: "#/definitions/v1alphaPipeline"
                 title: A pipeline resource
         title: LookUpPipelineResponse represents a response for a pipeline resource
     v1alphaLookUpPlanResponse:
         type: object
         properties:
             plan:
-                $ref: '#/definitions/v1alphaPlan'
+                $ref: "#/definitions/v1alphaPlan"
                 title: A plan resource
         title: LookUpPlanResponse represents a response for a plan resource
     v1alphaLookUpSourceConnectorResponse:
         type: object
         properties:
             source_connector:
-                $ref: '#/definitions/v1alphaSourceConnector'
+                $ref: "#/definitions/v1alphaSourceConnector"
                 title: SourceConnector resource
         title: LookUpSourceConnectorResponse represents a response for a source connector
     v1alphaLookUpUserResponse:
         type: object
         properties:
             user:
-                $ref: '#/definitions/v1alphaUser'
+                $ref: "#/definitions/v1alphaUser"
                 title: A user resource
         title: LookUpUserResponse represents a response for a user resource
     v1alphaMgmtUsageData:
@@ -4459,7 +4559,7 @@ definitions:
             usages:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaUser'
+                    $ref: "#/definitions/v1alphaUser"
                 title: Repeated user usage data
         title: Management service usage data
     v1alphaModel:
@@ -4512,7 +4612,7 @@ definitions:
                 description: The resource name of a user, e.g., "users/local-user".
                 readOnly: true
             visibility:
-                $ref: '#/definitions/v1alphaModelVisibility'
+                $ref: "#/definitions/v1alphaModelVisibility"
                 title: Model visibility including public or private
         title: Model represents a model
     v1alphaModelDefinition:
@@ -4561,7 +4661,7 @@ definitions:
                     "model-definitions/{model-definition}"
                 readOnly: true
             release_stage:
-                $ref: '#/definitions/vdpmodelv1alphaReleaseStage'
+                $ref: "#/definitions/vdpmodelv1alphaReleaseStage"
                 title: ModelDefinition release stage
             title:
                 type: string
@@ -4615,10 +4715,10 @@ definitions:
                     "models/{model}/instances/{instance}"
                 readOnly: true
             state:
-                $ref: '#/definitions/v1alphaModelInstanceState'
+                $ref: "#/definitions/v1alphaModelInstanceState"
                 title: Model instance state
             task:
-                $ref: '#/definitions/ModelInstanceTask'
+                $ref: "#/definitions/ModelInstanceTask"
                 title: Model instance task
             uid:
                 type: string
@@ -4668,12 +4768,12 @@ definitions:
                 title: The model instance
                 readOnly: true
             task:
-                $ref: '#/definitions/ModelInstanceTask'
+                $ref: "#/definitions/ModelInstanceTask"
                 title: The task type
             task_outputs:
                 type: array
                 items:
-                    $ref: '#/definitions/vdppipelinev1alphaTaskOutput'
+                    $ref: "#/definitions/vdppipelinev1alphaTaskOutput"
                 title: |-
                     The extended task outputs based on the model instance inference (i.e.,
                     from a trigger endpoint of model-backend)
@@ -4699,7 +4799,7 @@ definitions:
             usages:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaModelUsageDataUserUsageData'
+                    $ref: "#/definitions/v1alphaModelUsageDataUserUsageData"
                 title: Usage data of all users in the model service
         title: Model service usage data
     v1alphaModelUsageDataUserUsageData:
@@ -4741,7 +4841,7 @@ definitions:
             tasks:
                 type: array
                 items:
-                    $ref: '#/definitions/ModelInstanceTask'
+                    $ref: "#/definitions/ModelInstanceTask"
                 description: |-
                     Tasks of the model instances. Element in the list should not be
                     duplicated.
@@ -4901,7 +5001,7 @@ definitions:
         type: object
         properties:
             bounding_box:
-                $ref: '#/definitions/v1alphaBoundingBox'
+                $ref: "#/definitions/v1alphaBoundingBox"
                 title: OCR bounding box
             score:
                 type: number
@@ -4919,7 +5019,7 @@ definitions:
             objects:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaOcrObject'
+                    $ref: "#/definitions/v1alphaOcrObject"
                 title: A list of OCR objects
                 readOnly: true
         title: OcrOutput represents the output of ocr task
@@ -4954,7 +5054,7 @@ definitions:
                     letters, numbers, and hyphen, with the first character a letter, the last a
                     letter or a number, and a 63 character maximum.
             mode:
-                $ref: '#/definitions/PipelineMode'
+                $ref: "#/definitions/PipelineMode"
                 title: Pipeline mode
             name:
                 type: string
@@ -4965,10 +5065,10 @@ definitions:
                 title: The resource name of an organization
                 readOnly: true
             recipe:
-                $ref: '#/definitions/v1alphaRecipe'
+                $ref: "#/definitions/v1alphaRecipe"
                 title: Pipeline recipe
             state:
-                $ref: '#/definitions/v1alphaPipelineState'
+                $ref: "#/definitions/v1alphaPipelineState"
                 title: Pipeline state
             uid:
                 type: string
@@ -5004,7 +5104,7 @@ definitions:
             usages:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaPipelineUsageDataUserUsageData'
+                    $ref: "#/definitions/v1alphaPipelineUsageDataUserUsageData"
                 title: Usage data of all users in the pipeline service
         title: Pipeline service usage data
     v1alphaPipelineUsageDataUserUsageData:
@@ -5064,7 +5164,7 @@ definitions:
             id:
                 type: string
                 description: |-
-                    Pipeline resource ID (the last segment of the resource name) used to
+                    Plan resource ID (the last segment of the resource name) used to
                     construct the resource name. This conforms to RFC-1034, which restricts to
                     letters, numbers, and hyphen, with the first character a letter, the last a
                     letter or a number, and a 63 character maximum.
@@ -5080,11 +5180,11 @@ definitions:
                 required:
                     - spec
             tier:
-                $ref: '#/definitions/PlanTier'
+                $ref: "#/definitions/PlanTier"
                 title: Plan tier
             uid:
                 type: string
-                title: Pipeline UUID
+                title: Plan UUID
                 readOnly: true
             update_time:
                 type: string
@@ -5092,7 +5192,7 @@ definitions:
                 title: Plan update time
                 readOnly: true
             visibility:
-                $ref: '#/definitions/v1alphaPlanVisibility'
+                $ref: "#/definitions/v1alphaPlanVisibility"
                 title: Plan visibility
         title: Plan represents the content of a billing plan
         required:
@@ -5113,7 +5213,7 @@ definitions:
         type: object
         properties:
             model:
-                $ref: '#/definitions/v1alphaModel'
+                $ref: "#/definitions/v1alphaModel"
                 title: Published model
         title: PublishModelResponse represents a response for the published model
     v1alphaReadSourceConnectorResponse:
@@ -5145,7 +5245,7 @@ definitions:
         type: object
         properties:
             destination_connector:
-                $ref: '#/definitions/v1alphaDestinationConnector'
+                $ref: "#/definitions/v1alphaDestinationConnector"
                 title: A DestinationConnector resource
         title: |-
             RenameDestinationConnectorResponse represents a renamed DestinationConnector
@@ -5154,21 +5254,21 @@ definitions:
         type: object
         properties:
             model:
-                $ref: '#/definitions/v1alphaModel'
+                $ref: "#/definitions/v1alphaModel"
                 title: Renamed model
         title: RenameModelResponse represents a response for a model
     v1alphaRenamePipelineResponse:
         type: object
         properties:
             pipeline:
-                $ref: '#/definitions/v1alphaPipeline'
+                $ref: "#/definitions/v1alphaPipeline"
                 title: A pipeline resource
         title: RenamePipelineResponse represents a renamed pipeline resource
     v1alphaRenameSourceConnectorResponse:
         type: object
         properties:
             source_connector:
-                $ref: '#/definitions/v1alphaSourceConnector'
+                $ref: "#/definitions/v1alphaSourceConnector"
                 title: A SourceConnector resource
         title: RenameSourceConnectorResponse represents a renamed SourceConnector resource
     v1alphaSemanticSegmentationInput:
@@ -5187,7 +5287,7 @@ definitions:
             stuffs:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaSemanticSegmentationStuff'
+                    $ref: "#/definitions/v1alphaSemanticSegmentationStuff"
                 title: A list of semantic segmentation stuffs
                 readOnly: true
         title: |-
@@ -5223,7 +5323,7 @@ definitions:
                 readOnly: true
             edition:
                 type: string
-                title: 'Session edition, allowed values include: ''local-ce'' and ''local-ce:dev'''
+                title: "Session edition, allowed values include: 'local-ce' and 'local-ce:dev'"
                 required:
                     - edition
             name:
@@ -5242,7 +5342,7 @@ definitions:
                 required:
                     - report_time
             service:
-                $ref: '#/definitions/SessionService'
+                $ref: "#/definitions/SessionService"
                 title: name of the service to collect data from
             token:
                 type: string
@@ -5285,16 +5385,16 @@ definitions:
         type: object
         properties:
             connector_usage_data:
-                $ref: '#/definitions/v1alphaConnectorUsageData'
+                $ref: "#/definitions/v1alphaConnectorUsageData"
                 title: Connector service usage data
             mgmt_usage_data:
-                $ref: '#/definitions/v1alphaMgmtUsageData'
+                $ref: "#/definitions/v1alphaMgmtUsageData"
                 title: Management service usage data
             model_usage_data:
-                $ref: '#/definitions/v1alphaModelUsageData'
+                $ref: "#/definitions/v1alphaModelUsageData"
                 title: Model service usage data
             pipeline_usage_data:
-                $ref: '#/definitions/v1alphaPipelineUsageData'
+                $ref: "#/definitions/v1alphaPipelineUsageData"
                 title: Pipeline service usage data
             pow:
                 type: string
@@ -5302,7 +5402,7 @@ definitions:
                 required:
                     - pow
             session:
-                $ref: '#/definitions/v1alphaSession'
+                $ref: "#/definitions/v1alphaSession"
                 title: Session
             session_uid:
                 type: string
@@ -5325,7 +5425,7 @@ definitions:
         type: object
         properties:
             connector:
-                $ref: '#/definitions/v1alphaConnector'
+                $ref: "#/definitions/v1alphaConnector"
                 title: SourceConnector's connector data structure
             id:
                 type: string
@@ -5352,7 +5452,7 @@ definitions:
         type: object
         properties:
             connector_definition:
-                $ref: '#/definitions/v1alphaConnectorDefinition'
+                $ref: "#/definitions/v1alphaConnectorDefinition"
                 title: SourceConnectorDefinition connector definition
             id:
                 type: string
@@ -5376,7 +5476,7 @@ definitions:
         type: object
         properties:
             advanced_auth:
-                $ref: '#/definitions/v1alphaAdvancedAuth'
+                $ref: "#/definitions/v1alphaAdvancedAuth"
                 title: |-
                     Spec advanced auth, i.e., additional and optional specification object to
                     describe what an 'advanced' Auth flow would need to function
@@ -5392,7 +5492,7 @@ definitions:
             supported_destination_sync_modes:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaSupportedDestinationSyncModes'
+                    $ref: "#/definitions/v1alphaSupportedDestinationSyncModes"
                 title: |-
                     Spec destination sync mode, i.e., a list of destination sync modes
                     supported by the connector
@@ -5452,40 +5552,40 @@ definitions:
         type: object
         properties:
             classification:
-                $ref: '#/definitions/v1alphaClassificationInput'
+                $ref: "#/definitions/v1alphaClassificationInput"
                 title: The classification input
             detection:
-                $ref: '#/definitions/v1alphaDetectionInput'
+                $ref: "#/definitions/v1alphaDetectionInput"
                 title: The detection input
             instance_segmentation:
-                $ref: '#/definitions/v1alphaInstanceSegmentationInput'
+                $ref: "#/definitions/v1alphaInstanceSegmentationInput"
                 title: The instance segmentation input
             keypoint:
-                $ref: '#/definitions/v1alphaKeypointInput'
+                $ref: "#/definitions/v1alphaKeypointInput"
                 title: The keypoint input
             ocr:
-                $ref: '#/definitions/v1alphaOcrInput'
+                $ref: "#/definitions/v1alphaOcrInput"
                 title: The ocr input
             semantic_segmentation:
-                $ref: '#/definitions/v1alphaSemanticSegmentationInput'
+                $ref: "#/definitions/v1alphaSemanticSegmentationInput"
                 title: The semantic segmentation input
             text_to_image:
-                $ref: '#/definitions/v1alphaTextToImageInput'
+                $ref: "#/definitions/v1alphaTextToImageInput"
                 title: The text to image input
             unspecified:
-                $ref: '#/definitions/v1alphaUnspecifiedInput'
+                $ref: "#/definitions/v1alphaUnspecifiedInput"
                 title: The unspecified task input
         title: Input represents the input to trigger a model instance
     v1alphaTestModelInstanceBinaryFileUploadResponse:
         type: object
         properties:
             task:
-                $ref: '#/definitions/ModelInstanceTask'
+                $ref: "#/definitions/ModelInstanceTask"
                 title: The task type
             task_outputs:
                 type: array
                 items:
-                    $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+                    $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
                 title: The task output from a model instance
                 required:
                     - task_outputs
@@ -5498,12 +5598,12 @@ definitions:
         type: object
         properties:
             task:
-                $ref: '#/definitions/ModelInstanceTask'
+                $ref: "#/definitions/ModelInstanceTask"
                 title: The task type
             task_outputs:
                 type: array
                 items:
-                    $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+                    $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
                 title: The task output from a model instance
                 required:
                     - task_outputs
@@ -5549,12 +5649,12 @@ definitions:
         type: object
         properties:
             task:
-                $ref: '#/definitions/ModelInstanceTask'
+                $ref: "#/definitions/ModelInstanceTask"
                 title: The task type
             task_outputs:
                 type: array
                 items:
-                    $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+                    $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
                 title: The task output from a model instance
                 required:
                     - task_outputs
@@ -5567,12 +5667,12 @@ definitions:
         type: object
         properties:
             task:
-                $ref: '#/definitions/ModelInstanceTask'
+                $ref: "#/definitions/ModelInstanceTask"
                 title: The task type
             task_outputs:
                 type: array
                 items:
-                    $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+                    $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
                 title: The task output from a model instance
         title: |-
             TriggerModelInstanceResponse represents a response for the output for
@@ -5588,7 +5688,7 @@ definitions:
             model_instance_outputs:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaModelInstanceOutput'
+                    $ref: "#/definitions/v1alphaModelInstanceOutput"
                 title: The multiple model instance inference outputs
         title: |-
             TriggerPipelineBinaryFileUploadResponse represents a response for the output
@@ -5604,7 +5704,7 @@ definitions:
             model_instance_outputs:
                 type: array
                 items:
-                    $ref: '#/definitions/v1alphaModelInstanceOutput'
+                    $ref: "#/definitions/v1alphaModelInstanceOutput"
                 title: The multiple model instance inference outputs
         title: |-
             TriggerPipelineResponse represents a response for the output
@@ -5613,7 +5713,7 @@ definitions:
         type: object
         properties:
             operation:
-                $ref: '#/definitions/googlelongrunningOperation'
+                $ref: "#/definitions/googlelongrunningOperation"
                 title: Undeploy operation message
         title: |-
             UndeployModelInstanceResponse represents a response for a undeployed model
@@ -5622,7 +5722,7 @@ definitions:
         type: object
         properties:
             model:
-                $ref: '#/definitions/v1alphaModel'
+                $ref: "#/definitions/v1alphaModel"
                 title: Unpublished model
         title: UnpublishModelResponse represents a response for the unpublished model
     v1alphaUnspecifiedInput:
@@ -5648,7 +5748,7 @@ definitions:
         type: object
         properties:
             user:
-                $ref: '#/definitions/v1alphaUser'
+                $ref: "#/definitions/v1alphaUser"
                 title: A user resource
         title: |-
             UpdateAuthenticatedUserResponse represents a response for
@@ -5657,7 +5757,7 @@ definitions:
         type: object
         properties:
             destination_connector:
-                $ref: '#/definitions/v1alphaDestinationConnector'
+                $ref: "#/definitions/v1alphaDestinationConnector"
                 title: DestinationConnector resource
         title: |-
             UpdateDestinationConnectorResponse represents a response for a
@@ -5666,28 +5766,28 @@ definitions:
         type: object
         properties:
             model:
-                $ref: '#/definitions/v1alphaModel'
+                $ref: "#/definitions/v1alphaModel"
                 title: The updated model
         title: UpdateModelResponse represents a response for a model
     v1alphaUpdatePipelineResponse:
         type: object
         properties:
             pipeline:
-                $ref: '#/definitions/v1alphaPipeline'
+                $ref: "#/definitions/v1alphaPipeline"
                 title: An updated pipeline resource
         title: UpdatePipelineResponse represents a response for a pipeline resource
     v1alphaUpdatePlanResponse:
         type: object
         properties:
             plan:
-                $ref: '#/definitions/v1alphaPlan'
+                $ref: "#/definitions/v1alphaPlan"
                 title: A plan resource
         title: UpdatePlanResponse represents a response for a plan resource
     v1alphaUpdateSourceConnectorResponse:
         type: object
         properties:
             source_connector:
-                $ref: '#/definitions/v1alphaSourceConnector'
+                $ref: "#/definitions/v1alphaSourceConnector"
                 title: SourceConnector resource
         title: |-
             UpdateSourceConnectorResponse represents a response for a
@@ -5696,7 +5796,7 @@ definitions:
         type: object
         properties:
             user:
-                $ref: '#/definitions/v1alphaUser'
+                $ref: "#/definitions/v1alphaUser"
                 title: A user resource
         title: UpdateUserResponse represents a response for a user resource
     v1alphaUser:
@@ -5755,8 +5855,8 @@ definitions:
                      - "analytics-engineer"
                      - "hobbyist"
             type:
-                $ref: '#/definitions/v1alphaOwnerType'
-                title: 'Owner type: fixed to `OWNER_TYPE_USER`'
+                $ref: "#/definitions/v1alphaOwnerType"
+                title: "Owner type: fixed to `OWNER_TYPE_USER`"
             uid:
                 type: string
                 title: User ID in UUIDv4
@@ -5782,28 +5882,43 @@ definitions:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: LivenessResponse represents a response for a service liveness status
     vdpbillingv1alphaReadinessResponse:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: ReadinessResponse represents a response for a service readiness status
+    vdpbillingv1alphaView:
+        type: string
+        enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+        default: VIEW_UNSPECIFIED
+        description: |-
+            View represents a view of any resource. The resource view is implemented by
+            adding a parameter to the method request which allows the client to specify
+            which view of the resource it wants to receive in the response.
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
     vdpconnectorv1alphaLivenessResponse:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: LivenessResponse represents a response for a service liveness status
     vdpconnectorv1alphaReadinessResponse:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: ReadinessResponse represents a response for a service readiness status
     vdpconnectorv1alphaReleaseStage:
@@ -5838,28 +5953,43 @@ definitions:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: LivenessResponse represents a response for a service liveness status
     vdpmgmtv1alphaReadinessResponse:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: ReadinessResponse represents a response for a service readiness status
+    vdpmgmtv1alphaView:
+        type: string
+        enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+        default: VIEW_UNSPECIFIED
+        description: |-
+            View represents a view of any resource. The resource view is implemented by
+            adding a parameter to the method request which allows the client to specify
+            which view of the resource it wants to receive in the response.
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
     vdpmodelv1alphaLivenessResponse:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: LivenessResponse represents a response for a service liveness status
     vdpmodelv1alphaReadinessResponse:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: ReadinessResponse represents a response for a service readiness status
     vdpmodelv1alphaReleaseStage:
@@ -5882,28 +6012,28 @@ definitions:
         type: object
         properties:
             classification:
-                $ref: '#/definitions/v1alphaClassificationOutput'
+                $ref: "#/definitions/v1alphaClassificationOutput"
                 title: The classification output
             detection:
-                $ref: '#/definitions/v1alphaDetectionOutput'
+                $ref: "#/definitions/v1alphaDetectionOutput"
                 title: The detection output
             instance_segmentation:
-                $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
+                $ref: "#/definitions/v1alphaInstanceSegmentationOutput"
                 title: The instance segmentation output
             keypoint:
-                $ref: '#/definitions/v1alphaKeypointOutput'
+                $ref: "#/definitions/v1alphaKeypointOutput"
                 title: The keypoint output
             ocr:
-                $ref: '#/definitions/v1alphaOcrOutput'
+                $ref: "#/definitions/v1alphaOcrOutput"
                 title: The ocr output
             semantic_segmentation:
-                $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
+                $ref: "#/definitions/v1alphaSemanticSegmentationOutput"
                 title: The semantic segmentation output
             text_to_image:
-                $ref: '#/definitions/v1alphaTextToImageOutput'
+                $ref: "#/definitions/v1alphaTextToImageOutput"
                 title: The text to image output
             unspecified:
-                $ref: '#/definitions/v1alphaUnspecifiedOutput'
+                $ref: "#/definitions/v1alphaUnspecifiedOutput"
                 title: The unspecified task output
         title: TaskOutput represents the output of a CV Task result from a model instance
     vdpmodelv1alphaView:
@@ -5925,46 +6055,46 @@ definitions:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: LivenessResponse represents a response for a service liveness status
     vdppipelinev1alphaReadinessResponse:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: ReadinessResponse represents a response for a service readiness status
     vdppipelinev1alphaTaskOutput:
         type: object
         properties:
             classification:
-                $ref: '#/definitions/v1alphaClassificationOutput'
+                $ref: "#/definitions/v1alphaClassificationOutput"
                 title: The classification output
             detection:
-                $ref: '#/definitions/v1alphaDetectionOutput'
+                $ref: "#/definitions/v1alphaDetectionOutput"
                 title: The detection output
             index:
                 type: string
                 title: The index of input data in a batch
                 readOnly: true
             instance_segmentation:
-                $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
+                $ref: "#/definitions/v1alphaInstanceSegmentationOutput"
                 title: The instance segmentation output
             keypoint:
-                $ref: '#/definitions/v1alphaKeypointOutput'
+                $ref: "#/definitions/v1alphaKeypointOutput"
                 title: The keypoint output
             ocr:
-                $ref: '#/definitions/v1alphaOcrOutput'
+                $ref: "#/definitions/v1alphaOcrOutput"
                 title: The ocr output
             semantic_segmentation:
-                $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
+                $ref: "#/definitions/v1alphaSemanticSegmentationOutput"
                 title: The semantic segmentation output
             text_to_image:
-                $ref: '#/definitions/v1alphaTextToImageOutput'
+                $ref: "#/definitions/v1alphaTextToImageOutput"
                 title: The text to image output
             unspecified:
-                $ref: '#/definitions/v1alphaUnspecifiedOutput'
+                $ref: "#/definitions/v1alphaUnspecifiedOutput"
                 title: The unspecified task output
         description: |-
             TaskOutput represents the output of a CV Task result from a
@@ -5991,13 +6121,13 @@ definitions:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: LivenessResponse represents a response for a service liveness status
     vdpusagev1alphaReadinessResponse:
         type: object
         properties:
             health_check_response:
-                $ref: '#/definitions/v1alphaHealthCheckResponse'
+                $ref: "#/definitions/v1alphaHealthCheckResponse"
                 title: HealthCheckResponse message
         title: ReadinessResponse represents a response for a service readiness status

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2206,8 +2206,8 @@ paths:
                             type: string
                             title: User company or institution name
                         plan:
-                            $ref: '#/definitions/v1alphaPlan'
-                            title: User plan
+                            type: string
+                            description: User plan. This field is not used in open-source VDP.
                         role:
                             type: string
                             title: |-
@@ -5741,8 +5741,8 @@ definitions:
                 type: string
                 title: User company or institution name
             plan:
-                $ref: '#/definitions/v1alphaPlan'
-                title: User plan
+                type: string
+                description: User plan. This field is not used in open-source VDP.
             role:
                 type: string
                 title: |-

--- a/vdp/billing/v1alpha/healthcheck.proto
+++ b/vdp/billing/v1alpha/healthcheck.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package vdp.billing.v1alpha;
+
+// Google API
+import "google/api/field_behavior.proto";
+
+import "vdp/healthcheck/v1alpha/healthcheck.proto";
+
+// LivenessRequest represents a request to check a service liveness status
+message LivenessRequest {
+  // HealthCheckRequest message
+  optional healthcheck.v1alpha.HealthCheckRequest health_check_request = 1
+      [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// LivenessResponse represents a response for a service liveness status
+message LivenessResponse {
+  // HealthCheckResponse message
+  healthcheck.v1alpha.HealthCheckResponse health_check_response = 1;
+}
+
+// ReadinessRequest represents a request to check a service readiness status
+message ReadinessRequest {
+  // HealthCheckRequest message
+  optional healthcheck.v1alpha.HealthCheckRequest health_check_request = 1
+      [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// ReadinessResponse represents a response for a service readiness status
+message ReadinessResponse {
+  // HealthCheckResponse message
+  healthcheck.v1alpha.HealthCheckResponse health_check_response = 1;
+}

--- a/vdp/billing/v1alpha/plan.proto
+++ b/vdp/billing/v1alpha/plan.proto
@@ -42,9 +42,9 @@ message Plan {
   // Resource name. It must have the format of "plans/*".
   // For example: "plans/free".
   string name = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Pipeline UUID
+  // Plan UUID
   string uid = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Pipeline resource ID (the last segment of the resource name) used to
+  // Plan resource ID (the last segment of the resource name) used to
   // construct the resource name. This conforms to RFC-1034, which restricts to
   // letters, numbers, and hyphen, with the first character a letter, the last a
   // letter or a number, and a 63 character maximum.
@@ -63,6 +63,18 @@ message Plan {
   google.protobuf.Struct spec = 8 [ (google.api.field_behavior) = REQUIRED ];
 }
 
+// View represents a view of any resource. The resource view is implemented by
+// adding a parameter to the method request which allows the client to specify
+// which view of the resource it wants to receive in the response.
+enum View {
+  // View: UNSPECIFIED
+  VIEW_UNSPECIFIED = 0;
+  // View: BASIC
+  VIEW_BASIC = 1;
+  // View: FULL
+  VIEW_FULL = 2;
+}
+
 // ListPlanRequest represents a request to list all plans
 message ListPlanRequest {
   // Page size: the maximum number of resources to return. The service may
@@ -72,6 +84,10 @@ message ListPlanRequest {
   optional int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
   // Page token
   optional string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
+  // View view (default is VIEW_BASIC)
+  optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
+  // Filter expression to list plans
+  optional string filter = 4 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // ListPlanResponse represents a response for a list of plans
@@ -110,6 +126,8 @@ message GetPlanRequest {
       field_configuration : {path_param_name : "plan.name"}
     }
   ];
+  // Plan resource view (default is VIEW_BASIC)
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // GetPlanResponse represents a response for a plan resource
@@ -139,7 +157,7 @@ message UpdatePlanResponse {
 // DeletePlanRequest represents a request to delete a plan
 message DeletePlanRequest {
   // The resource name of the plan to be deleted,
-  // for example: "plans/local-plan"
+  // for example: "plans/free"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Plan",
@@ -157,6 +175,8 @@ message LookUpPlanRequest {
   // Permalink of a plan. For example:
   // "plans/{uid}"
   string permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Plan resource view (default is VIEW_BASIC)
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // LookUpPlanResponse represents a response for a plan resource

--- a/vdp/billing/v1alpha/plan.proto
+++ b/vdp/billing/v1alpha/plan.proto
@@ -26,7 +26,7 @@ message Plan {
     // PlanType: FREE
     TIER_FREE = 1;
     // PlanType: CUSTOM
-    TIER_CUSTOM = 5;
+    TIER_CUSTOM = 2;
   }
 
    // Plan visibility including public or private

--- a/vdp/billing/v1alpha/plan.proto
+++ b/vdp/billing/v1alpha/plan.proto
@@ -1,0 +1,166 @@
+syntax = "proto3";
+
+package vdp.billing.v1alpha;
+
+// Protocol Buffers Well-Known Types
+import "google/protobuf/struct.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/timestamp.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
+
+// Google API
+import "google/api/resource.proto";
+import "google/api/field_behavior.proto";
+
+// Plan represents the content of a billing plan
+message Plan {
+  option (google.api.resource) = {
+    type : "api.instill.tech/Plan"
+    pattern : "plans/{plan}"
+  };
+
+  // Tier enumerates the billing plan tier type
+  enum Tier {
+    // PlanType: UNSPECIFIED, equivalent to FREE.
+    TIER_UNSPECIFIED = 0;
+    // PlanType: FREE
+    TIER_FREE = 1;
+    // PlanType: CUSTOM
+    TIER_CUSTOM = 5;
+  }
+
+   // Plan visibility including public or private
+  enum Visibility {
+    // Visibility: UNSPECIFIED, equivalent to PRIVATE.
+    VISIBILITY_UNSPECIFIED = 0;
+    // Visibility: PRIVATE
+    VISIBILITY_PRIVATE = 1;
+    // Visibility: PUBLIC
+    VISIBILITY_PUBLIC = 2;
+  }
+
+  // Resource name. It must have the format of "plans/*".
+  // For example: "plans/free".
+  string name = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Pipeline UUID
+  string uid = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Pipeline resource ID (the last segment of the resource name) used to
+  // construct the resource name. This conforms to RFC-1034, which restricts to
+  // letters, numbers, and hyphen, with the first character a letter, the last a
+  // letter or a number, and a 63 character maximum.
+  string id = 3 [ (google.api.field_behavior) = IMMUTABLE ];
+  // Plan creation time
+  google.protobuf.Timestamp create_time = 4
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Plan update time
+  google.protobuf.Timestamp update_time = 5
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Plan tier
+  Tier tier = 6 [ (google.api.field_behavior) = REQUIRED ];
+  // Plan visibility
+  Visibility visibility = 7 [ (google.api.field_behavior) = REQUIRED ];
+  // Plan specification in JSON format
+  google.protobuf.Struct spec = 8 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// ListPlanRequest represents a request to list all plans
+message ListPlanRequest {
+  // Page size: the maximum number of resources to return. The service may
+  // return fewer than this value. If unspecified, at most 10 plans will be
+  // returned. The maximum value is 100; values above 100 will be coereced to
+  // 100.
+  optional int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
+  // Page token
+  optional string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// ListPlanResponse represents a response for a list of plans
+message ListPlanResponse {
+  // A list of plans
+  repeated Plan plans = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of plans
+  int64 total_size = 3;
+}
+
+// CreatePlanRequest represents a request to create a plan
+message CreatePlanRequest {
+  // The plan to be created
+  //
+  // The plan's `name` field is used to identify the plan to create.
+  // Format: plans/{plan}
+  Plan plan = 1 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// CreatePlanResponse represents a response for a plan response
+message CreatePlanResponse {
+  // A plan resource
+  Plan plan = 1;
+}
+
+// GetPlanRequest represents a request to query a plan
+message GetPlanRequest {
+  // Resource name of a plan. For example:
+  // "plans/free"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Plan",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "plan.name"}
+    }
+  ];
+}
+
+// GetPlanResponse represents a response for a plan resource
+message GetPlanResponse {
+  // A plan resource
+  Plan plan = 1;
+}
+
+// UpdatePlanRequest represents a request to update a plan
+message UpdatePlanRequest {
+  // The plan to update
+  //
+  // The plan's `name` field is used to identify the plan to update.
+  // Format: plans/{plan}
+  Plan plan = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Update mask for a plan resource
+  google.protobuf.FieldMask update_mask = 2
+      [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// UpdatePlanResponse represents a response for a plan resource
+message UpdatePlanResponse {
+  // A plan resource
+  Plan plan = 1;
+}
+
+// DeletePlanRequest represents a request to delete a plan
+message DeletePlanRequest {
+  // The resource name of the plan to be deleted,
+  // for example: "plans/local-plan"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Plan",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "plan.name"}
+    }
+  ];
+}
+
+// DeletePlanResponse represents an empty response
+message DeletePlanResponse {}
+
+// LookUpPlanRequest represents a request to query a plan by permalink
+message LookUpPlanRequest {
+  // Permalink of a plan. For example:
+  // "plans/{uid}"
+  string permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// LookUpPlanResponse represents a response for a plan resource
+message LookUpPlanResponse {
+  // A plan resource
+  Plan plan = 1;
+}

--- a/vdp/billing/v1alpha/plan_service.proto
+++ b/vdp/billing/v1alpha/plan_service.proto
@@ -1,0 +1,92 @@
+syntax = "proto3";
+
+package vdp.billing.v1alpha;
+
+// Google API
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+
+import "vdp/billing/v1alpha/healthcheck.proto";
+import "vdp/billing/v1alpha/plan.proto";
+
+// Plan service responds to incoming billing plan requests.
+service PlanService {
+  option (google.api.default_host) = "api.instill.tech";
+
+  // Liveness method receives a LivenessRequest message and returns a
+  // LivenessResponse message.
+  // See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+  rpc Liveness(LivenessRequest) returns (LivenessResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/__liveness"
+      additional_bindings : [ {get : "/v1alpha/health/billing"} ]
+    };
+  }
+  
+  // Readiness method receives a ReadinessRequest message and returns a
+  // ReadinessResponse message.
+  // See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+  rpc Readiness(ReadinessRequest) returns (ReadinessResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/__readiness"
+      additional_bindings : [ {get : "/v1alpha/ready/billing"} ]
+    };
+  }
+
+  // ========== Admin API: create, get, update and delete billing plans
+
+  // ListPlan method receives a ListPlanRequest message and returns a
+  // ListPlanResponse message.
+  rpc ListPlan(ListPlanRequest) returns (ListPlanResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/admin/plans"
+    };
+  }
+
+  // CreatePlan receives a CreatePlanRequest message and returns a
+  // aGetPlanResponses
+  rpc CreatePlan(CreatePlanRequest) returns (CreatePlanResponse) {
+    option (google.api.http) = {
+      post : "/v1alpha/admin/plans"
+      body : "plan"
+    };
+    option (google.api.method_signature) = "plan";
+  }
+
+  // GetPlan method receives a GetPlanRequest message and returns
+  // a GetPlanResponse message.
+  rpc GetPlan(GetPlanRequest) returns (GetPlanResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/admin/{name=plans/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // UpdatePlan method receives a UpdatePlanRequest message and returns
+  // a UpdatePlanResponse
+  rpc UpdatePlan(UpdatePlanRequest) returns (UpdatePlanResponse) {
+    option (google.api.http) = {
+      patch : "/v1alpha/admin/{plan.name=plans/*}"
+      body : "plan"
+    };
+    option (google.api.method_signature) = "plan,update_mask";
+  }
+
+  // DeletePlan method receives a DeletePlanRequest message and returns a
+  // DeletePlanResponse
+  rpc DeletePlan(DeletePlanRequest) returns (DeletePlanResponse) {
+    option (google.api.http) = {
+      delete : "/v1alpha/admin/{name=plans/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // LookUpPlan method receives a LookUpPlanRequest message and returns a
+  // LookUpPlanResponse
+  rpc LookUpPlan(LookUpPlanRequest) returns (LookUpPlanResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/admin/{permalink=plans/*}/lookUp"
+    };
+    option (google.api.method_signature) = "permalink";
+  }
+}

--- a/vdp/mgmt/v1alpha/mgmt.proto
+++ b/vdp/mgmt/v1alpha/mgmt.proto
@@ -11,8 +11,6 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
 
-import "vdp/billing/v1alpha/plan.proto";
-
 // OwnerType enumerates the owner type of any resource
 enum OwnerType {
   // OwnerType: UNSPECIFIED
@@ -52,8 +50,11 @@ message User {
   
   // User email
   string email = 7 [ (google.api.field_behavior) = REQUIRED ];
-  // User plan
-  billing.v1alpha.Plan plan = 8 [ (google.api.field_behavior) = REQUIRED ];
+  // User plan. This field is not used in open-source VDP.
+  optional string plan = 8 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.resource_reference).type = "api.instill.tech/Plan"
+  ];
   // User first name
   optional string first_name = 9 [ (google.api.field_behavior) = OPTIONAL ];
   // User last name

--- a/vdp/mgmt/v1alpha/mgmt.proto
+++ b/vdp/mgmt/v1alpha/mgmt.proto
@@ -11,6 +11,8 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
 
+import "vdp/billing/v1alpha/plan.proto";
+
 // OwnerType enumerates the owner type of any resource
 enum OwnerType {
   // OwnerType: UNSPECIFIED
@@ -32,16 +34,32 @@ message User {
   // For example: "users/local-user".
   string name = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // User ID in UUIDv4
-  string uid = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // User email
-  optional string email = 3 [ (google.api.field_behavior) = OPTIONAL ];
-  // Resource ID (the last segment of the resource name), also the user login
-  // username. This conforms to RFC-1034, which restricts to letters, numbers,
+  string uid = 2 [ (google.api.field_behavior) = REQUIRED ];
+  // Resource ID (the last segment of the resource name), also the user username. 
+  // This conforms to RFC-1034, which restricts to letters, numbers,
   // and hyphen, with the first character a letter, the last a letter or a
   // number, and a 63 character maximum.
-  string id = 4 [ (google.api.field_behavior) = IMMUTABLE ];
-  // User company name
-  optional string company_name = 5 [ (google.api.field_behavior) = OPTIONAL ];
+  // Note that the ID can be updated.
+  string id = 3 [ (google.api.field_behavior) = REQUIRED ];
+  // Owner type: fixed to `OWNER_TYPE_USER`
+  OwnerType type = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // User creation time
+  google.protobuf.Timestamp create_time = 5
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // User update time
+  google.protobuf.Timestamp update_time = 6
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  
+  // User email
+  string email = 7 [ (google.api.field_behavior) = REQUIRED ];
+  // User plan
+  billing.v1alpha.Plan plan = 8 [ (google.api.field_behavior) = REQUIRED ];
+  // User first name
+  optional string first_name = 9 [ (google.api.field_behavior) = OPTIONAL ];
+  // User last name
+  optional string last_name = 10 [ (google.api.field_behavior) = OPTIONAL ];
+  // User company or institution name
+  optional string org_name = 11 [ (google.api.field_behavior) = OPTIONAL ];
   // User role. Allowed roles:
   //  - "manager"
   //  - "ai-researcher"
@@ -50,19 +68,11 @@ message User {
   //  - "data-scientist",
   //  - "analytics-engineer"
   //  - "hobbyist"
-  optional string role = 6 [ (google.api.field_behavior) = OPTIONAL ];
+  optional string role = 12 [ (google.api.field_behavior) = OPTIONAL ];
   // User newsletter subscription
-  bool newsletter_subscription = 7 [ (google.api.field_behavior) = REQUIRED ];
+  bool newsletter_subscription = 13 [ (google.api.field_behavior) = REQUIRED ];
   // User console cookie token
-  optional string cookie_token = 8 [ (google.api.field_behavior) = OPTIONAL ];
-  // Owner type: fixed to `OWNER_TYPE_USER`
-  OwnerType type = 9 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // User creation time
-  google.protobuf.Timestamp create_time = 10
-      [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // User update time
-  google.protobuf.Timestamp update_time = 11
-      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  optional string cookie_token = 14 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // ListUserRequest represents a request to list all users
@@ -165,4 +175,53 @@ message LookUpUserRequest {
 message LookUpUserResponse {
   // A user resource
   User user = 1;
+}
+
+// GetAuthenticatedUserRequest represents a request to 
+// query the authenticated user
+message GetAuthenticatedUserRequest {}
+
+// GetAuthenticatedUserResponse represents a response for
+// the authenticated user resource
+message GetAuthenticatedUserResponse {
+  // A user resource
+  User user = 1;
+}
+
+// UpdateAuthenticatedUserRequest represents a request to
+// update the authenticated user
+message UpdateAuthenticatedUserRequest {
+  // The user to update
+  User user = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Update mask for a user resource
+  google.protobuf.FieldMask update_mask = 2
+      [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// UpdateAuthenticatedUserResponse represents a response for
+// the authenticated user resource
+message UpdateAuthenticatedUserResponse {
+  // A user resource
+  User user = 1;
+}
+
+// ExistUsernameRequest represents a request to verify if
+// a username has been occupied
+message ExistUsernameRequest{
+  // The resource name of the user to be deleted,
+  // for example: "users/local-user"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/User",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "user.name"}
+    }
+  ];
+}
+
+// ExistUsernameResponse represents a response about whether
+// the queried username has been occupied
+message ExistUsernameResponse{
+  // A boolean value indicating whether the username has been occupied
+  bool exists = 1;
 }

--- a/vdp/mgmt/v1alpha/mgmt.proto
+++ b/vdp/mgmt/v1alpha/mgmt.proto
@@ -76,6 +76,18 @@ message User {
   optional string cookie_token = 14 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
+// View represents a view of any resource. The resource view is implemented by
+// adding a parameter to the method request which allows the client to specify
+// which view of the resource it wants to receive in the response.
+enum View {
+  // View: UNSPECIFIED, equivalent to BASIC.
+  VIEW_UNSPECIFIED = 0;
+  // View: BASIC
+  VIEW_BASIC = 1;
+  // View: FULL
+  VIEW_FULL = 2;
+}
+
 // ListUserRequest represents a request to list all users
 message ListUserRequest {
   // Page size: the maximum number of resources to return. The service may
@@ -85,6 +97,10 @@ message ListUserRequest {
   optional int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
   // Page token
   optional string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
+  // View view (default is VIEW_BASIC)
+  optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
+  // Filter expression to list users
+  optional string filter = 4 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // ListUserResponse represents a response for a list of users
@@ -123,6 +139,8 @@ message GetUserRequest {
       field_configuration : {path_param_name : "user.name"}
     }
   ];
+  // View view (default is VIEW_BASIC)
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // GetUserResponse represents a response for a user resource
@@ -170,6 +188,8 @@ message LookUpUserRequest {
   // Permalink of a user. For example:
   // "users/{uid}"
   string permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // View view (default is VIEW_BASIC)
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
 // LookUpUserResponse represents a response for a user resource

--- a/vdp/mgmt/v1alpha/mgmt_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_service.proto
@@ -29,14 +29,17 @@ service UserService {
   rpc Readiness(ReadinessRequest) returns (ReadinessResponse) {
     option (google.api.http) = {
       get : "/v1alpha/__readiness"
+      additional_bindings : [ {get : "/v1alpha/ready/mgmt"} ]
     };
   }
+
+  // ========== Admin API: create, get, update and delete user accounts
 
   // ListUser method receives a ListUserRequest message and returns a
   // ListUserResponse message.
   rpc ListUser(ListUserRequest) returns (ListUserResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/users"
+      get : "/v1alpha/admin/users"
     };
   }
 
@@ -44,7 +47,7 @@ service UserService {
   // aGetUserResponse
   rpc CreateUser(CreateUserRequest) returns (CreateUserResponse) {
     option (google.api.http) = {
-      post : "/v1alpha/users"
+      post : "/v1alpha/admin/users"
       body : "user"
     };
     option (google.api.method_signature) = "user";
@@ -54,7 +57,7 @@ service UserService {
   // a GetUserResponse message.
   rpc GetUser(GetUserRequest) returns (GetUserResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=users/*}"
+      get : "/v1alpha/admin/{name=users/*}"
     };
     option (google.api.method_signature) = "name";
   }
@@ -63,7 +66,7 @@ service UserService {
   // a UpdateUserResponse
   rpc UpdateUser(UpdateUserRequest) returns (UpdateUserResponse) {
     option (google.api.http) = {
-      patch : "/v1alpha/{user.name=users/*}"
+      patch : "/v1alpha/admin/{user.name=users/*}"
       body : "user"
     };
     option (google.api.method_signature) = "user,update_mask";
@@ -73,7 +76,7 @@ service UserService {
   // DeleteUserResponse
   rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse) {
     option (google.api.http) = {
-      delete : "/v1alpha/{name=users/*}"
+      delete : "/v1alpha/admin/{name=users/*}"
     };
     option (google.api.method_signature) = "name";
   }
@@ -82,8 +85,37 @@ service UserService {
   // LookUpUserResponse
   rpc LookUpUser(LookUpUserRequest) returns (LookUpUserResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{permalink=users/*}/lookUp"
+      get : "/v1alpha/admin/{permalink=users/*}/lookUp"
     };
     option (google.api.method_signature) = "permalink";
+  }
+
+  // ========== Public API: endpoints exposed to public internet traffic
+
+  // GetAuthenticatedUser method receives a GetAuthenticatedUserRequest message and returns
+  // a GetAuthenticatedUserResponse message.
+  rpc GetAuthenticatedUser(GetAuthenticatedUserRequest) returns (GetAuthenticatedUserResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/user"
+    };
+  }
+
+  // UpdateAuthenticatedUser method receives a UpdateAuthenticatedUserRequest message and returns 
+  // a UpdateAuthenticatedUserResponse message.
+  rpc UpdateAuthenticatedUser(UpdateAuthenticatedUserRequest) returns (UpdateAuthenticatedUserResponse) {
+    option (google.api.http) = {
+      patch : "/v1alpha/user"
+      body : "user"
+    };
+    option (google.api.method_signature) = "user,update_mask";
+  }
+
+  // ExistUsername method receives a ExistUsernameRequest message and returns a
+  // ExistUsernameResponse
+  rpc ExistUsername(ExistUsernameRequest) returns (ExistUsernameResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/{name=users/*}/exists"
+    };
+    option (google.api.method_signature) = "name";
   }
 }


### PR DESCRIPTION
Because

- list, create, update, delete and lookup user operations should be admin API that is not exposed to the public internet

This commit

- add billing service so each user is assigned with a billing plan
- redesign mgmt-backend endpoints into Admin and Public APIs
- update the message user fields 
