### PR TITLE
chore: refactor mgmt service names

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -6,7 +6,7 @@ tags:
   - name: PlanService
   - name: ConnectorService
   - name: MgmtAdminService
-  - name: MgmtrPublicService
+  - name: MgmtPublicService
   - name: ModelService
   - name: PipelineService
   - name: UsageService
@@ -26,11 +26,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpusagev1alphaLivenessResponse'
+            $ref: "#/definitions/vdpusagev1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -50,11 +50,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpusagev1alphaReadinessResponse'
+            $ref: "#/definitions/vdpusagev1alphaReadinessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -73,11 +73,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaGetDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: destination_connector.name
           description: |-
@@ -114,11 +114,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeleteDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaDeleteDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: destination_connector.name
           description: |-
@@ -140,11 +140,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdateDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaUpdateDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: destination_connector.name
           description: |-
@@ -176,7 +176,7 @@ paths:
                 type: string
                 title: DestinationConnectorDefinition resource
               connector:
-                $ref: '#/definitions/v1alphaConnector'
+                $ref: "#/definitions/v1alphaConnector"
                 title: DestinationConnector's connector data structure
             title: DestinationConnector resource
             required:
@@ -199,11 +199,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetDestinationConnectorDefinitionResponse'
+            $ref: "#/definitions/v1alphaGetDestinationConnectorDefinitionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: destination_connector_definition.name
           description: |-
@@ -241,11 +241,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelResponse'
+            $ref: "#/definitions/v1alphaGetModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: model.name
           description: |-
@@ -283,11 +283,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeleteModelResponse'
+            $ref: "#/definitions/v1alphaDeleteModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: model.name
           description: |-
@@ -308,11 +308,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdateModelResponse'
+            $ref: "#/definitions/v1alphaUpdateModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: model.name
           description: |-
@@ -356,7 +356,7 @@ paths:
                   Model configuration represents the configuration JSON that has been
                   validated using the `model_spec` JSON schema of a ModelDefinition
               visibility:
-                $ref: '#/definitions/v1alphaModelVisibility'
+                $ref: "#/definitions/v1alphaModelVisibility"
                 title: Model visibility including public or private
                 readOnly: true
               user:
@@ -398,11 +398,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelDefinitionResponse'
+            $ref: "#/definitions/v1alphaGetModelDefinitionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: model_definition.name
           description: |-
@@ -442,11 +442,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelInstanceCardResponse'
+            $ref: "#/definitions/v1alphaGetModelInstanceCardResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: model_instance.name/readme
           description: |-
@@ -468,11 +468,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelInstanceResponse'
+            $ref: "#/definitions/v1alphaGetModelInstanceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: model_instance.name
           description: |-
@@ -514,11 +514,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaConnectDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaConnectDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name_1
           description: |-
@@ -551,11 +551,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDisconnectDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaDisconnectDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name_1
           description: |-
@@ -586,11 +586,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRenameDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaRenameDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name_1
           description: |-
@@ -629,11 +629,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTriggerPipelineResponse'
+            $ref: "#/definitions/v1alphaTriggerPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name_1
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -650,7 +650,7 @@ paths:
               task_inputs:
                 type: array
                 items:
-                  $ref: '#/definitions/v1alphaTaskInput'
+                  $ref: "#/definitions/v1alphaTaskInput"
                 title: Input to the pipeline
             title: TriggerPipelineRequest represents a request to trigger a pipeline
             required:
@@ -665,11 +665,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRenameModelResponse'
+            $ref: "#/definitions/v1alphaRenameModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name_2
           description: Resource name for the model to be renamed.
@@ -701,11 +701,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRenamePipelineResponse'
+            $ref: "#/definitions/v1alphaRenamePipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name_3
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -742,11 +742,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelOperationResponse'
+            $ref: "#/definitions/v1alphaGetModelOperationResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: The name of the operation resource.
@@ -785,11 +785,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaActivatePipelineResponse'
+            $ref: "#/definitions/v1alphaActivatePipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -815,11 +815,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCancelModelOperationResponse'
+            $ref: "#/definitions/v1alphaCancelModelOperationResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: The name of the operation resource.
@@ -848,11 +848,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaConnectSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaConnectSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -884,11 +884,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeactivatePipelineResponse'
+            $ref: "#/definitions/v1alphaDeactivatePipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -912,11 +912,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeployModelInstanceResponse'
+            $ref: "#/definitions/v1alphaDeployModelInstanceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -949,11 +949,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDisconnectSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaDisconnectSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -983,11 +983,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaPublishModelResponse'
+            $ref: "#/definitions/v1alphaPublishModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -1015,11 +1015,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaReadSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaReadSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -1049,11 +1049,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRenameSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaRenameSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -1092,11 +1092,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTestModelInstanceResponse'
+            $ref: "#/definitions/v1alphaTestModelInstanceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -1115,7 +1115,7 @@ paths:
               task_inputs:
                 type: array
                 items:
-                  $ref: '#/definitions/v1alphaTaskInput'
+                  $ref: "#/definitions/v1alphaTaskInput"
                 title: Input to trigger the model instance
             title: TestModelInstanceRequest represents a request to test a model instance
             required:
@@ -1133,11 +1133,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTriggerModelInstanceResponse'
+            $ref: "#/definitions/v1alphaTriggerModelInstanceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -1156,7 +1156,7 @@ paths:
               task_inputs:
                 type: array
                 items:
-                  $ref: '#/definitions/v1alphaTaskInput'
+                  $ref: "#/definitions/v1alphaTaskInput"
                 title: Input to trigger the model instance
             title: TriggerModelInstanceRequest represents a request to trigger a model instance
             required:
@@ -1171,11 +1171,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUndeployModelInstanceResponse'
+            $ref: "#/definitions/v1alphaUndeployModelInstanceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -1205,11 +1205,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUnpublishModelResponse'
+            $ref: "#/definitions/v1alphaUnpublishModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -1238,11 +1238,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaWriteDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaWriteDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: name
           description: |-
@@ -1259,12 +1259,12 @@ paths:
             type: object
             properties:
               sync_mode:
-                $ref: '#/definitions/v1alphaSupportedSyncModes'
+                $ref: "#/definitions/v1alphaSupportedSyncModes"
                 title: |-
                   Sync mode:
                   https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
               destination_sync_mode:
-                $ref: '#/definitions/v1alphaSupportedDestinationSyncModes'
+                $ref: "#/definitions/v1alphaSupportedDestinationSyncModes"
                 title: |-
                   Destination sync mode:
                   https://docs.airbyte.com/understanding-airbyte/connections/#sync-modes
@@ -1272,7 +1272,7 @@ paths:
                 type: string
                 title: Pipeline resource name
               recipe:
-                $ref: '#/definitions/v1alphaRecipe'
+                $ref: "#/definitions/v1alphaRecipe"
                 title: Pipeline recipe
               data_mapping_indices:
                 type: array
@@ -1282,7 +1282,7 @@ paths:
               model_instance_outputs:
                 type: array
                 items:
-                  $ref: '#/definitions/v1alphaModelInstanceOutput'
+                  $ref: "#/definitions/v1alphaModelInstanceOutput"
                 title: JSON data to write
             title: |-
               WriteDestinationConnectorRequest represents a request to perform write
@@ -1306,11 +1306,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListModelInstanceResponse'
+            $ref: "#/definitions/v1alphaListModelInstanceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -1365,11 +1365,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaLookUpDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: permalink_1
           description: |-
@@ -1406,11 +1406,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpModelResponse'
+            $ref: "#/definitions/v1alphaLookUpModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: permalink_2
           description: |-
@@ -1450,11 +1450,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpModelInstanceResponse'
+            $ref: "#/definitions/v1alphaLookUpModelInstanceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: permalink_3
           description: |-
@@ -1493,11 +1493,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpPipelineResponse'
+            $ref: "#/definitions/v1alphaLookUpPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: permalink_4
           description: |-
@@ -1534,11 +1534,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaLookUpSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: permalink
           description: |-
@@ -1575,11 +1575,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetPipelineResponse'
+            $ref: "#/definitions/v1alphaGetPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1613,11 +1613,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeletePipelineResponse'
+            $ref: "#/definitions/v1alphaDeletePipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1636,11 +1636,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdatePipelineResponse'
+            $ref: "#/definitions/v1alphaUpdatePipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1670,14 +1670,14 @@ paths:
                 type: string
                 title: Pipeline description
               recipe:
-                $ref: '#/definitions/v1alphaRecipe'
+                $ref: "#/definitions/v1alphaRecipe"
                 title: Pipeline recipe
               mode:
-                $ref: '#/definitions/PipelineMode'
+                $ref: "#/definitions/PipelineMode"
                 title: Pipeline mode
                 readOnly: true
               state:
-                $ref: '#/definitions/v1alphaPipelineState'
+                $ref: "#/definitions/v1alphaPipelineState"
                 title: Pipeline state
                 readOnly: true
               user:
@@ -1716,11 +1716,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaGetSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: source_connector.name
           description: |-
@@ -1756,11 +1756,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeleteSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaDeleteSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: source_connector.name
           description: |-
@@ -1781,11 +1781,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdateSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaUpdateSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: source_connector.name
           description: |-
@@ -1817,7 +1817,7 @@ paths:
                 type: string
                 title: SourceConnectorDefinition resource
               connector:
-                $ref: '#/definitions/v1alphaConnector'
+                $ref: "#/definitions/v1alphaConnector"
                 title: SourceConnector's connector data structure
             title: SourceConnector resource
             required:
@@ -1840,11 +1840,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetSourceConnectorDefinitionResponse'
+            $ref: "#/definitions/v1alphaGetSourceConnectorDefinitionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: source_connector_definition.name
           description: |-
@@ -1876,16 +1876,16 @@ paths:
       summary: |-
         ExistUsername method receives a ExistUsernameRequest message and returns a
         ExistUsernameResponse
-      operationId: MgmtrPublicService_ExistUsername
+      operationId: MgmtPublicService_ExistUsername
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaExistUsernameResponse'
+            $ref: "#/definitions/v1alphaExistUsernameResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: user.name
           description: |-
@@ -1896,7 +1896,7 @@ paths:
           type: string
           pattern: users/[^/]+
       tags:
-        - MgmtrPublicService
+        - MgmtPublicService
   /v1alpha/admin/{permalink_1}/lookUp:
     get:
       summary: |-
@@ -1907,11 +1907,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpUserResponse'
+            $ref: "#/definitions/v1alphaLookUpUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: permalink_1
           description: |-
@@ -1948,11 +1948,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpPlanResponse'
+            $ref: "#/definitions/v1alphaLookUpPlanResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: permalink
           description: |-
@@ -1989,11 +1989,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetPlanResponse'
+            $ref: "#/definitions/v1alphaGetPlanResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: plan.name
           description: |-
@@ -2029,11 +2029,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeletePlanResponse'
+            $ref: "#/definitions/v1alphaDeletePlanResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: plan.name
           description: |-
@@ -2054,11 +2054,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdatePlanResponse'
+            $ref: "#/definitions/v1alphaUpdatePlanResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: plan.name
           description: |-
@@ -2101,10 +2101,10 @@ paths:
                 title: Plan update time
                 readOnly: true
               tier:
-                $ref: '#/definitions/PlanTier'
+                $ref: "#/definitions/PlanTier"
                 title: Plan tier
               visibility:
-                $ref: '#/definitions/v1alphaPlanVisibility'
+                $ref: "#/definitions/v1alphaPlanVisibility"
                 title: Plan visibility
               spec:
                 type: object
@@ -2134,11 +2134,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetUserResponse'
+            $ref: "#/definitions/v1alphaGetUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: user.name
           description: |-
@@ -2174,11 +2174,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeleteUserResponse'
+            $ref: "#/definitions/v1alphaDeleteUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: user.name
           description: |-
@@ -2199,11 +2199,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdateUserResponse'
+            $ref: "#/definitions/v1alphaUpdateUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: user.name
           description: |-
@@ -2231,8 +2231,8 @@ paths:
                 type: string
                 description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
               type:
-                $ref: '#/definitions/v1alphaOwnerType'
-                title: 'Owner type: fixed to `OWNER_TYPE_USER`'
+                $ref: "#/definitions/v1alphaOwnerType"
+                title: "Owner type: fixed to `OWNER_TYPE_USER`"
                 readOnly: true
               create_time:
                 type: string
@@ -2304,11 +2304,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListPlanResponse'
+            $ref: "#/definitions/v1alphaListPlanResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -2356,11 +2356,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCreatePlanResponse'
+            $ref: "#/definitions/v1alphaCreatePlanResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: plan
           description: |-
@@ -2371,7 +2371,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaPlan'
+            $ref: "#/definitions/v1alphaPlan"
             required:
               - plan
       tags:
@@ -2386,11 +2386,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListUserResponse'
+            $ref: "#/definitions/v1alphaListUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -2438,11 +2438,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCreateUserResponse'
+            $ref: "#/definitions/v1alphaCreateUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: user
           description: |-
@@ -2453,7 +2453,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaUser'
+            $ref: "#/definitions/v1alphaUser"
             required:
               - user
       tags:
@@ -2469,11 +2469,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListDestinationConnectorDefinitionResponse'
+            $ref: "#/definitions/v1alphaListDestinationConnectorDefinitionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -2517,11 +2517,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaListDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -2564,18 +2564,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCreateDestinationConnectorResponse'
+            $ref: "#/definitions/v1alphaCreateDestinationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: destination_connector
           description: DestinationConnector resource
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaDestinationConnector'
+            $ref: "#/definitions/v1alphaDestinationConnector"
             required:
               - destination_connector
       tags:
@@ -2591,11 +2591,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpbillingv1alphaLivenessResponse'
+            $ref: "#/definitions/vdpbillingv1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2615,11 +2615,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpconnectorv1alphaLivenessResponse'
+            $ref: "#/definitions/vdpconnectorv1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2634,16 +2634,16 @@ paths:
         Liveness method receives a LivenessRequest message and returns a
         LivenessResponse message.
         See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-      operationId: MgmtrPublicService_Liveness2
+      operationId: MgmtPublicService_Liveness2
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpmgmtv1alphaLivenessResponse'
+            $ref: "#/definitions/vdpmgmtv1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2651,7 +2651,7 @@ paths:
           required: false
           type: string
       tags:
-        - MgmtrPublicService
+        - MgmtPublicService
   /v1alpha/health/model:
     get:
       summary: |-
@@ -2663,11 +2663,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpmodelv1alphaLivenessResponse'
+            $ref: "#/definitions/vdpmodelv1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2687,11 +2687,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdppipelinev1alphaLivenessResponse'
+            $ref: "#/definitions/vdppipelinev1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2711,11 +2711,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpusagev1alphaLivenessResponse'
+            $ref: "#/definitions/vdpusagev1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2734,11 +2734,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListModelDefinitionResponse'
+            $ref: "#/definitions/v1alphaListModelDefinitionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -2785,11 +2785,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListModelResponse'
+            $ref: "#/definitions/v1alphaListModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -2834,11 +2834,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCreateModelResponse'
+            $ref: "#/definitions/v1alphaCreateModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: model
           description: |-
@@ -2849,7 +2849,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaModel'
+            $ref: "#/definitions/v1alphaModel"
             required:
               - model
       tags:
@@ -2864,11 +2864,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListModelOperationResponse'
+            $ref: "#/definitions/v1alphaListModelOperationResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -2919,11 +2919,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListPipelineResponse'
+            $ref: "#/definitions/v1alphaListPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -2970,18 +2970,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCreatePipelineResponse'
+            $ref: "#/definitions/v1alphaCreatePipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: pipeline
           description: A pipeline resource to create
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaPipeline'
+            $ref: "#/definitions/v1alphaPipeline"
             required:
               - pipeline
       tags:
@@ -2997,11 +2997,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpbillingv1alphaReadinessResponse'
+            $ref: "#/definitions/vdpbillingv1alphaReadinessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -3016,16 +3016,16 @@ paths:
         Readiness method receives a ReadinessRequest message and returns a
         ReadinessResponse message.
         See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-      operationId: MgmtrPublicService_Readiness2
+      operationId: MgmtPublicService_Readiness2
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpmgmtv1alphaReadinessResponse'
+            $ref: "#/definitions/vdpmgmtv1alphaReadinessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -3033,7 +3033,7 @@ paths:
           required: false
           type: string
       tags:
-        - MgmtrPublicService
+        - MgmtPublicService
   /v1alpha/ready/model:
     get:
       summary: |-
@@ -3045,11 +3045,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpmodelv1alphaReadinessResponse'
+            $ref: "#/definitions/vdpmodelv1alphaReadinessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -3068,18 +3068,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaSendSessionReportResponse'
+            $ref: "#/definitions/v1alphaSendSessionReportResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: report
           description: A report resource to create
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaSessionReport'
+            $ref: "#/definitions/v1alphaSessionReport"
             required:
               - report
       tags:
@@ -3094,18 +3094,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCreateSessionResponse'
+            $ref: "#/definitions/v1alphaCreateSessionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: session
           description: A session resource to create
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaSession'
+            $ref: "#/definitions/v1alphaSession"
             required:
               - session
       tags:
@@ -3121,11 +3121,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListSourceConnectorDefinitionResponse'
+            $ref: "#/definitions/v1alphaListSourceConnectorDefinitionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -3169,11 +3169,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaListSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -3215,18 +3215,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCreateSourceConnectorResponse'
+            $ref: "#/definitions/v1alphaCreateSourceConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: source_connector
           description: SourceConnector resource
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaSourceConnector'
+            $ref: "#/definitions/v1alphaSourceConnector"
             required:
               - source_connector
       tags:
@@ -3236,37 +3236,37 @@ paths:
       summary: |-
         GetAuthenticatedUser method receives a GetAuthenticatedUserRequest message and returns
         a GetAuthenticatedUserResponse message.
-      operationId: MgmtrPublicService_GetAuthenticatedUser
+      operationId: MgmtPublicService_GetAuthenticatedUser
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetAuthenticatedUserResponse'
+            $ref: "#/definitions/v1alphaGetAuthenticatedUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       tags:
-        - MgmtrPublicService
+        - MgmtPublicService
     patch:
       summary: "UpdateAuthenticatedUser method receives a UpdateAuthenticatedUserRequest message and returns \na UpdateAuthenticatedUserResponse message."
-      operationId: MgmtrPublicService_UpdateAuthenticatedUser
+      operationId: MgmtPublicService_UpdateAuthenticatedUser
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdateAuthenticatedUserResponse'
+            $ref: "#/definitions/v1alphaUpdateAuthenticatedUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: "#/definitions/rpcStatus"
       parameters:
         - name: user
           description: The user to update
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaUser'
+            $ref: "#/definitions/v1alphaUser"
             required:
               - user
         - name: update_mask
@@ -3275,7 +3275,7 @@ paths:
           required: true
           type: string
       tags:
-        - MgmtrPublicService
+        - MgmtPublicService
 definitions:
   AdvancedAuthAuthFlowType:
     type: string
@@ -3373,7 +3373,7 @@ definitions:
           originally returns it. If you use the default HTTP mapping, the
           `name` should be a resource name ending with `operations/{unique_id}`.
       metadata:
-        $ref: '#/definitions/protobufAny'
+        $ref: "#/definitions/protobufAny"
         description: |-
           Service-specific metadata associated with the operation.  It typically
           contains progress information and common metadata such as create time.
@@ -3386,10 +3386,10 @@ definitions:
           If `true`, the operation is completed, and either `error` or `response` is
           available.
       error:
-        $ref: '#/definitions/rpcStatus'
+        $ref: "#/definitions/rpcStatus"
         description: The error result of the operation in case of failure or cancellation.
       response:
-        $ref: '#/definitions/protobufAny'
+        $ref: "#/definitions/protobufAny"
         description: |-
           The normal response of the operation in case of success.  If the original
           method returns no data on success, such as `Delete`, the response is
@@ -3405,7 +3405,7 @@ definitions:
   protobufAny:
     type: object
     properties:
-      '@type':
+      "@type":
         type: string
         description: |-
           A URL/resource name that uniquely identifies the type of the serialized
@@ -3550,7 +3550,7 @@ definitions:
       details:
         type: array
         items:
-          $ref: '#/definitions/protobufAny'
+          $ref: "#/definitions/protobufAny"
         description: |-
           A list of messages that carry the error details.  There is a common set of
           message types for APIs to use.
@@ -3602,14 +3602,14 @@ definitions:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
+        $ref: "#/definitions/v1alphaPipeline"
         title: A pipeline resource
     title: ActivatePipelineResponse represents an activated pipeline
   v1alphaAdvancedAuth:
     type: object
     properties:
       auth_flow_type:
-        $ref: '#/definitions/AdvancedAuthAuthFlowType'
+        $ref: "#/definitions/AdvancedAuthAuthFlowType"
         title: AdvancedAuth auth flow type
       predicate_key:
         type: array
@@ -3625,7 +3625,7 @@ definitions:
           AdvancedAuth predicate value, i.e., the value of the predicate key fields
           for the advanced auth to be applicable
       oauth_config_specification:
-        $ref: '#/definitions/v1alphaOauthConfigSpecification'
+        $ref: "#/definitions/v1alphaOauthConfigSpecification"
         title: OauthConfigSpecification represents OAuth config specification
     description: |-
       Additional and optional specification object to describe what an 'advanced'
@@ -3693,7 +3693,7 @@ definitions:
     type: object
     properties:
       destination_connector:
-        $ref: '#/definitions/v1alphaDestinationConnector'
+        $ref: "#/definitions/v1alphaDestinationConnector"
         title: A DestinationConnector resource
     title: |-
       ConnectDestinationConnectorResponse represents a connected destination
@@ -3702,7 +3702,7 @@ definitions:
     type: object
     properties:
       source_connector:
-        $ref: '#/definitions/v1alphaSourceConnector'
+        $ref: "#/definitions/v1alphaSourceConnector"
         title: A SourceConnector resource
     title: ConnectSourceConnectorResponse represents a connected source connector
   v1alphaConnector:
@@ -3715,7 +3715,7 @@ definitions:
         type: object
         title: Connector configuration in JSON format
       state:
-        $ref: '#/definitions/v1alphaConnectorState'
+        $ref: "#/definitions/v1alphaConnectorState"
         title: Connector state
         readOnly: true
       tombstone:
@@ -3767,7 +3767,7 @@ definitions:
         title: ConnectorDefinition icon
         readOnly: true
       spec:
-        $ref: '#/definitions/v1alphaSpec'
+        $ref: "#/definitions/v1alphaSpec"
         title: ConnectorDefinition spec
         readOnly: true
       tombstone:
@@ -3790,11 +3790,11 @@ definitions:
           connector definition
         readOnly: true
       release_stage:
-        $ref: '#/definitions/vdpconnectorv1alphaReleaseStage'
+        $ref: "#/definitions/vdpconnectorv1alphaReleaseStage"
         title: ConnectorDefinition release stage
         readOnly: true
       release_date:
-        $ref: '#/definitions/typeDate'
+        $ref: "#/definitions/typeDate"
         description: |-
           ConnectorDefinition release date, i.e., the date when this connector
           was first released, in yyyy-mm-dd format.
@@ -3834,7 +3834,7 @@ definitions:
       usages:
         type: array
         items:
-          $ref: '#/definitions/v1alphaConnectorUsageDataUserUsageData'
+          $ref: "#/definitions/v1alphaConnectorUsageDataUserUsageData"
         title: Usage data of all users in the connector service
     title: Connector service usage data
   v1alphaConnectorUsageDataUserUsageData:
@@ -3886,7 +3886,7 @@ definitions:
     type: object
     properties:
       destination_connector:
-        $ref: '#/definitions/v1alphaDestinationConnector'
+        $ref: "#/definitions/v1alphaDestinationConnector"
         title: DestinationConnector resource
     title: |-
       CreateDestinationConnectorResponse represents a response for a
@@ -3895,7 +3895,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Create model operation message
         readOnly: true
     title: |-
@@ -3905,7 +3905,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Create model operation message
         readOnly: true
     title: CreateModelResponse represents a response for a model
@@ -3913,28 +3913,28 @@ definitions:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
+        $ref: "#/definitions/v1alphaPipeline"
         title: The created pipeline resource
     title: CreatePipelineResponse represents a response for a pipeline resource
   v1alphaCreatePlanResponse:
     type: object
     properties:
       plan:
-        $ref: '#/definitions/v1alphaPlan'
+        $ref: "#/definitions/v1alphaPlan"
         title: A plan resource
     title: CreatePlanResponse represents a response for a plan response
   v1alphaCreateSessionResponse:
     type: object
     properties:
       session:
-        $ref: '#/definitions/v1alphaSession'
+        $ref: "#/definitions/v1alphaSession"
         title: A session resource
     title: CreateSessionResponse represents a response for a session response
   v1alphaCreateSourceConnectorResponse:
     type: object
     properties:
       source_connector:
-        $ref: '#/definitions/v1alphaSourceConnector'
+        $ref: "#/definitions/v1alphaSourceConnector"
         title: SourceConnector resource
     title: |-
       CreateSourceConnectorResponse represents a response for a
@@ -3943,14 +3943,14 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1alphaUser'
+        $ref: "#/definitions/v1alphaUser"
         title: A user resource
     title: CreateUserResponse represents a response for a user response
   v1alphaDeactivatePipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
+        $ref: "#/definitions/v1alphaPipeline"
         title: A pipeline resource
     title: DeactivatePipelineResponse represents an inactivated pipeline
   v1alphaDeleteDestinationConnectorResponse:
@@ -3975,7 +3975,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Deploy operation message
     title: |-
       DeployModelInstanceResponse represents a response for a deployed model
@@ -4004,7 +4004,7 @@ definitions:
         type: string
         title: DestinationConnectorDefinition resource
       connector:
-        $ref: '#/definitions/v1alphaConnector'
+        $ref: "#/definitions/v1alphaConnector"
         title: DestinationConnector's connector data structure
     title: DestinationConnector represents a destination connector resource
     required:
@@ -4031,7 +4031,7 @@ definitions:
           character a letter, the last a letter or a number, and a 63 character
           maximum.
       connector_definition:
-        $ref: '#/definitions/v1alphaConnectorDefinition'
+        $ref: "#/definitions/v1alphaConnectorDefinition"
         title: DestinationConnectorDefinition connector definition
         readOnly: true
     title: |-
@@ -4060,7 +4060,7 @@ definitions:
         title: Detection object score
         readOnly: true
       bounding_box:
-        $ref: '#/definitions/v1alphaBoundingBox'
+        $ref: "#/definitions/v1alphaBoundingBox"
         title: Detection bounding box
         readOnly: true
     title: DetectionObject represents a predicted object
@@ -4070,7 +4070,7 @@ definitions:
       objects:
         type: array
         items:
-          $ref: '#/definitions/v1alphaDetectionObject'
+          $ref: "#/definitions/v1alphaDetectionObject"
         title: A list of detection objects
         readOnly: true
     title: DetectionOutput represents the output of detection task
@@ -4078,7 +4078,7 @@ definitions:
     type: object
     properties:
       destination_connector:
-        $ref: '#/definitions/v1alphaDestinationConnector'
+        $ref: "#/definitions/v1alphaDestinationConnector"
         title: A DestinationConnector resource
     title: |-
       DisconnectDestinationConnectorResponse represents a disconnected destination
@@ -4087,7 +4087,7 @@ definitions:
     type: object
     properties:
       source_connector:
-        $ref: '#/definitions/v1alphaSourceConnector'
+        $ref: "#/definitions/v1alphaSourceConnector"
         title: A SourceConnector resource
     title: DisconnectSourceConnectorResponse represents a disconnected source connector
   v1alphaExistUsernameResponse:
@@ -4103,7 +4103,7 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1alphaUser'
+        $ref: "#/definitions/v1alphaUser"
         title: A user resource
     title: |-
       GetAuthenticatedUserResponse represents a response for
@@ -4112,7 +4112,7 @@ definitions:
     type: object
     properties:
       destination_connector_definition:
-        $ref: '#/definitions/v1alphaDestinationConnectorDefinition'
+        $ref: "#/definitions/v1alphaDestinationConnectorDefinition"
         title: A DestinationConnectorDefinition resource
     title: |-
       GetDestinationConnectorDefinitionResponse represents a
@@ -4121,7 +4121,7 @@ definitions:
     type: object
     properties:
       destination_connector:
-        $ref: '#/definitions/v1alphaDestinationConnector'
+        $ref: "#/definitions/v1alphaDestinationConnector"
         title: DestinationConnector resource
     title: |-
       GetDestinationConnectorResponse represents a response for a
@@ -4130,14 +4130,14 @@ definitions:
     type: object
     properties:
       model_definition:
-        $ref: '#/definitions/v1alphaModelDefinition'
+        $ref: "#/definitions/v1alphaModelDefinition"
         title: A model definition instance
     title: GetModelDefinitionResponse represents a response for a model definition
   v1alphaGetModelInstanceCardResponse:
     type: object
     properties:
       readme:
-        $ref: '#/definitions/v1alphaModelInstanceCard'
+        $ref: "#/definitions/v1alphaModelInstanceCard"
         title: Retrieved model instance card
     title: |-
       GetModelInstanceCardResponse represents a response to fetch a model
@@ -4146,42 +4146,42 @@ definitions:
     type: object
     properties:
       instance:
-        $ref: '#/definitions/v1alphaModelInstance'
+        $ref: "#/definitions/v1alphaModelInstance"
         title: Retrieved model instance
     title: GetModelInstanceResponse represents a response for a model instance
   v1alphaGetModelOperationResponse:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: The retrieved model operation
     title: GetModelOperationResponse represents a response for a model operation
   v1alphaGetModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: The retrieved model
     title: GetModelResponse represents a response for a model
   v1alphaGetPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
+        $ref: "#/definitions/v1alphaPipeline"
         title: A pipeline resource
     title: GetPipelineResponse represents a response for a pipeline resource
   v1alphaGetPlanResponse:
     type: object
     properties:
       plan:
-        $ref: '#/definitions/v1alphaPlan'
+        $ref: "#/definitions/v1alphaPlan"
         title: A plan resource
     title: GetPlanResponse represents a response for a plan resource
   v1alphaGetSourceConnectorDefinitionResponse:
     type: object
     properties:
       source_connector_definition:
-        $ref: '#/definitions/v1alphaSourceConnectorDefinition'
+        $ref: "#/definitions/v1alphaSourceConnectorDefinition"
         title: A SourceConnectorDefinition resource
     title: |-
       GetSourceConnectorDefinitionResponse represents a SourceConnectorDefinition
@@ -4190,7 +4190,7 @@ definitions:
     type: object
     properties:
       source_connector:
-        $ref: '#/definitions/v1alphaSourceConnector'
+        $ref: "#/definitions/v1alphaSourceConnector"
         title: SourceConnector resource
     title: |-
       GetSourceConnectorResponse represents a response for a
@@ -4199,7 +4199,7 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1alphaUser'
+        $ref: "#/definitions/v1alphaUser"
         title: A user resource
     title: GetUserResponse represents a response for a user resource
   v1alphaHealthCheckRequest:
@@ -4213,7 +4213,7 @@ definitions:
     type: object
     properties:
       status:
-        $ref: '#/definitions/HealthCheckResponseServingStatus'
+        $ref: "#/definitions/HealthCheckResponseServingStatus"
         title: Status is the instance of the enum type ServingStatus
     title: HealthCheckResponse represents a response for a service heath status
   v1alphaInstanceSegmentationInput:
@@ -4243,7 +4243,7 @@ definitions:
         title: Instance score
         readOnly: true
       bounding_box:
-        $ref: '#/definitions/v1alphaBoundingBox'
+        $ref: "#/definitions/v1alphaBoundingBox"
         title: Instance bounding box
         readOnly: true
     title: InstanceSegmentationObject corresponding to a instance segmentation object
@@ -4253,7 +4253,7 @@ definitions:
       objects:
         type: array
         items:
-          $ref: '#/definitions/v1alphaInstanceSegmentationObject'
+          $ref: "#/definitions/v1alphaInstanceSegmentationObject"
         title: A list of instance segmentation objects
         readOnly: true
     title: |-
@@ -4294,7 +4294,7 @@ definitions:
       keypoints:
         type: array
         items:
-          $ref: '#/definitions/v1alphaKeypoint'
+          $ref: "#/definitions/v1alphaKeypoint"
         title: Keypoints
         readOnly: true
       score:
@@ -4303,7 +4303,7 @@ definitions:
         title: Keypoint score
         readOnly: true
       bounding_box:
-        $ref: '#/definitions/v1alphaBoundingBox'
+        $ref: "#/definitions/v1alphaBoundingBox"
         title: Bounding box object
         readOnly: true
     title: KeypointObject corresponding to a person object
@@ -4313,7 +4313,7 @@ definitions:
       objects:
         type: array
         items:
-          $ref: '#/definitions/v1alphaKeypointObject'
+          $ref: "#/definitions/v1alphaKeypointObject"
         title: A list of keypoint objects
         readOnly: true
     title: KeypointOutput represents the output of keypoint detection task
@@ -4323,7 +4323,7 @@ definitions:
       destination_connector_definitions:
         type: array
         items:
-          $ref: '#/definitions/v1alphaDestinationConnectorDefinition'
+          $ref: "#/definitions/v1alphaDestinationConnectorDefinition"
         title: A list of DestinationConnectorDefinition resources
       next_page_token:
         type: string
@@ -4341,7 +4341,7 @@ definitions:
       destination_connectors:
         type: array
         items:
-          $ref: '#/definitions/v1alphaDestinationConnector'
+          $ref: "#/definitions/v1alphaDestinationConnector"
         title: A list of DestinationConnector resources
       next_page_token:
         type: string
@@ -4359,7 +4359,7 @@ definitions:
       model_definitions:
         type: array
         items:
-          $ref: '#/definitions/v1alphaModelDefinition'
+          $ref: "#/definitions/v1alphaModelDefinition"
         title: a list of ModelDefinition instances
       next_page_token:
         type: string
@@ -4377,7 +4377,7 @@ definitions:
       instances:
         type: array
         items:
-          $ref: '#/definitions/v1alphaModelInstance'
+          $ref: "#/definitions/v1alphaModelInstance"
         title: a list of Model instances
       next_page_token:
         type: string
@@ -4393,7 +4393,7 @@ definitions:
       operations:
         type: array
         items:
-          $ref: '#/definitions/googlelongrunningOperation'
+          $ref: "#/definitions/googlelongrunningOperation"
         title: a list of model operations
       next_page_token:
         type: string
@@ -4411,7 +4411,7 @@ definitions:
       models:
         type: array
         items:
-          $ref: '#/definitions/v1alphaModel'
+          $ref: "#/definitions/v1alphaModel"
         title: a list of Models
       next_page_token:
         type: string
@@ -4427,7 +4427,7 @@ definitions:
       pipelines:
         type: array
         items:
-          $ref: '#/definitions/v1alphaPipeline'
+          $ref: "#/definitions/v1alphaPipeline"
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -4443,7 +4443,7 @@ definitions:
       plans:
         type: array
         items:
-          $ref: '#/definitions/v1alphaPlan'
+          $ref: "#/definitions/v1alphaPlan"
         title: A list of plans
       next_page_token:
         type: string
@@ -4459,7 +4459,7 @@ definitions:
       source_connector_definitions:
         type: array
         items:
-          $ref: '#/definitions/v1alphaSourceConnectorDefinition'
+          $ref: "#/definitions/v1alphaSourceConnectorDefinition"
         title: A list of SourceConnectorDefinition resources
       next_page_token:
         type: string
@@ -4477,7 +4477,7 @@ definitions:
       source_connectors:
         type: array
         items:
-          $ref: '#/definitions/v1alphaSourceConnector'
+          $ref: "#/definitions/v1alphaSourceConnector"
         title: A list of SourceConnector resources
       next_page_token:
         type: string
@@ -4495,7 +4495,7 @@ definitions:
       users:
         type: array
         items:
-          $ref: '#/definitions/v1alphaUser'
+          $ref: "#/definitions/v1alphaUser"
         title: A list of users
       next_page_token:
         type: string
@@ -4509,7 +4509,7 @@ definitions:
     type: object
     properties:
       destination_connector:
-        $ref: '#/definitions/v1alphaDestinationConnector'
+        $ref: "#/definitions/v1alphaDestinationConnector"
         title: DestinationConnector resource
     title: |-
       LookUpDestinationConnectorResponse represents a response for a destination
@@ -4518,42 +4518,42 @@ definitions:
     type: object
     properties:
       instance:
-        $ref: '#/definitions/v1alphaModelInstance'
+        $ref: "#/definitions/v1alphaModelInstance"
         title: A model instance
     title: LookUpModelInstanceResponse represents a response for a model instance
   v1alphaLookUpModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: A model resource
     title: LookUpModelResponse represents a response for a model instance
   v1alphaLookUpPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
+        $ref: "#/definitions/v1alphaPipeline"
         title: A pipeline resource
     title: LookUpPipelineResponse represents a response for a pipeline resource
   v1alphaLookUpPlanResponse:
     type: object
     properties:
       plan:
-        $ref: '#/definitions/v1alphaPlan'
+        $ref: "#/definitions/v1alphaPlan"
         title: A plan resource
     title: LookUpPlanResponse represents a response for a plan resource
   v1alphaLookUpSourceConnectorResponse:
     type: object
     properties:
       source_connector:
-        $ref: '#/definitions/v1alphaSourceConnector'
+        $ref: "#/definitions/v1alphaSourceConnector"
         title: SourceConnector resource
     title: LookUpSourceConnectorResponse represents a response for a source connector
   v1alphaLookUpUserResponse:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1alphaUser'
+        $ref: "#/definitions/v1alphaUser"
         title: A user resource
     title: LookUpUserResponse represents a response for a user resource
   v1alphaMgmtUsageData:
@@ -4562,7 +4562,7 @@ definitions:
       usages:
         type: array
         items:
-          $ref: '#/definitions/v1alphaUser'
+          $ref: "#/definitions/v1alphaUser"
         title: Repeated user usage data
     title: Management service usage data
   v1alphaModel:
@@ -4597,7 +4597,7 @@ definitions:
           Model configuration represents the configuration JSON that has been
           validated using the `model_spec` JSON schema of a ModelDefinition
       visibility:
-        $ref: '#/definitions/v1alphaModelVisibility'
+        $ref: "#/definitions/v1alphaModelVisibility"
         title: Model visibility including public or private
         readOnly: true
       user:
@@ -4651,7 +4651,7 @@ definitions:
         title: ModelDefinition icon
         readOnly: true
       release_stage:
-        $ref: '#/definitions/vdpmodelv1alphaReleaseStage'
+        $ref: "#/definitions/vdpmodelv1alphaReleaseStage"
         title: ModelDefinition release stage
         readOnly: true
       model_spec:
@@ -4706,11 +4706,11 @@ definitions:
           letter or a number, and a 63 character maximum.
         readOnly: true
       state:
-        $ref: '#/definitions/v1alphaModelInstanceState'
+        $ref: "#/definitions/v1alphaModelInstanceState"
         title: Model instance state
         readOnly: true
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: "#/definitions/ModelInstanceTask"
         title: Model instance task
         readOnly: true
       model_definition:
@@ -4773,13 +4773,13 @@ definitions:
         title: The model instance
         readOnly: true
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: "#/definitions/ModelInstanceTask"
         title: The task type
         readOnly: true
       task_outputs:
         type: array
         items:
-          $ref: '#/definitions/vdppipelinev1alphaTaskOutput'
+          $ref: "#/definitions/vdppipelinev1alphaTaskOutput"
         title: |-
           The extended task outputs based on the model instance inference (i.e.,
           from a trigger endpoint of model-backend)
@@ -4805,7 +4805,7 @@ definitions:
       usages:
         type: array
         items:
-          $ref: '#/definitions/v1alphaModelUsageDataUserUsageData'
+          $ref: "#/definitions/v1alphaModelUsageDataUserUsageData"
         title: Usage data of all users in the model service
     title: Model service usage data
   v1alphaModelUsageDataUserUsageData:
@@ -4840,7 +4840,7 @@ definitions:
       tasks:
         type: array
         items:
-          $ref: '#/definitions/ModelInstanceTask'
+          $ref: "#/definitions/ModelInstanceTask"
         description: |-
           Tasks of the model instances. Element in the list should not be
           duplicated.
@@ -5000,7 +5000,7 @@ definitions:
         title: OCR text score
         readOnly: true
       bounding_box:
-        $ref: '#/definitions/v1alphaBoundingBox'
+        $ref: "#/definitions/v1alphaBoundingBox"
         title: OCR bounding box
         readOnly: true
     title: OcrObject represents a predicted ocr object
@@ -5010,7 +5010,7 @@ definitions:
       objects:
         type: array
         items:
-          $ref: '#/definitions/v1alphaOcrObject'
+          $ref: "#/definitions/v1alphaOcrObject"
         title: A list of OCR objects
         readOnly: true
     title: OcrOutput represents the output of ocr task
@@ -5048,14 +5048,14 @@ definitions:
         type: string
         title: Pipeline description
       recipe:
-        $ref: '#/definitions/v1alphaRecipe'
+        $ref: "#/definitions/v1alphaRecipe"
         title: Pipeline recipe
       mode:
-        $ref: '#/definitions/PipelineMode'
+        $ref: "#/definitions/PipelineMode"
         title: Pipeline mode
         readOnly: true
       state:
-        $ref: '#/definitions/v1alphaPipelineState'
+        $ref: "#/definitions/v1alphaPipelineState"
         title: Pipeline state
         readOnly: true
       user:
@@ -5097,7 +5097,7 @@ definitions:
       usages:
         type: array
         items:
-          $ref: '#/definitions/v1alphaPipelineUsageDataUserUsageData'
+          $ref: "#/definitions/v1alphaPipelineUsageDataUserUsageData"
         title: Usage data of all users in the pipeline service
     title: Pipeline service usage data
   v1alphaPipelineUsageDataUserUsageData:
@@ -5165,10 +5165,10 @@ definitions:
         title: Plan update time
         readOnly: true
       tier:
-        $ref: '#/definitions/PlanTier'
+        $ref: "#/definitions/PlanTier"
         title: Plan tier
       visibility:
-        $ref: '#/definitions/v1alphaPlanVisibility'
+        $ref: "#/definitions/v1alphaPlanVisibility"
         title: Plan visibility
       spec:
         type: object
@@ -5194,7 +5194,7 @@ definitions:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: Published model
     title: PublishModelResponse represents a response for the published model
   v1alphaReadSourceConnectorResponse:
@@ -5226,7 +5226,7 @@ definitions:
     type: object
     properties:
       destination_connector:
-        $ref: '#/definitions/v1alphaDestinationConnector'
+        $ref: "#/definitions/v1alphaDestinationConnector"
         title: A DestinationConnector resource
     title: |-
       RenameDestinationConnectorResponse represents a renamed DestinationConnector
@@ -5235,21 +5235,21 @@ definitions:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: Renamed model
     title: RenameModelResponse represents a response for a model
   v1alphaRenamePipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
+        $ref: "#/definitions/v1alphaPipeline"
         title: A pipeline resource
     title: RenamePipelineResponse represents a renamed pipeline resource
   v1alphaRenameSourceConnectorResponse:
     type: object
     properties:
       source_connector:
-        $ref: '#/definitions/v1alphaSourceConnector'
+        $ref: "#/definitions/v1alphaSourceConnector"
         title: A SourceConnector resource
     title: RenameSourceConnectorResponse represents a renamed SourceConnector resource
   v1alphaSemanticSegmentationInput:
@@ -5268,7 +5268,7 @@ definitions:
       stuffs:
         type: array
         items:
-          $ref: '#/definitions/v1alphaSemanticSegmentationStuff'
+          $ref: "#/definitions/v1alphaSemanticSegmentationStuff"
         title: A list of semantic segmentation stuffs
         readOnly: true
     title: |-
@@ -5301,11 +5301,11 @@ definitions:
         title: Resource UUID
         readOnly: true
       service:
-        $ref: '#/definitions/SessionService'
+        $ref: "#/definitions/SessionService"
         title: name of the service to collect data from
       edition:
         type: string
-        title: 'Session edition, allowed values include: ''local-ce'' and ''local-ce:dev'''
+        title: "Session edition, allowed values include: 'local-ce' and 'local-ce:dev'"
       version:
         type: string
         title: Version of the service
@@ -5364,19 +5364,19 @@ definitions:
         type: string
         title: Proof-of-work See https://en.wikipedia.org/wiki/Proof_of_work
       session:
-        $ref: '#/definitions/v1alphaSession'
+        $ref: "#/definitions/v1alphaSession"
         title: Session
       mgmt_usage_data:
-        $ref: '#/definitions/v1alphaMgmtUsageData'
+        $ref: "#/definitions/v1alphaMgmtUsageData"
         title: Management service usage data
       connector_usage_data:
-        $ref: '#/definitions/v1alphaConnectorUsageData'
+        $ref: "#/definitions/v1alphaConnectorUsageData"
         title: Connector service usage data
       model_usage_data:
-        $ref: '#/definitions/v1alphaModelUsageData'
+        $ref: "#/definitions/v1alphaModelUsageData"
         title: Model service usage data
       pipeline_usage_data:
-        $ref: '#/definitions/v1alphaPipelineUsageData'
+        $ref: "#/definitions/v1alphaPipelineUsageData"
         title: Pipeline service usage data
     title: |-
       SessionReport represents a report to be sent to the server that includes the
@@ -5410,7 +5410,7 @@ definitions:
         type: string
         title: SourceConnectorDefinition resource
       connector:
-        $ref: '#/definitions/v1alphaConnector'
+        $ref: "#/definitions/v1alphaConnector"
         title: SourceConnector's connector data structure
     title: SourceConnector represents a source connector resource
     required:
@@ -5436,7 +5436,7 @@ definitions:
           restricts to letters, numbers, and hyphen, with the first character a
           letter, the last a letter or a number, and a 63 character maximum.
       connector_definition:
-        $ref: '#/definitions/v1alphaConnectorDefinition'
+        $ref: "#/definitions/v1alphaConnectorDefinition"
         title: SourceConnectorDefinition connector definition
         readOnly: true
     title: SourceConnectorDefinition represents the source connector definition resource
@@ -5469,13 +5469,13 @@ definitions:
       supported_destination_sync_modes:
         type: array
         items:
-          $ref: '#/definitions/v1alphaSupportedDestinationSyncModes'
+          $ref: "#/definitions/v1alphaSupportedDestinationSyncModes"
         title: |-
           Spec destination sync mode, i.e., a list of destination sync modes
           supported by the connector
         readOnly: true
       advanced_auth:
-        $ref: '#/definitions/v1alphaAdvancedAuth'
+        $ref: "#/definitions/v1alphaAdvancedAuth"
         title: |-
           Spec advanced auth, i.e., additional and optional specification object to
           describe what an 'advanced' Auth flow would need to function
@@ -5519,40 +5519,40 @@ definitions:
     type: object
     properties:
       classification:
-        $ref: '#/definitions/v1alphaClassificationInput'
+        $ref: "#/definitions/v1alphaClassificationInput"
         title: The classification input
       detection:
-        $ref: '#/definitions/v1alphaDetectionInput'
+        $ref: "#/definitions/v1alphaDetectionInput"
         title: The detection input
       keypoint:
-        $ref: '#/definitions/v1alphaKeypointInput'
+        $ref: "#/definitions/v1alphaKeypointInput"
         title: The keypoint input
       ocr:
-        $ref: '#/definitions/v1alphaOcrInput'
+        $ref: "#/definitions/v1alphaOcrInput"
         title: The ocr input
       instance_segmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationInput'
+        $ref: "#/definitions/v1alphaInstanceSegmentationInput"
         title: The instance segmentation input
       semantic_segmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationInput'
+        $ref: "#/definitions/v1alphaSemanticSegmentationInput"
         title: The semantic segmentation input
       text_to_image:
-        $ref: '#/definitions/v1alphaTextToImageInput'
+        $ref: "#/definitions/v1alphaTextToImageInput"
         title: The text to image input
       unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedInput'
+        $ref: "#/definitions/v1alphaUnspecifiedInput"
         title: The unspecified task input
     title: Input represents the input to trigger a model instance
   v1alphaTestModelInstanceBinaryFileUploadResponse:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: "#/definitions/ModelInstanceTask"
         title: The task type
       task_outputs:
         type: array
         items:
-          $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+          $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
         title: The task output from a model instance
     title: |-
       TestModelInstanceBinaryFileUploadResponse represents a response for the
@@ -5564,12 +5564,12 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: "#/definitions/ModelInstanceTask"
         title: The task type
       task_outputs:
         type: array
         items:
-          $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+          $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
         title: The task output from a model instance
     title: |-
       TestModelInstanceResponse represents a response for the output for
@@ -5614,12 +5614,12 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: "#/definitions/ModelInstanceTask"
         title: The task type
       task_outputs:
         type: array
         items:
-          $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+          $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
         title: The task output from a model instance
     title: |-
       TriggerModelInstanceBinaryFileUploadResponse represents a response for the
@@ -5631,12 +5631,12 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: "#/definitions/ModelInstanceTask"
         title: The task type
       task_outputs:
         type: array
         items:
-          $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
+          $ref: "#/definitions/vdpmodelv1alphaTaskOutput"
         title: The task output from a model instance
     title: |-
       TriggerModelInstanceResponse represents a response for the output for
@@ -5652,7 +5652,7 @@ definitions:
       model_instance_outputs:
         type: array
         items:
-          $ref: '#/definitions/v1alphaModelInstanceOutput'
+          $ref: "#/definitions/v1alphaModelInstanceOutput"
         title: The multiple model instance inference outputs
     title: |-
       TriggerPipelineBinaryFileUploadResponse represents a response for the output
@@ -5668,7 +5668,7 @@ definitions:
       model_instance_outputs:
         type: array
         items:
-          $ref: '#/definitions/v1alphaModelInstanceOutput'
+          $ref: "#/definitions/v1alphaModelInstanceOutput"
         title: The multiple model instance inference outputs
     title: |-
       TriggerPipelineResponse represents a response for the output
@@ -5677,7 +5677,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Undeploy operation message
     title: |-
       UndeployModelInstanceResponse represents a response for a undeployed model
@@ -5686,7 +5686,7 @@ definitions:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: Unpublished model
     title: UnpublishModelResponse represents a response for the unpublished model
   v1alphaUnspecifiedInput:
@@ -5712,7 +5712,7 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1alphaUser'
+        $ref: "#/definitions/v1alphaUser"
         title: A user resource
     title: |-
       UpdateAuthenticatedUserResponse represents a response for
@@ -5721,7 +5721,7 @@ definitions:
     type: object
     properties:
       destination_connector:
-        $ref: '#/definitions/v1alphaDestinationConnector'
+        $ref: "#/definitions/v1alphaDestinationConnector"
         title: DestinationConnector resource
     title: |-
       UpdateDestinationConnectorResponse represents a response for a
@@ -5730,28 +5730,28 @@ definitions:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: The updated model
     title: UpdateModelResponse represents a response for a model
   v1alphaUpdatePipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
+        $ref: "#/definitions/v1alphaPipeline"
         title: An updated pipeline resource
     title: UpdatePipelineResponse represents a response for a pipeline resource
   v1alphaUpdatePlanResponse:
     type: object
     properties:
       plan:
-        $ref: '#/definitions/v1alphaPlan'
+        $ref: "#/definitions/v1alphaPlan"
         title: A plan resource
     title: UpdatePlanResponse represents a response for a plan resource
   v1alphaUpdateSourceConnectorResponse:
     type: object
     properties:
       source_connector:
-        $ref: '#/definitions/v1alphaSourceConnector'
+        $ref: "#/definitions/v1alphaSourceConnector"
         title: SourceConnector resource
     title: |-
       UpdateSourceConnectorResponse represents a response for a
@@ -5760,7 +5760,7 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1alphaUser'
+        $ref: "#/definitions/v1alphaUser"
         title: A user resource
     title: UpdateUserResponse represents a response for a user resource
   v1alphaUser:
@@ -5779,8 +5779,8 @@ definitions:
         type: string
         description: "Resource ID (the last segment of the resource name), also the user username. \nThis conforms to RFC-1034, which restricts to letters, numbers,\nand hyphen, with the first character a letter, the last a letter or a\nnumber, and a 63 character maximum.\nNote that the ID can be updated."
       type:
-        $ref: '#/definitions/v1alphaOwnerType'
-        title: 'Owner type: fixed to `OWNER_TYPE_USER`'
+        $ref: "#/definitions/v1alphaOwnerType"
+        title: "Owner type: fixed to `OWNER_TYPE_USER`"
         readOnly: true
       create_time:
         type: string
@@ -5841,14 +5841,14 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdpbillingv1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   vdpbillingv1alphaView:
@@ -5870,14 +5870,14 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdpconnectorv1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   vdpconnectorv1alphaReleaseStage:
@@ -5912,14 +5912,14 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdpmgmtv1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   vdpmgmtv1alphaView:
@@ -5941,14 +5941,14 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdpmodelv1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   vdpmodelv1alphaReleaseStage:
@@ -5971,35 +5971,35 @@ definitions:
     type: object
     properties:
       classification:
-        $ref: '#/definitions/v1alphaClassificationOutput'
+        $ref: "#/definitions/v1alphaClassificationOutput"
         title: The classification output
         readOnly: true
       detection:
-        $ref: '#/definitions/v1alphaDetectionOutput'
+        $ref: "#/definitions/v1alphaDetectionOutput"
         title: The detection output
         readOnly: true
       keypoint:
-        $ref: '#/definitions/v1alphaKeypointOutput'
+        $ref: "#/definitions/v1alphaKeypointOutput"
         title: The keypoint output
         readOnly: true
       ocr:
-        $ref: '#/definitions/v1alphaOcrOutput'
+        $ref: "#/definitions/v1alphaOcrOutput"
         title: The ocr output
         readOnly: true
       instance_segmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
+        $ref: "#/definitions/v1alphaInstanceSegmentationOutput"
         title: The instance segmentation output
         readOnly: true
       semantic_segmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
+        $ref: "#/definitions/v1alphaSemanticSegmentationOutput"
         title: The semantic segmentation output
         readOnly: true
       text_to_image:
-        $ref: '#/definitions/v1alphaTextToImageOutput'
+        $ref: "#/definitions/v1alphaTextToImageOutput"
         title: The text to image output
         readOnly: true
       unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedOutput'
+        $ref: "#/definitions/v1alphaUnspecifiedOutput"
         title: The unspecified task output
         readOnly: true
     title: TaskOutput represents the output of a CV Task result from a model instance
@@ -6022,14 +6022,14 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdppipelinev1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   vdppipelinev1alphaTaskOutput:
@@ -6040,35 +6040,35 @@ definitions:
         title: The index of input data in a batch
         readOnly: true
       classification:
-        $ref: '#/definitions/v1alphaClassificationOutput'
+        $ref: "#/definitions/v1alphaClassificationOutput"
         title: The classification output
         readOnly: true
       detection:
-        $ref: '#/definitions/v1alphaDetectionOutput'
+        $ref: "#/definitions/v1alphaDetectionOutput"
         title: The detection output
         readOnly: true
       keypoint:
-        $ref: '#/definitions/v1alphaKeypointOutput'
+        $ref: "#/definitions/v1alphaKeypointOutput"
         title: The keypoint output
         readOnly: true
       ocr:
-        $ref: '#/definitions/v1alphaOcrOutput'
+        $ref: "#/definitions/v1alphaOcrOutput"
         title: The ocr output
         readOnly: true
       instance_segmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
+        $ref: "#/definitions/v1alphaInstanceSegmentationOutput"
         title: The instance segmentation output
         readOnly: true
       semantic_segmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
+        $ref: "#/definitions/v1alphaSemanticSegmentationOutput"
         title: The semantic segmentation output
         readOnly: true
       text_to_image:
-        $ref: '#/definitions/v1alphaTextToImageOutput'
+        $ref: "#/definitions/v1alphaTextToImageOutput"
         title: The text to image output
         readOnly: true
       unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedOutput'
+        $ref: "#/definitions/v1alphaUnspecifiedOutput"
         title: The unspecified task output
         readOnly: true
     description: |-
@@ -6096,13 +6096,13 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdpusagev1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1alphaHealthCheckResponse'
+        $ref: "#/definitions/v1alphaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -5,8 +5,8 @@ info:
 tags:
   - name: PlanService
   - name: ConnectorService
-  - name: UserAdminService
-  - name: UserPublicService
+  - name: MgmtAdminService
+  - name: MgmtrPublicService
   - name: ModelService
   - name: PipelineService
   - name: UsageService
@@ -1876,7 +1876,7 @@ paths:
       summary: |-
         ExistUsername method receives a ExistUsernameRequest message and returns a
         ExistUsernameResponse
-      operationId: UserPublicService_ExistUsername
+      operationId: MgmtrPublicService_ExistUsername
       responses:
         "200":
           description: A successful response.
@@ -1896,13 +1896,13 @@ paths:
           type: string
           pattern: users/[^/]+
       tags:
-        - UserPublicService
+        - MgmtrPublicService
   /v1alpha/admin/{permalink_1}/lookUp:
     get:
       summary: |-
         LookUpUser method receives a LookUpUserRequest message and returns a
         LookUpUserResponse
-      operationId: UserAdminService_LookUpUser
+      operationId: MgmtAdminService_LookUpUser
       responses:
         "200":
           description: A successful response.
@@ -1937,7 +1937,7 @@ paths:
             - VIEW_FULL
           default: VIEW_UNSPECIFIED
       tags:
-        - UserAdminService
+        - MgmtAdminService
   /v1alpha/admin/{permalink}/lookUp:
     get:
       summary: |-
@@ -2129,7 +2129,7 @@ paths:
       summary: |-
         GetUser method receives a GetUserRequest message and returns
         a GetUserResponse message.
-      operationId: UserAdminService_GetUser
+      operationId: MgmtAdminService_GetUser
       responses:
         "200":
           description: A successful response.
@@ -2164,12 +2164,12 @@ paths:
             - VIEW_FULL
           default: VIEW_UNSPECIFIED
       tags:
-        - UserAdminService
+        - MgmtAdminService
     delete:
       summary: |-
         DeleteUser method receives a DeleteUserRequest message and returns a
         DeleteUserResponse
-      operationId: UserAdminService_DeleteUser
+      operationId: MgmtAdminService_DeleteUser
       responses:
         "200":
           description: A successful response.
@@ -2189,12 +2189,12 @@ paths:
           type: string
           pattern: users/[^/]+
       tags:
-        - UserAdminService
+        - MgmtAdminService
     patch:
       summary: |-
         UpdateUser method receives a UpdateUserRequest message and returns
         a UpdateUserResponse
-      operationId: UserAdminService_UpdateUser
+      operationId: MgmtAdminService_UpdateUser
       responses:
         "200":
           description: A successful response.
@@ -2293,7 +2293,7 @@ paths:
           required: true
           type: string
       tags:
-        - UserAdminService
+        - MgmtAdminService
   /v1alpha/admin/plans:
     get:
       summary: |-
@@ -2381,7 +2381,7 @@ paths:
       summary: |-
         ListUser method receives a ListUserRequest message and returns a
         ListUserResponse message.
-      operationId: UserAdminService_ListUser
+      operationId: MgmtAdminService_ListUser
       responses:
         "200":
           description: A successful response.
@@ -2428,12 +2428,12 @@ paths:
           required: false
           type: string
       tags:
-        - UserAdminService
+        - MgmtAdminService
     post:
       summary: |-
         CreateUser receives a CreateUserRequest message and returns a
         aGetUserResponse
-      operationId: UserAdminService_CreateUser
+      operationId: MgmtAdminService_CreateUser
       responses:
         "200":
           description: A successful response.
@@ -2457,7 +2457,7 @@ paths:
             required:
               - user
       tags:
-        - UserAdminService
+        - MgmtAdminService
   /v1alpha/destination-connector-definitions:
     get:
       summary: |-
@@ -2634,7 +2634,7 @@ paths:
         Liveness method receives a LivenessRequest message and returns a
         LivenessResponse message.
         See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-      operationId: UserPublicService_Liveness2
+      operationId: MgmtrPublicService_Liveness2
       responses:
         "200":
           description: A successful response.
@@ -2651,7 +2651,7 @@ paths:
           required: false
           type: string
       tags:
-        - UserPublicService
+        - MgmtrPublicService
   /v1alpha/health/model:
     get:
       summary: |-
@@ -3016,7 +3016,7 @@ paths:
         Readiness method receives a ReadinessRequest message and returns a
         ReadinessResponse message.
         See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
-      operationId: UserPublicService_Readiness2
+      operationId: MgmtrPublicService_Readiness2
       responses:
         "200":
           description: A successful response.
@@ -3033,7 +3033,7 @@ paths:
           required: false
           type: string
       tags:
-        - UserPublicService
+        - MgmtrPublicService
   /v1alpha/ready/model:
     get:
       summary: |-
@@ -3236,7 +3236,7 @@ paths:
       summary: |-
         GetAuthenticatedUser method receives a GetAuthenticatedUserRequest message and returns
         a GetAuthenticatedUserResponse message.
-      operationId: UserPublicService_GetAuthenticatedUser
+      operationId: MgmtrPublicService_GetAuthenticatedUser
       responses:
         "200":
           description: A successful response.
@@ -3247,10 +3247,10 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       tags:
-        - UserPublicService
+        - MgmtrPublicService
     patch:
       summary: "UpdateAuthenticatedUser method receives a UpdateAuthenticatedUserRequest message and returns \na UpdateAuthenticatedUserResponse message."
-      operationId: UserPublicService_UpdateAuthenticatedUser
+      operationId: MgmtrPublicService_UpdateAuthenticatedUser
       responses:
         "200":
           description: A successful response.
@@ -3275,7 +3275,7 @@ paths:
           required: true
           type: string
       tags:
-        - UserPublicService
+        - MgmtrPublicService
 definitions:
   AdvancedAuthAuthFlowType:
     type: string

--- a/vdp/mgmt/v1alpha/mgmt_admin_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_admin_service.proto
@@ -8,8 +8,8 @@ import "google/api/client.proto";
 
 import "vdp/mgmt/v1alpha/mgmt.proto";
 
-// User service responds to incoming user requests.
-service UserAdminService {
+// Mgmt service responds to incoming requests.
+service MgmtAdminService {
   option (google.api.default_host) = "api.instill.tech";
 
   // ========== Admin API: create, get, update and delete user accounts

--- a/vdp/mgmt/v1alpha/mgmt_public_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_public_service.proto
@@ -10,7 +10,7 @@ import "vdp/mgmt/v1alpha/healthcheck.proto";
 import "vdp/mgmt/v1alpha/mgmt.proto";
 
 // Mgmt service responds to incoming requests.
-service MgmtrPublicService {
+service MgmtPublicService {
   option (google.api.default_host) = "api.instill.tech";
 
   // Liveness method receives a LivenessRequest message and returns a

--- a/vdp/mgmt/v1alpha/mgmt_public_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_public_service.proto
@@ -9,8 +9,8 @@ import "google/api/client.proto";
 import "vdp/mgmt/v1alpha/healthcheck.proto";
 import "vdp/mgmt/v1alpha/mgmt.proto";
 
-// User service responds to incoming user requests.
-service UserPublicService {
+// Mgmt service responds to incoming requests.
+service MgmtrPublicService {
   option (google.api.default_host) = "api.instill.tech";
 
   // Liveness method receives a LivenessRequest message and returns a


### PR DESCRIPTION
Because

- we want to name the services concisely

This commit

- rename the mgmt-backend services
- update openapi swagger yaml
