### PR TITLE
chore(model): change type of guidance scale from int to float

### DIFF
--- a/vdp/model/v1alpha/task_text_to_image.proto
+++ b/vdp/model/v1alpha/task_text_to_image.proto
@@ -12,7 +12,7 @@ message TextToImageInput {
   // The steps
   optional int64 steps = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // The guidance scale
-  optional int64 cfg_scale = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  optional float cfg_scale = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // The seed
   optional int64 seed = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }


### PR DESCRIPTION
Because

- wrong type of `guidance scale` in model text to image input

This commit

- change type of `guidance scale` from int64 to float
