### PR TITLE
chore: update pipeline trigger input stream method

### DIFF
--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -359,12 +359,27 @@ message TriggerPipelineBinaryFileUploadRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type : "api.instill.tech/Pipeline"}
   ];
-  // The list of file name for each uploaded binary file
-  repeated string file_names = 2 [ (google.api.field_behavior) = REQUIRED ];
-  // The list of file length for each uploaded binary file
-  repeated uint64 file_lengths = 3 [ (google.api.field_behavior) = REQUIRED ];
-  // Content (i.e., images) used to trigger the pipeline in bytes
-  bytes content = 4 [ (google.api.field_behavior) = REQUIRED ];
+  // Input type
+  oneof input {
+    // The classification input
+    model.v1alpha.ClassificationInputStream classification = 2;
+    // The detection input
+    model.v1alpha.DetectionInputStream detection = 3;
+    // The keypoint input
+    model.v1alpha.KeypointInputStream keypoint = 4;
+    // The ocr input
+    model.v1alpha.OcrInputStream ocr = 5;
+    // The instance segmentation input
+    model.v1alpha.InstanceSegmentationInputStream instance_segmentation = 6;
+    // The semantic segmentation input
+    model.v1alpha.SemanticSegmentationInputStream semantic_segmentation = 7;
+    // The text to image input
+    model.v1alpha.TextToImageInput text_to_image = 8;
+    // The text generation input
+    model.v1alpha.TextGenerationInput text_generation = 9;
+    // The unspecified task input
+    model.v1alpha.UnspecifiedInput unspecified = 10;
+  }
 }
 
 // TriggerPipelineBinaryFileUploadResponse represents a response for the output

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -360,7 +360,7 @@ message TriggerPipelineBinaryFileUploadRequest {
     (google.api.resource_reference) = {type : "api.instill.tech/Pipeline"}
   ];
   // Input to the pipeline
-  model.v1alpha.TaskInputStream task_input = 2;
+  model.v1alpha.TaskInputStream task_input = 2 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // TriggerPipelineBinaryFileUploadResponse represents a response for the output

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -359,27 +359,8 @@ message TriggerPipelineBinaryFileUploadRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type : "api.instill.tech/Pipeline"}
   ];
-  // Input type
-  oneof input {
-    // The classification input
-    model.v1alpha.ClassificationInputStream classification = 2;
-    // The detection input
-    model.v1alpha.DetectionInputStream detection = 3;
-    // The keypoint input
-    model.v1alpha.KeypointInputStream keypoint = 4;
-    // The ocr input
-    model.v1alpha.OcrInputStream ocr = 5;
-    // The instance segmentation input
-    model.v1alpha.InstanceSegmentationInputStream instance_segmentation = 6;
-    // The semantic segmentation input
-    model.v1alpha.SemanticSegmentationInputStream semantic_segmentation = 7;
-    // The text to image input
-    model.v1alpha.TextToImageInput text_to_image = 8;
-    // The text generation input
-    model.v1alpha.TextGenerationInput text_generation = 9;
-    // The unspecified task input
-    model.v1alpha.UnspecifiedInput unspecified = 10;
-  }
+  // Input to the pipeline
+  model.v1alpha.TaskInputStream task_input = 2;
 }
 
 // TriggerPipelineBinaryFileUploadResponse represents a response for the output


### PR DESCRIPTION
Because

- unify task input when triggering the model instance

This commit

- update the task input in the pipeline backend for stream method
