### PR TITLE
chore(connector,mgmt,model,pipeline,usage): unify comments

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1905,8 +1905,9 @@ paths:
   /v1alpha/admin/{destination_connector.name}:
     get:
       summary: |-
-        GetDestinationConnectorAdmin method receives a GetDestinationConnectorAdminRequest
-        message and returns a GetDestinationConnectorAdminResponse message.
+        GetDestinationConnectorAdmin method receives a
+        GetDestinationConnectorAdminRequest message and returns a
+        GetDestinationConnectorAdminResponse message.
       operationId: ConnectorPrivateService_GetDestinationConnectorAdmin
       responses:
         "200":
@@ -1989,8 +1990,9 @@ paths:
   /v1alpha/admin/{permalink_1}/lookUp:
     get:
       summary: |-
-        LookUpSourceConnectorAdmin method receives a LookUpSourceConnectorAdminRequest
-        message and returns a LookUpSourceConnectorAdminResponse
+        LookUpSourceConnectorAdmin method receives a
+        LookUpSourceConnectorAdminRequest message and returns a
+        LookUpSourceConnectorAdminResponse
       operationId: ConnectorPrivateService_LookUpSourceConnectorAdmin
       responses:
         "200":
@@ -2072,8 +2074,8 @@ paths:
   /v1alpha/admin/{permalink_3}/lookUp:
     get:
       summary: |-
-        LookUpUserAdmin method receives a LookUpUserAdminRequest message and returns a
-        LookUpUserAdminResponse
+        LookUpUserAdmin method receives a LookUpUserAdminRequest message and
+        returns a LookUpUserAdminResponse
       operationId: MgmtPrivateService_LookUpUserAdmin
       responses:
         "200":
@@ -2113,8 +2115,8 @@ paths:
   /v1alpha/admin/{permalink_4}/lookUp:
     get:
       summary: |-
-        LookUpModelAdmin method receives a LookUpModelAdminRequest message and returns a
-        LookUpModelAdminResponse
+        LookUpModelAdmin method receives a LookUpModelAdminRequest message and
+        returns a LookUpModelAdminResponse
       operationId: ModelPrivateService_LookUpModelAdmin
       responses:
         "200":
@@ -2156,8 +2158,8 @@ paths:
   /v1alpha/admin/{permalink_5}/lookUp:
     get:
       summary: |-
-        LookUpPipelineAdmin method receives a LookUpPipelineAdminRequest message and returns
-        a LookUpPipelineAdminResponse
+        LookUpPipelineAdmin method receives a LookUpPipelineAdminRequest message
+        and returns a LookUpPipelineAdminResponse
       operationId: PipelinePrivateService_LookUpPipelineAdmin
       responses:
         "200":
@@ -2238,8 +2240,8 @@ paths:
   /v1alpha/admin/{pipeline.name}:
     get:
       summary: |-
-        GetPipelineAdmin method receives a GetPipelineAdminRequest message and returns a
-        GetPipelineAdminResponse message.
+        GetPipelineAdmin method receives a GetPipelineAdminRequest message and
+        returns a GetPipelineAdminResponse message.
       operationId: PipelinePrivateService_GetPipelineAdmin
       responses:
         "200":
@@ -2422,8 +2424,8 @@ paths:
   /v1alpha/admin/{source_connector.name}:
     get:
       summary: |-
-        GetSourceConnectorAdmin method receives a GetSourceConnectorAdminRequest message and
-        returns a GetSourceConnectorAdminResponse message.
+        GetSourceConnectorAdmin method receives a GetSourceConnectorAdminRequest
+        message and returns a GetSourceConnectorAdminResponse message.
       operationId: ConnectorPrivateService_GetSourceConnectorAdmin
       responses:
         "200":
@@ -2503,8 +2505,8 @@ paths:
         - MgmtPrivateService
     delete:
       summary: |-
-        DeleteUserAdmin method receives a DeleteUserAdminRequest message and returns a
-        DeleteUserAdminResponse
+        DeleteUserAdmin method receives a DeleteUserAdminRequest message and
+        returns a DeleteUserAdminResponse
       operationId: MgmtPrivateService_DeleteUserAdmin
       responses:
         "200":
@@ -2528,8 +2530,8 @@ paths:
         - MgmtPrivateService
     patch:
       summary: |-
-        UpdateUserAdmin method receives a UpdateUserAdminRequest message and returns
-        a UpdateUserAdminResponse
+        UpdateUserAdmin method receives a UpdateUserAdminRequest message and
+        returns a UpdateUserAdminResponse
       operationId: MgmtPrivateService_UpdateUserAdmin
       responses:
         "200":
@@ -2633,8 +2635,9 @@ paths:
   /v1alpha/admin/destination-connectors:
     get:
       summary: |-
-        ListDestinationConnectorAdmin method receives a ListDestinationConnectorAdminRequest
-        message and returns a ListDestinationConnectorResponse message.
+        ListDestinationConnectorAdmin method receives a
+        ListDestinationConnectorAdminRequest message and returns a
+        ListDestinationConnectorResponse message.
       operationId: ConnectorPrivateService_ListDestinationConnectorAdmin
       responses:
         "200":
@@ -2680,8 +2683,8 @@ paths:
   /v1alpha/admin/models:
     get:
       summary: |-
-        ListModelAdmin method receives a ListModelAdminRequest message and returns a
-        ListModelAdminResponse
+        ListModelAdmin method receives a ListModelAdminRequest message and returns
+        a ListModelAdminResponse
       operationId: ModelPrivateService_ListModelAdmin
       responses:
         "200":
@@ -2730,8 +2733,8 @@ paths:
   /v1alpha/admin/pipelines:
     get:
       summary: |-
-        ListPipelinesAdmin method receives a ListPipelinesAdminRequest message and returns a
-        ListPipelinesAdminResponse message.
+        ListPipelinesAdmin method receives a ListPipelinesAdminRequest message and
+        returns a ListPipelinesAdminResponse message.
       operationId: PipelinePrivateService_ListPipelinesAdmin
       responses:
         "200":
@@ -2864,8 +2867,8 @@ paths:
   /v1alpha/admin/source-connectors:
     get:
       summary: |-
-        ListSourceConnectorAdmin method receives a ListSourceConnectorAdminRequest message
-        and returns a ListSourceConnectorAdminResponse message.
+        ListSourceConnectorAdmin method receives a ListSourceConnectorAdminRequest
+        message and returns a ListSourceConnectorAdminResponse message.
       operationId: ConnectorPrivateService_ListSourceConnectorAdmin
       responses:
         "200":
@@ -2911,8 +2914,8 @@ paths:
   /v1alpha/admin/users:
     get:
       summary: |-
-        ListUsersAdmin method receives a ListUsersAdminRequest message and returns a
-        ListUsersAdminResponse message.
+        ListUsersAdmin method receives a ListUsersAdminRequest message and returns
+        a ListUsersAdminResponse message.
       operationId: MgmtPrivateService_ListUsersAdmin
       responses:
         "200":
@@ -3766,8 +3769,8 @@ paths:
   /v1alpha/users/me:
     get:
       summary: |-
-        QueryAuthenticatedUser method receives a QueryAuthenticatedUserRequest message and returns
-        a QueryAuthenticatedUserResponse message.
+        QueryAuthenticatedUser method receives a QueryAuthenticatedUserRequest
+        message and returns a QueryAuthenticatedUserResponse message.
       operationId: MgmtPublicService_QueryAuthenticatedUser
       responses:
         "200":
@@ -3781,7 +3784,9 @@ paths:
       tags:
         - MgmtPublicService
     patch:
-      summary: "PatchAuthenticatedUser method receives a PatchAuthenticatedUserRequest message and returns \na PatchAuthenticatedUserResponse message."
+      summary: |-
+        PatchAuthenticatedUser method receives a PatchAuthenticatedUserRequest
+        message and returns a PatchAuthenticatedUserResponse message.
       operationId: MgmtPublicService_PatchAuthenticatedUser
       responses:
         "200":

--- a/vdp/connector/v1alpha/connector_private_service.proto
+++ b/vdp/connector/v1alpha/connector_private_service.proto
@@ -8,16 +8,13 @@ import "google/api/client.proto";
 
 import "vdp/connector/v1alpha/connector.proto";
 
-///////////////////////////////////////////////////////////////////////////////
-// Connector service responds to internal incoming connector requests.
+// Connector service responds to internal access
 service ConnectorPrivateService {
-
-  // ========== Admin API ========== 
 
   // *SourceConnector methods
 
-  // ListSourceConnectorAdmin method receives a ListSourceConnectorAdminRequest message
-  // and returns a ListSourceConnectorAdminResponse message.
+  // ListSourceConnectorAdmin method receives a ListSourceConnectorAdminRequest
+  // message and returns a ListSourceConnectorAdminResponse message.
   rpc ListSourceConnectorAdmin(ListSourceConnectorAdminRequest)
       returns (ListSourceConnectorAdminResponse) {
     option (google.api.http) = {
@@ -25,8 +22,8 @@ service ConnectorPrivateService {
     };
   }
 
-  // GetSourceConnectorAdmin method receives a GetSourceConnectorAdminRequest message and
-  // returns a GetSourceConnectorAdminResponse message.
+  // GetSourceConnectorAdmin method receives a GetSourceConnectorAdminRequest
+  // message and returns a GetSourceConnectorAdminResponse message.
   rpc GetSourceConnectorAdmin(GetSourceConnectorAdminRequest)
       returns (GetSourceConnectorAdminResponse) {
     option (google.api.http) = {
@@ -35,8 +32,9 @@ service ConnectorPrivateService {
     option (google.api.method_signature) = "name";
   }
 
-  // LookUpSourceConnectorAdmin method receives a LookUpSourceConnectorAdminRequest
-  // message and returns a LookUpSourceConnectorAdminResponse
+  // LookUpSourceConnectorAdmin method receives a
+  // LookUpSourceConnectorAdminRequest message and returns a
+  // LookUpSourceConnectorAdminResponse
   rpc LookUpSourceConnectorAdmin(LookUpSourceConnectorAdminRequest)
       returns (LookUpSourceConnectorAdminResponse) {
     option (google.api.http) = {
@@ -47,8 +45,9 @@ service ConnectorPrivateService {
 
   // *DestinationConnector methods
 
-  // ListDestinationConnectorAdmin method receives a ListDestinationConnectorAdminRequest
-  // message and returns a ListDestinationConnectorResponse message.
+  // ListDestinationConnectorAdmin method receives a
+  // ListDestinationConnectorAdminRequest message and returns a
+  // ListDestinationConnectorResponse message.
   rpc ListDestinationConnectorAdmin(ListDestinationConnectorAdminRequest)
       returns (ListDestinationConnectorAdminResponse) {
     option (google.api.http) = {
@@ -56,8 +55,9 @@ service ConnectorPrivateService {
     };
   }
 
-  // GetDestinationConnectorAdmin method receives a GetDestinationConnectorAdminRequest
-  // message and returns a GetDestinationConnectorAdminResponse message.
+  // GetDestinationConnectorAdmin method receives a
+  // GetDestinationConnectorAdminRequest message and returns a
+  // GetDestinationConnectorAdminResponse message.
   rpc GetDestinationConnectorAdmin(GetDestinationConnectorAdminRequest)
       returns (GetDestinationConnectorAdminResponse) {
     option (google.api.http) = {

--- a/vdp/connector/v1alpha/connector_public_service.proto
+++ b/vdp/connector/v1alpha/connector_public_service.proto
@@ -10,9 +10,9 @@ import "vdp/connector/v1alpha/healthcheck.proto";
 import "vdp/connector/v1alpha/connector_definition.proto";
 import "vdp/connector/v1alpha/connector.proto";
 
-///////////////////////////////////////////////////////////////////////////////
-// Connector service responds to external incoming connector requests.
+// Connector service responds to external access
 service ConnectorPublicService {
+  option (google.api.default_host) = "api.instill.tech";
 
   /////////////////////////////////
   // Connector definition methods

--- a/vdp/mgmt/v1alpha/mgmt_private_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_private_service.proto
@@ -8,14 +8,11 @@ import "google/api/client.proto";
 
 import "vdp/mgmt/v1alpha/mgmt.proto";
 
-// Mgmt service responds to incoming internal requests.
+// Mgmt service responds to internal access
 service MgmtPrivateService {
-  option (google.api.default_host) = "api.instill.tech";
 
-  // ========== Admin endpoints ==========
-
-  // ListUsersAdmin method receives a ListUsersAdminRequest message and returns a
-  // ListUsersAdminResponse message.
+  // ListUsersAdmin method receives a ListUsersAdminRequest message and returns
+  // a ListUsersAdminResponse message.
   rpc ListUsersAdmin(ListUsersAdminRequest) returns (ListUsersAdminResponse) {
     option (google.api.http) = {
       get : "/v1alpha/admin/users"
@@ -24,7 +21,8 @@ service MgmtPrivateService {
 
   // CreateUserAdmin receives a CreateUserAdminRequest message and returns a
   // a GetUserAdminResponse
-  rpc CreateUserAdmin(CreateUserAdminRequest) returns (CreateUserAdminResponse) {
+  rpc CreateUserAdmin(CreateUserAdminRequest)
+      returns (CreateUserAdminResponse) {
     option (google.api.http) = {
       post : "/v1alpha/admin/users"
       body : "user"
@@ -41,9 +39,10 @@ service MgmtPrivateService {
     option (google.api.method_signature) = "name";
   }
 
-  // UpdateUserAdmin method receives a UpdateUserAdminRequest message and returns
-  // a UpdateUserAdminResponse
-  rpc UpdateUserAdmin(UpdateUserAdminRequest) returns (UpdateUserAdminResponse) {
+  // UpdateUserAdmin method receives a UpdateUserAdminRequest message and
+  // returns a UpdateUserAdminResponse
+  rpc UpdateUserAdmin(UpdateUserAdminRequest)
+      returns (UpdateUserAdminResponse) {
     option (google.api.http) = {
       patch : "/v1alpha/admin/{user.name=users/*}"
       body : "user"
@@ -51,18 +50,20 @@ service MgmtPrivateService {
     option (google.api.method_signature) = "user,update_mask";
   }
 
-  // DeleteUserAdmin method receives a DeleteUserAdminRequest message and returns a
-  // DeleteUserAdminResponse
-  rpc DeleteUserAdmin(DeleteUserAdminRequest) returns (DeleteUserAdminResponse) {
+  // DeleteUserAdmin method receives a DeleteUserAdminRequest message and
+  // returns a DeleteUserAdminResponse
+  rpc DeleteUserAdmin(DeleteUserAdminRequest)
+      returns (DeleteUserAdminResponse) {
     option (google.api.http) = {
       delete : "/v1alpha/admin/{name=users/*}"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // LookUpUserAdmin method receives a LookUpUserAdminRequest message and returns a
-  // LookUpUserAdminResponse
-  rpc LookUpUserAdmin(LookUpUserAdminRequest) returns (LookUpUserAdminResponse) {
+  // LookUpUserAdmin method receives a LookUpUserAdminRequest message and
+  // returns a LookUpUserAdminResponse
+  rpc LookUpUserAdmin(LookUpUserAdminRequest)
+      returns (LookUpUserAdminResponse) {
     option (google.api.http) = {
       get : "/v1alpha/admin/{permalink=users/*}/lookUp"
     };

--- a/vdp/mgmt/v1alpha/mgmt_public_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_public_service.proto
@@ -9,7 +9,7 @@ import "google/api/client.proto";
 import "vdp/mgmt/v1alpha/healthcheck.proto";
 import "vdp/mgmt/v1alpha/mgmt.proto";
 
-// Mgmt service responds to external incoming requests.
+// Mgmt service responds to external access
 service MgmtPublicService {
   option (google.api.default_host) = "api.instill.tech";
 
@@ -33,19 +33,19 @@ service MgmtPublicService {
     };
   }
 
-  // ========== Public API: endpoints exposed to public internet traffic
-
-  // QueryAuthenticatedUser method receives a QueryAuthenticatedUserRequest message and returns
-  // a QueryAuthenticatedUserResponse message.
-  rpc QueryAuthenticatedUser(QueryAuthenticatedUserRequest) returns (QueryAuthenticatedUserResponse) {
+  // QueryAuthenticatedUser method receives a QueryAuthenticatedUserRequest
+  // message and returns a QueryAuthenticatedUserResponse message.
+  rpc QueryAuthenticatedUser(QueryAuthenticatedUserRequest)
+      returns (QueryAuthenticatedUserResponse) {
     option (google.api.http) = {
       get : "/v1alpha/users/me"
     };
   }
 
-  // PatchAuthenticatedUser method receives a PatchAuthenticatedUserRequest message and returns 
-  // a PatchAuthenticatedUserResponse message.
-  rpc PatchAuthenticatedUser(PatchAuthenticatedUserRequest) returns (PatchAuthenticatedUserResponse) {
+  // PatchAuthenticatedUser method receives a PatchAuthenticatedUserRequest
+  // message and returns a PatchAuthenticatedUserResponse message.
+  rpc PatchAuthenticatedUser(PatchAuthenticatedUserRequest)
+      returns (PatchAuthenticatedUserResponse) {
     option (google.api.http) = {
       patch : "/v1alpha/users/me"
       body : "user"

--- a/vdp/model/v1alpha/model_private_service.proto
+++ b/vdp/model/v1alpha/model_private_service.proto
@@ -8,14 +8,11 @@ import "google/api/client.proto";
 
 import "vdp/model/v1alpha/model.proto";
 
-// Model service responds to internal incoming model requests
+// Model service responds to internal access
 service ModelPrivateService {
-  option (google.api.default_host) = "api.instill.tech";
 
-    // ========== Admin API ========== 
-
-  // ListModelAdmin method receives a ListModelAdminRequest message and returns a
-  // ListModelAdminResponse
+  // ListModelAdmin method receives a ListModelAdminRequest message and returns
+  // a ListModelAdminResponse
   rpc ListModelAdmin(ListModelAdminRequest) returns (ListModelAdminResponse) {
     option (google.api.http) = {
       get : "/v1alpha/admin/models"
@@ -31,9 +28,10 @@ service ModelPrivateService {
     option (google.api.method_signature) = "name";
   }
 
-  // LookUpModelAdmin method receives a LookUpModelAdminRequest message and returns a
-  // LookUpModelAdminResponse
-  rpc LookUpModelAdmin(LookUpModelAdminRequest) returns (LookUpModelAdminResponse) {
+  // LookUpModelAdmin method receives a LookUpModelAdminRequest message and
+  // returns a LookUpModelAdminResponse
+  rpc LookUpModelAdmin(LookUpModelAdminRequest)
+      returns (LookUpModelAdminResponse) {
     option (google.api.http) = {
       get : "/v1alpha/admin/{permalink=models/*}/lookUp"
     };

--- a/vdp/model/v1alpha/model_public_service.proto
+++ b/vdp/model/v1alpha/model_public_service.proto
@@ -10,7 +10,7 @@ import "vdp/model/v1alpha/healthcheck.proto";
 import "vdp/model/v1alpha/model_definition.proto";
 import "vdp/model/v1alpha/model.proto";
 
-// Model service responds to external incoming model requests
+// Model service responds to external access
 service ModelPublicService {
   option (google.api.default_host) = "api.instill.tech";
 
@@ -257,27 +257,30 @@ service ModelPublicService {
   // GetModelOperation method receives a
   // GetModelOperationRequest message and returns a
   // GetModelOperationResponse message.
-  rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
+  rpc GetModelOperation(GetModelOperationRequest)
+      returns (GetModelOperationResponse) {
     option (google.api.http) = {
-      get: "/v1alpha/{name=operations/*}"
+      get : "/v1alpha/{name=operations/*}"
     };
     option (google.api.method_signature) = "name";
   }
 
   // ListModelOperation method receives a ListModelOperationRequest message
   // and returns a ListModelOperationResponse
-  rpc ListModelOperation(ListModelOperationRequest) returns (ListModelOperationResponse) {
+  rpc ListModelOperation(ListModelOperationRequest)
+      returns (ListModelOperationResponse) {
     option (google.api.http) = {
-      get: "/v1alpha/operations"
+      get : "/v1alpha/operations"
     };
   }
 
   // CancelModelOperation method receives a CancelModelOperationRequest message
   // and returns a CancelModelOperationResponse
-  rpc CancelModelOperation(CancelModelOperationRequest) returns (CancelModelOperationResponse) {
+  rpc CancelModelOperation(CancelModelOperationRequest)
+      returns (CancelModelOperationResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=operations/*}/cancel"
-      body: "*"
+      post : "/v1alpha/{name=operations/*}/cancel"
+      body : "*"
     };
     option (google.api.method_signature) = "name";
   }

--- a/vdp/pipeline/v1alpha/pipeline_private_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_private_service.proto
@@ -8,32 +8,32 @@ import "google/api/client.proto";
 
 import "vdp/pipeline/v1alpha/pipeline.proto";
 
-// Pipeline service responds to internal incoming pipeline requests.
+// Pipeline service responds to internal access
 service PipelinePrivateService {
 
-  // ========== Admin API ========== 
-
-  // ListPipelinesAdmin method receives a ListPipelinesAdminRequest message and returns a
-  // ListPipelinesAdminResponse message.
-  rpc ListPipelinesAdmin(ListPipelinesAdminRequest) returns (ListPipelinesAdminResponse) {
+  // ListPipelinesAdmin method receives a ListPipelinesAdminRequest message and
+  // returns a ListPipelinesAdminResponse message.
+  rpc ListPipelinesAdmin(ListPipelinesAdminRequest)
+      returns (ListPipelinesAdminResponse) {
     option (google.api.http) = {
       get : "/v1alpha/admin/pipelines"
     };
   }
 
-  // GetPipelineAdmin method receives a GetPipelineAdminRequest message and returns a
-  // GetPipelineAdminResponse message.
-  rpc GetPipelineAdmin(GetPipelineAdminRequest) returns (GetPipelineAdminResponse) {
+  // GetPipelineAdmin method receives a GetPipelineAdminRequest message and
+  // returns a GetPipelineAdminResponse message.
+  rpc GetPipelineAdmin(GetPipelineAdminRequest)
+      returns (GetPipelineAdminResponse) {
     option (google.api.http) = {
       get : "/v1alpha/admin/{name=pipelines/*}"
     };
     option (google.api.method_signature) = "name";
   }
 
-
-  // LookUpPipelineAdmin method receives a LookUpPipelineAdminRequest message and returns
-  // a LookUpPipelineAdminResponse
-  rpc LookUpPipelineAdmin(LookUpPipelineAdminRequest) returns (LookUpPipelineAdminResponse) {
+  // LookUpPipelineAdmin method receives a LookUpPipelineAdminRequest message
+  // and returns a LookUpPipelineAdminResponse
+  rpc LookUpPipelineAdmin(LookUpPipelineAdminRequest)
+      returns (LookUpPipelineAdminResponse) {
     option (google.api.http) = {
       get : "/v1alpha/admin/{permalink=pipelines/*}/lookUp"
     };

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -9,8 +9,9 @@ import "google/api/client.proto";
 import "vdp/pipeline/v1alpha/healthcheck.proto";
 import "vdp/pipeline/v1alpha/pipeline.proto";
 
-// Pipeline service responds to external incoming pipeline requests.
+// Pipeline service responds to external access
 service PipelinePublicService {
+  option (google.api.default_host) = "api.instill.tech";
 
   // Liveness method receives a LivenessRequest message and returns a
   // LivenessResponse message.

--- a/vdp/usage/v1alpha/usage_service.proto
+++ b/vdp/usage/v1alpha/usage_service.proto
@@ -11,6 +11,8 @@ import "vdp/usage/v1alpha/usage.proto";
 
 // UsageService responds to incoming usage requests.
 service UsageService {
+  option (google.api.default_host) = "usage.instill.tech";
+
   // Liveness method receives a LivenessRequest message and returns a
   // LivenessResponse message.
   // See https://github.com/grpc/grpc/blob/master/doc/health-checking.md


### PR DESCRIPTION
Because

- there are many inconsistent comments

This commit

- clean up and unify the discrepant comments
