### PR TITLE
chore: add watch, check rpc methods in connector-backend

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -68,6 +68,32 @@ paths:
           type: string
       tags:
         - UsageService
+  /v1alpha/{destination_connector.name/watch}/watch:
+    get:
+      summary: |-
+        WatchDestinationConnector method receives a WatchDestinationConnectorRequest message
+        and returns a WatchDestinationConnectorResponse
+      operationId: ConnectorPublicService_WatchDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: destination_connector.name/watch
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+      tags:
+        - ConnectorPublicService
   /v1alpha/{destination_connector.name}:
     get:
       summary: |-
@@ -532,6 +558,48 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ModelPublicService
+  /v1alpha/{name_1}:
+    get:
+      summary: |-
+        GetModelOperation method receives a
+        GetModelOperationRequest message and returns a
+        GetModelOperationResponse message.
+      operationId: ModelPublicService_GetModelOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetModelOperationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_1
+          description: The name of the operation resource.
+          in: path
+          required: true
+          type: string
+          pattern: operations/[^/]+
+        - name: view
+          description: |-
+            View (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
+            `ModelInstance.configuration` VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelPublicService
   /v1alpha/{name_1}/connect:
     post:
       summary: |-
@@ -765,15 +833,15 @@ paths:
   /v1alpha/{name}:
     get:
       summary: |-
-        GetModelOperation method receives a
-        GetModelOperationRequest message and returns a
-        GetModelOperationResponse message.
-      operationId: ModelPublicService_GetModelOperation
+        GetOperation method receives a
+        GetOperationRequest message and returns a
+        GetOperationResponse message.
+      operationId: ConnectorPublicService_GetOperation
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelOperationResponse'
+            $ref: '#/definitions/v1alphaGetOperationResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -787,13 +855,11 @@ paths:
           pattern: operations/[^/]+
         - name: view
           description: |-
-            View (default is VIEW_BASIC)
-            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-            `ModelInstance.configuration` VIEW_FULL: show full information
+            SourceConnector view (default is VIEW_BASIC)
 
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-             - VIEW_FULL: View: FULL, full representation of the resource
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
           in: query
           required: false
           type: string
@@ -803,7 +869,7 @@ paths:
             - VIEW_FULL
           default: VIEW_UNSPECIFIED
       tags:
-        - ModelPublicService
+        - ConnectorPublicService
   /v1alpha/{name}/activate:
     post:
       summary: |-
@@ -1836,6 +1902,32 @@ paths:
           type: string
       tags:
         - ControllerPrivateService
+  /v1alpha/{source_connector.name/watch}/watch:
+    get:
+      summary: |-
+        WatchSourceConnector method receives a WatchSourceConnectorRequest message
+        and returns a WatchSourceConnectorResponse
+      operationId: ConnectorPublicService_WatchSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: source_connector.name/watch
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+      tags:
+        - ConnectorPublicService
   /v1alpha/{source_connector.name}:
     get:
       summary: |-
@@ -2112,7 +2204,33 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ModelPrivateService
-  /v1alpha/admin/{name}/check:
+  /v1alpha/admin/{name_1}/check:
+    get:
+      summary: |-
+        CheckDestinationConnector method receives a CheckDestinationConnectorRequest message and returns a
+        CheckDestinationConnectorResponse
+      operationId: ConnectorPrivateService_CheckDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCheckDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_1
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+      tags:
+        - ConnectorPrivateService
+  /v1alpha/admin/{name_2}/check:
     get:
       summary: |-
         CheckModelInstance method receives a CheckModelInstanceRequest message and returns a
@@ -2128,7 +2246,7 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: name
+        - name: name_2
           description: |-
             Resource name of the model instance.
             For example "models/{model}/instances/{instance}"
@@ -2138,6 +2256,32 @@ paths:
           pattern: models/[^/]+/instances/[^/]+
       tags:
         - ModelPrivateService
+  /v1alpha/admin/{name}/check:
+    get:
+      summary: |-
+        CheckSourceConnector method receives a CheckSourceConnectorRequest message and returns a
+        CheckSourceConnectorResponse
+      operationId: ConnectorPrivateService_CheckSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCheckSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+      tags:
+        - ConnectorPrivateService
   /v1alpha/admin/{permalink_1}/lookUp:
     get:
       summary: |-
@@ -4047,6 +4191,15 @@ definitions:
     title: |-
       CancelModelOperationResponse represents a response for canceling a model
       operation
+  v1alphaCheckDestinationConnectorResponse:
+    type: object
+    properties:
+      workflow_id:
+        type: string
+        title: Retrieved longrunning workflow id
+    title: |-
+      CheckDestinationConnectorResponse represents a response to fetch a destination connector's
+      current state
   v1alphaCheckModelInstanceResponse:
     type: object
     properties:
@@ -4056,6 +4209,15 @@ definitions:
     title: |-
       CheckModelInstanceResponse represents a response to fetch a model
       instance's current state and longrunning progress
+  v1alphaCheckSourceConnectorResponse:
+    type: object
+    properties:
+      workflow_id:
+        type: string
+        title: Retrieved longrunning workflow id
+    title: |-
+      CheckSourceConnectorResponse represents a response to fetch a source connector's
+      current state
   v1alphaClassificationInput:
     type: object
     properties:
@@ -4823,6 +4985,13 @@ definitions:
     title: GetPipelinesResponse represents a respond to GetModelsRequest
     required:
       - models
+  v1alphaGetOperationResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: The retrieved longrunning operation
+    title: GetOperationResponse represents a response for a longrunning operation
   v1alphaGetPipelineAdminResponse:
     type: object
     properties:
@@ -6999,6 +7168,15 @@ definitions:
     title: User records definition
     required:
       - uid
+  v1alphaWatchDestinationConnectorResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaConnectorState'
+        title: Retrieved connector state
+    title: |-
+      WatchDestinationConnectorResponse represents a response to fetch a destination connector's
+      current state
   v1alphaWatchModelInstanceResponse:
     type: object
     properties:
@@ -7012,6 +7190,15 @@ definitions:
     title: |-
       WatchModelInstanceResponse represents a public response to
       fetch a model instance's current state and longrunning progress
+  v1alphaWatchSourceConnectorResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaConnectorState'
+        title: Retrieved connector state
+    title: |-
+      WatchSourceConnectorResponse represents a response to fetch a source connector's
+      current state
   v1alphaWriteDestinationConnectorResponse:
     type: object
     title: |-

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -11,6 +11,7 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 // Google API
 import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
+import "google/longrunning/operations.proto";
 
 import "vdp/pipeline/v1alpha/pipeline.proto";
 import "vdp/connector/v1alpha/connector_definition.proto";
@@ -610,6 +611,42 @@ message LookUpSourceConnectorAdminResponse {
   SourceConnector source_connector = 1;
 }
 
+// WatchSourceConnectorRequest represents a public request to query
+// a source connector's current state
+message WatchSourceConnectorRequest {
+  // SourceConnector resource name. It must have the format of
+  // "source-connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/SourceConnector",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "source_connector.name/watch"}
+    }
+  ];
+}
+
+// WatchSourceConnectorResponse represents a response to fetch a source connector's
+// current state
+message WatchSourceConnectorResponse {
+  // Retrieved connector state
+  Connector.State state = 1;
+}
+
+// CheckSourceConnectorRequest represents a private request to query
+// a source connector's current state
+message CheckSourceConnectorRequest {
+  // SourceConnector resource name. It must have the format of
+  // "source-connectors/*"
+  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// CheckSourceConnectorResponse represents a response to fetch a source connector's
+// current state
+message CheckSourceConnectorResponse {
+  // Retrieved longrunning workflow id
+  string workflow_id = 1;
+}
+
 // ListDestinationConnectorsAdminRequest represents a request to list
 // DestinationConnector resources from all users by admin
 message ListDestinationConnectorsAdminRequest {
@@ -674,4 +711,54 @@ message LookUpDestinationConnectorAdminRequest {
 message LookUpDestinationConnectorAdminResponse {
   // DestinationConnector resource
   DestinationConnector destination_connector = 1;
+}
+
+// WatchDestinationConnectorRequest represents a public request to query
+// a destination connector's current state
+message WatchDestinationConnectorRequest {
+  // SourceConnector resource name. It must have the format of
+  // "destination-connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/DestinationConnector",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "destination_connector.name/watch"}
+    }
+  ];
+}
+
+// WatchDestinationConnectorResponse represents a response to fetch a destination connector's
+// current state
+message WatchDestinationConnectorResponse {
+  // Retrieved connector state
+  Connector.State state = 1;
+}
+
+// CheckDestinationConnectorRequest represents a private request to query
+// a destination connector's current state
+message CheckDestinationConnectorRequest {
+  // SourceConnector resource name. It must have the format of
+  // "destination-connectors/*"
+  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// CheckDestinationConnectorResponse represents a response to fetch a destination connector's
+// current state
+message CheckDestinationConnectorResponse {
+  // Retrieved longrunning workflow id
+  string workflow_id = 1;
+}
+
+// GetOperationRequest represents a request to query a longrunning operation
+message GetOperationRequest {
+  // The name of the operation resource.
+  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // SourceConnector view (default is VIEW_BASIC)
+  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// GetOperationResponse represents a response for a longrunning operation
+message GetOperationResponse {
+  // The retrieved longrunning operation
+  google.longrunning.Operation operation = 1;
 }

--- a/vdp/connector/v1alpha/connector_private_service.proto
+++ b/vdp/connector/v1alpha/connector_private_service.proto
@@ -43,6 +43,15 @@ service ConnectorPrivateService {
     option (google.api.method_signature) = "permalink";
   }
 
+  // CheckSourceConnector method receives a CheckSourceConnectorRequest message and returns a
+  // CheckSourceConnectorResponse
+  rpc CheckSourceConnector(CheckSourceConnectorRequest) returns (CheckSourceConnectorResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/admin/{name=source-connectors/*}/check"
+    };
+    option (google.api.method_signature) = "name";
+  };
+
   // *DestinationConnector methods
 
   // ListDestinationConnectorsAdmin method receives a ListDestinationConnectorsAdminRequest
@@ -75,4 +84,13 @@ service ConnectorPrivateService {
     };
     option (google.api.method_signature) = "permalink";
   }
+
+  // CheckDestinationConnector method receives a CheckDestinationConnectorRequest message and returns a
+  // CheckDestinationConnectorResponse
+  rpc CheckDestinationConnector(CheckDestinationConnectorRequest) returns (CheckDestinationConnectorResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/admin/{name=destination-connectors/*}/check"
+    };
+    option (google.api.method_signature) = "name";
+  };
 }

--- a/vdp/connector/v1alpha/connector_public_service.proto
+++ b/vdp/connector/v1alpha/connector_public_service.proto
@@ -198,6 +198,16 @@ service ConnectorPublicService {
     option (google.api.method_signature) = "name,new_source_connector_id";
   }
 
+  // WatchSourceConnector method receives a WatchSourceConnectorRequest message
+  // and returns a WatchSourceConnectorResponse
+  rpc WatchSourceConnector(WatchSourceConnectorRequest)
+      returns (WatchSourceConnectorResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/{name=source-connectors/*}/watch"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
   // *DestinationConnector methods
 
   // CreateDestinationConnector method receives a
@@ -315,5 +325,28 @@ service ConnectorPublicService {
       body : "*"
     };
     option (google.api.method_signature) = "name,new_destination_connector_id";
+  }
+
+  // WatchDestinationConnector method receives a WatchDestinationConnectorRequest message
+  // and returns a WatchDestinationConnectorResponse
+  rpc WatchDestinationConnector(WatchDestinationConnectorRequest)
+      returns (WatchDestinationConnectorResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/{name=destination-connectors/*}/watch"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // *Longrunning operation methods
+
+  // GetOperation method receives a
+  // GetOperationRequest message and returns a
+  // GetOperationResponse message.
+  rpc GetOperation(GetOperationRequest)
+      returns (GetOperationResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/{name=operations/*}"
+    };
+    option (google.api.method_signature) = "name";
   }
 }


### PR DESCRIPTION
Because

- define rpc methods for connector resource state monitoring

This commit

- add public /watch endpoint
- add private /check endpoint
