### PR TITLE
chore(mgmt): implement API token in mgmt backend

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2093,6 +2093,87 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPublicService
+  /v1alpha/{token.name}:
+    get:
+      summary: |-
+        GetToken method receives a GetTokenRequest message and returns a
+        GetTokenResponse message.
+      operationId: MgmtPublicService_GetToken
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetTokenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: token.name
+          description: API tokens resource name. It must have the format of "tokens/*"
+          in: path
+          required: true
+          type: string
+          pattern: tokens/[^/]+
+      tags:
+        - MgmtPublicService
+    delete:
+      summary: |-
+        DeleteToken method receives a DeleteTokenRequest message and returns
+        a DeleteTokenResponse message.
+      operationId: MgmtPublicService_DeleteToken
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteTokenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: token.name
+          description: API token resource name. It must have the format of "tokens/*"
+          in: path
+          required: true
+          type: string
+          pattern: tokens/[^/]+
+      tags:
+        - MgmtPublicService
+  /v1alpha/{token.name}/validate:
+    post:
+      summary: |-
+        ValidateToken method receives a ValidateTokenRequest message and
+        returns a ValidateTokenResponse
+      operationId: MgmtPrivateService_ValidateToken
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaValidateTokenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: token.name
+          description: |-
+            The resource name of the API token to validate,
+            for example: "tokens/test-token"
+          in: path
+          required: true
+          type: string
+          pattern: tokens/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              ValidateTokenRequest represents a request to validate whether
+              an API token is valid to be used for triggering pipelines
+      tags:
+        - MgmtPrivateService
   /v1alpha/{user.name}/exist:
     get:
       summary: |-
@@ -2111,7 +2192,7 @@ paths:
       parameters:
         - name: user.name
           description: |-
-            The resource name of the user to be deleted,
+            The resource name of the user to check,
             for example: "users/local-user"
           in: path
           required: true
@@ -3749,6 +3830,63 @@ paths:
               - source_connector
       tags:
         - ConnectorPublicService
+  /v1alpha/tokens:
+    get:
+      summary: |-
+        ListTokens method receives a ListTokensRequest message and returns a
+        ListTokensResponse message.
+      operationId: MgmtPublicService_ListTokens
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListTokensResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of API tokens to return. The service may return fewer
+            than this value. If unspecified, at most 10 API tokens will be returned. The
+            maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+      tags:
+        - MgmtPublicService
+    post:
+      summary: |-
+        CreateToken method receives a CreateTokenRequest message and returns
+        a CreateTokenResponse message.
+      operationId: MgmtPublicService_CreateToken
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateTokenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: token
+          description: A token resource to create
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaApiToken'
+            required:
+              - token
+      tags:
+        - MgmtPublicService
   /v1alpha/users/me:
     get:
       summary: |-
@@ -3983,6 +4121,10 @@ definitions:
           if (any.is(Foo.class)) {
             foo = any.unpack(Foo.class);
           }
+          // or ...
+          if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+            foo = any.unpack(Foo.getDefaultInstance());
+          }
 
       Example 3: Pack and unpack a message in Python.
 
@@ -4012,7 +4154,6 @@ definitions:
       methods only use the fully qualified type name after the last '/'
       in the type URL, for example "foo.bar.com/x/y.z" will yield type
       name "y.z".
-
 
       JSON
 
@@ -4159,6 +4300,71 @@ definitions:
       instance or workspace admins beforehand. The trade-off is that the user does
       not have to provide as many technical inputs anymore and the auth process is
       faster and easier to complete.
+  v1alphaApiToken:
+    type: object
+    properties:
+      name:
+        type: string
+        title: API token resource name. It must have the format of "tokens/*"
+        readOnly: true
+      uid:
+        type: string
+        title: API token UUID
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          API token resource ID (the last segment of the resource name) used to
+          construct the resource name. This conforms to RFC-1034, which restricts to
+          letters, numbers, and hyphen, with the first character a letter, the last a
+          letter or a number, and a 63 character maximum.
+          Use this field to define where it's being used.
+      create_time:
+        type: string
+        format: date-time
+        title: API token creation time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: API token update time
+        readOnly: true
+      access_token:
+        type: string
+        description: "An opaque access token representing the API token string. \nTo validate the token, the recipient of the token needs to call the server that issued the token."
+        readOnly: true
+      state:
+        $ref: '#/definitions/v1alphaApiTokenState'
+        title: API token state
+        readOnly: true
+      token_type:
+        type: string
+        title: API token type, value is fixed to "Bearer"
+        readOnly: true
+      lifetime:
+        type: string
+        format: int64
+        title: The amount of time (in seconds) the API token will live. If set to -1, indicating a non-expire token
+      expires_in:
+        type: string
+        format: int64
+        title: The amount of time (in seconds) the API token will expire. If value is -1, indicating a non-expire token
+        readOnly: true
+    title: ApiToken represents the content of a API token
+  v1alphaApiTokenState:
+    type: string
+    enum:
+      - STATE_UNSPECIFIED
+      - STATE_INACTIVE
+      - STATE_ACTIVE
+      - STATE_EXPIRED
+    default: STATE_UNSPECIFIED
+    description: |-
+      - STATE_UNSPECIFIED: State: UNSPECIFIED
+       - STATE_INACTIVE: State: INACTIVE
+       - STATE_ACTIVE: State: ACTIVE
+       - STATE_EXPIRED: State: EXPIRED
+    title: State enumerates the state of an API token
   v1alphaBoundingBox:
     type: object
     properties:
@@ -4498,6 +4704,13 @@ definitions:
     title: |-
       CreateSourceConnectorResponse represents a response for a
       SourceConnector resource
+  v1alphaCreateTokenResponse:
+    type: object
+    properties:
+      token:
+        $ref: '#/definitions/v1alphaApiToken'
+        title: The created API token resource
+    title: CreateTokenResponse represents a response for a API token resource
   v1alphaCreateUserAdminResponse:
     type: object
     properties:
@@ -4527,6 +4740,9 @@ definitions:
   v1alphaDeleteSourceConnectorResponse:
     type: object
     title: DeleteSourceConnectorResponse represents an empty response
+  v1alphaDeleteTokenResponse:
+    type: object
+    title: DeleteTokenResponse represents an empty response
   v1alphaDeleteUserAdminResponse:
     type: object
     title: DeleteUserAdminResponse represents an empty response
@@ -5128,6 +5344,13 @@ definitions:
     title: |-
       GetSourceConnectorResponse represents a response for a
       SourceConnector resource
+  v1alphaGetTokenResponse:
+    type: object
+    properties:
+      token:
+        $ref: '#/definitions/v1alphaApiToken'
+        title: An API token resource
+    title: GetTokenResponse represents a response for an API token resource
   v1alphaGetUserAdminResponse:
     type: object
     properties:
@@ -5508,6 +5731,22 @@ definitions:
     title: |-
       ListSourceConnectorsResponse represents a response for a list of
       SourceConnector resources
+  v1alphaListTokensResponse:
+    type: object
+    properties:
+      tokens:
+        type: array
+        items:
+          $ref: '#/definitions/v1alphaApiToken'
+        title: A list of API tokens resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of API tokens resources
+    title: ListTokensResponse represents a response for a list of API tokens
   v1alphaListUsersAdminResponse:
     type: object
     properties:
@@ -7165,6 +7404,15 @@ definitions:
     title: User records definition
     required:
       - uid
+  v1alphaValidateTokenResponse:
+    type: object
+    properties:
+      valid:
+        type: boolean
+        title: A boolean value indicating whether the token is valid
+    title: |-
+      ValidateTokenResponse represents a response about whether
+      the queried token is valid
   v1alphaWatchDestinationConnectorResponse:
     type: object
     properties:

--- a/vdp/mgmt/v1alpha/mgmt.proto
+++ b/vdp/mgmt/v1alpha/mgmt.proto
@@ -227,7 +227,7 @@ message PatchAuthenticatedUserResponse {
 // ExistUsernameRequest represents a request to verify if
 // a username has been occupied
 message ExistUsernameRequest {
-  // The resource name of the user to be deleted,
+  // The resource name of the user to check,
   // for example: "users/local-user"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,

--- a/vdp/mgmt/v1alpha/mgmt.proto
+++ b/vdp/mgmt/v1alpha/mgmt.proto
@@ -244,3 +244,138 @@ message ExistUsernameResponse {
   // A boolean value indicating whether the username has been occupied
   bool exists = 1;
 }
+
+// ApiToken represents the content of a API token
+message ApiToken {
+  option (google.api.resource) = {
+    type : "api.instill.tech/ApiToken"
+    pattern : "tokens/{token}"
+  };
+
+  // google.protobuf.Timestamp last_use_time = 6;
+  reserved 6;
+
+  // State enumerates the state of an API token
+  enum State {
+    // State: UNSPECIFIED
+    STATE_UNSPECIFIED = 0;
+    // State: INACTIVE
+    STATE_INACTIVE = 1;
+    // State: ACTIVE
+    STATE_ACTIVE = 2;
+    // State: EXPIRED
+    STATE_EXPIRED = 3;
+  }
+  
+  // API token resource name. It must have the format of "tokens/*"
+  string name = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // API token UUID
+  string uid = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // API token resource ID (the last segment of the resource name) used to
+  // construct the resource name. This conforms to RFC-1034, which restricts to
+  // letters, numbers, and hyphen, with the first character a letter, the last a
+  // letter or a number, and a 63 character maximum.
+  // Use this field to define where it's being used. 
+  string id = 3 [ (google.api.field_behavior) = IMMUTABLE ];
+  // API token creation time
+  google.protobuf.Timestamp create_time = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // API token update time
+  google.protobuf.Timestamp update_time = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // An opaque access token representing the API token string. 
+  // To validate the token, the recipient of the token needs to call the server that issued the token.
+  string access_token = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // API token state
+  State state = 8  [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // API token type, value is fixed to "Bearer"
+  string token_type = 9  [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // The amount of time (in seconds) the API token will live. If set to -1, indicating a non-expire token
+  int64 lifetime = 10  [ (google.api.field_behavior) = INPUT_ONLY ];
+  // The amount of time (in seconds) the API token will expire. If value is -1, indicating a non-expire token
+  int64 expires_in = 11  [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+// CreateTokenRequest represents a request to create a API token
+message CreateTokenRequest {
+  // A token resource to create
+  ApiToken token = 1 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// CreateTokenResponse represents a response for a API token resource
+message CreateTokenResponse {
+  // The created API token resource
+  ApiToken token = 1;
+}
+
+// ListTokensRequest represents a request to list tokens
+message ListTokensRequest {
+  // The maximum number of API tokens to return. The service may return fewer
+  // than this value. If unspecified, at most 10 API tokens will be returned. The
+  // maximum value is 100; values above 100 will be coerced to 100.
+  optional int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
+  // Page token
+  optional string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// ListTokensResponse represents a response for a list of API tokens
+message ListTokensResponse {
+  // A list of API tokens resources
+  repeated ApiToken tokens = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of API tokens resources
+  int64 total_size = 3;
+}
+
+// GetTokenRequest represents a request to query an API token
+message GetTokenRequest {
+  // API tokens resource name. It must have the format of "tokens/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type : "api.instill.tech/ApiToken"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "token.name"}
+    }
+  ];
+}
+
+// GetTokenResponse represents a response for an API token resource
+message GetTokenResponse {
+  // An API token resource
+  ApiToken token = 1;
+}
+
+// DeleteTokenRequest represents a request to delete an API token resource
+message DeleteTokenRequest {
+  // API token resource name. It must have the format of "tokens/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type : "api.instill.tech/ApiToken"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "token.name"}
+    }
+  ];
+}
+
+// DeleteTokenResponse represents an empty response
+message DeleteTokenResponse {}
+
+// ValidateTokenRequest represents a request to validate whether
+// an API token is valid to be used for triggering pipelines
+message ValidateTokenRequest {
+  // The resource name of the API token to validate,
+  // for example: "tokens/test-token"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/ApiToken",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "token.name"}
+    }
+  ];
+}
+
+// ValidateTokenResponse represents a response about whether
+// the queried token is valid
+message ValidateTokenResponse {
+  // A boolean value indicating whether the token is valid
+  bool valid = 1;
+}

--- a/vdp/mgmt/v1alpha/mgmt.proto
+++ b/vdp/mgmt/v1alpha/mgmt.proto
@@ -11,6 +11,18 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
 
+// View represents a view of any resource. The resource view is implemented by
+// adding a parameter to the method request which allows the client to specify
+// which view of the resource it wants to receive in the response.
+enum View {
+  // View: UNSPECIFIED, equivalent to BASIC.
+  VIEW_UNSPECIFIED = 0;
+  // View: BASIC
+  VIEW_BASIC = 1;
+  // View: FULL
+  VIEW_FULL = 2;
+}
+
 // OwnerType enumerates the owner type of any resource
 enum OwnerType {
   // OwnerType: UNSPECIFIED
@@ -72,18 +84,6 @@ message User {
   bool newsletter_subscription = 13 [ (google.api.field_behavior) = REQUIRED ];
   // User console cookie token
   optional string cookie_token = 14 [ (google.api.field_behavior) = OPTIONAL ];
-}
-
-// View represents a view of any resource. The resource view is implemented by
-// adding a parameter to the method request which allows the client to specify
-// which view of the resource it wants to receive in the response.
-enum View {
-  // View: UNSPECIFIED, equivalent to BASIC.
-  VIEW_UNSPECIFIED = 0;
-  // View: BASIC
-  VIEW_BASIC = 1;
-  // View: FULL
-  VIEW_FULL = 2;
 }
 
 // ListUsersAdminRequest represents a request to list all users by admin

--- a/vdp/mgmt/v1alpha/mgmt_private_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_private_service.proto
@@ -69,4 +69,15 @@ service MgmtPrivateService {
     };
     option (google.api.method_signature) = "permalink";
   }
+
+  // ValidateToken method receives a ValidateTokenRequest message and
+  // returns a ValidateTokenResponse
+  rpc ValidateToken(ValidateTokenRequest) 
+      returns (ValidateTokenResponse) {
+    option (google.api.http) = {
+      post : "/v1alpha/{name=tokens/*}/validate"
+      body : "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
 }

--- a/vdp/mgmt/v1alpha/mgmt_public_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_public_service.proto
@@ -61,4 +61,40 @@ service MgmtPublicService {
     };
     option (google.api.method_signature) = "name";
   }
+
+// CreateToken method receives a CreateTokenRequest message and returns
+  // a CreateTokenResponse message.
+  rpc CreateToken(CreateTokenRequest) returns (CreateTokenResponse) {
+    option (google.api.http) = {
+      post : "/v1alpha/tokens"
+      body : "token"
+    };
+    option (google.api.method_signature) = "token";
+  }
+
+  // ListTokens method receives a ListTokensRequest message and returns a
+  // ListTokensResponse message.
+  rpc ListTokens(ListTokensRequest) returns (ListTokensResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/tokens"
+    };
+  }
+
+  // GetToken method receives a GetTokenRequest message and returns a
+  // GetTokenResponse message.
+  rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/{name=tokens/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // DeleteToken method receives a DeleteTokenRequest message and returns
+  // a DeleteTokenResponse message.
+  rpc DeleteToken(DeleteTokenRequest) returns (DeleteTokenResponse) {
+    option (google.api.http) = {
+      delete : "/v1alpha/{name=tokens/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
 }


### PR DESCRIPTION
Because

- we want to use API tokens to trigger pipelines in Instill Cloud

This commit

- add API token resource in mgmt-backend
- update OpenAPI
