### PR TITLE
feat(model,pipeline,connector,controller,usage): remove model instance

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -262,6 +262,58 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPublicService
+  /v1alpha/{model.name/readme}:
+    get:
+      summary: |-
+        GetModelCard method receives a GetModelCardRequest message
+        and returns a GetModelCardResponse
+      operationId: ModelPublicService_GetModelCard
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetModelCardResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: model.name/readme
+          description: |-
+            Resource name of the model card.
+            For example "models/{model}/readme"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+/readme
+      tags:
+        - ModelPublicService
+  /v1alpha/{model.name/watch}/watch:
+    get:
+      summary: |-
+        WatchModel method receives a WatchModelRequest message
+        and returns a WatchModelResponse
+      operationId: ModelPublicService_WatchModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: model.name/watch
+          description: |-
+            Resource name of the model.
+            For example "models/{model}"
+          in: path
+          required: true
+          type: string
+          pattern: models/[^/]+
+      tags:
+        - ModelPublicService
   /v1alpha/{model.name}:
     get:
       summary: |-
@@ -386,6 +438,14 @@ paths:
                 title: |-
                   Model configuration represents the configuration JSON that has been
                   validated using the `model_spec` JSON schema of a ModelDefinition
+              task:
+                $ref: '#/definitions/ModelTask'
+                title: Model task
+                readOnly: true
+              state:
+                $ref: '#/definitions/v1alphaModelState'
+                title: Model state
+                readOnly: true
               visibility:
                 $ref: '#/definitions/ModelVisibility'
                 title: Model visibility including public or private
@@ -447,102 +507,7 @@ paths:
           description: |-
             Definition view (default is VIEW_BASIC)
             VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
-            `ModelDefinition.model_instance_spec`
-            VIEW_FULL: show full information
-
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-             - VIEW_FULL: View: FULL, full representation of the resource
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-          default: VIEW_UNSPECIFIED
-      tags:
-        - ModelPublicService
-  /v1alpha/{model_instance.name/readme}:
-    get:
-      summary: |-
-        GetModelInstanceCard method receives a GetModelInstanceCardRequest message
-        and returns a GetModelInstanceCardResponse
-      operationId: ModelPublicService_GetModelInstanceCard
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetModelInstanceCardResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: model_instance.name/readme
-          description: |-
-            Resource name of the model instance card.
-            For example "models/{model}/instances/{instance}/readme"
-          in: path
-          required: true
-          type: string
-          pattern: models/[^/]+/instances/[^/]+/readme
-      tags:
-        - ModelPublicService
-  /v1alpha/{model_instance.name/watch}/watch:
-    get:
-      summary: |-
-        WatchModelInstance method receives a WatchModelInstanceRequest message
-        and returns a WatchModelInstanceResponse
-      operationId: ModelPublicService_WatchModelInstance
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaWatchModelInstanceResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: model_instance.name/watch
-          description: |-
-            Resource name of the model instance.
-            For example "models/{model}/instances/{instance}"
-          in: path
-          required: true
-          type: string
-          pattern: models/[^/]+/instances/[^/]+
-      tags:
-        - ModelPublicService
-  /v1alpha/{model_instance.name}:
-    get:
-      summary: |-
-        GetModelInstance method receives a GetModelInstanceRequest message and
-        returns a GetModelInstanceResponse
-      operationId: ModelPublicService_GetModelInstance
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetModelInstanceResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: model_instance.name
-          description: |-
-            Resource name of the model instance.
-            For example "models/{model}/instances/{instance}"
-          in: path
-          required: true
-          type: string
-          pattern: models/[^/]+/instances/[^/]+
-        - name: view
-          description: |-
-            Model instance view (default is VIEW_BASIC)
-            VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
+            `ModelDefinition.model_spec`
             VIEW_FULL: show full information
 
              - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
@@ -585,7 +550,7 @@ paths:
           description: |-
             View (default is VIEW_BASIC)
             VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-            `ModelInstance.configuration` VIEW_FULL: show full information
+            `Model.configuration` VIEW_FULL: show full information
 
              - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
              - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
@@ -1003,13 +968,13 @@ paths:
         - PipelinePublicService
   /v1alpha/{name}/deploy:
     post:
-      summary: DeployModelInstance deploy a model instance to online state
-      operationId: ModelPublicService_DeployModelInstance
+      summary: DeployModel deploy a model to online state
+      operationId: ModelPublicService_DeployModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeployModelInstanceResponse'
+            $ref: '#/definitions/v1alphaDeployModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1017,20 +982,18 @@ paths:
       parameters:
         - name: name
           description: |-
-            Resource name for the model instance to be deployed.
-            Format: models/{model}/instances/{instance}
+            Resource name for the model to be deployed.
+            Format: models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+/instances/[^/]+
+          pattern: models/[^/]+
         - name: body
           in: body
           required: true
           schema:
             type: object
-            title: |-
-              DeployModelInstanceRequest represents a request to deploy a model instance to
-              online state
+            title: DeployModelRequest represents a request to deploy a model to online state
       tags:
         - ModelPublicService
   /v1alpha/{name}/disconnect:
@@ -1182,14 +1145,14 @@ paths:
   /v1alpha/{name}/test:
     post:
       summary: |-
-        TestModelInstance method receives a TestModelInstanceRequest message
-        and returns a TestModelInstanceResponse message.
-      operationId: ModelPublicService_TestModelInstance
+        TestModel method receives a TestModelRequest message
+        and returns a TestModelResponse message.
+      operationId: ModelPublicService_TestModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTestModelInstanceResponse'
+            $ref: '#/definitions/v1alphaTestModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1197,12 +1160,12 @@ paths:
       parameters:
         - name: name
           description: |-
-            The resource name of the model instance to trigger.
-            For example "models/{model}/instances/{instance}"
+            The resource name of the model to trigger.
+            For example "models/{model}"
           in: path
           required: true
           type: string
-          pattern: models/[^/]+/instances/[^/]+
+          pattern: models/[^/]+
         - name: body
           in: body
           required: true
@@ -1213,8 +1176,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/v1alphaTaskInput'
-                title: Input to trigger the model instance
-            title: TestModelInstanceRequest represents a request to test a model instance
+                title: Input to trigger the model
+            title: TestModelRequest represents a request to test a model
             required:
               - task_inputs
       tags:
@@ -1223,14 +1186,14 @@ paths:
     post:
       summary: /////////////////////////////////////////////////////
       description: |-
-        TriggerModelInstance method receives a TriggerModelInstanceRequest message
-        and returns a TriggerModelInstanceResponse message.
-      operationId: ModelPublicService_TriggerModelInstance
+        TriggerModel method receives a TriggerModelRequest message
+        and returns a TriggerModelResponse message.
+      operationId: ModelPublicService_TriggerModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTriggerModelInstanceResponse'
+            $ref: '#/definitions/v1alphaTriggerModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1238,12 +1201,12 @@ paths:
       parameters:
         - name: name
           description: |-
-            The resource name of the model instance to trigger.
-            For example "models/{model}/instances/{instance}"
+            The resource name of the model to trigger.
+            For example "models/{model}"
           in: path
           required: true
           type: string
-          pattern: models/[^/]+/instances/[^/]+
+          pattern: models/[^/]+
         - name: body
           in: body
           required: true
@@ -1254,21 +1217,21 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/v1alphaTaskInput'
-                title: Input to trigger the model instance
-            title: TriggerModelInstanceRequest represents a request to trigger a model instance
+                title: Input to trigger the model
+            title: TriggerModelRequest represents a request to trigger a model
             required:
               - task_inputs
       tags:
         - ModelPublicService
   /v1alpha/{name}/undeploy:
     post:
-      summary: UndeployModelInstance undeploy a model instance to offline state
-      operationId: ModelPublicService_UndeployModelInstance
+      summary: UndeployModel undeploy a model to offline state
+      operationId: ModelPublicService_UndeployModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUndeployModelInstanceResponse'
+            $ref: '#/definitions/v1alphaUndeployModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1276,20 +1239,18 @@ paths:
       parameters:
         - name: name
           description: |-
-            Resource name for the model instance to be undeployed.
-            Format: models/{model}/instances/{instance}
+            Resource name for the model to be undeployed.
+            Format: models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+/instances/[^/]+
+          pattern: models/[^/]+
         - name: body
           in: body
           required: true
           schema:
             type: object
-            title: |-
-              UndeployModelInstanceRequest represents a request to undeploy a model
-              instance to offline state
+            title: UndeployModelRequest represents a request to undeploy a model to offline state
       tags:
         - ModelPublicService
   /v1alpha/{name}/unpublish:
@@ -1376,10 +1337,10 @@ paths:
                 items:
                   type: string
                 title: Indices corresponds to each JSON data element
-              model_instance_outputs:
+              model_outputs:
                 type: array
                 items:
-                  $ref: '#/definitions/v1alphaModelInstanceOutput'
+                  $ref: '#/definitions/v1alphaModelOutput'
                 title: JSON data to write
             title: |-
               WriteDestinationConnectorRequest represents a request to perform write
@@ -1390,67 +1351,9 @@ paths:
               - pipeline
               - recipe
               - data_mapping_indices
-              - model_instance_outputs
+              - model_outputs
       tags:
         - ConnectorPublicService
-  /v1alpha/{parent}/instances:
-    get:
-      summary: |-
-        ListModelInstances method receives a ListModelInstancesRequest message and
-        returns a ListModelInstancesResponse
-      operationId: ModelPublicService_ListModelInstances
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaListModelInstancesResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: parent
-          description: |-
-            The name of the model whose instances we'd like to list.
-            e.g., "models/yolov4"
-          in: path
-          required: true
-          type: string
-          pattern: models/[^/]+
-        - name: page_size
-          description: |-
-            Page size: the maximum number of resources to return. The service may
-            return fewer than this value. If unspecified, at most 10 model instances
-            will be returned. The maximum value is 100; values above 100 will be
-            coereced to 100.
-          in: query
-          required: false
-          type: string
-          format: int64
-        - name: page_token
-          description: Page token
-          in: query
-          required: false
-          type: string
-        - name: view
-          description: |-
-            Model instance view (default is VIEW_BASIC)
-            VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-            VIEW_FULL: show full information
-
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-             - VIEW_FULL: View: FULL, full representation of the resource
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-          default: VIEW_UNSPECIFIED
-      tags:
-        - ModelPublicService
   /v1alpha/{permalink_1}/lookUp:
     get:
       summary: |-
@@ -1539,50 +1442,6 @@ paths:
   /v1alpha/{permalink_3}/lookUp:
     get:
       summary: |-
-        LookUpModelInstance method receives a LookUpModelInstanceRequest message
-        and returns a
-        LookUpModelInstanceResponse
-      operationId: ModelPublicService_LookUpModelInstance
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaLookUpModelInstanceResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: permalink_3
-          description: |-
-            Permalink of a model instance. For example:
-            "models/{model_uid}/instances/{instance_uid}"
-          in: path
-          required: true
-          type: string
-          pattern: models/[^/]+/instances/[^/]+
-        - name: view
-          description: |-
-            Model instance view (default is VIEW_BASIC)
-            VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-            VIEW_FULL: show full information
-
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-             - VIEW_FULL: View: FULL, full representation of the resource
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-          default: VIEW_UNSPECIFIED
-      tags:
-        - ModelPublicService
-  /v1alpha/{permalink_4}/lookUp:
-    get:
-      summary: |-
         LookUpPipeline method receives a LookUpPipelineRequest message and returns
         a LookUpPipelineResponse
       operationId: PipelinePublicService_LookUpPipeline
@@ -1596,7 +1455,7 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: permalink_4
+        - name: permalink_3
           description: |-
             Permalink of a pipeline. For example:
             "pipelines/{uid}"
@@ -1878,9 +1737,9 @@ paths:
           schema:
             type: object
             properties:
-              model_instance_state:
-                $ref: '#/definitions/v1alphaModelInstanceState'
-                title: Model instance state
+              model_state:
+                $ref: '#/definitions/v1alphaModelState'
+                title: Model state
               pipeline_state:
                 $ref: '#/definitions/v1alphaPipelineState'
                 title: Pipeline state
@@ -2233,14 +2092,14 @@ paths:
   /v1alpha/admin/{name_2}/check:
     get:
       summary: |-
-        CheckModelInstance method receives a CheckModelInstanceRequest message and returns a
-        CheckModelInstanceResponse
-      operationId: ModelPrivateService_CheckModelInstance
+        CheckModel method receives a CheckModelRequest message and returns a
+        CheckModelResponse
+      operationId: ModelPrivateService_CheckModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCheckModelInstanceResponse'
+            $ref: '#/definitions/v1alphaCheckModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -2248,12 +2107,12 @@ paths:
       parameters:
         - name: name_2
           description: |-
-            Resource name of the model instance.
-            For example "models/{model}/instances/{instance}"
+            Resource name of the model.
+            For example "models/{model}"
           in: path
           required: true
           type: string
-          pattern: models/[^/]+/instances/[^/]+
+          pattern: models/[^/]+
       tags:
         - ModelPrivateService
   /v1alpha/admin/{name}/check:
@@ -3301,7 +3160,7 @@ paths:
           description: |-
             Definition view (default is VIEW_BASIC)
             VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
-            `ModelDefinition.model_instance_spec`
+            `ModelDefinition.model_spec`
             VIEW_FULL: show full information
 
              - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
@@ -3436,7 +3295,7 @@ paths:
           description: |-
             View (default is VIEW_BASIC)
             VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-            `ModelInstance.configuration` VIEW_FULL: show full information
+            `Model.configuration` VIEW_FULL: show full information
 
              - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
              - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
@@ -3821,7 +3680,7 @@ definitions:
        - SERVING_STATUS_SERVING: Serving status: SERVING
        - SERVING_STATUS_NOT_SERVING: Serving status: NOT SERVING
     title: ServingStatus enumerates the status of a queried service
-  ModelInstanceTask:
+  ModelTask:
     type: string
     enum:
       - TASK_UNSPECIFIED
@@ -3844,7 +3703,7 @@ definitions:
        - TASK_SEMANTIC_SEGMENTATION: Task: SEMANTIC SEGMENTATION
        - TASK_TEXT_TO_IMAGE: Task: TEXT TO IMAGE
        - TASK_TEXT_GENERATION: Task: TEXT Generation
-    title: Task enumerates the task type of a model instance
+    title: Task enumerates the task type of a model
   ModelVisibility:
     type: string
     enum:
@@ -4197,15 +4056,15 @@ definitions:
     title: |-
       CheckDestinationConnectorResponse represents a response to fetch a destination connector's
       current state
-  v1alphaCheckModelInstanceResponse:
+  v1alphaCheckModelResponse:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1alphaModelInstanceState'
-        title: Retrieved model instance state
+        $ref: '#/definitions/v1alphaModelState'
+        title: Retrieved model state
     title: |-
-      CheckModelInstanceResponse represents a response to fetch a model
-      instance's current state and longrunning progress
+      CheckModelResponse represents a response to fetch a model's
+      current state and longrunning progress
   v1alphaCheckSourceConnectorResponse:
     type: object
     properties:
@@ -4464,9 +4323,7 @@ definitions:
         $ref: '#/definitions/googlelongrunningOperation'
         title: Create model operation message
         readOnly: true
-    title: |-
-      CreateModelBinaryFileUploadResponse represents a response for a model
-      instance
+    title: CreateModelBinaryFileUploadResponse represents a response for a model
   v1alphaCreateModelResponse:
     type: object
     properties:
@@ -4530,15 +4387,13 @@ definitions:
   v1alphaDeleteUserAdminResponse:
     type: object
     title: DeleteUserAdminResponse represents an empty response
-  v1alphaDeployModelInstanceResponse:
+  v1alphaDeployModelResponse:
     type: object
     properties:
       operation:
         $ref: '#/definitions/googlelongrunningOperation'
         title: Deploy operation message
-    title: |-
-      DeployModelInstanceResponse represents a response for a deployed model
-      instance
+    title: DeployModelResponse represents a response for a deployed model
   v1alphaDestinationConnector:
     type: object
     properties:
@@ -4859,6 +4714,13 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: The retrieved model
     title: GetModelAdminResponse represents a response for a model
+  v1alphaGetModelCardResponse:
+    type: object
+    properties:
+      readme:
+        $ref: '#/definitions/v1alphaModelCard'
+        title: Retrieved model card
+    title: GetModelCardResponse represents a response to fetch a model's README card
   v1alphaGetModelDefinitionResponse:
     type: object
     properties:
@@ -4866,22 +4728,6 @@ definitions:
         $ref: '#/definitions/v1alphaModelDefinition'
         title: A model definition instance
     title: GetModelDefinitionResponse represents a response for a model definition
-  v1alphaGetModelInstanceCardResponse:
-    type: object
-    properties:
-      readme:
-        $ref: '#/definitions/v1alphaModelInstanceCard'
-        title: Retrieved model instance card
-    title: |-
-      GetModelInstanceCardResponse represents a response to fetch a model
-      instance's README card
-  v1alphaGetModelInstanceResponse:
-    type: object
-    properties:
-      instance:
-        $ref: '#/definitions/v1alphaModelInstance'
-        title: Retrieved model instance
-    title: GetModelInstanceResponse represents a response for a model instance
   v1alphaGetModelOnlinePriceRequest:
     type: object
     properties:
@@ -5356,22 +5202,6 @@ definitions:
     title: |-
       ListModelDefinitionsResponse represents a response to list all supported model
       definitions
-  v1alphaListModelInstancesResponse:
-    type: object
-    properties:
-      instances:
-        type: array
-        items:
-          $ref: '#/definitions/v1alphaModelInstance'
-        title: a list of Model instances
-      next_page_token:
-        type: string
-        title: Next page token
-      total_size:
-        type: string
-        format: int64
-        title: Total count of model instances
-    title: ListModelInstancesResponse represents a response for a list of model instances
   v1alphaListModelOperationsResponse:
     type: object
     properties:
@@ -5548,21 +5378,14 @@ definitions:
       model:
         $ref: '#/definitions/v1alphaModel'
         title: A model resource
-    title: LookUpModelResponse represents a response for a model instance
-  v1alphaLookUpModelInstanceResponse:
-    type: object
-    properties:
-      instance:
-        $ref: '#/definitions/v1alphaModelInstance'
-        title: A model instance
-    title: LookUpModelInstanceResponse represents a response for a model instance
+    title: LookUpModelResponse represents a response for a model
   v1alphaLookUpModelResponse:
     type: object
     properties:
       model:
         $ref: '#/definitions/v1alphaModel'
         title: A model resource
-    title: LookUpModelResponse represents a response for a model instance
+    title: LookUpModelResponse represents a response for a model
   v1alphaLookUpPipelineAdminResponse:
     type: object
     properties:
@@ -5638,6 +5461,14 @@ definitions:
         title: |-
           Model configuration represents the configuration JSON that has been
           validated using the `model_spec` JSON schema of a ModelDefinition
+      task:
+        $ref: '#/definitions/ModelTask'
+        title: Model task
+        readOnly: true
+      state:
+        $ref: '#/definitions/v1alphaModelState'
+        title: Model state
+        readOnly: true
       visibility:
         $ref: '#/definitions/ModelVisibility'
         title: Model visibility including public or private
@@ -5661,6 +5492,36 @@ definitions:
         title: Model update time
         readOnly: true
     title: Model represents a model
+  v1alphaModelCard:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          Resource name. It must have the format of
+          "models/{model}/readme"
+        readOnly: true
+      size:
+        type: integer
+        format: int32
+        title: Size of the file
+        readOnly: true
+      type:
+        type: string
+        description: Type of the resource. Fixed to "file".
+        readOnly: true
+      content:
+        type: string
+        format: byte
+        title: Content of the README file in bytes and base64 format
+        readOnly: true
+      encoding:
+        type: string
+        description: Encoding type of the content. Fixed to "base64".
+        readOnly: true
+    description: |-
+      ModelCard represents the README card for a model. There
+      exists one and exactly one README card per model.
   v1alphaModelData:
     type: object
     properties:
@@ -5725,13 +5586,6 @@ definitions:
           source. Must be a valid JSON that includes what fields are needed to
           create/display a model.
         readOnly: true
-      model_instance_spec:
-        type: object
-        description: |-
-          ModelDefinition model instance specification represents the JSON schema
-          used to validate the JSON configurations of a model instance from a
-          specific model source. Must be a valid JSON that includes what fields are
-          needed to display a model instance.
       create_time:
         type: string
         format: date-time
@@ -5745,98 +5599,15 @@ definitions:
     title: |-
       /////////////////////////////////////////////////////////////////
       ModelDefinition represents the definition of a model
-    required:
-      - model_instance_spec
-  v1alphaModelInstance:
+  v1alphaModelOutput:
     type: object
     properties:
-      name:
+      model:
         type: string
-        title: |-
-          Resource name. It must have the format of
-          "models/{model}/instances/{instance}"
-        readOnly: true
-      uid:
-        type: string
-        title: Model instance ID in UUIDv4
-        readOnly: true
-      id:
-        type: string
-        description: |-
-          Model instance ID (the last segment of the resource name), used to
-          construct the resource name. This conforms to RFC-1034, which restricts to
-          letters, numbers, and hyphen, with the first character a letter, the last a
-          letter or a number, and a 63 character maximum.
-        readOnly: true
-      state:
-        $ref: '#/definitions/v1alphaModelInstanceState'
-        title: Model instance state
+        title: The model
         readOnly: true
       task:
-        $ref: '#/definitions/ModelInstanceTask'
-        title: Model instance task
-        readOnly: true
-      model_definition:
-        type: string
-        title: Model definition resource name
-        readOnly: true
-      configuration:
-        type: object
-        title: |-
-          Model instance configuration represents the configuration JSON that
-          has been validated using the `model_instance_spec` JSON schema of a
-          ModelDefinition
-        readOnly: true
-      create_time:
-        type: string
-        format: date-time
-        title: Model instance create time
-        readOnly: true
-      update_time:
-        type: string
-        format: date-time
-        title: Model instance update time
-        readOnly: true
-    title: ModelVersion represents one deployable instance of a model
-  v1alphaModelInstanceCard:
-    type: object
-    properties:
-      name:
-        type: string
-        title: |-
-          Resource name. It must have the format of
-          "models/{model}/instances/{instance}/readme"
-        readOnly: true
-      size:
-        type: integer
-        format: int32
-        title: Size of the file
-        readOnly: true
-      type:
-        type: string
-        description: Type of the resource. Fixed to "file".
-        readOnly: true
-      content:
-        type: string
-        format: byte
-        title: Content of the README file in bytes and base64 format
-        readOnly: true
-      encoding:
-        type: string
-        description: Encoding type of the content. Fixed to "base64".
-        readOnly: true
-    description: |-
-      ModelInstanceCard represents the README card for a model instance. There
-      exists one and exactly one README card per model instance.
-  v1alphaModelInstanceOutput:
-    type: object
-    properties:
-      model_instance:
-        type: string
-        title: The model instance
-        readOnly: true
-      task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: '#/definitions/ModelTask'
         title: The task type
         readOnly: true
       task_outputs:
@@ -5844,11 +5615,11 @@ definitions:
         items:
           $ref: '#/definitions/vdppipelinev1alphaTaskOutput'
         title: |-
-          The extended task outputs based on the model instance inference (i.e.,
+          The extended task outputs based on the model inference (i.e.,
           from a trigger endpoint of model-backend)
         readOnly: true
-    title: ModelInstanceOutput represents one model instance inference result
-  v1alphaModelInstanceState:
+    title: ModelOutput represents one model inference result
+  v1alphaModelState:
     type: string
     enum:
       - STATE_UNSPECIFIED
@@ -5861,7 +5632,7 @@ definitions:
        - STATE_OFFLINE: State: OFFLINE
        - STATE_ONLINE: State: ONLINE
        - STATE_ERROR: State: ERROR
-    title: State enumerates a model instance state
+    title: State enumerates a model state
   v1alphaModelUsageData:
     type: object
     properties:
@@ -5880,44 +5651,34 @@ definitions:
       model_online_state_num:
         type: string
         format: int64
-        title: Number of models that have at least one 'online' instance
+        title: Number of 'online' models
       model_offline_state_num:
         type: string
         format: int64
-        title: Number of models that have no 'online' instances
-      instance_online_state_num:
-        type: string
-        format: int64
-        title: Number of model instances with 'online' state
-      instance_offline_state_num:
-        type: string
-        format: int64
-        title: Number of model instances with 'offline' state
+        title: Number of 'offline' models
       model_definition_ids:
         type: array
         items:
           type: string
         description: |-
-          Definition IDs of the model instances. Element in the list
+          Definition IDs of the model. Element in the list
           should not be duplicated.
       tasks:
         type: array
         items:
-          $ref: '#/definitions/ModelInstanceTask'
+          $ref: '#/definitions/ModelTask'
         description: |-
-          Tasks of the model instances. Element in the list should not be
+          Tasks of the models. Element in the list should not be
           duplicated.
       test_num:
         type: string
         format: int64
-        title: Number of model instance testing operations
+        title: Number of model testing operations
     title: Per user usage data in the model service
     required:
       - user_uid
       - model_online_state_num
       - model_offline_state_num
-      - instance_online_state_num
-      - instance_offline_state_num
       - model_definition_ids
       - tasks
       - test_num
@@ -6336,11 +6097,11 @@ definitions:
       destination:
         type: string
         title: A destination connector resource
-      model_instances:
+      model:
         type: array
         items:
           type: string
-        title: A list of model instance resources
+        title: A list of model resources
     title: Pipeline represents a pipeline recipe
   v1alphaRenameDestinationConnectorResponse:
     type: object
@@ -6440,9 +6201,9 @@ definitions:
       name:
         type: string
         description: Resource name.
-      model_instance_state:
-        $ref: '#/definitions/v1alphaModelInstanceState'
-        title: Model instance state
+      model_state:
+        $ref: '#/definitions/v1alphaModelState'
+        title: Model state
       pipeline_state:
         $ref: '#/definitions/v1alphaPipelineState'
         title: Pipeline state
@@ -6769,7 +6530,7 @@ definitions:
       unspecified:
         $ref: '#/definitions/v1alphaUnspecifiedInput'
         title: The unspecified task input
-    title: Input represents the input to trigger a model instance
+    title: Input represents the input to trigger a model
   v1alphaTaskInputStream:
     type: object
     properties:
@@ -6800,38 +6561,38 @@ definitions:
       unspecified:
         $ref: '#/definitions/v1alphaUnspecifiedInput'
         title: The unspecified task input
-    title: TaskInputStream represents the input to trigger a model instance with stream method
-  v1alphaTestModelInstanceBinaryFileUploadResponse:
+    title: TaskInputStream represents the input to trigger a model with stream method
+  v1alphaTestModelBinaryFileUploadResponse:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: '#/definitions/ModelTask'
         title: The task type
       task_outputs:
         type: array
         items:
           $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
-        title: The task output from a model instance
+        title: The task output from a model
     title: |-
-      TestModelInstanceBinaryFileUploadResponse represents a response for the
-      output for testing a model instance
+      TestModelBinaryFileUploadResponse represents a response for the
+      output for testing a model
     required:
       - task
       - task_outputs
-  v1alphaTestModelInstanceResponse:
+  v1alphaTestModelResponse:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: '#/definitions/ModelTask'
         title: The task type
       task_outputs:
         type: array
         items:
           $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
-        title: The task output from a model instance
+        title: The task output from a model
     title: |-
-      TestModelInstanceResponse represents a response for the output for
-      testing a model instance
+      TestModelResponse represents a response for the output for
+      testing a model
     required:
       - task
       - task_outputs
@@ -6920,37 +6681,37 @@ definitions:
     required:
       - start_time
       - end_time
-  v1alphaTriggerModelInstanceBinaryFileUploadResponse:
+  v1alphaTriggerModelBinaryFileUploadResponse:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: '#/definitions/ModelTask'
         title: The task type
       task_outputs:
         type: array
         items:
           $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
-        title: The task output from a model instance
+        title: The task output from a model
     title: |-
-      TriggerModelInstanceBinaryFileUploadResponse represents a response for the
-      output for testing a model instance
+      TriggerModelBinaryFileUploadResponse represents a response for the
+      output for testing a model
     required:
       - task
       - task_outputs
-  v1alphaTriggerModelInstanceResponse:
+  v1alphaTriggerModelResponse:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelInstanceTask'
+        $ref: '#/definitions/ModelTask'
         title: The task type
       task_outputs:
         type: array
         items:
           $ref: '#/definitions/vdpmodelv1alphaTaskOutput'
-        title: The task output from a model instance
+        title: The task output from a model
     title: |-
-      TriggerModelInstanceResponse represents a response for the output for
-      triggering a model instance
+      TriggerModelResponse represents a response for the output for
+      triggering a model
   v1alphaTriggerPipelineBinaryFileUploadResponse:
     type: object
     properties:
@@ -6959,14 +6720,14 @@ definitions:
         items:
           type: string
         title: The data mapping indices stores UUID for each input
-      model_instance_outputs:
+      model_outputs:
         type: array
         items:
-          $ref: '#/definitions/v1alphaModelInstanceOutput'
-        title: The multiple model instance inference outputs
+          $ref: '#/definitions/v1alphaModelOutput'
+        title: The multiple model inference outputs
     title: |-
       TriggerPipelineBinaryFileUploadResponse represents a response for the output
-      of a pipeline, i.e., the multiple model instance inference outputs
+      of a pipeline, i.e., the multiple model inference outputs
   v1alphaTriggerPipelineResponse:
     type: object
     properties:
@@ -6975,23 +6736,21 @@ definitions:
         items:
           type: string
         title: The data mapping indices stores UUID for each input
-      model_instance_outputs:
+      model_outputs:
         type: array
         items:
-          $ref: '#/definitions/v1alphaModelInstanceOutput'
-        title: The multiple model instance inference outputs
+          $ref: '#/definitions/v1alphaModelOutput'
+        title: The multiple model inference outputs
     title: |-
       TriggerPipelineResponse represents a response for the output
-      of a pipeline, i.e., the multiple model instance inference outputs
-  v1alphaUndeployModelInstanceResponse:
+      of a pipeline, i.e., the multiple model inference outputs
+  v1alphaUndeployModelResponse:
     type: object
     properties:
       operation:
         $ref: '#/definitions/googlelongrunningOperation'
         title: Undeploy operation message
-    title: |-
-      UndeployModelInstanceResponse represents a response for a undeployed model
-      instance
+    title: UndeployModelResponse represents a response for a undeployed model
   v1alphaUnpublishModelResponse:
     type: object
     properties:
@@ -7174,19 +6933,19 @@ definitions:
     title: |-
       WatchDestinationConnectorResponse represents a response to fetch a destination connector's
       current state
-  v1alphaWatchModelInstanceResponse:
+  v1alphaWatchModelResponse:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1alphaModelInstanceState'
-        title: Retrieved model instance state
+        $ref: '#/definitions/v1alphaModelState'
+        title: Retrieved model state
       progress:
         type: integer
         format: int32
-        title: Retrieved model instance logrunning progress
+        title: Retrieved model logrunning progress
     title: |-
-      WatchModelInstanceResponse represents a public response to
-      fetch a model instance's current state and longrunning progress
+      WatchModelResponse represents a public response to
+      fetch a model current state and longrunning progress
   v1alphaWatchSourceConnectorResponse:
     type: object
     properties:
@@ -7355,7 +7114,7 @@ definitions:
         $ref: '#/definitions/v1alphaUnspecifiedOutput'
         title: The unspecified task output
         readOnly: true
-    title: TaskOutput represents the output of a CV Task result from a model instance
+    title: TaskOutput represents the output of a CV Task result from a model
   vdpmodelv1alphaView:
     type: string
     enum:
@@ -7430,10 +7189,10 @@ definitions:
         readOnly: true
     description: |-
       TaskOutput represents the output of a CV Task result from a
-      model instance, extended from model.v1alpha.TaskOutput.
+      model, extended from model.v1alpha.TaskOutput.
       Here we don't use a model.v1alpha.TaskOutput type field but explicitly use
       the replicated oneof field because we want the CV Task output to be at the
-      same message layer like the trigger output of model instance.
+      same message layer like the trigger output of model.
   vdppipelinev1alphaView:
     type: string
     enum:

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -536,7 +536,7 @@ message WriteDestinationConnectorRequest {
   repeated string data_mapping_indices = 6
       [ (google.api.field_behavior) = REQUIRED ];
   // JSON data to write
-  repeated pipeline.v1alpha.ModelInstanceOutput model_instance_outputs = 7
+  repeated pipeline.v1alpha.ModelOutput model_outputs = 7
       [ (google.api.field_behavior) = REQUIRED ];
 }
 

--- a/vdp/controller/v1alpha/controller.proto
+++ b/vdp/controller/v1alpha/controller.proto
@@ -25,8 +25,8 @@ message Resource {
     string name = 1 [ (google.api.field_behavior) = REQUIRED ];
     // Resource state
     oneof state {
-        // Model instance state
-        vdp.model.v1alpha.ModelInstance.State model_instance_state = 2;
+        // Model state
+        vdp.model.v1alpha.Model.State model_state = 2;
         // Pipeline state
         vdp.pipeline.v1alpha.Pipeline.State pipeline_state = 3;
         // Connector state

--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -41,58 +41,7 @@ message Model {
     VISIBILITY_PUBLIC = 2;
   }
 
-  // Resource name. It must have the format of "models/{model}".
-  // For example: "models/yolov4"
-  string name = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Model ID in UUIDv4
-  string uid = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Resource ID (the last segment of the resource name) used to construct the
-  // resource name. This conforms to RFC-1034, which restricts to letters,
-  // numbers, and hyphen, with the first character a letter, the last a letter
-  // or a number, and a 63 character maximum.
-  string id = 3 [ (google.api.field_behavior) = IMMUTABLE ];
-  // Model description
-  optional string description = 4 [ (google.api.field_behavior) = OPTIONAL ];
-  // Model definition resource name
-  string model_definition = 5 [
-    (google.api.field_behavior) = IMMUTABLE,
-    (google.api.resource_reference).type = "api.instill.tech/ModelDefinition"
-  ];
-  // Model configuration represents the configuration JSON that has been
-  // validated using the `model_spec` JSON schema of a ModelDefinition
-  google.protobuf.Struct configuration = 6
-      [ (google.api.field_behavior) = IMMUTABLE ];
-  // Model visibility including public or private
-  Visibility visibility = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Model owner
-  oneof owner {
-    // The resource name of a user, e.g., "users/local-user".
-    string user = 8 [
-      (google.api.resource_reference).type = "api.instill.tech/User",
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-    // The resource name of an organization
-    string org = 9 [
-      (google.api.resource_reference).type = "api.instill.tech/Organization",
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-  };
-  // Model create time
-  google.protobuf.Timestamp create_time = 10
-      [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Model update time
-  google.protobuf.Timestamp update_time = 11
-      [ (google.api.field_behavior) = OUTPUT_ONLY ];
-}
-
-// ModelVersion represents one deployable instance of a model
-message ModelInstance {
-  option (google.api.resource) = {
-    type : "api.instill.tech/ModelInstance",
-    pattern : "models/{model}/instances/{instance}"
-  };
-
-  // Task enumerates the task type of a model instance
+  // Task enumerates the task type of a model
   enum Task {
     // Task: UNSPECIFIED
     TASK_UNSPECIFIED = 0;
@@ -114,7 +63,7 @@ message ModelInstance {
     TASK_TEXT_GENERATION = 8;
   }
 
-  // State enumerates a model instance state
+  // State enumerates a model state
   enum State {
     // State: UNSPECIFIED
     STATE_UNSPECIFIED = 0;
@@ -126,48 +75,64 @@ message ModelInstance {
     STATE_ERROR = 3;
   }
 
-  // Resource name. It must have the format of
-  // "models/{model}/instances/{instance}"
+  // Resource name. It must have the format of "models/{model}".
+  // For example: "models/yolov4"
   string name = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Model instance ID in UUIDv4
+  // Model ID in UUIDv4
   string uid = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Model instance ID (the last segment of the resource name), used to
-  // construct the resource name. This conforms to RFC-1034, which restricts to
-  // letters, numbers, and hyphen, with the first character a letter, the last a
-  // letter or a number, and a 63 character maximum.
-  string id = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Model instance state
-  State state = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Model instance task
-  Task task = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Resource ID (the last segment of the resource name) used to construct the
+  // resource name. This conforms to RFC-1034, which restricts to letters,
+  // numbers, and hyphen, with the first character a letter, the last a letter
+  // or a number, and a 63 character maximum.
+  string id = 3 [ (google.api.field_behavior) = IMMUTABLE ];
+  // Model description
+  optional string description = 4 [ (google.api.field_behavior) = OPTIONAL ];
   // Model definition resource name
-  string model_definition = 6 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
+  string model_definition = 5 [
+    (google.api.field_behavior) = IMMUTABLE,
     (google.api.resource_reference).type = "api.instill.tech/ModelDefinition"
   ];
-  // Model instance configuration represents the configuration JSON that
-  // has been validated using the `model_instance_spec` JSON schema of a
-  // ModelDefinition
-  google.protobuf.Struct configuration = 7
+  // Model configuration represents the configuration JSON that has been
+  // validated using the `model_spec` JSON schema of a ModelDefinition
+  google.protobuf.Struct configuration = 6
+      [ (google.api.field_behavior) = IMMUTABLE ];
+  // Model task
+  Task task = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Model state
+  State state = 8 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Model visibility including public or private
+  Visibility visibility = 9 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Model owner
+  oneof owner {
+    // The resource name of a user, e.g., "users/local-user".
+    string user = 10 [
+      (google.api.resource_reference).type = "api.instill.tech/User",
+      (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+    // The resource name of an organization
+    string org = 11 [
+      (google.api.resource_reference).type = "api.instill.tech/Organization",
+      (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+  };
+  // Model create time
+  google.protobuf.Timestamp create_time = 12
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Model instance create time
-  google.protobuf.Timestamp create_time = 8
-      [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Model instance update time
-  google.protobuf.Timestamp update_time = 9
+  // Model update time
+  google.protobuf.Timestamp update_time = 13
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
-// ModelInstanceCard represents the README card for a model instance. There
-// exists one and exactly one README card per model instance.
-message ModelInstanceCard {
+// ModelCard represents the README card for a model. There
+// exists one and exactly one README card per model.
+message ModelCard {
   option (google.api.resource) = {
-    type : "api.instill.tech/ModelInstanceCard"
-    pattern : "models/{model}/instances/{instance}/readme"
+    type : "api.instill.tech/ModelCard"
+    pattern : "models/{model}/readme"
   };
 
   // Resource name. It must have the format of
-  // "models/{model}/instances/{instance}/readme"
+  // "models/{model}/readme"
   string name = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Size of the file
   int32 size = 2 [ (google.api.field_behavior) = OUTPUT_ONLY ];
@@ -232,7 +197,6 @@ message CreateModelBinaryFileUploadRequest {
 }
 
 // CreateModelBinaryFileUploadResponse represents a response for a model
-// instance
 message CreateModelBinaryFileUploadResponse {
   // Create model operation message
   google.longrunning.Operation operation = 1
@@ -296,8 +260,7 @@ message DeleteModelRequest {
 // DeleteModelResponse represents an empty response
 message DeleteModelResponse {}
 
-// LookUpModelRequest represents a request to query a model instance via
-// permalink
+// LookUpModelRequest represents a request to query a model via permalink
 message LookUpModelRequest {
   // Permalink of a model. For example:
   // "models/{uid}"
@@ -308,7 +271,7 @@ message LookUpModelRequest {
   optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
-// LookUpModelResponse represents a response for a model instance
+// LookUpModelResponse represents a response for a model
 message LookUpModelResponse {
   // A model resource
   Model model = 1;
@@ -364,157 +327,77 @@ message UnpublishModelResponse {
   Model model = 1;
 }
 
-// ListModelInstancesRequest represents a request to list all instances of a
-// model
-message ListModelInstancesRequest {
-  // The name of the model whose instances we'd like to list.
-  // e.g., "models/yolov4"
-  string parent = 1 [
+// DeployModelRequest represents a request to deploy a model to online state
+message DeployModelRequest {
+  // Resource name for the model to be deployed.
+  // Format: models/{model}
+  string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
-
-  // Page size: the maximum number of resources to return. The service may
-  // return fewer than this value. If unspecified, at most 10 model instances
-  // will be returned. The maximum value is 100; values above 100 will be
-  // coereced to 100.
-  optional int64 page_size = 2 [ (google.api.field_behavior) = OPTIONAL ];
-  // Page token
-  optional string page_token = 3 [ (google.api.field_behavior) = OPTIONAL ];
-  // Model instance view (default is VIEW_BASIC)
-  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-  // VIEW_FULL: show full information
-  optional View view = 4 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
-// ListModelInstancesResponse represents a response for a list of model instances
-message ListModelInstancesResponse {
-  // a list of Model instances
-  repeated ModelInstance instances = 1;
-  // Next page token
-  string next_page_token = 2;
-  // Total count of model instances
-  int64 total_size = 3;
-}
-
-// GetModelInstanceRequest represents a request to query a model instance
-message GetModelInstanceRequest {
-  // Resource name of the model instance.
-  // For example "models/{model}/instances/{instance}"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "model_instance.name"}
-    }
-  ];
-  // Model instance view (default is VIEW_BASIC)
-  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-  // VIEW_FULL: show full information
-  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
-}
-
-// GetModelInstanceResponse represents a response for a model instance
-message GetModelInstanceResponse {
-  // Retrieved model instance
-  ModelInstance instance = 1;
-}
-
-// LookUpModelInstanceRequest represents a request to query a model instance via
-// permalink
-message LookUpModelInstanceRequest {
-  // Permalink of a model instance. For example:
-  // "models/{model_uid}/instances/{instance_uid}"
-  string permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // Model instance view (default is VIEW_BASIC)
-  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelInstance.configuration`
-  // VIEW_FULL: show full information
-  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
-}
-
-// LookUpModelInstanceResponse represents a response for a model instance
-message LookUpModelInstanceResponse {
-  // A model instance
-  ModelInstance instance = 1;
-}
-
-// DeployModelInstanceRequest represents a request to deploy a model instance to
-// online state
-message DeployModelInstanceRequest {
-  // Resource name for the model instance to be deployed.
-  // Format: models/{model}/instances/{instance}
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
-  ];
-}
-
-// DeployModelInstanceResponse represents a response for a deployed model
-// instance
-message DeployModelInstanceResponse {
+// DeployModelResponse represents a response for a deployed model
+message DeployModelResponse {
   // Deploy operation message
   google.longrunning.Operation operation = 1;
 }
 
-// UndeployModelInstanceRequest represents a request to undeploy a model
-// instance to offline state
-message UndeployModelInstanceRequest {
-  // Resource name for the model instance to be undeployed.
-  // Format: models/{model}/instances/{instance}
+// UndeployModelRequest represents a request to undeploy a model to offline state
+message UndeployModelRequest {
+  // Resource name for the model to be undeployed.
+  // Format: models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
+    (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
 }
 
-// UndeployModelInstanceResponse represents a response for a undeployed model
-// instance
-message UndeployModelInstanceResponse {
+// UndeployModelResponse represents a response for a undeployed model
+message UndeployModelResponse {
   // Undeploy operation message
   google.longrunning.Operation operation = 1;
 }
 
-// GetModelInstanceCardRequest represents a request to query a model instance's
-// README card
-message GetModelInstanceCardRequest {
-  // Resource name of the model instance card.
-  // For example "models/{model}/instances/{instance}/readme"
+// GetModelCardRequest represents a request to query a model's README card
+message GetModelCardRequest {
+  // Resource name of the model card.
+  // For example "models/{model}/readme"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstanceCard",
+    (google.api.resource_reference).type = "api.instill.tech/ModelCard",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "model_instance.name/readme"}
+      field_configuration : {path_param_name : "model.name/readme"}
     }
   ];
 }
 
-// GetModelInstanceCardResponse represents a response to fetch a model
-// instance's README card
-message GetModelInstanceCardResponse {
-  // Retrieved model instance card
-  ModelInstanceCard readme = 1;
+// GetModelCardResponse represents a response to fetch a model's README card
+message GetModelCardResponse {
+  // Retrieved model card
+  ModelCard readme = 1;
 }
 
-// WatchModelInstanceRequest represents a public request to query
-// a model instance's current state and longrunning progress
-message WatchModelInstanceRequest {
-  // Resource name of the model instance.
-  // For example "models/{model}/instances/{instance}"
+// WatchModelRequest represents a public request to query
+// a model's current state and longrunning progress
+message WatchModelRequest {
+  // Resource name of the model.
+  // For example "models/{model}"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance",
+    (google.api.resource_reference).type = "api.instill.tech/Model",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "model_instance.name/watch"}
+      field_configuration : {path_param_name : "model.name/watch"}
     }
   ];
 }
 
-// WatchModelInstanceResponse represents a public response to
-// fetch a model instance's current state and longrunning progress
-message WatchModelInstanceResponse {
-  // Retrieved model instance state
-  ModelInstance.State state = 1;
-  // Retrieved model instance logrunning progress
+// WatchModelResponse represents a public response to
+// fetch a model current state and longrunning progress
+message WatchModelResponse {
+  // Retrieved model state
+  Model.State state = 1;
+  // Retrieved model logrunning progress
   int32 progress = 2;
 }
 
@@ -522,7 +405,7 @@ message WatchModelInstanceResponse {
 //  Trigger methods
 ////////////////////////////////////
 
-// Input represents the input to trigger a model instance
+// Input represents the input to trigger a model
 message TaskInput {
   // Input type
   oneof input {
@@ -547,7 +430,7 @@ message TaskInput {
   }
 }
 
-// TaskInputStream represents the input to trigger a model instance with stream method
+// TaskInputStream represents the input to trigger a model with stream method
 message TaskInputStream {
   // Input type
   oneof input {
@@ -572,7 +455,7 @@ message TaskInputStream {
   }
 }
 
-// TaskOutput represents the output of a CV Task result from a model instance
+// TaskOutput represents the output of a CV Task result from a model
 message TaskOutput {
   // The inference task output
   oneof output {
@@ -603,91 +486,91 @@ message TaskOutput {
   }
 }
 
-// TriggerModelInstanceRequest represents a request to trigger a model instance
-message TriggerModelInstanceRequest {
-  // The resource name of the model instance to trigger.
-  // For example "models/{model}/instances/{instance}"
+// TriggerModelRequest represents a request to trigger a model
+message TriggerModelRequest {
+  // The resource name of the model to trigger.
+  // For example "models/{model}"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
+    (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
-  // Input to trigger the model instance
+  // Input to trigger the model
   repeated TaskInput task_inputs = 2 [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// TriggerModelInstanceResponse represents a response for the output for
-// triggering a model instance
-message TriggerModelInstanceResponse {
+// TriggerModelResponse represents a response for the output for
+// triggering a model
+message TriggerModelResponse {
   // The task type
-  ModelInstance.Task task = 1;
-  // The task output from a model instance
+  Model.Task task = 1;
+  // The task output from a model
   repeated TaskOutput task_outputs = 2;
 }
 
-// TriggerModelInstanceBinaryFileUploadRequest represents a request to test a
-// model instance by uploading binary file
-message TriggerModelInstanceBinaryFileUploadRequest {
-  // The resource name of the model instance to trigger.
-  // For example "models/{model}/instances/{instance}"
+// TriggerModelBinaryFileUploadRequest represents a request to test a
+// model by uploading binary file
+message TriggerModelBinaryFileUploadRequest {
+  // The resource name of the model to trigger.
+  // For example "models/{model}"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
+    (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
-  // Input to trigger the model instance
+  // Input to trigger the model
   TaskInputStream task_input = 2 [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// TriggerModelInstanceBinaryFileUploadResponse represents a response for the
-// output for testing a model instance
-message TriggerModelInstanceBinaryFileUploadResponse {
+// TriggerModelBinaryFileUploadResponse represents a response for the
+// output for testing a model
+message TriggerModelBinaryFileUploadResponse {
   // The task type
-  ModelInstance.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // The task output from a model instance
+  Model.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // The task output from a model
   repeated TaskOutput task_outputs = 2
       [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// TestModelInstanceRequest represents a request to test a model instance
-message TestModelInstanceRequest {
-  // The resource name of the model instance to trigger.
-  // For example "models/{model}/instances/{instance}"
+// TestModelRequest represents a request to test a model
+message TestModelRequest {
+  // The resource name of the model to trigger.
+  // For example "models/{model}"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
+    (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
-  // Input to trigger the model instance
+  // Input to trigger the model
   repeated TaskInput task_inputs = 2 [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// TestModelInstanceResponse represents a response for the output for
-// testing a model instance
-message TestModelInstanceResponse {
+// TestModelResponse represents a response for the output for
+// testing a model
+message TestModelResponse {
   // The task type
-  ModelInstance.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // The task output from a model instance
+  Model.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // The task output from a model
   repeated TaskOutput task_outputs = 2
       [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// TestModelInstanceBinaryFileUploadRequest represents a request to test a
-// model instance by uploading binary file
-message TestModelInstanceBinaryFileUploadRequest {
-  // The resource name of the model instance to trigger.
-  // For example "models/{model}/instances/{instance}"
+// TestModelBinaryFileUploadRequest represents a request to test a
+// model by uploading binary file
+message TestModelBinaryFileUploadRequest {
+  // The resource name of the model to trigger.
+  // For example "models/{model}"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
+    (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
-  // Input to trigger the model instance
+  // Input to trigger the model
   TaskInputStream task_input = 2 [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// TestModelInstanceBinaryFileUploadResponse represents a response for the
-// output for testing a model instance
-message TestModelInstanceBinaryFileUploadResponse {
+// TestModelBinaryFileUploadResponse represents a response for the
+// output for testing a model
+message TestModelBinaryFileUploadResponse {
   // The task type
-  ModelInstance.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // The task output from a model instance
+  Model.Task task = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // The task output from a model
   repeated TaskOutput task_outputs = 2
       [ (google.api.field_behavior) = REQUIRED ];
 }
@@ -698,7 +581,7 @@ message GetModelOperationRequest {
   string name = 1 [ (google.api.field_behavior) = REQUIRED ];
   // View (default is VIEW_BASIC)
   // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-  // `ModelInstance.configuration` VIEW_FULL: show full information
+  // `Model.configuration` VIEW_FULL: show full information
   optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
@@ -722,7 +605,7 @@ message ListModelOperationsRequest {
   optional string filter = 3 [ (google.api.field_behavior) = OPTIONAL ];
   // View (default is VIEW_BASIC)
   // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-  // `ModelInstance.configuration` VIEW_FULL: show full information
+  // `Model.configuration` VIEW_FULL: show full information
   optional View view = 4 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
@@ -797,7 +680,7 @@ message GetModelAdminResponse {
   Model model = 1;
 }
 
-// LookUpModelAdminRequest represents a request to query a model instance via
+// LookUpModelAdminRequest represents a request to query a model via
 // permalink by admin
 message LookUpModelAdminRequest {
   // Permalink of a model. For example:
@@ -809,23 +692,23 @@ message LookUpModelAdminRequest {
   optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }
 
-// LookUpModelResponse represents a response for a model instance
+// LookUpModelResponse represents a response for a model
 message LookUpModelAdminResponse {
   // A model resource
   Model model = 1;
 }
 
-// CheckModelInstanceRequest represents a private request to query
-// a model instance's current state and longrunning progress
-message CheckModelInstanceRequest {
-  // Resource name of the model instance.
-  // For example "models/{model}/instances/{instance}"
+// CheckModelRequest represents a private request to query
+// a model current state and longrunning progress
+message CheckModelRequest {
+  // Resource name of the model.
+  // For example "models/{model}"
   string name = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// CheckModelInstanceResponse represents a response to fetch a model
-// instance's current state and longrunning progress
-message CheckModelInstanceResponse {
-  // Retrieved model instance state
-  ModelInstance.State state = 1;
+// CheckModelResponse represents a response to fetch a model's
+// current state and longrunning progress
+message CheckModelResponse {
+  // Retrieved model state
+  Model.State state = 1;
 }

--- a/vdp/model/v1alpha/model_definition.proto
+++ b/vdp/model/v1alpha/model_definition.proto
@@ -60,18 +60,11 @@ message ModelDefinition {
   google.protobuf.Struct model_spec = 8
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 
-  // ModelDefinition model instance specification represents the JSON schema
-  // used to validate the JSON configurations of a model instance from a
-  // specific model source. Must be a valid JSON that includes what fields are
-  // needed to display a model instance.
-  google.protobuf.Struct model_instance_spec = 9
-      [ (google.api.field_behavior) = REQUIRED ];
-
   // ModelDefinition create time
-  google.protobuf.Timestamp create_time = 10
+  google.protobuf.Timestamp create_time = 9
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // ModelDefinition update time
-  google.protobuf.Timestamp update_time = 11
+  google.protobuf.Timestamp update_time = 10
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
@@ -99,7 +92,7 @@ message ListModelDefinitionsRequest {
   optional string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
   // Definition view (default is VIEW_BASIC)
   // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
-  // `ModelDefinition.model_instance_spec`
+  // `ModelDefinition.model_spec`
   // VIEW_FULL: show full information
   optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
 }
@@ -128,7 +121,7 @@ message GetModelDefinitionRequest {
   ];
   // Definition view (default is VIEW_BASIC)
   // VIEW_UNSPECIFIED/VIEW_BASIC: omit `ModelDefinition.model_spec` and
-  // `ModelDefinition.model_instance_spec`
+  // `ModelDefinition.model_spec`
   // VIEW_FULL: show full information
   optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
 }

--- a/vdp/model/v1alpha/model_private_service.proto
+++ b/vdp/model/v1alpha/model_private_service.proto
@@ -40,11 +40,11 @@ service ModelPrivateService {
     option (google.api.method_signature) = "permalink";
   }
 
-  // CheckModelInstance method receives a CheckModelInstanceRequest message and returns a
-  // CheckModelInstanceResponse
-  rpc CheckModelInstance(CheckModelInstanceRequest) returns (CheckModelInstanceResponse) {
+  // CheckModel method receives a CheckModelRequest message and returns a
+  // CheckModelResponse
+  rpc CheckModel(CheckModelRequest) returns (CheckModelResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/admin/{name=models/*/instances/*}/check"
+      get : "/v1alpha/admin/{name=models/*}/check"
     };
     option (google.api.method_signature) = "name";
   };

--- a/vdp/model/v1alpha/model_public_service.proto
+++ b/vdp/model/v1alpha/model_public_service.proto
@@ -147,120 +147,89 @@ service ModelPublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // ListModelInstances method receives a ListModelInstancesRequest message and
-  // returns a ListModelInstancesResponse
-  rpc ListModelInstances(ListModelInstancesRequest)
-      returns (ListModelInstancesResponse) {
+  // DeployModel deploy a model to online state
+  rpc DeployModel(DeployModelRequest)
+      returns (DeployModelResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{parent=models/*}/instances"
-    };
-    option (google.api.method_signature) = "parent";
-  }
-
-  // GetModelInstance method receives a GetModelInstanceRequest message and
-  // returns a GetModelInstanceResponse
-  rpc GetModelInstance(GetModelInstanceRequest)
-      returns (GetModelInstanceResponse) {
-    option (google.api.http) = {
-      get : "/v1alpha/{name=models/*/instances/*}"
-    };
-    option (google.api.method_signature) = "name";
-  }
-
-  // LookUpModelInstance method receives a LookUpModelInstanceRequest message
-  // and returns a
-  // LookUpModelInstanceResponse
-  rpc LookUpModelInstance(LookUpModelInstanceRequest)
-      returns (LookUpModelInstanceResponse) {
-    option (google.api.http) = {
-      get : "/v1alpha/{permalink=models/*/instances/*}/lookUp"
-    };
-    option (google.api.method_signature) = "permalink";
-  }
-
-  // DeployModelInstance deploy a model instance to online state
-  rpc DeployModelInstance(DeployModelInstanceRequest)
-      returns (DeployModelInstanceResponse) {
-    option (google.api.http) = {
-      post : "/v1alpha/{name=models/*/instances/*}/deploy"
+      post : "/v1alpha/{name=models/*}/deploy"
       body : "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // UndeployModelInstance undeploy a model instance to offline state
-  rpc UndeployModelInstance(UndeployModelInstanceRequest)
-      returns (UndeployModelInstanceResponse) {
+  // UndeployModel undeploy a model to offline state
+  rpc UndeployModel(UndeployModelRequest)
+      returns (UndeployModelResponse) {
     option (google.api.http) = {
-      post : "/v1alpha/{name=models/*/instances/*}/undeploy"
+      post : "/v1alpha/{name=models/*}/undeploy"
       body : "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // GetModelInstanceCard method receives a GetModelInstanceCardRequest message
-  // and returns a GetModelInstanceCardResponse
-  rpc GetModelInstanceCard(GetModelInstanceCardRequest)
-      returns (GetModelInstanceCardResponse) {
+  // GetModelCard method receives a GetModelCardRequest message
+  // and returns a GetModelCardResponse
+  rpc GetModelCard(GetModelCardRequest)
+      returns (GetModelCardResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=models/*/instances/*/readme}"
+      get : "/v1alpha/{name=models/*/readme}"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // WatchModelInstance method receives a WatchModelInstanceRequest message
-  // and returns a WatchModelInstanceResponse
-  rpc WatchModelInstance(WatchModelInstanceRequest)
-      returns (WatchModelInstanceResponse) {
+  // WatchModel method receives a WatchModelRequest message
+  // and returns a WatchModelResponse
+  rpc WatchModel(WatchModelRequest)
+      returns (WatchModelResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=models/*/instances/*}/watch"
+      get : "/v1alpha/{name=models/*}/watch"
     };
     option (google.api.method_signature) = "name";
   }
 
   ///////////////////////////////////////////////////////
   //
-  // TriggerModelInstance method receives a TriggerModelInstanceRequest message
-  // and returns a TriggerModelInstanceResponse message.
-  rpc TriggerModelInstance(TriggerModelInstanceRequest)
-      returns (TriggerModelInstanceResponse) {
+  // TriggerModel method receives a TriggerModelRequest message
+  // and returns a TriggerModelResponse message.
+  rpc TriggerModel(TriggerModelRequest)
+      returns (TriggerModelResponse) {
     option (google.api.http) = {
-      post : "/v1alpha/{name=models/*/instances/*}/trigger"
+      post : "/v1alpha/{name=models/*}/trigger"
       body : "*"
     };
     option (google.api.method_signature) = "name,inputs";
   }
 
-  // TriggerModelInstanceBinaryFileUpload method receives a
-  // TriggerModelInstanceBinaryFileUploadRequest message and returns a
-  // TriggerModelInstanceBinaryFileUploadResponse message.
+  // TriggerModelBinaryFileUpload method receives a
+  // TriggerModelBinaryFileUploadRequest message and returns a
+  // TriggerModelBinaryFileUploadResponse message.
   //
-  // Endpoint: "POST/v1alpha/{name=models/*/instances/*}/trigger-multipart"
-  rpc TriggerModelInstanceBinaryFileUpload(
-      stream TriggerModelInstanceBinaryFileUploadRequest)
-      returns (TriggerModelInstanceBinaryFileUploadResponse) {
+  // Endpoint: "POST/v1alpha/{name=models/*}/trigger-multipart"
+  rpc TriggerModelBinaryFileUpload(
+      stream TriggerModelBinaryFileUploadRequest)
+      returns (TriggerModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
   }
 
-  // TestModelInstance method receives a TestModelInstanceRequest message
-  // and returns a TestModelInstanceResponse message.
-  rpc TestModelInstance(TestModelInstanceRequest)
-      returns (TestModelInstanceResponse) {
+  // TestModel method receives a TestModelRequest message
+  // and returns a TestModelResponse message.
+  rpc TestModel(TestModelRequest)
+      returns (TestModelResponse) {
     option (google.api.http) = {
-      post : "/v1alpha/{name=models/*/instances/*}/test"
+      post : "/v1alpha/{name=models/*}/test"
       body : "*"
     };
     option (google.api.method_signature) = "name,inputs";
   }
 
-  // TestModelInstanceBinaryFileUpload method receives a
-  // TestModelInstanceBinaryFileUploadRequest message and returns a
-  // TestModelInstanceBinaryFileUploadResponse message.
+  // TestModelBinaryFileUpload method receives a
+  // TestModelBinaryFileUploadRequest message and returns a
+  // TestModelBinaryFileUploadResponse message.
   //
-  // Endpoint: "POST/v1alpha/{name=models/*/instances/*}/test-multipart"
-  rpc TestModelInstanceBinaryFileUpload(
-      stream TestModelInstanceBinaryFileUploadRequest)
-      returns (TestModelInstanceBinaryFileUploadResponse) {
+  // Endpoint: "POST/v1alpha/{name=models/*}/test-multipart"
+  rpc TestModelBinaryFileUpload(
+      stream TestModelBinaryFileUploadRequest)
+      returns (TestModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
   }
 

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -34,10 +34,10 @@ message Recipe {
     (google.api.field_behavior) = IMMUTABLE,
     (google.api.resource_reference).type = "api.instill.tech/Connector"
   ];
-  // A list of model instance resources
-  repeated string model_instances = 3 [
+  // A list of model resources
+  repeated string model = 3 [
     (google.api.field_behavior) = IMMUTABLE,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
+    (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
 }
 
@@ -275,10 +275,10 @@ message RenamePipelineResponse {
 ////////////////////////////////////
 
 // TaskOutput represents the output of a CV Task result from a
-// model instance, extended from model.v1alpha.TaskOutput.
+// model, extended from model.v1alpha.TaskOutput.
 // Here we don't use a model.v1alpha.TaskOutput type field but explicitly use
 // the replicated oneof field because we want the CV Task output to be at the
-// same message layer like the trigger output of model instance.
+// same message layer like the trigger output of model.
 message TaskOutput {
   // The index of input data in a batch
   string index = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
@@ -314,17 +314,17 @@ message TaskOutput {
   }
 }
 
-// ModelInstanceOutput represents one model instance inference result
-message ModelInstanceOutput {
-  // The model instance
-  string model_instance = 1 [
+// ModelOutput represents one model inference result
+message ModelOutput {
+  // The model
+  string model = 1 [
     (google.api.field_behavior) = OUTPUT_ONLY,
-    (google.api.resource_reference).type = "api.instill.tech/ModelInstance"
+    (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
   // The task type
-  model.v1alpha.ModelInstance.Task task = 2
+  model.v1alpha.Model.Task task = 2
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // The extended task outputs based on the model instance inference (i.e.,
+  // The extended task outputs based on the model inference (i.e.,
   // from a trigger endpoint of model-backend)
   repeated TaskOutput task_outputs = 3
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
@@ -343,12 +343,12 @@ message TriggerPipelineRequest {
 }
 
 // TriggerPipelineResponse represents a response for the output
-// of a pipeline, i.e., the multiple model instance inference outputs
+// of a pipeline, i.e., the multiple model inference outputs
 message TriggerPipelineResponse {
   // The data mapping indices stores UUID for each input
   repeated string data_mapping_indices = 1;
-  // The multiple model instance inference outputs
-  repeated ModelInstanceOutput model_instance_outputs = 2;
+  // The multiple model inference outputs
+  repeated ModelOutput model_outputs = 2;
 }
 
 // TriggerPipelineBinaryFileUploadRequest represents a request to trigger a
@@ -364,12 +364,12 @@ message TriggerPipelineBinaryFileUploadRequest {
 }
 
 // TriggerPipelineBinaryFileUploadResponse represents a response for the output
-// of a pipeline, i.e., the multiple model instance inference outputs
+// of a pipeline, i.e., the multiple model inference outputs
 message TriggerPipelineBinaryFileUploadResponse {
   // The data mapping indices stores UUID for each input
   repeated string data_mapping_indices = 1;
-  // The multiple model instance inference outputs
-  repeated ModelInstanceOutput model_instance_outputs = 2;
+  // The multiple model inference outputs
+  repeated ModelOutput model_outputs = 2;
 }
 
 // ========== Private endpoints

--- a/vdp/usage/v1alpha/usage.proto
+++ b/vdp/usage/v1alpha/usage.proto
@@ -108,27 +108,21 @@ message ModelUsageData {
   message UserUsageData {
     // User UUID
     string user_uid = 1 [ (google.api.field_behavior) = REQUIRED ];
-    // Number of models that have at least one 'online' instance
+    // Number of 'online' models
     int64 model_online_state_num = 2 [ (google.api.field_behavior) = REQUIRED ];
-    // Number of models that have no 'online' instances
+    // Number of 'offline' models
     int64 model_offline_state_num = 3
         [ (google.api.field_behavior) = REQUIRED ];
-    // Number of model instances with 'online' state
-    int64 instance_online_state_num = 4
-        [ (google.api.field_behavior) = REQUIRED ];
-    // Number of model instances with 'offline' state
-    int64 instance_offline_state_num = 5
-        [ (google.api.field_behavior) = REQUIRED ];
-    // Definition IDs of the model instances. Element in the list
+    // Definition IDs of the model. Element in the list
     // should not be duplicated.
-    repeated string model_definition_ids = 6
+    repeated string model_definition_ids = 4
         [ (google.api.field_behavior) = REQUIRED ];
-    // Tasks of the model instances. Element in the list should not be
+    // Tasks of the models. Element in the list should not be
     // duplicated.
-    repeated model.v1alpha.ModelInstance.Task tasks = 7
+    repeated model.v1alpha.Model.Task tasks = 5
         [ (google.api.field_behavior) = REQUIRED ];
-    // Number of model instance testing operations
-    int64 test_num = 8 [ (google.api.field_behavior) = REQUIRED ];
+    // Number of model testing operations
+    int64 test_num = 6 [ (google.api.field_behavior) = REQUIRED ];
   }
   // Usage data of all users in the model service
   repeated UserUsageData usages = 1;


### PR DESCRIPTION
Because

- model and model instance concepts make users confused

This commit

- remove the model instance concept and move the state, task from the model instance into the model
- INS-333
