### PR TITLE
chore(mgmt,pipeline): add public watch method for pipeline state monitoring

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -7216,8 +7216,17 @@ definitions:
         format: int32
         title: Retrieved model logrunning progress
     title: |-
-      WatchModelResponse represents a public response to
-      fetch a model current state and longrunning progress
+      WatchModelInstanceResponse represents a public response to
+      fetch a model instance's current state and longrunning progress
+  v1alphaWatchPipelineResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaPipelineState'
+        title: Retrieved pipeline state
+    title: |-
+      WatchPipelineResponse represents a response to fetch a pipeline's
+      current state
   v1alphaWatchSourceConnectorResponse:
     type: object
     properties:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1521,6 +1521,30 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPublicService
+  /v1alpha/{pipeline.name/watch}/watch:
+    get:
+      summary: |-
+        WatchPipeline method receives a WatchPipelineRequest message
+        and returns a WatchPipelineResponse
+      operationId: PipelinePublicService_WatchPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: pipeline.name/watch
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+      tags:
+        - PipelinePublicService
   /v1alpha/{pipeline.name}:
     get:
       summary: |-

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -7215,8 +7215,8 @@ definitions:
         format: int32
         title: Retrieved model logrunning progress
     title: |-
-      WatchModelInstanceResponse represents a public response to
-      fetch a model instance's current state and longrunning progress
+      WatchModelResponse represents a public response to
+      fetch a model current state and longrunning progress
   v1alphaWatchPipelineResponse:
     type: object
     properties:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4004,10 +4004,6 @@ definitions:
           if (any.is(Foo.class)) {
             foo = any.unpack(Foo.class);
           }
-          // or ...
-          if (any.isSameTypeAs(Foo.getDefaultInstance())) {
-            foo = any.unpack(Foo.getDefaultInstance());
-          }
 
       Example 3: Pack and unpack a message in Python.
 
@@ -4037,6 +4033,7 @@ definitions:
       methods only use the fully qualified type name after the last '/'
       in the type URL, for example "foo.bar.com/x/y.z" will yield type
       name "y.z".
+
 
       JSON
 
@@ -4214,7 +4211,9 @@ definitions:
         readOnly: true
       access_token:
         type: string
-        description: "An opaque access token representing the API token string. \nTo validate the token, the recipient of the token needs to call the server that issued the token."
+        description: |-
+          An opaque access token representing the API token string.
+          To validate the token, the recipient of the token needs to call the server that issued the token.
         readOnly: true
       state:
         $ref: '#/definitions/v1alphaApiTokenState'

--- a/vdp/mgmt/v1alpha/mgmt.proto
+++ b/vdp/mgmt/v1alpha/mgmt.proto
@@ -266,7 +266,7 @@ message ApiToken {
     // State: EXPIRED
     STATE_EXPIRED = 3;
   }
-  
+
   // API token resource name. It must have the format of "tokens/*"
   string name = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // API token UUID
@@ -275,13 +275,13 @@ message ApiToken {
   // construct the resource name. This conforms to RFC-1034, which restricts to
   // letters, numbers, and hyphen, with the first character a letter, the last a
   // letter or a number, and a 63 character maximum.
-  // Use this field to define where it's being used. 
+  // Use this field to define where it's being used.
   string id = 3 [ (google.api.field_behavior) = IMMUTABLE ];
   // API token creation time
   google.protobuf.Timestamp create_time = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // API token update time
   google.protobuf.Timestamp update_time = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // An opaque access token representing the API token string. 
+  // An opaque access token representing the API token string.
   // To validate the token, the recipient of the token needs to call the server that issued the token.
   string access_token = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // API token state

--- a/vdp/mgmt/v1alpha/mgmt_private_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_private_service.proto
@@ -72,7 +72,7 @@ service MgmtPrivateService {
 
   // ValidateToken method receives a ValidateTokenRequest message and
   // returns a ValidateTokenResponse
-  rpc ValidateToken(ValidateTokenRequest) 
+  rpc ValidateToken(ValidateTokenRequest)
       returns (ValidateTokenResponse) {
     option (google.api.http) = {
       post : "/v1alpha/{name=tokens/*}/validate"

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -372,6 +372,26 @@ message TriggerPipelineBinaryFileUploadResponse {
   repeated ModelOutput model_outputs = 2;
 }
 
+// WatchPipelineRequest represents a public request to query
+// a pipeline's current state
+message WatchPipelineRequest {
+  // Pipeline resource name. It must have the format of "pipelines/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type : "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "pipeline.name/watch"}
+    }
+  ];
+}
+
+// WatchPipelineResponse represents a response to fetch a pipeline's
+// current state
+message WatchPipelineResponse {
+  // Retrieved pipeline state
+  Pipeline.State state = 1;
+}
+
 // ========== Private endpoints
 
 // ListPipelinesAdminRequest represents a request to list all pipelines from all users by admin

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -144,4 +144,14 @@ service PipelinePublicService {
       returns (TriggerPipelineBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
   }
+
+  // WatchPipeline method receives a WatchPipelineRequest message
+  // and returns a WatchPipelineResponse
+  rpc WatchPipeline(WatchPipelineRequest)
+      returns (WatchPipelineResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/{name=pipelines/*}/watch"
+    };
+    option (google.api.method_signature) = "name";
+  }
 }


### PR DESCRIPTION
Because

- support public endpoint for pipeline status monitoring

This commit

- add /watch endpoint to pipeline-backend
- fix whitepsaces
