### PR TITLE
chore(pipeline): update recipe message

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -6359,7 +6359,7 @@ definitions:
       destination:
         type: string
         title: A destination connector resource
-      model:
+      models:
         type: array
         items:
           type: string

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -35,7 +35,7 @@ message Recipe {
     (google.api.resource_reference).type = "api.instill.tech/Connector"
   ];
   // A list of model resources
-  repeated string model = 3 [
+  repeated string models = 3 [
     (google.api.field_behavior) = IMMUTABLE,
     (google.api.resource_reference).type = "api.instill.tech/Model"
   ];


### PR DESCRIPTION
Because

- a wrong name for the array field

This commit

- change to plural name for array field
