### PR TITLE
chore(mgmt,pipeline,connector): return owner uuid instead of id

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -452,11 +452,11 @@ paths:
                 readOnly: true
               user:
                 type: string
-                description: The resource name of a user, e.g., "users/local-user".
+                description: The resource name with UUID of a user, e.g., "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
                 readOnly: true
               org:
                 type: string
-                title: The resource name of an organization
+                title: The resource name with UUID of an organization
                 readOnly: true
               create_time:
                 type: string
@@ -1592,11 +1592,11 @@ paths:
                 readOnly: true
               user:
                 type: string
-                description: The resource name of a user, e.g., "users/local-user".
+                description: The resource name with UUID of a user, e.g., "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
                 readOnly: true
               org:
                 type: string
-                title: The resource name of an organization
+                title: The resource name with UUID of an organization
                 readOnly: true
               create_time:
                 type: string
@@ -4275,11 +4275,11 @@ definitions:
         readOnly: true
       user:
         type: string
-        description: The resource name of a user, e.g., "users/local-user".
+        description: The resource name with UUID of a user, e.g., "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
         readOnly: true
       org:
         type: string
-        title: The resource name of an organization
+        title: The resource name with UUID of an organization
         readOnly: true
       create_time:
         type: string
@@ -5609,11 +5609,11 @@ definitions:
         readOnly: true
       user:
         type: string
-        description: The resource name of a user, e.g., "users/local-user".
+        description: The resource name with UUID of a user, e.g., "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
         readOnly: true
       org:
         type: string
-        title: The resource name of an organization
+        title: The resource name with UUID of an organization
         readOnly: true
       create_time:
         type: string
@@ -6055,11 +6055,11 @@ definitions:
         readOnly: true
       user:
         type: string
-        description: The resource name of a user, e.g., "users/local-user".
+        description: The resource name with UUID of a user, e.g., "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
         readOnly: true
       org:
         type: string
-        title: The resource name of an organization
+        title: The resource name with UUID of an organization
         readOnly: true
       create_time:
         type: string

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -42,12 +42,12 @@ message Connector {
   bool tombstone = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Connector owner
   oneof owner {
-    // The resource name of a user, e.g., "users/local-user".
+    // The resource name with UUID of a user, e.g., "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
     string user = 5 [
       (google.api.resource_reference).type = "api.instill.tech/User",
       (google.api.field_behavior) = OUTPUT_ONLY
     ];
-    // The resource name of an organization
+    // The resource name with UUID of an organization
     string org = 6 [
       (google.api.resource_reference).type = "api.instill.tech/Organization",
       (google.api.field_behavior) = OUTPUT_ONLY

--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -104,12 +104,12 @@ message Model {
   Visibility visibility = 9 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Model owner
   oneof owner {
-    // The resource name of a user, e.g., "users/local-user".
+    // The resource name with UUID of a user, e.g., "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
     string user = 10 [
       (google.api.resource_reference).type = "api.instill.tech/User",
       (google.api.field_behavior) = OUTPUT_ONLY
     ];
-    // The resource name of an organization
+    // The resource name with UUID of an organization
     string org = 11 [
       (google.api.resource_reference).type = "api.instill.tech/Organization",
       (google.api.field_behavior) = OUTPUT_ONLY

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -89,12 +89,12 @@ message Pipeline {
   State state = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Pipeline owner
   oneof owner {
-    // The resource name of a user, e.g., "users/local-user".
+    // The resource name with UUID of a user, e.g., "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
     string user = 8 [
       (google.api.resource_reference).type = "api.instill.tech/User",
       (google.api.field_behavior) = OUTPUT_ONLY
     ];
-    // The resource name of an organization
+    // The resource name with UUID of an organization
     string org = 9 [
       (google.api.resource_reference).type = "api.instill.tech/Organization",
       (google.api.field_behavior) = OUTPUT_ONLY


### PR DESCRIPTION
Because

- Reduce the query requests to the mgmt-backend to get the owner ID
- The user ID can be changed now (in Instill Cloud), so using the owner ID is not reliable

This commit

- refactor owner of resource to use resource UUID, not resource ID
