### PR TITLE
chore(mgmt): change expires_in to expires_at, remove ValidateToken()

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1953,40 +1953,6 @@ paths:
           pattern: tokens/[^/]+
       tags:
         - MgmtPublicService
-  /v1alpha/{token.name}/validate:
-    post:
-      summary: |-
-        ValidateToken method receives a ValidateTokenRequest message and
-        returns a ValidateTokenResponse
-      operationId: MgmtPrivateService_ValidateToken
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaValidateTokenResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: token.name
-          description: |-
-            The resource name of the API token to validate,
-            for example: "tokens/test-token"
-          in: path
-          required: true
-          type: string
-          pattern: tokens/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            title: |-
-              ValidateTokenRequest represents a request to validate whether
-              an API token is valid to be used for triggering pipelines
-      tags:
-        - MgmtPrivateService
   /v1alpha/{user.name}/exist:
     get:
       summary: |-
@@ -4129,10 +4095,10 @@ definitions:
         type: string
         format: int64
         title: The amount of time (in seconds) the API token will live. If set to -1, indicating a non-expire token
-      expires_in:
+      expires_at:
         type: string
-        format: int64
-        title: The amount of time (in seconds) the API token will expire. If value is -1, indicating a non-expire token
+        format: date-time
+        title: API token expire time
         readOnly: true
     title: ApiToken represents the content of a API token
   v1alphaApiTokenState:
@@ -7058,15 +7024,6 @@ definitions:
     title: User records definition
     required:
       - uid
-  v1alphaValidateTokenResponse:
-    type: object
-    properties:
-      valid:
-        type: boolean
-        title: A boolean value indicating whether the token is valid
-    title: |-
-      ValidateTokenResponse represents a response about whether
-      the queried token is valid
   v1alphaWatchDestinationConnectorResponse:
     type: object
     properties:

--- a/vdp/mgmt/v1alpha/mgmt.proto
+++ b/vdp/mgmt/v1alpha/mgmt.proto
@@ -290,8 +290,8 @@ message ApiToken {
   string token_type = 9  [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // The amount of time (in seconds) the API token will live. If set to -1, indicating a non-expire token
   int64 lifetime = 10  [ (google.api.field_behavior) = INPUT_ONLY ];
-  // The amount of time (in seconds) the API token will expire. If value is -1, indicating a non-expire token
-  int64 expires_in = 11  [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // API token expire time
+  google.protobuf.Timestamp expires_at = 11  [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // CreateTokenRequest represents a request to create a API token
@@ -358,24 +358,3 @@ message DeleteTokenRequest {
 
 // DeleteTokenResponse represents an empty response
 message DeleteTokenResponse {}
-
-// ValidateTokenRequest represents a request to validate whether
-// an API token is valid to be used for triggering pipelines
-message ValidateTokenRequest {
-  // The resource name of the API token to validate,
-  // for example: "tokens/test-token"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ApiToken",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "token.name"}
-    }
-  ];
-}
-
-// ValidateTokenResponse represents a response about whether
-// the queried token is valid
-message ValidateTokenResponse {
-  // A boolean value indicating whether the token is valid
-  bool valid = 1;
-}

--- a/vdp/mgmt/v1alpha/mgmt_private_service.proto
+++ b/vdp/mgmt/v1alpha/mgmt_private_service.proto
@@ -70,14 +70,4 @@ service MgmtPrivateService {
     option (google.api.method_signature) = "permalink";
   }
 
-  // ValidateToken method receives a ValidateTokenRequest message and
-  // returns a ValidateTokenResponse
-  rpc ValidateToken(ValidateTokenRequest)
-      returns (ValidateTokenResponse) {
-    option (google.api.http) = {
-      post : "/v1alpha/{name=tokens/*}/validate"
-      body : "*"
-    };
-    option (google.api.method_signature) = "name";
-  }
 }


### PR DESCRIPTION
Because

- Because `expires_in` has same meaning as `lifetime`, change it to `expires_at` will be more friendly.

This commit

- change `expires_in` to `expires_at`
- remove ValidateToken()
