### PR TITLE
chore(mgmt): change token `lifetime` to `ttl`

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4091,15 +4091,14 @@ definitions:
         type: string
         title: API token type, value is fixed to "Bearer"
         readOnly: true
-      lifetime:
+      ttl:
         type: string
         format: int64
-        title: The amount of time (in seconds) the API token will live. If set to -1, indicating a non-expire token
-      expires_at:
+        description: Input only. The TTL in seconds for this resource.
+      expire_time:
         type: string
         format: date-time
         title: API token expire time
-        readOnly: true
     title: ApiToken represents the content of a API token
   v1alphaApiTokenState:
     type: string

--- a/vdp/mgmt/v1alpha/mgmt.proto
+++ b/vdp/mgmt/v1alpha/mgmt.proto
@@ -288,10 +288,14 @@ message ApiToken {
   State state = 8  [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // API token type, value is fixed to "Bearer"
   string token_type = 9  [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // The amount of time (in seconds) the API token will live. If set to -1, indicating a non-expire token
-  int64 lifetime = 10  [ (google.api.field_behavior) = INPUT_ONLY ];
-  // API token expire time
-  google.protobuf.Timestamp expires_at = 11  [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // API token expiration
+  oneof expiration {
+    // Input only. The TTL in seconds for this resource.
+    int64 ttl = 10 [(google.api.field_behavior) = INPUT_ONLY];
+
+    // API token expire time
+    google.protobuf.Timestamp expire_time = 11;
+  }
 }
 
 // CreateTokenRequest represents a request to create a API token


### PR DESCRIPTION
Because

- According to Google [AIP](https://google.aip.dev/214), we should provide both `ttl` and `expire_time` for resource expiration.

This commit

- Add `ttl` and `expire_time` in mgmt ApiToken protobuf
