### PR TITLE
chore(controller,connector,pipeline,model): update controller and remove Get admin api

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1656,7 +1656,7 @@ paths:
           type: string
       tags:
         - PipelinePublicService
-  /v1alpha/{resource.name}:
+  /v1alpha/{resource.resource_permalink}:
     get:
       summary: |-
         GetResource method receives a GetResourceRequest message
@@ -1672,8 +1672,10 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: resource.name
-          description: Resource name
+        - name: resource.resource_permalink
+          description: |-
+            Permalink of a resouce. For example:
+            "resources/{resource_uuid}/types/{type}"
           in: path
           required: true
           type: string
@@ -1695,8 +1697,10 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: resource.name
-          description: Resource name
+        - name: resource.resource_permalink
+          description: |-
+            Permalink of a resouce. For example:
+            "resources/{resource_uuid}/types/{type}"
           in: path
           required: true
           type: string
@@ -1718,8 +1722,10 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: resource.name
-          description: Resource name.
+        - name: resource.resource_permalink
+          description: |-
+            Permalink of a resouce. For example:
+            "resources/{resource_uuid}/types/{type}"
           in: path
           required: true
           type: string
@@ -2019,92 +2025,7 @@ paths:
           pattern: users/[^/]+
       tags:
         - MgmtPublicService
-  /v1alpha/admin/{destination_connector.name}:
-    get:
-      summary: |-
-        GetDestinationConnectorAdmin method receives a
-        GetDestinationConnectorAdminRequest message and returns a
-        GetDestinationConnectorAdminResponse message.
-      operationId: ConnectorPrivateService_GetDestinationConnectorAdmin
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetDestinationConnectorAdminResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: destination_connector.name
-          description: |-
-            DestinationConnectorConnector resource name. It must have the format of
-            "destination-connectors/*"
-          in: path
-          required: true
-          type: string
-          pattern: destination-connectors/[^/]+
-        - name: view
-          description: |-
-            DestinationConnector view (default is VIEW_BASIC)
-
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED
-             - VIEW_BASIC: View: BASIC
-             - VIEW_FULL: View: FULL
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-          default: VIEW_UNSPECIFIED
-      tags:
-        - ConnectorPrivateService
-  /v1alpha/admin/{model.name}:
-    get:
-      summary: |-
-        GetModelAdmin method receives a GetModelAdminRequest message and returns a
-        GetModelAdminResponse
-      operationId: ModelPrivateService_GetModelAdmin
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetModelAdminResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: model.name
-          description: |-
-            Resource name of the model.
-            For example "models/{model}"
-          in: path
-          required: true
-          type: string
-          pattern: models/[^/]+
-        - name: view
-          description: |-
-            Model view (default is VIEW_BASIC)
-            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
-            VIEW_FULL: show full information
-
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-             - VIEW_FULL: View: FULL, full representation of the resource
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-          default: VIEW_UNSPECIFIED
-      tags:
-        - ModelPrivateService
-  /v1alpha/admin/{name_1}/check:
+  /v1alpha/admin/{destination_connector_permalink}/check:
     get:
       summary: |-
         CheckDestinationConnector method receives a CheckDestinationConnectorRequest message and returns a
@@ -2120,17 +2041,17 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: name_1
+        - name: destination_connector_permalink
           description: |-
-            SourceConnector resource name. It must have the format of
-            "destination-connectors/*"
+            Permalink of a destination connector. For example:
+            "destination-connectors/{uid}"
           in: path
           required: true
           type: string
           pattern: destination-connectors/[^/]+
       tags:
         - ConnectorPrivateService
-  /v1alpha/admin/{name_2}/check:
+  /v1alpha/admin/{model_permalink}/check:
     get:
       summary: |-
         CheckModel method receives a CheckModelRequest message and returns a
@@ -2146,42 +2067,16 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: name_2
+        - name: model_permalink
           description: |-
-            Resource name of the model.
-            For example "models/{model}"
+            Permalink of a model. For example:
+            "models/{uid}"
           in: path
           required: true
           type: string
           pattern: models/[^/]+
       tags:
         - ModelPrivateService
-  /v1alpha/admin/{name}/check:
-    get:
-      summary: |-
-        CheckSourceConnector method receives a CheckSourceConnectorRequest message and returns a
-        CheckSourceConnectorResponse
-      operationId: ConnectorPrivateService_CheckSourceConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaCheckSourceConnectorResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: name
-          description: |-
-            SourceConnector resource name. It must have the format of
-            "source-connectors/*"
-          in: path
-          required: true
-          type: string
-          pattern: source-connectors/[^/]+
-      tags:
-        - ConnectorPrivateService
   /v1alpha/admin/{permalink_1}/lookUp:
     get:
       summary: |-
@@ -2391,84 +2286,30 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPrivateService
-  /v1alpha/admin/{pipeline.name}:
+  /v1alpha/admin/{source_connector_permalink}/check:
     get:
       summary: |-
-        GetPipelineAdmin method receives a GetPipelineAdminRequest message and
-        returns a GetPipelineAdminResponse message.
-      operationId: PipelinePrivateService_GetPipelineAdmin
+        CheckSourceConnector method receives a CheckSourceConnectorRequest message and returns a
+        CheckSourceConnectorResponse
+      operationId: ConnectorPrivateService_CheckSourceConnector
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetPipelineAdminResponse'
+            $ref: '#/definitions/v1alphaCheckSourceConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: pipeline.name
-          description: Pipeline resource name. It must have the format of "pipelines/*"
-          in: path
-          required: true
-          type: string
-          pattern: pipelines/[^/]+
-        - name: view
+        - name: source_connector_permalink
           description: |-
-            Pipeline resource view (default is VIEW_BASIC)
-
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED
-             - VIEW_BASIC: View: BASIC
-             - VIEW_FULL: View: FULL
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-          default: VIEW_UNSPECIFIED
-      tags:
-        - PipelinePrivateService
-  /v1alpha/admin/{source_connector.name}:
-    get:
-      summary: |-
-        GetSourceConnectorAdmin method receives a GetSourceConnectorAdminRequest
-        message and returns a GetSourceConnectorAdminResponse message.
-      operationId: ConnectorPrivateService_GetSourceConnectorAdmin
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetSourceConnectorAdminResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: source_connector.name
-          description: |-
-            SourceConnectorConnector resource name. It must have the format of
-            "source-connectors/*"
+            Permalink of a source connector. For example:
+            "source-connectors/{uid}"
           in: path
           required: true
           type: string
           pattern: source-connectors/[^/]+
-        - name: view
-          description: |-
-            SourceConnector view (default is VIEW_BASIC)
-
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED
-             - VIEW_BASIC: View: BASIC
-             - VIEW_FULL: View: FULL
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-          default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPrivateService
   /v1alpha/admin/{user.name}:
@@ -3909,6 +3750,10 @@ definitions:
           if (any.is(Foo.class)) {
             foo = any.unpack(Foo.class);
           }
+          // or ...
+          if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+            foo = any.unpack(Foo.getDefaultInstance());
+          }
 
       Example 3: Pack and unpack a message in Python.
 
@@ -3938,7 +3783,6 @@ definitions:
       methods only use the fully qualified type name after the last '/'
       in the type URL, for example "foo.bar.com/x/y.z" will yield type
       name "y.z".
-
 
       JSON
 
@@ -4818,15 +4662,6 @@ definitions:
     title: GetCumulativePipelineTriggerRecordsResponse represents a response to GetCumulativePipelineTriggerRecordsRequest
     required:
       - cumulative_records
-  v1alphaGetDestinationConnectorAdminResponse:
-    type: object
-    properties:
-      destination_connector:
-        $ref: '#/definitions/v1alphaDestinationConnector'
-        title: DestinationConnector resource
-    title: |-
-      GetDestinationConnectorAdminResponse represents a response for a
-      DestinationConnector resource
   v1alphaGetDestinationConnectorDefinitionResponse:
     type: object
     properties:
@@ -4845,13 +4680,6 @@ definitions:
     title: |-
       GetDestinationConnectorResponse represents a response for a
       DestinationConnector resource
-  v1alphaGetModelAdminResponse:
-    type: object
-    properties:
-      model:
-        $ref: '#/definitions/v1alphaModel'
-        title: The retrieved model
-    title: GetModelAdminResponse represents a response for a model
   v1alphaGetModelCardResponse:
     type: object
     properties:
@@ -4973,13 +4801,6 @@ definitions:
     title: GetPipelinesResponse represents a respond to GetModelsRequest
     required:
       - models
-  v1alphaGetPipelineAdminResponse:
-    type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
-        title: A pipeline resource
-    title: GetPipelineAdminResponse represents a response for a pipeline resource
   v1alphaGetPipelineResponse:
     type: object
     properties:
@@ -5085,15 +4906,6 @@ definitions:
         $ref: '#/definitions/v1alphaResource'
         title: Retrieved resource state
     title: GetResourceResponse represents a response to fetch a resource's state
-  v1alphaGetSourceConnectorAdminResponse:
-    type: object
-    properties:
-      source_connector:
-        $ref: '#/definitions/v1alphaSourceConnector'
-        title: SourceConnector resource
-    title: |-
-      GetSourceConnectorAdminResponse represents a response for a
-      SourceConnector resource
   v1alphaGetSourceConnectorDefinitionResponse:
     type: object
     properties:
@@ -5394,7 +5206,10 @@ definitions:
         type: string
         format: int64
         title: Total count of pipeline resources
-    title: ListPipelinesAdminResponse represents a response for a list of pipelines
+    title: |-
+      ListPipelinesAdminResponse represents a response for a list of pipelines
+      The recipe returned will be permaLinks instead of resourceName temporary,
+      this will be refactored soon
   v1alphaListPipelinesResponse:
     type: object
     properties:
@@ -6341,9 +6156,11 @@ definitions:
   v1alphaResource:
     type: object
     properties:
-      name:
+      resource_permalink:
         type: string
-        description: Resource name.
+        title: |-
+          Permalink of a resouce. For example:
+          "resources/{resource_uuid}/types/{type}"
       model_state:
         $ref: '#/definitions/v1alphaModelState'
         title: Model state
@@ -6362,7 +6179,7 @@ definitions:
         title: Resource longrunning progress
     title: Resource represents the current information of a resource
     required:
-      - name
+      - resource_permalink
   v1alphaSemanticSegmentationInput:
     type: object
     properties:

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -570,31 +570,6 @@ message ListSourceConnectorsAdminResponse {
   int64 total_size = 3;
 }
 
-// GetSourceConnectorAdminRequest represents a request to query a
-// SourceConnector resource by admin
-message GetSourceConnectorAdminRequest {
-  // SourceConnectorConnector resource name. It must have the format of
-  // "source-connectors/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      type : "api.instill.tech/SourceConnector"
-    },
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "source_connector.name"}
-    }
-  ];
-  // SourceConnector view (default is VIEW_BASIC)
-  optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
-}
-
-// GetSourceConnectorAdminResponse represents a response for a
-// SourceConnector resource
-message GetSourceConnectorAdminResponse {
-  // SourceConnector resource
-  SourceConnector source_connector = 1;
-}
-
 // LookUpSourceConnectorAdminRequest represents a request to query a source connector
 // via permalink by admin
 message LookUpSourceConnectorAdminRequest {
@@ -635,9 +610,9 @@ message WatchSourceConnectorResponse {
 // CheckSourceConnectorRequest represents a private request to query
 // a source connector's current state
 message CheckSourceConnectorRequest {
-  // SourceConnector resource name. It must have the format of
-  // "source-connectors/*"
-  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Permalink of a source connector. For example:
+  // "source-connectors/{uid}"
+  string source_connector_permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // CheckSourceConnectorResponse represents a response to fetch a source connector's
@@ -669,31 +644,6 @@ message ListDestinationConnectorsAdminResponse {
   string next_page_token = 2;
   // Total count of connector resources
   int64 total_size = 3;
-}
-
-// GetDestinationConnectorAdminRequest represents a request to query a
-// DestinationConnector resource by admin
-message GetDestinationConnectorAdminRequest {
-  // DestinationConnectorConnector resource name. It must have the format of
-  // "destination-connectors/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      type : "api.instill.tech/DestinationConnector"
-    },
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "destination_connector.name"}
-    }
-  ];
-  // DestinationConnector view (default is VIEW_BASIC)
-  optional View view = 3 [ (google.api.field_behavior) = OPTIONAL ];
-}
-
-// GetDestinationConnectorAdminResponse represents a response for a
-// DestinationConnector resource
-message GetDestinationConnectorAdminResponse {
-  // DestinationConnector resource
-  DestinationConnector destination_connector = 1;
 }
 
 // LookUpDestinationConnectorAdminRequest represents a request to query a destination
@@ -737,9 +687,9 @@ message WatchDestinationConnectorResponse {
 // CheckDestinationConnectorRequest represents a private request to query
 // a destination connector's current state
 message CheckDestinationConnectorRequest {
-  // SourceConnector resource name. It must have the format of
-  // "destination-connectors/*"
-  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Permalink of a destination connector. For example:
+  // "destination-connectors/{uid}"
+  string destination_connector_permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // CheckDestinationConnectorResponse represents a response to fetch a destination connector's

--- a/vdp/connector/v1alpha/connector_private_service.proto
+++ b/vdp/connector/v1alpha/connector_private_service.proto
@@ -22,16 +22,6 @@ service ConnectorPrivateService {
     };
   }
 
-  // GetSourceConnectorAdmin method receives a GetSourceConnectorAdminRequest
-  // message and returns a GetSourceConnectorAdminResponse message.
-  rpc GetSourceConnectorAdmin(GetSourceConnectorAdminRequest)
-      returns (GetSourceConnectorAdminResponse) {
-    option (google.api.http) = {
-      get : "/v1alpha/admin/{name=source-connectors/*}"
-    };
-    option (google.api.method_signature) = "name";
-  }
-
   // LookUpSourceConnectorAdmin method receives a
   // LookUpSourceConnectorAdminRequest message and returns a
   // LookUpSourceConnectorAdminResponse
@@ -47,9 +37,9 @@ service ConnectorPrivateService {
   // CheckSourceConnectorResponse
   rpc CheckSourceConnector(CheckSourceConnectorRequest) returns (CheckSourceConnectorResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/admin/{name=source-connectors/*}/check"
+      get : "/v1alpha/admin/{source_connector_permalink=source-connectors/*}/check"
     };
-    option (google.api.method_signature) = "name";
+    option (google.api.method_signature) = "source_connector_permalink";
   };
 
   // *DestinationConnector methods
@@ -61,17 +51,6 @@ service ConnectorPrivateService {
     option (google.api.http) = {
       get : "/v1alpha/admin/destination-connectors"
     };
-  }
-
-  // GetDestinationConnectorAdmin method receives a
-  // GetDestinationConnectorAdminRequest message and returns a
-  // GetDestinationConnectorAdminResponse message.
-  rpc GetDestinationConnectorAdmin(GetDestinationConnectorAdminRequest)
-      returns (GetDestinationConnectorAdminResponse) {
-    option (google.api.http) = {
-      get : "/v1alpha/admin/{name=destination-connectors/*}"
-    };
-    option (google.api.method_signature) = "name";
   }
 
   // LookUpDestinationConnectorAdmin method receives a
@@ -89,8 +68,8 @@ service ConnectorPrivateService {
   // CheckDestinationConnectorResponse
   rpc CheckDestinationConnector(CheckDestinationConnectorRequest) returns (CheckDestinationConnectorResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/admin/{name=destination-connectors/*}/check"
+      get : "/v1alpha/admin/{destination_connector_permalink=destination-connectors/*}/check"
     };
-    option (google.api.method_signature) = "name";
+    option (google.api.method_signature) = "destination_connector_permalink";
   };
 }

--- a/vdp/controller/v1alpha/controller.proto
+++ b/vdp/controller/v1alpha/controller.proto
@@ -18,11 +18,12 @@ import "vdp/healthcheck/v1alpha/healthcheck.proto";
 message Resource {
     option (google.api.resource) = {
       type : "api.instill.tech/Resource"
-      pattern : "resources/{resource}/types/{type}"
+      pattern : "resources/{resource_uuid}/types/{type}"
     };
 
-    // Resource name.
-    string name = 1 [ (google.api.field_behavior) = REQUIRED ];
+    // Permalink of a resouce. For example:
+    // "resources/{resource_uuid}/types/{type}"
+    string resource_permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
     // Resource state
     oneof state {
         // Model state
@@ -40,12 +41,13 @@ message Resource {
 
 // GetResourceRequest represents a request to query a resource's state
 message GetResourceRequest {
-    // Resource name
-    string name = 1 [
+    // Permalink of a resouce. For example:
+    // "resources/{resource_uuid}/types/{type}"
+    string resource_permalink = 1 [
       (google.api.field_behavior) = REQUIRED,
       (google.api.resource_reference) = {type : "api.instill.tech/Resource"},
       (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-        field_configuration : {path_param_name : "resource.name"}
+        field_configuration : {path_param_name : "resource.resource_permalink"}
       }
     ];
 }
@@ -72,12 +74,13 @@ message UpdateResourceResponse {
 
 // DeleteResourceRequest represents a request to delete a resource's state
 message DeleteResourceRequest {
-    // Resource name
-    string name = 1 [
+    // Permalink of a resouce. For example:
+    // "resources/{resource_uuid}/types/{type}"
+    string resource_permalink = 1 [
       (google.api.field_behavior) = REQUIRED,
       (google.api.resource_reference) = {type : "api.instill.tech/Resource"},
       (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-        field_configuration : {path_param_name : "resource.name"}
+        field_configuration : {path_param_name : "resource.resource_permalink"}
       }
     ];
 }

--- a/vdp/controller/v1alpha/controller_service.proto
+++ b/vdp/controller/v1alpha/controller_service.proto
@@ -34,16 +34,16 @@ service ControllerPrivateService {
   // and returns a GetResourceResponse
   rpc GetResource(GetResourceRequest) returns (GetResourceResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=resources/*/types/*}"
+      get : "/v1alpha/{resource_permalink=resources/*/types/*}"
     };
-    option (google.api.method_signature) = "name";
+    option (google.api.method_signature) = "resource_permalink";
   }
 
   // UpdateResource method receives a UpdateResourceRequest message
   // and returns a UpdateResourceResponse
   rpc UpdateResource(UpdateResourceRequest) returns (UpdateResourceResponse) {
     option (google.api.http) = {
-      patch : "/v1alpha/{resource.name=resources/*/types/*}"
+      patch : "/v1alpha/{resource.resource_permalink=resources/*/types/*}"
       body : "resource"
     };
   }
@@ -52,8 +52,8 @@ service ControllerPrivateService {
   // and returns a DeleteResourceResponse
   rpc DeleteResource(DeleteResourceRequest) returns (DeleteResourceResponse) {
     option (google.api.http) = {
-      delete : "/v1alpha/{name=resources/*/types/*}"
+      delete : "/v1alpha/{resource_permalink=resources/*/types/*}"
     };
-    option (google.api.method_signature) = "name";
+    option (google.api.method_signature) = "resource_permalink";
   }
 }

--- a/vdp/model/v1alpha/model.proto
+++ b/vdp/model/v1alpha/model.proto
@@ -618,29 +618,6 @@ message ListModelsAdminResponse {
   int64 total_size = 3;
 }
 
-// GetModelAdminRequest represents a request to query a model by admin
-message GetModelAdminRequest {
-  // Resource name of the model.
-  // For example "models/{model}"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Model",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "model.name"}
-    }
-  ];
-  // Model view (default is VIEW_BASIC)
-  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
-  // VIEW_FULL: show full information
-  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
-}
-
-// GetModelAdminResponse represents a response for a model
-message GetModelAdminResponse {
-  // The retrieved model
-  Model model = 1;
-}
-
 // LookUpModelAdminRequest represents a request to query a model via
 // permalink by admin
 message LookUpModelAdminRequest {
@@ -662,9 +639,9 @@ message LookUpModelAdminResponse {
 // CheckModelRequest represents a private request to query
 // a model current state and longrunning progress
 message CheckModelRequest {
-  // Resource name of the model.
-  // For example "models/{model}"
-  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // Permalink of a model. For example:
+  // "models/{uid}"
+  string model_permalink = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
 // CheckModelResponse represents a response to fetch a model's

--- a/vdp/model/v1alpha/model_private_service.proto
+++ b/vdp/model/v1alpha/model_private_service.proto
@@ -21,15 +21,6 @@ service ModelPrivateService {
     };
   }
 
-  // GetModelAdmin method receives a GetModelAdminRequest message and returns a
-  // GetModelAdminResponse
-  rpc GetModelAdmin(GetModelAdminRequest) returns (GetModelAdminResponse) {
-    option (google.api.http) = {
-      get : "/v1alpha/admin/{name=models/*}"
-    };
-    option (google.api.method_signature) = "name";
-  }
-
   // LookUpModelAdmin method receives a LookUpModelAdminRequest message and
   // returns a LookUpModelAdminResponse
   rpc LookUpModelAdmin(LookUpModelAdminRequest)
@@ -44,8 +35,8 @@ service ModelPrivateService {
   // CheckModelResponse
   rpc CheckModel(CheckModelRequest) returns (CheckModelResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/admin/{name=models/*}/check"
+      get : "/v1alpha/admin/{model_permalink=models/*}/check"
     };
-    option (google.api.method_signature) = "name";
+    option (google.api.method_signature) = "model_permalink";
   };
 }

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -409,6 +409,8 @@ message ListPipelinesAdminRequest {
 }
 
 // ListPipelinesAdminResponse represents a response for a list of pipelines
+// The recipe returned will be permaLinks instead of resourceName temporary,
+// this will be refactored soon
 message ListPipelinesAdminResponse {
   // A list of pipeline resources
   repeated Pipeline pipelines = 1;

--- a/vdp/pipeline/v1alpha/pipeline_private_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_private_service.proto
@@ -20,16 +20,6 @@ service PipelinePrivateService {
     };
   }
 
-  // GetPipelineAdmin method receives a GetPipelineAdminRequest message and
-  // returns a GetPipelineAdminResponse message.
-  rpc GetPipelineAdmin(GetPipelineAdminRequest)
-      returns (GetPipelineAdminResponse) {
-    option (google.api.http) = {
-      get : "/v1alpha/admin/{name=pipelines/*}"
-    };
-    option (google.api.method_signature) = "name";
-  }
-
   // LookUpPipelineAdmin method receives a LookUpPipelineAdminRequest message
   // and returns a LookUpPipelineAdminResponse
   rpc LookUpPipelineAdmin(LookUpPipelineAdminRequest)


### PR DESCRIPTION
Because

- allow same resource name under different user namespace

This commit

- update controller resource name to uuid
- remove Get admin API in connector/pipeline/model backends
