### PR TITLE
chore(pipeline): update dag recipe format

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4086,6 +4086,31 @@ definitions:
         title: Classification score
         readOnly: true
     title: ClassificationOutput represents the output of classification task
+  v1alphaComponent:
+    type: object
+    properties:
+      id:
+        type: string
+        title: Component id that is given by the users
+      resource_name:
+        type: string
+        title: A pipeline component resource name
+      resource_detail:
+        type: object
+        title: A pipeline component resource detail
+        readOnly: true
+      metadata:
+        type: object
+        title: Metadata for the pipeline component
+      dependencies:
+        type: object
+        additionalProperties:
+          type: string
+        title: Dependencies for the pipeline component
+    title: Represents a pipeline component
+    required:
+      - id
+      - resource_name
   v1alphaConnectDestinationConnectorResponse:
     type: object
     properties:
@@ -6049,17 +6074,14 @@ definitions:
   v1alphaRecipe:
     type: object
     properties:
-      source:
+      version:
         type: string
-        title: A source connector resource
-      destination:
-        type: string
-        title: A destination connector resource
-      models:
+        title: Recipe schema version
+      components:
         type: array
         items:
-          type: string
-        title: A list of model resources
+          $ref: '#/definitions/v1alphaComponent'
+        title: List of pipeline components
     title: Pipeline represents a pipeline recipe
   v1alphaRenameDestinationConnectorResponse:
     type: object

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -4,6 +4,7 @@ package vdp.pipeline.v1alpha;
 
 // Protocol Buffers Well-Known Types
 import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -22,23 +23,32 @@ import "vdp/model/v1alpha/task_text_to_image.proto";
 import "vdp/model/v1alpha/task_text_generation.proto";
 import "vdp/model/v1alpha/task_unspecified.proto";
 
+
+// Represents a pipeline component 
+message Component {
+
+  // Component id that is given by the users
+  string id = 1 [ (google.api.field_behavior) = REQUIRED ];
+  // A pipeline component resource name
+  string resource_name = 2 [ 
+    (google.api.field_behavior) = REQUIRED ,
+    (google.api.resource_reference).type = "*"
+  ];
+  // A pipeline component resource detail
+  google.protobuf.Struct resource_detail = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Metadata for the pipeline component
+  google.protobuf.Struct metadata = 4;
+  // Dependencies for the pipeline component
+  map<string, string> dependencies = 5;
+  
+}
+
 // Pipeline represents a pipeline recipe
 message Recipe {
-  // A source connector resource
-  string source = 1 [
-    (google.api.field_behavior) = IMMUTABLE,
-    (google.api.resource_reference).type = "api.instill.tech/Connector"
-  ];
-  // A destination connector resource
-  string destination = 2 [
-    (google.api.field_behavior) = IMMUTABLE,
-    (google.api.resource_reference).type = "api.instill.tech/Connector"
-  ];
-  // A list of model resources
-  repeated string models = 3 [
-    (google.api.field_behavior) = IMMUTABLE,
-    (google.api.resource_reference).type = "api.instill.tech/Model"
-  ];
+  // Recipe schema version
+  string version = 1;
+  // List of pipeline components
+  repeated Component components = 2;
 }
 
 // Pipeline represents the content of a pipeline


### PR DESCRIPTION
Because

- We are planning to support DAG pipeline. The original pipeline recipe format can not cover the complex DAG pipeline. We design a new recipe which is consists of list of components. Every component represent a node in a graph, these node can be model or connector.

This commit

- update the recipe format
