### PR TITLE
chore(pipeline): separate pipeline trigger to sync and async endpoints

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1141,6 +1141,75 @@ paths:
               - task_inputs
       tags:
         - ModelPublicService
+  /v1alpha/{name}/trigger-async:
+    post:
+      summary: |-
+        TriggerAsyncPipeline method receives a TriggerPipelineRequest message and
+        returns a TriggerAsyncPipelineResponse.
+      operationId: PipelinePublicService_TriggerAsyncPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerAsyncPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              task_inputs:
+                type: array
+                items:
+                  $ref: '#/definitions/v1alphaTaskInput'
+                title: Input to the pipeline
+            title: TriggerAsyncPipelineRequest represents a request to trigger a async pipeline
+            required:
+              - task_inputs
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name}/trigger-async/{name}:
+    get:
+      summary: |-
+        GetPipelineOperation method receives a
+        GetPipelineOperationRequest message and returns a
+        GetPipelineOperationResponse message.
+      operationId: PipelinePublicService_GetPipelineOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetPipelineOperationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: The name of the operation resource.
+          in: path
+          required: true
+          type: string
+          pattern: operations/[^/]+
+        - name: name
+          description: The name of the operation resource.
+          in: path
+          required: true
+          type: string
+          pattern: operations/[^/]+
+      tags:
+        - PipelinePublicService
   /v1alpha/{name}/trigger-sync:
     post:
       summary: |-
@@ -4831,6 +4900,14 @@ definitions:
     title: GetPipelinesResponse represents a respond to GetModelsRequest
     required:
       - models
+  v1alphaGetPipelineOperationResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: The retrieved longrunning operation
+        readOnly: true
+    title: GetPipelineOperationResponse represents a response for a longrunning operation
   v1alphaGetPipelineResponse:
     type: object
     properties:
@@ -6686,6 +6763,38 @@ definitions:
     required:
       - start_time
       - end_time
+  v1alphaTriggerAsyncPipelineBinaryFileUploadResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Trigger async pipeline operation message
+        readOnly: true
+      data_mapping_indices:
+        type: array
+        items:
+          type: string
+        title: The data mapping indices for each input
+        readOnly: true
+    title: |-
+      TriggerAsyncPipelineBinaryFileUploadResponse represents a response for the longrunning operation
+      of a pipeline
+  v1alphaTriggerAsyncPipelineResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Trigger async pipeline operation message
+        readOnly: true
+      data_mapping_indices:
+        type: array
+        items:
+          type: string
+        title: The data mapping indices for each input
+        readOnly: true
+    title: |-
+      TriggerAsyncPipelineResponse represents a response for the longrunning operation
+      of a pipeline
   v1alphaTriggerModelBinaryFileUploadResponse:
     type: object
     properties:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -667,44 +667,6 @@ paths:
               - new_destination_connector_id
       tags:
         - ConnectorPublicService
-  /v1alpha/{name_1}/trigger:
-    post:
-      summary: |-
-        TriggerPipeline method receives a TriggerPipelineRequest message and
-        returns a TriggerPipelineResponse.
-      operationId: PipelinePublicService_TriggerPipeline
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaTriggerPipelineResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: name_1
-          description: Pipeline resource name. It must have the format of "pipelines/*"
-          in: path
-          required: true
-          type: string
-          pattern: pipelines/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              task_inputs:
-                type: array
-                items:
-                  $ref: '#/definitions/v1alphaTaskInput'
-                title: Input to the pipeline
-            title: TriggerPipelineRequest represents a request to trigger a pipeline
-            required:
-              - task_inputs
-      tags:
-        - PipelinePublicService
   /v1alpha/{name_2}/rename:
     post:
       summary: RenameModel method rename a model
@@ -1179,6 +1141,44 @@ paths:
               - task_inputs
       tags:
         - ModelPublicService
+  /v1alpha/{name}/trigger-sync:
+    post:
+      summary: |-
+        TriggerSyncPipeline method receives a TriggerSyncPipelineRequest message and
+        returns a TriggerSyncPipelineResponse.
+      operationId: PipelinePublicService_TriggerSyncPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerSyncPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              task_inputs:
+                type: array
+                items:
+                  $ref: '#/definitions/v1alphaTaskInput'
+                title: Input to the pipeline
+            title: TriggerSyncPipelineRequest represents a request to trigger a pipeline
+            required:
+              - task_inputs
+      tags:
+        - PipelinePublicService
   /v1alpha/{name}/undeploy:
     post:
       summary: UndeployModel undeploy a model to offline state
@@ -6717,7 +6717,7 @@ definitions:
     title: |-
       TriggerModelResponse represents a response for the output for
       triggering a model
-  v1alphaTriggerPipelineBinaryFileUploadResponse:
+  v1alphaTriggerSyncPipelineBinaryFileUploadResponse:
     type: object
     properties:
       data_mapping_indices:
@@ -6731,9 +6731,9 @@ definitions:
           $ref: '#/definitions/v1alphaModelOutput'
         title: The multiple model inference outputs
     title: |-
-      TriggerPipelineBinaryFileUploadResponse represents a response for the output
+      TriggerSyncPipelineBinaryFileUploadResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
-  v1alphaTriggerPipelineResponse:
+  v1alphaTriggerSyncPipelineResponse:
     type: object
     properties:
       data_mapping_indices:
@@ -6747,7 +6747,7 @@ definitions:
           $ref: '#/definitions/v1alphaModelOutput'
         title: The multiple model inference outputs
     title: |-
-      TriggerPipelineResponse represents a response for the output
+      TriggerSyncPipelineResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
   v1alphaUndeployModelResponse:
     type: object

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -549,6 +549,31 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ModelPublicService
+  /v1alpha/{name_1}:
+    get:
+      summary: |-
+        GetPipelineOperation method receives a
+        GetPipelineOperationRequest message and returns a
+        GetPipelineOperationResponse message.
+      operationId: PipelinePublicService_GetPipelineOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetPipelineOperationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_1
+          description: The name of the operation resource.
+          in: path
+          required: true
+          type: string
+          pattern: operations/[^/]+
+      tags:
+        - PipelinePublicService
   /v1alpha/{name_1}/connect:
     post:
       summary: |-
@@ -1141,7 +1166,7 @@ paths:
               - task_inputs
       tags:
         - ModelPublicService
-  /v1alpha/{name}/trigger-async:
+  /v1alpha/{name}/triggerAsync:
     post:
       summary: |-
         TriggerAsyncPipeline method receives a TriggerPipelineRequest message and
@@ -1179,38 +1204,7 @@ paths:
               - task_inputs
       tags:
         - PipelinePublicService
-  /v1alpha/{name}/trigger-async/{name}:
-    get:
-      summary: |-
-        GetPipelineOperation method receives a
-        GetPipelineOperationRequest message and returns a
-        GetPipelineOperationResponse message.
-      operationId: PipelinePublicService_GetPipelineOperation
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetPipelineOperationResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: name
-          description: The name of the operation resource.
-          in: path
-          required: true
-          type: string
-          pattern: operations/[^/]+
-        - name: name
-          description: The name of the operation resource.
-          in: path
-          required: true
-          type: string
-          pattern: operations/[^/]+
-      tags:
-        - PipelinePublicService
-  /v1alpha/{name}/trigger-sync:
+  /v1alpha/{name}/triggerSync:
     post:
       summary: |-
         TriggerSyncPipeline method receives a TriggerSyncPipelineRequest message and

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -552,15 +552,15 @@ paths:
   /v1alpha/{name_1}:
     get:
       summary: |-
-        GetPipelineOperation method receives a
-        GetPipelineOperationRequest message and returns a
-        GetPipelineOperationResponse message.
-      operationId: PipelinePublicService_GetPipelineOperation
+        GetTriggerAsyncOperation method receives a
+        GetTriggerAsyncOperationRequest message and returns a
+        GetTriggerAsyncOperationResponse message.
+      operationId: PipelinePublicService_GetTriggerAsyncOperation
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetPipelineOperationResponse'
+            $ref: '#/definitions/v1alphaGetTriggerAsyncOperationResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -571,7 +571,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: operations/[^/]+
+          pattern: triggerAsyncOperations/[^/]+
       tags:
         - PipelinePublicService
   /v1alpha/{name_1}/connect:
@@ -4894,14 +4894,6 @@ definitions:
     title: GetPipelinesResponse represents a respond to GetModelsRequest
     required:
       - models
-  v1alphaGetPipelineOperationResponse:
-    type: object
-    properties:
-      operation:
-        $ref: '#/definitions/googlelongrunningOperation'
-        title: The retrieved longrunning operation
-        readOnly: true
-    title: GetPipelineOperationResponse represents a response for a longrunning operation
   v1alphaGetPipelineResponse:
     type: object
     properties:
@@ -5032,6 +5024,14 @@ definitions:
         $ref: '#/definitions/v1alphaApiToken'
         title: An API token resource
     title: GetTokenResponse represents a response for an API token resource
+  v1alphaGetTriggerAsyncOperationResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: The retrieved longrunning operation
+        readOnly: true
+    title: GetTriggerAsyncOperationResponse represents a response for a longrunning operation
   v1alphaGetUserAdminResponse:
     type: object
     properties:

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -340,8 +340,8 @@ message ModelOutput {
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
-// TriggerPipelineRequest represents a request to trigger a pipeline
-message TriggerPipelineRequest {
+// TriggerSyncPipelineRequest represents a request to trigger a pipeline
+message TriggerSyncPipelineRequest {
   // Pipeline resource name. It must have the format of "pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -352,18 +352,18 @@ message TriggerPipelineRequest {
       [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// TriggerPipelineResponse represents a response for the output
+// TriggerSyncPipelineResponse represents a response for the output
 // of a pipeline, i.e., the multiple model inference outputs
-message TriggerPipelineResponse {
+message TriggerSyncPipelineResponse {
   // The data mapping indices stores UUID for each input
   repeated string data_mapping_indices = 1;
   // The multiple model inference outputs
   repeated ModelOutput model_outputs = 2;
 }
 
-// TriggerPipelineBinaryFileUploadRequest represents a request to trigger a
+// TriggerSyncPipelineBinaryFileUploadRequest represents a request to trigger a
 // pipeline
-message TriggerPipelineBinaryFileUploadRequest {
+message TriggerSyncPipelineBinaryFileUploadRequest {
   // Pipeline resource name. It must have the format of "pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -373,9 +373,9 @@ message TriggerPipelineBinaryFileUploadRequest {
   model.v1alpha.TaskInputStream task_input = 2 [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// TriggerPipelineBinaryFileUploadResponse represents a response for the output
+// TriggerSyncPipelineBinaryFileUploadResponse represents a response for the output
 // of a pipeline, i.e., the multiple model inference outputs
-message TriggerPipelineBinaryFileUploadResponse {
+message TriggerSyncPipelineBinaryFileUploadResponse {
   // The data mapping indices stores UUID for each input
   repeated string data_mapping_indices = 1;
   // The multiple model inference outputs

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -431,14 +431,14 @@ message TriggerAsyncPipelineBinaryFileUploadResponse {
 }
 
 
-// GetPipelineOperationRequest represents a request to query a longrunning operation
-message GetPipelineOperationRequest {
+// GetTriggerAsyncOperationRequest represents a request to query a longrunning operation
+message GetTriggerAsyncOperationRequest {
   // The name of the operation resource.
   string name = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// GetPipelineOperationResponse represents a response for a longrunning operation
-message GetPipelineOperationResponse {
+// GetTriggerAsyncOperationResponse represents a response for a longrunning operation
+message GetTriggerAsyncOperationResponse {
   // The retrieved longrunning operation
   google.longrunning.Operation operation = 1
     [ (google.api.field_behavior) = OUTPUT_ONLY ];

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -11,6 +11,7 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 // Google API
 import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
+import "google/longrunning/operations.proto";
 
 import "vdp/model/v1alpha/model.proto";
 import "vdp/model/v1alpha/task_classification.proto";
@@ -381,6 +382,68 @@ message TriggerSyncPipelineBinaryFileUploadResponse {
   // The multiple model inference outputs
   repeated ModelOutput model_outputs = 2;
 }
+
+// TriggerAsyncPipelineRequest represents a request to trigger a async pipeline
+message TriggerAsyncPipelineRequest {
+  // Pipeline resource name. It must have the format of "pipelines/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type : "api.instill.tech/Pipeline"}
+  ];
+  // Input to the pipeline
+  repeated model.v1alpha.TaskInput task_inputs = 2
+      [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// TriggerAsyncPipelineResponse represents a response for the longrunning operation
+// of a pipeline
+message TriggerAsyncPipelineResponse {
+  // Trigger async pipeline operation message
+  google.longrunning.Operation operation = 1
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // The data mapping indices for each input
+  repeated string data_mapping_indices = 2
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+
+// TriggerAsyncPipelineBinaryFileUploadRequest represents a request to trigger a
+// pipeline
+message TriggerAsyncPipelineBinaryFileUploadRequest {
+  // Pipeline resource name. It must have the format of "pipelines/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type : "api.instill.tech/Pipeline"}
+  ];
+  // Input to the pipeline
+  model.v1alpha.TaskInputStream task_input = 2 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// TriggerAsyncPipelineBinaryFileUploadResponse represents a response for the longrunning operation
+// of a pipeline
+message TriggerAsyncPipelineBinaryFileUploadResponse {
+  // Trigger async pipeline operation message
+  google.longrunning.Operation operation = 1
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // The data mapping indices for each input
+  repeated string data_mapping_indices = 2
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+
+// GetPipelineOperationRequest represents a request to query a longrunning operation
+message GetPipelineOperationRequest {
+  // The name of the operation resource.
+  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// GetPipelineOperationResponse represents a response for a longrunning operation
+message GetPipelineOperationResponse {
+  // The retrieved longrunning operation
+  google.longrunning.Operation operation = 1
+    [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
 
 // WatchPipelineRequest represents a public request to query
 // a pipeline's current state

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -128,7 +128,7 @@ service PipelinePublicService {
   rpc TriggerSyncPipeline(TriggerSyncPipelineRequest)
       returns (TriggerSyncPipelineResponse) {
     option (google.api.http) = {
-      post : "/v1alpha/{name=pipelines/*}/trigger-sync"
+      post : "/v1alpha/{name=pipelines/*}/triggerSync"
       body : "*"
     };
     option (google.api.method_signature) = "name,inputs";
@@ -138,7 +138,7 @@ service PipelinePublicService {
   // TriggerSyncPipelineBinaryFileUploadRequest message and returns a
   // TriggerSyncPipelineBinaryFileUploadResponse message.
   //
-  // Endpoint: "POST /v1alpha/{name=pipelines/*}/trigger-sync-multipart"
+  // Endpoint: "POST /v1alpha/{name=pipelines/*}/triggerSyncMultipart"
   rpc TriggerSyncPipelineBinaryFileUpload(
       stream TriggerSyncPipelineBinaryFileUploadRequest)
       returns (TriggerSyncPipelineBinaryFileUploadResponse) {
@@ -150,7 +150,7 @@ service PipelinePublicService {
   rpc TriggerAsyncPipeline(TriggerAsyncPipelineRequest)
       returns (TriggerAsyncPipelineResponse) {
     option (google.api.http) = {
-      post : "/v1alpha/{name=pipelines/*}/trigger-async"
+      post : "/v1alpha/{name=pipelines/*}/triggerAsync"
       body : "*"
     };
     option (google.api.method_signature) = "name,inputs";
@@ -160,7 +160,7 @@ service PipelinePublicService {
   // TriggerPipelineBinaryFileUploadRequest message and returns a
   // TriggerAsyncPipelineResponse message.
   //
-  // Endpoint: "POST /v1alpha/{name=pipelines/*}/trigger-async-multipart"
+  // Endpoint: "POST /v1alpha/{name=pipelines/*}/triggerAsyncMultipart"
   rpc TriggerAsyncPipelineBinaryFileUpload(
       stream TriggerAsyncPipelineBinaryFileUploadRequest)
       returns (TriggerAsyncPipelineBinaryFileUploadResponse) {
@@ -185,7 +185,7 @@ service PipelinePublicService {
   rpc GetPipelineOperation(GetPipelineOperationRequest)
       returns (GetPipelineOperationResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=pipelines/*}/trigger-async/{name=operations/*}"
+      get : "/v1alpha/{name=operations/*}"
     };
     option (google.api.method_signature) = "name";
   }

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -123,25 +123,25 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name,new_pipeline_id";
   }
 
-  // TriggerPipeline method receives a TriggerPipelineRequest message and
-  // returns a TriggerPipelineResponse.
-  rpc TriggerPipeline(TriggerPipelineRequest)
-      returns (TriggerPipelineResponse) {
+  // TriggerSyncPipeline method receives a TriggerSyncPipelineRequest message and
+  // returns a TriggerSyncPipelineResponse.
+  rpc TriggerSyncPipeline(TriggerSyncPipelineRequest)
+      returns (TriggerSyncPipelineResponse) {
     option (google.api.http) = {
-      post : "/v1alpha/{name=pipelines/*}/trigger"
+      post : "/v1alpha/{name=pipelines/*}/trigger-sync"
       body : "*"
     };
     option (google.api.method_signature) = "name,inputs";
   }
 
-  // TriggerPipelineBinaryFileUpload method receives a
-  // TriggerPipelineBinaryFileUploadRequest message and returns a
-  // TriggerPipelineBinaryFileUploadResponse message.
+  // TriggerSyncPipelineBinaryFileUpload method receives a
+  // TriggerSyncPipelineBinaryFileUploadRequest message and returns a
+  // TriggerSyncPipelineBinaryFileUploadResponse message.
   //
-  // Endpoint: "POST /v1alpha/{name=pipelines/*}/trigger-multipart"
-  rpc TriggerPipelineBinaryFileUpload(
-      stream TriggerPipelineBinaryFileUploadRequest)
-      returns (TriggerPipelineBinaryFileUploadResponse) {
+  // Endpoint: "POST /v1alpha/{name=pipelines/*}/trigger-sync-multipart"
+  rpc TriggerSyncPipelineBinaryFileUpload(
+      stream TriggerSyncPipelineBinaryFileUploadRequest)
+      returns (TriggerSyncPipelineBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
   }
 

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -145,12 +145,47 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name,file";
   }
 
+  // TriggerAsyncPipeline method receives a TriggerPipelineRequest message and
+  // returns a TriggerAsyncPipelineResponse.
+  rpc TriggerAsyncPipeline(TriggerAsyncPipelineRequest)
+      returns (TriggerAsyncPipelineResponse) {
+    option (google.api.http) = {
+      post : "/v1alpha/{name=pipelines/*}/trigger-async"
+      body : "*"
+    };
+    option (google.api.method_signature) = "name,inputs";
+  }
+
+  // TriggerAsyncPipelineBinaryFileUpload method receives a
+  // TriggerPipelineBinaryFileUploadRequest message and returns a
+  // TriggerAsyncPipelineResponse message.
+  //
+  // Endpoint: "POST /v1alpha/{name=pipelines/*}/trigger-async-multipart"
+  rpc TriggerAsyncPipelineBinaryFileUpload(
+      stream TriggerAsyncPipelineBinaryFileUploadRequest)
+      returns (TriggerAsyncPipelineBinaryFileUploadResponse) {
+    option (google.api.method_signature) = "name,file";
+  }
+
   // WatchPipeline method receives a WatchPipelineRequest message
   // and returns a WatchPipelineResponse
   rpc WatchPipeline(WatchPipelineRequest)
       returns (WatchPipelineResponse) {
     option (google.api.http) = {
       get : "/v1alpha/{name=pipelines/*}/watch"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // *Longrunning operation methods
+
+  // GetPipelineOperation method receives a
+  // GetPipelineOperationRequest message and returns a
+  // GetPipelineOperationResponse message.
+  rpc GetPipelineOperation(GetPipelineOperationRequest)
+      returns (GetPipelineOperationResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/{name=pipelines/*}/trigger-async/{name=operations/*}"
     };
     option (google.api.method_signature) = "name";
   }

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -179,13 +179,13 @@ service PipelinePublicService {
 
   // *Longrunning operation methods
 
-  // GetPipelineOperation method receives a
-  // GetPipelineOperationRequest message and returns a
-  // GetPipelineOperationResponse message.
-  rpc GetPipelineOperation(GetPipelineOperationRequest)
-      returns (GetPipelineOperationResponse) {
+  // GetTriggerAsyncOperation method receives a
+  // GetTriggerAsyncOperationRequest message and returns a
+  // GetTriggerAsyncOperationResponse message.
+  rpc GetTriggerAsyncOperation(GetTriggerAsyncOperationRequest)
+      returns (GetTriggerAsyncOperationResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=operations/*}"
+      get : "/v1alpha/{name=triggerAsyncOperations/*}"
     };
     option (google.api.method_signature) = "name";
   }


### PR DESCRIPTION
Because

- Use the same endpoint for sync/async trigger is not good. We need to separate them.

This commit

- separate pipeline trigger to sync and async two endpoints
