### PR TITLE
chore(connector): remove longrunning operation and add custome test method

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -68,32 +68,6 @@ paths:
           type: string
       tags:
         - UsageService
-  /v1alpha/{destination_connector.name/watch}/watch:
-    get:
-      summary: |-
-        WatchDestinationConnector method receives a WatchDestinationConnectorRequest message
-        and returns a WatchDestinationConnectorResponse
-      operationId: ConnectorPublicService_WatchDestinationConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaWatchDestinationConnectorResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: destination_connector.name/watch
-          description: |-
-            SourceConnector resource name. It must have the format of
-            "destination-connectors/*"
-          in: path
-          required: true
-          type: string
-          pattern: destination-connectors/[^/]+
-      tags:
-        - ConnectorPublicService
   /v1alpha/{destination_connector.name}:
     get:
       summary: |-
@@ -217,6 +191,58 @@ paths:
           in: query
           required: true
           type: string
+      tags:
+        - ConnectorPublicService
+  /v1alpha/{destination_connector.name}/test:
+    get:
+      summary: |-
+        TestDestinationConnector method receives a TestDestinationConnectorRequest message
+        and returns a TestDestinationConnectorResponse
+      operationId: ConnectorPublicService_TestDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTestDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: destination_connector.name
+          description: |-
+            DestinationConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
+      tags:
+        - ConnectorPublicService
+  /v1alpha/{destination_connector.name}/watch:
+    get:
+      summary: |-
+        WatchDestinationConnector method receives a WatchDestinationConnectorRequest message
+        and returns a WatchDestinationConnectorResponse
+      operationId: ConnectorPublicService_WatchDestinationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchDestinationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: destination_connector.name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "destination-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: destination-connectors/[^/]+
       tags:
         - ConnectorPublicService
   /v1alpha/{destination_connector_definition.name}:
@@ -523,48 +549,6 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ModelPublicService
-  /v1alpha/{name_1}:
-    get:
-      summary: |-
-        GetModelOperation method receives a
-        GetModelOperationRequest message and returns a
-        GetModelOperationResponse message.
-      operationId: ModelPublicService_GetModelOperation
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetModelOperationResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: name_1
-          description: The name of the operation resource.
-          in: path
-          required: true
-          type: string
-          pattern: operations/[^/]+
-        - name: view
-          description: |-
-            View (default is VIEW_BASIC)
-            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
-            `Model.configuration` VIEW_FULL: show full information
-
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
-             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
-             - VIEW_FULL: View: FULL, full representation of the resource
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_UNSPECIFIED
-            - VIEW_BASIC
-            - VIEW_FULL
-          default: VIEW_UNSPECIFIED
-      tags:
-        - ModelPublicService
   /v1alpha/{name_1}/connect:
     post:
       summary: |-
@@ -798,15 +782,15 @@ paths:
   /v1alpha/{name}:
     get:
       summary: |-
-        GetConnectorOperation method receives a
-        GetConnectorOperationRequest message and returns a
-        GetConnectorOperationResponse message.
-      operationId: ConnectorPublicService_GetConnectorOperation
+        GetModelOperation method receives a
+        GetModelOperationRequest message and returns a
+        GetModelOperationResponse message.
+      operationId: ModelPublicService_GetModelOperation
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetConnectorOperationResponse'
+            $ref: '#/definitions/v1alphaGetModelOperationResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -820,11 +804,13 @@ paths:
           pattern: operations/[^/]+
         - name: view
           description: |-
-            SourceConnector view (default is VIEW_BASIC)
+            View (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`,
+            `Model.configuration` VIEW_FULL: show full information
 
-             - VIEW_UNSPECIFIED: View: UNSPECIFIED
-             - VIEW_BASIC: View: BASIC
-             - VIEW_FULL: View: FULL
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
           in: query
           required: false
           type: string
@@ -834,7 +820,7 @@ paths:
             - VIEW_FULL
           default: VIEW_UNSPECIFIED
       tags:
-        - ConnectorPublicService
+        - ModelPublicService
   /v1alpha/{name}/activate:
     post:
       summary: |-
@@ -1761,32 +1747,6 @@ paths:
           type: string
       tags:
         - ControllerPrivateService
-  /v1alpha/{source_connector.name/watch}/watch:
-    get:
-      summary: |-
-        WatchSourceConnector method receives a WatchSourceConnectorRequest message
-        and returns a WatchSourceConnectorResponse
-      operationId: ConnectorPublicService_WatchSourceConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaWatchSourceConnectorResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: source_connector.name/watch
-          description: |-
-            SourceConnector resource name. It must have the format of
-            "source-connectors/*"
-          in: path
-          required: true
-          type: string
-          pattern: source-connectors/[^/]+
-      tags:
-        - ConnectorPublicService
   /v1alpha/{source_connector.name}:
     get:
       summary: |-
@@ -1908,6 +1868,58 @@ paths:
           in: query
           required: true
           type: string
+      tags:
+        - ConnectorPublicService
+  /v1alpha/{source_connector.name}/test:
+    get:
+      summary: |-
+        TestSourceConnector method receives a TestSourceConnectorRequest message
+        and returns a TestSourceConnectorResponse
+      operationId: ConnectorPublicService_TestSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTestSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: source_connector.name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
+      tags:
+        - ConnectorPublicService
+  /v1alpha/{source_connector.name}/watch:
+    get:
+      summary: |-
+        WatchSourceConnector method receives a WatchSourceConnectorRequest message
+        and returns a WatchSourceConnectorResponse
+      operationId: ConnectorPublicService_WatchSourceConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchSourceConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: source_connector.name
+          description: |-
+            SourceConnector resource name. It must have the format of
+            "source-connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: source-connectors/[^/]+
       tags:
         - ConnectorPublicService
   /v1alpha/{source_connector_definition.name}:
@@ -4022,9 +4034,9 @@ definitions:
   v1alphaCheckDestinationConnectorResponse:
     type: object
     properties:
-      workflow_id:
-        type: string
-        title: Retrieved longrunning workflow id
+      state:
+        $ref: '#/definitions/v1alphaConnectorState'
+        title: Retrieved connector state
     title: |-
       CheckDestinationConnectorResponse represents a response to fetch a destination connector's
       current state
@@ -4040,9 +4052,9 @@ definitions:
   v1alphaCheckSourceConnectorResponse:
     type: object
     properties:
-      workflow_id:
-        type: string
-        title: Retrieved longrunning workflow id
+      state:
+        $ref: '#/definitions/v1alphaConnectorState'
+        title: Retrieved connector state
     title: |-
       CheckSourceConnectorResponse represents a response to fetch a source connector's
       current state
@@ -4625,13 +4637,6 @@ definitions:
     title: GetBulkPipelineTriggerSummariesResponse represents a response to GetBulkPipelineTriggerSummariesRequest
     required:
       - bulk_summaries
-  v1alphaGetConnectorOperationResponse:
-    type: object
-    properties:
-      operation:
-        $ref: '#/definitions/googlelongrunningOperation'
-        title: The retrieved longrunning operation
-    title: GetConnectorOperationResponse represents a response for a longrunning operation
   v1alphaGetCumulativeModelOnlineRecordsRequest:
     type: object
     properties:
@@ -6544,6 +6549,15 @@ definitions:
         $ref: '#/definitions/v1alphaUnspecifiedInput'
         title: The unspecified task input
     title: TaskInputStream represents the input to trigger a model with stream method
+  v1alphaTestDestinationConnectorResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaConnectorState'
+        title: Retrieved connector state
+    title: |-
+      TestDestinationConnectorResponse represents a response containing a destination
+      connector's current state
   v1alphaTestModelBinaryFileUploadResponse:
     type: object
     properties:
@@ -6578,6 +6592,15 @@ definitions:
     required:
       - task
       - task_outputs
+  v1alphaTestSourceConnectorResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaConnectorState'
+        title: Retrieved connector state
+    title: |-
+      TestSourceConnectorResponse represents a response containing a source connector's
+      current state
   v1alphaTextGenerationInput:
     type: object
     properties:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -193,7 +193,7 @@ paths:
           type: string
       tags:
         - ConnectorPublicService
-  /v1alpha/{destination_connector.name}/test:
+  /v1alpha/{destination_connector.name}/testConnection:
     get:
       summary: |-
         TestDestinationConnector method receives a TestDestinationConnectorRequest message
@@ -1870,7 +1870,7 @@ paths:
           type: string
       tags:
         - ConnectorPublicService
-  /v1alpha/{source_connector.name}/test:
+  /v1alpha/{source_connector.name}/testConnection:
     get:
       summary: |-
         TestSourceConnector method receives a TestSourceConnectorRequest message

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -11,7 +11,6 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 // Google API
 import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
-import "google/longrunning/operations.proto";
 
 import "vdp/pipeline/v1alpha/pipeline.proto";
 import "vdp/connector/v1alpha/connector_definition.proto";
@@ -595,7 +594,7 @@ message WatchSourceConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/SourceConnector",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "source_connector.name/watch"}
+      field_configuration : {path_param_name : "source_connector.name"}
     }
   ];
 }
@@ -618,8 +617,29 @@ message CheckSourceConnectorRequest {
 // CheckSourceConnectorResponse represents a response to fetch a source connector's
 // current state
 message CheckSourceConnectorResponse {
-  // Retrieved longrunning workflow id
-  string workflow_id = 1;
+  // Retrieved connector state
+  Connector.State state = 1;
+}
+
+// TestSourceConnectorRequest represents a public request to trigger check
+// action on a source connector
+message TestSourceConnectorRequest {
+  // SourceConnector resource name. It must have the format of
+  // "source-connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/SourceConnector",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "source_connector.name"}
+    }
+  ];
+}
+
+// TestSourceConnectorResponse represents a response containing a source connector's
+// current state
+message TestSourceConnectorResponse {
+  // Retrieved connector state
+  Connector.State state = 1;
 }
 
 // ListDestinationConnectorsAdminRequest represents a request to list
@@ -672,7 +692,7 @@ message WatchDestinationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/DestinationConnector",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration : {path_param_name : "destination_connector.name/watch"}
+      field_configuration : {path_param_name : "destination_connector.name"}
     }
   ];
 }
@@ -695,20 +715,27 @@ message CheckDestinationConnectorRequest {
 // CheckDestinationConnectorResponse represents a response to fetch a destination connector's
 // current state
 message CheckDestinationConnectorResponse {
-  // Retrieved longrunning workflow id
-  string workflow_id = 1;
+  // Retrieved connector state
+  Connector.State state = 1;
 }
 
-// GetConnectorOperationRequest represents a request to query a longrunning operation
-message GetConnectorOperationRequest {
-  // The name of the operation resource.
-  string name = 1 [ (google.api.field_behavior) = REQUIRED ];
-  // SourceConnector view (default is VIEW_BASIC)
-  optional View view = 2 [ (google.api.field_behavior) = OPTIONAL ];
+// TestDestinationConnectorRequest represents a public request to trigger check
+// action on a destination connector
+message TestDestinationConnectorRequest {
+  // DestinationConnector resource name. It must have the format of
+  // "destination-connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/DestinationConnector",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration : {path_param_name : "destination_connector.name"}
+    }
+  ];
 }
 
-// GetConnectorOperationResponse represents a response for a longrunning operation
-message GetConnectorOperationResponse {
-  // The retrieved longrunning operation
-  google.longrunning.Operation operation = 1;
+// TestDestinationConnectorResponse represents a response containing a destination
+// connector's current state
+message TestDestinationConnectorResponse {
+  // Retrieved connector state
+  Connector.State state = 1;
 }

--- a/vdp/connector/v1alpha/connector_public_service.proto
+++ b/vdp/connector/v1alpha/connector_public_service.proto
@@ -213,7 +213,7 @@ service ConnectorPublicService {
   rpc TestSourceConnector(TestSourceConnectorRequest)
       returns (TestSourceConnectorResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=source-connectors/*}/test"
+      get : "/v1alpha/{name=source-connectors/*}/testConnection"
     };
     option (google.api.method_signature) = "name";
   }
@@ -352,7 +352,7 @@ service ConnectorPublicService {
   rpc TestDestinationConnector(TestDestinationConnectorRequest)
       returns (TestDestinationConnectorResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=destination-connectors/*}/test"
+      get : "/v1alpha/{name=destination-connectors/*}/testConnection"
     };
     option (google.api.method_signature) = "name";
   }

--- a/vdp/connector/v1alpha/connector_public_service.proto
+++ b/vdp/connector/v1alpha/connector_public_service.proto
@@ -208,6 +208,16 @@ service ConnectorPublicService {
     option (google.api.method_signature) = "name";
   }
 
+  // TestSourceConnector method receives a TestSourceConnectorRequest message
+  // and returns a TestSourceConnectorResponse
+  rpc TestSourceConnector(TestSourceConnectorRequest)
+      returns (TestSourceConnectorResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/{name=source-connectors/*}/test"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
   // *DestinationConnector methods
 
   // CreateDestinationConnector method receives a
@@ -337,15 +347,12 @@ service ConnectorPublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // *Longrunning operation methods
-
-  // GetConnectorOperation method receives a
-  // GetConnectorOperationRequest message and returns a
-  // GetConnectorOperationResponse message.
-  rpc GetConnectorOperation(GetConnectorOperationRequest)
-      returns (GetConnectorOperationResponse) {
+  // TestDestinationConnector method receives a TestDestinationConnectorRequest message
+  // and returns a TestDestinationConnectorResponse
+  rpc TestDestinationConnector(TestDestinationConnectorRequest)
+      returns (TestDestinationConnectorResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=operations/*}"
+      get : "/v1alpha/{name=destination-connectors/*}/test"
     };
     option (google.api.method_signature) = "name";
   }

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -24,13 +24,13 @@ import "vdp/model/v1alpha/task_text_generation.proto";
 import "vdp/model/v1alpha/task_unspecified.proto";
 
 
-// Represents a pipeline component 
+// Represents a pipeline component
 message Component {
 
   // Component id that is given by the users
   string id = 1 [ (google.api.field_behavior) = REQUIRED ];
   // A pipeline component resource name
-  string resource_name = 2 [ 
+  string resource_name = 2 [
     (google.api.field_behavior) = REQUIRED ,
     (google.api.resource_reference).type = "*"
   ];
@@ -40,7 +40,7 @@ message Component {
   google.protobuf.Struct metadata = 4;
   // Dependencies for the pipeline component
   map<string, string> dependencies = 5;
-  
+
 }
 
 // Pipeline represents a pipeline recipe


### PR DESCRIPTION
Because

- update /check endpoint to be sync
- add /test endpoint for on demand connector state check

This commit

- remove longrunning operation related endpoint
- update /check to return state instead of workflow id
- add /test endpoint in connector-backend for on demand state check
