### PR TITLE
chore(connector): fix testConnection method type

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -194,7 +194,7 @@ paths:
       tags:
         - ConnectorPublicService
   /v1alpha/{destination_connector.name}/testConnection:
-    get:
+    post:
       summary: |-
         TestDestinationConnector method receives a TestDestinationConnectorRequest message
         and returns a TestDestinationConnectorResponse
@@ -1934,7 +1934,7 @@ paths:
       tags:
         - ConnectorPublicService
   /v1alpha/{source_connector.name}/testConnection:
-    get:
+    post:
       summary: |-
         TestSourceConnector method receives a TestSourceConnectorRequest message
         and returns a TestSourceConnectorResponse

--- a/vdp/connector/v1alpha/connector_public_service.proto
+++ b/vdp/connector/v1alpha/connector_public_service.proto
@@ -213,7 +213,7 @@ service ConnectorPublicService {
   rpc TestSourceConnector(TestSourceConnectorRequest)
       returns (TestSourceConnectorResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=source-connectors/*}/testConnection"
+      post : "/v1alpha/{name=source-connectors/*}/testConnection"
     };
     option (google.api.method_signature) = "name";
   }
@@ -352,7 +352,7 @@ service ConnectorPublicService {
   rpc TestDestinationConnector(TestDestinationConnectorRequest)
       returns (TestDestinationConnectorResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=destination-connectors/*}/testConnection"
+      post : "/v1alpha/{name=destination-connectors/*}/testConnection"
     };
     option (google.api.method_signature) = "name";
   }


### PR DESCRIPTION
Because

- use POST for potential resource state change in system

This commit

- update test connection method type to POST
