### PR TITLE
chore(connector): rename `json` to `structured_data` and `CONNECTOR_TYPE_MODEL` to `CONNECTOR_TYPE_AI`

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -3897,14 +3897,14 @@ definitions:
       - CONNECTOR_TYPE_UNSPECIFIED
       - CONNECTOR_TYPE_SOURCE
       - CONNECTOR_TYPE_DESTINATION
-      - CONNECTOR_TYPE_MODEL
+      - CONNECTOR_TYPE_AI
       - CONNECTOR_TYPE_BLOCKCHAIN
     default: CONNECTOR_TYPE_UNSPECIFIED
     description: |-
       - CONNECTOR_TYPE_UNSPECIFIED: ConnectorType: UNSPECIFIED
        - CONNECTOR_TYPE_SOURCE: ConnectorType: SOURCE
        - CONNECTOR_TYPE_DESTINATION: ConnectorType: DESTINATION
-       - CONNECTOR_TYPE_MODEL: ConnectorType: Model
+       - CONNECTOR_TYPE_AI: ConnectorType: AI
        - CONNECTOR_TYPE_BLOCKCHAIN: ConnectorType: Blockchain
     title: ConnectorType enumerates connector types
   v1alphaConnectorUsageData:
@@ -4044,9 +4044,9 @@ definitions:
           type: string
           format: byte
         title: 'Unstructured: image field'
-      json:
+      structured_data:
         type: object
-        title: '[semi-]structured data: json field'
+        title: '[semi-]structured data: structured_data field'
       metadata:
         type: object
         title: Metadata

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -433,8 +433,8 @@ message DataPayload {
   // repeated bytes audios = 4;
   // repeated bytes videos = 5;
 
-  // [semi-]structured data: json field
-  google.protobuf.Struct json = 6;
+  // [semi-]structured data: structured_data field
+  google.protobuf.Struct structured_data = 6;
 
   // Metadata
   google.protobuf.Struct metadata = 7;

--- a/vdp/connector/v1alpha/connector_definition.proto
+++ b/vdp/connector/v1alpha/connector_definition.proto
@@ -32,8 +32,8 @@ enum ConnectorType {
   CONNECTOR_TYPE_SOURCE = 1;
   // ConnectorType: DESTINATION
   CONNECTOR_TYPE_DESTINATION = 2;
-  // ConnectorType: Model
-  CONNECTOR_TYPE_MODEL = 3;
+  // ConnectorType: AI
+  CONNECTOR_TYPE_AI = 3;
   // ConnectorType: Blockchain
   CONNECTOR_TYPE_BLOCKCHAIN = 4;
 }


### PR DESCRIPTION
Because

- we need a better naming for connector type and payload, or the user will be confused

This commit

- rename `json` to `structured_data`
- rename `CONNECTOR_TYPE_MODEL` to `CONNECTOR_TYPE_AI`
