### PR TITLE
chore(connector): embed the ConnectorDefinition detail in Connector when VIEW_FULL

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -227,6 +227,10 @@ paths:
                 $ref: '#/definitions/v1alphaConnectorVisibility'
                 title: Connector visibility including public or private
                 readOnly: true
+              connector_definition_detail:
+                $ref: '#/definitions/v1alphaConnectorDefinition'
+                title: Embed the content of the connector_definition_detail
+                readOnly: true
             title: Connector resource
             required:
               - configuration
@@ -3852,6 +3856,10 @@ definitions:
       visibility:
         $ref: '#/definitions/v1alphaConnectorVisibility'
         title: Connector visibility including public or private
+        readOnly: true
+      connector_definition_detail:
+        $ref: '#/definitions/v1alphaConnectorDefinition'
+        title: Embed the content of the connector_definition_detail
         readOnly: true
     title: Connector represents a connector data model
     required:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -178,7 +178,7 @@ paths:
                   used to construct the resource name. This conforms to RFC-1034, which
                   restricts to letters, numbers, and hyphen, with the first character a
                   letter, the last a letter or a number, and a 63 character maximum.
-              connector_definition:
+              connector_definition_name:
                 type: string
                 title: ConnectorDefinition resource
               connector_type:
@@ -227,9 +227,9 @@ paths:
                 $ref: '#/definitions/v1alphaConnectorVisibility'
                 title: Connector visibility including public or private
                 readOnly: true
-              connector_definition_detail:
+              connector_definition:
                 $ref: '#/definitions/v1alphaConnectorDefinition'
-                title: Embed the content of the connector_definition_detail
+                title: Embed the content of the connector_definition
                 readOnly: true
             title: Connector resource
             required:
@@ -3808,7 +3808,7 @@ definitions:
           used to construct the resource name. This conforms to RFC-1034, which
           restricts to letters, numbers, and hyphen, with the first character a
           letter, the last a letter or a number, and a 63 character maximum.
-      connector_definition:
+      connector_definition_name:
         type: string
         title: ConnectorDefinition resource
       connector_type:
@@ -3857,9 +3857,9 @@ definitions:
         $ref: '#/definitions/v1alphaConnectorVisibility'
         title: Connector visibility including public or private
         readOnly: true
-      connector_definition_detail:
+      connector_definition:
         $ref: '#/definitions/v1alphaConnectorDefinition'
-        title: Embed the content of the connector_definition_detail
+        title: Embed the content of the connector_definition
         readOnly: true
     title: Connector represents a connector data model
     required:

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -82,7 +82,7 @@ message Connector {
   // letter, the last a letter or a number, and a 63 character maximum.
   string id = 3 [ (google.api.field_behavior) = IMMUTABLE ];
   // ConnectorDefinition resource
-  string connector_definition = 4 [
+  string connector_definition_name = 4 [
     (google.api.field_behavior) = IMMUTABLE,
     (google.api.resource_reference) = {
       type : "api.instill.tech/ConnectorDefinition"
@@ -123,8 +123,8 @@ message Connector {
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Connector visibility including public or private
   Visibility visibility = 15 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // Embed the content of the connector_definition_detail
-  ConnectorDefinition connector_definition_detail = 16
+  // Embed the content of the connector_definition
+  ConnectorDefinition connector_definition = 16
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -123,6 +123,9 @@ message Connector {
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Connector visibility including public or private
   Visibility visibility = 15 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  // Embed the content of the connector_definition_detail
+  ConnectorDefinition connector_definition_detail = 16
+      [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because

- currently, the frontend need to call api twice to get the complete info for connector and its definition

This commit

- provide a field that can embed the `ConnectorDefinition` in `Connector`
