### PR TITLE
chore(pipeline): remove redundant data_mapping_indices fields

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -6258,11 +6258,6 @@ definitions:
   v1alphaTriggerSyncPipelineResponse:
     type: object
     properties:
-      data_mapping_indices:
-        type: array
-        items:
-          type: string
-        title: The data mapping indices stores UUID for each input
       outputs:
         type: array
         items:

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -405,10 +405,8 @@ message TriggerSyncPipelineRequest {
 // TriggerSyncPipelineResponse represents a response for the output
 // of a pipeline, i.e., the multiple model inference outputs
 message TriggerSyncPipelineResponse {
-  // The data mapping indices stores UUID for each input
-  repeated string data_mapping_indices = 1;
   // The multiple model inference outputs
-  repeated PipelineDataPayload outputs = 2;
+  repeated PipelineDataPayload outputs = 1;
 }
 
 // TriggerAsyncPipelineRequest represents a request to trigger a async pipeline


### PR DESCRIPTION
Because

- we already have `data_mapping_index` inside `PipelineDataPayload`, so the `data_mapping_indices` is no needed

This commit

- remove redundant data_mapping_indices fields
