### PR TITLE
chore(mgmt): fix metric method field name

### DIFF
--- a/base/mgmt/v1alpha/metric.proto
+++ b/base/mgmt/v1alpha/metric.proto
@@ -46,7 +46,7 @@ message ListPipelineTriggerRecordsRequest {
 // of pipeline trigger record
 message ListPipelineTriggerRecordsResponse {
     // A list of pipeline trigger records
-    repeated PipelineTriggerRecord pipeline_trigger_data_point = 1;
+    repeated PipelineTriggerRecord pipeline_trigger_record = 1;
     // Next page token
     string next_page_token = 2;
     // Total count of pipeline trigger records

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4966,7 +4966,7 @@ definitions:
   v1alphaListPipelineTriggerRecordsResponse:
     type: object
     properties:
-      pipeline_trigger_data_point:
+      pipeline_trigger_record:
         type: array
         items:
           type: object


### PR DESCRIPTION
Because

- fix metric method field name

This commit

- fix metric method field name
