### PR TITLE
chore(mgmt): align trigger record field name with backend

### DIFF
--- a/base/mgmt/v1alpha/metric.proto
+++ b/base/mgmt/v1alpha/metric.proto
@@ -17,10 +17,10 @@ message PipelineTriggerRecord {
     google.protobuf.Timestamp trigger_time = 1;
     // Unique uuid for each pipeline trigger
     string pipeline_trigger_id = 2;
-    // Resource name for the triggered pipeline
-    string pipeline_name = 3;
-    // Permalink for the triggered pipeline
-    string pipeline_permalink = 4;
+    // ID for the triggered pipeline
+    string pipeline_id = 3;
+    // UID for the triggered pipeline
+    string pipeline_uid = 4;
     // Pipeline mode
     vdp.pipeline.v1alpha.Pipeline.Mode pipeline_mode = 5;
     // Total compute time duration for this pipeline trigger
@@ -46,7 +46,7 @@ message ListPipelineTriggerRecordsRequest {
 // of pipeline trigger record
 message ListPipelineTriggerRecordsResponse {
     // A list of pipeline trigger records
-    repeated PipelineTriggerRecord pipeline_trigger_record = 1;
+    repeated PipelineTriggerRecord pipeline_trigger_records = 1;
     // Next page token
     string next_page_token = 2;
     // Total count of pipeline trigger records

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4966,7 +4966,7 @@ definitions:
   v1alphaListPipelineTriggerRecordsResponse:
     type: object
     properties:
-      pipeline_trigger_record:
+      pipeline_trigger_records:
         type: array
         items:
           type: object
@@ -5588,12 +5588,12 @@ definitions:
       pipeline_trigger_id:
         type: string
         title: Unique uuid for each pipeline trigger
-      pipeline_name:
+      pipeline_id:
         type: string
-        title: Resource name for the triggered pipeline
-      pipeline_permalink:
+        title: ID for the triggered pipeline
+      pipeline_uid:
         type: string
-        title: Permalink for the triggered pipeline
+        title: UID for the triggered pipeline
       pipeline_mode:
         $ref: '#/definitions/PipelineMode'
         title: Pipeline mode

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -361,10 +361,10 @@ message PipelineDataPayload {
   message UnstructuredData {
     // UnstructuredData
     oneof unstructured_data {
-      // UnstructuredData using bytes, 
+      // UnstructuredData using bytes,
       // grpc-gateway will do base64 conversion for http endpoint
       bytes blob = 1;
-      // UnstructuredData using url 
+      // UnstructuredData using url
       string url = 2;
     }
   }


### PR DESCRIPTION
Because

- align trigger record field name with backend

This commit

- align trigger record field name with backend
