### PR TITLE
chore(pipeline): remove pipeline mode and rename sync async endpoints

### DIFF
--- a/base/mgmt/v1alpha/metric.proto
+++ b/base/mgmt/v1alpha/metric.proto
@@ -8,8 +8,15 @@ import "google/protobuf/timestamp.proto";
 // Google API
 import "google/api/field_behavior.proto";
 
-import "vdp/pipeline/v1alpha/pipeline.proto";
-
+// Mode enumerates the pipeline modes
+enum Mode {
+    // Mode: UNSPECIFIED
+    MODE_UNSPECIFIED = 0;
+    // Mode: SYNC
+    MODE_SYNC = 1;
+    // Mode: ASYNC
+    MODE_ASYNC = 2;
+}
 
 // PipelineTriggerRecord represents a record for pipeline trigger
 message PipelineTriggerRecord {
@@ -22,7 +29,7 @@ message PipelineTriggerRecord {
     // UID for the triggered pipeline
     string pipeline_uid = 4;
     // Pipeline mode
-    vdp.pipeline.v1alpha.Pipeline.Mode pipeline_mode = 5;
+    Mode pipeline_mode = 5;
     // Total compute time duration for this pipeline trigger
     float compute_time_duration = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // Final status for pipeline trigger

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -593,15 +593,15 @@ paths:
   /v1alpha/{name_1}:
     get:
       summary: |-
-        GetTriggerAsyncOperation method receives a
-        GetTriggerAsyncOperationRequest message and returns a
-        GetTriggerAsyncOperationResponse message.
-      operationId: PipelinePublicService_GetTriggerAsyncOperation
+        GetOperation method receives a
+        GetOperationRequest message and returns a
+        GetOperationResponse message.
+      operationId: PipelinePublicService_GetOperation
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetTriggerAsyncOperationResponse'
+            $ref: '#/definitions/v1alphaGetOperationResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -612,7 +612,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: triggerAsyncOperations/[^/]+
+          pattern: operations/[^/]+
       tags:
         - PipelinePublicService
   /v1alpha/{name_1}/rename:
@@ -659,6 +659,45 @@ paths:
               - new_connector_id
       tags:
         - ConnectorPublicService
+  /v1alpha/{name_1}/trigger:
+    post:
+      summary: |-
+        TriggerPipeline method receives a TriggerPipelineRequest message
+        and returns a TriggerPipelineResponse.
+      operationId: PipelinePublicService_TriggerPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name_1
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1alphaPipelineDataPayload'
+                title: Input to the pipeline
+            title: TriggerPipelineRequest represents a request to trigger a pipeline
+            required:
+              - inputs
+      tags:
+        - PipelinePublicService
   /v1alpha/{name_2}/rename:
     post:
       summary: |-
@@ -1139,45 +1178,6 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
-  /v1alpha/{name}/triggerSync:
-    post:
-      summary: |-
-        TriggerSyncPipeline method receives a TriggerSyncPipelineRequest message
-        and returns a TriggerSyncPipelineResponse.
-      operationId: PipelinePublicService_TriggerSyncPipeline
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaTriggerSyncPipelineResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: name
-          description: Pipeline resource name. It must have the format of "pipelines/*"
-          in: path
-          required: true
-          type: string
-          pattern: pipelines/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              inputs:
-                type: array
-                items:
-                  type: object
-                  $ref: '#/definitions/v1alphaPipelineDataPayload'
-                title: Input to the pipeline
-            title: TriggerSyncPipelineRequest represents a request to trigger a pipeline
-            required:
-              - inputs
-      tags:
-        - PipelinePublicService
   /v1alpha/{name}/undeploy:
     post:
       summary: UndeployModel undeploy a model to offline state
@@ -1499,10 +1499,6 @@ paths:
               recipe:
                 $ref: '#/definitions/v1alphaRecipe'
                 title: Pipeline recipe
-              mode:
-                $ref: '#/definitions/PipelineMode'
-                title: Pipeline mode
-                readOnly: true
               state:
                 $ref: '#/definitions/v1alphaPipelineState'
                 title: Pipeline state
@@ -3261,18 +3257,6 @@ definitions:
         type: string
         title: UnstructuredData using url
     title: UnstructuredData
-  PipelineMode:
-    type: string
-    enum:
-      - MODE_UNSPECIFIED
-      - MODE_SYNC
-      - MODE_ASYNC
-    default: MODE_UNSPECIFIED
-    description: |-
-      - MODE_UNSPECIFIED: Mode: UNSPECIFIED
-       - MODE_SYNC: Mode: SYNC
-       - MODE_ASYNC: Mode: ASYNC
-    title: Mode enumerates the pipeline modes
   SessionService:
     type: string
     enum:
@@ -4629,6 +4613,16 @@ definitions:
     title: GetPipelinesResponse represents a respond to GetModelsRequest
     required:
       - models
+  v1alphaGetOperationResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: The retrieved longrunning operation
+        readOnly: true
+    title: |-
+      GetOperationResponse represents a response for a longrunning
+      operation
   v1alphaGetPipelineResponse:
     type: object
     properties:
@@ -4751,16 +4745,6 @@ definitions:
         $ref: '#/definitions/v1alphaApiToken'
         title: An API token resource
     title: GetTokenResponse represents a response for an API token resource
-  v1alphaGetTriggerAsyncOperationResponse:
-    type: object
-    properties:
-      operation:
-        $ref: '#/definitions/googlelongrunningOperation'
-        title: The retrieved longrunning operation
-        readOnly: true
-    title: |-
-      GetTriggerAsyncOperationResponse represents a response for a longrunning
-      operation
   v1alphaGetUserAdminResponse:
     type: object
     properties:
@@ -5187,6 +5171,18 @@ definitions:
           $ref: '#/definitions/v1alphaUser'
         title: Repeated user usage data
     title: Management service usage data
+  v1alphaMode:
+    type: string
+    enum:
+      - MODE_UNSPECIFIED
+      - MODE_SYNC
+      - MODE_ASYNC
+    default: MODE_UNSPECIFIED
+    description: |-
+      - MODE_UNSPECIFIED: Mode: UNSPECIFIED
+       - MODE_SYNC: Mode: SYNC
+       - MODE_ASYNC: Mode: ASYNC
+    title: Mode enumerates the pipeline modes
   v1alphaModel:
     type: object
     properties:
@@ -5560,10 +5556,6 @@ definitions:
       recipe:
         $ref: '#/definitions/v1alphaRecipe'
         title: Pipeline recipe
-      mode:
-        $ref: '#/definitions/PipelineMode'
-        title: Pipeline mode
-        readOnly: true
       state:
         $ref: '#/definitions/v1alphaPipelineState'
         title: Pipeline state
@@ -5666,7 +5658,7 @@ definitions:
         type: string
         title: UID for the triggered pipeline
       pipeline_mode:
-        $ref: '#/definitions/PipelineMode'
+        $ref: '#/definitions/v1alphaMode'
         title: Pipeline mode
       compute_time_duration:
         type: number
@@ -6284,12 +6276,6 @@ definitions:
         $ref: '#/definitions/googlelongrunningOperation'
         title: Trigger async pipeline operation message
         readOnly: true
-      data_mapping_indices:
-        type: array
-        items:
-          type: string
-        title: The data mapping indices for each input
-        readOnly: true
     title: |-
       TriggerAsyncPipelineResponse represents a response for the longrunning
       operation of a pipeline
@@ -6326,7 +6312,7 @@ definitions:
     title: |-
       TriggerModelResponse represents a response for the output for
       triggering a model
-  v1alphaTriggerSyncPipelineResponse:
+  v1alphaTriggerPipelineResponse:
     type: object
     properties:
       outputs:
@@ -6336,7 +6322,7 @@ definitions:
           $ref: '#/definitions/v1alphaPipelineDataPayload'
         title: The multiple model inference outputs
     title: |-
-      TriggerSyncPipelineResponse represents a response for the output
+      TriggerPipelineResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
   v1alphaUndeployModelAdminResponse:
     type: object

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -86,16 +86,6 @@ message Pipeline {
     pattern : "pipelines/{pipeline}"
   };
 
-  // Mode enumerates the pipeline modes
-  enum Mode {
-    // Mode: UNSPECIFIED
-    MODE_UNSPECIFIED = 0;
-    // Mode: SYNC
-    MODE_SYNC = 1;
-    // Mode: ASYNC
-    MODE_ASYNC = 2;
-  }
-
   // State enumerates the state of a pipeline
   enum State {
     // State: UNSPECIFIED
@@ -121,8 +111,6 @@ message Pipeline {
   optional string description = 4 [ (google.api.field_behavior) = OPTIONAL ];
   // Pipeline recipe
   Recipe recipe = 5 [ (google.api.field_behavior) = IMMUTABLE ];
-  // Pipeline mode
-  Mode mode = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Pipeline state
   State state = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Pipeline owner
@@ -390,8 +378,8 @@ message PipelineDataPayload {
   google.protobuf.Struct metadata = 7;
 }
 
-// TriggerSyncPipelineRequest represents a request to trigger a pipeline
-message TriggerSyncPipelineRequest {
+// TriggerPipelineRequest represents a request to trigger a pipeline
+message TriggerPipelineRequest {
   // Pipeline resource name. It must have the format of "pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -402,9 +390,9 @@ message TriggerSyncPipelineRequest {
       [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// TriggerSyncPipelineResponse represents a response for the output
+// TriggerPipelineResponse represents a response for the output
 // of a pipeline, i.e., the multiple model inference outputs
-message TriggerSyncPipelineResponse {
+message TriggerPipelineResponse {
   // The multiple model inference outputs
   repeated PipelineDataPayload outputs = 1;
 }
@@ -427,21 +415,18 @@ message TriggerAsyncPipelineResponse {
   // Trigger async pipeline operation message
   google.longrunning.Operation operation = 1
       [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // The data mapping indices for each input
-  repeated string data_mapping_indices = 2
-      [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
-// GetTriggerAsyncOperationRequest represents a request to query a longrunning
+// GetOperationRequest represents a request to query a longrunning
 // operation
-message GetTriggerAsyncOperationRequest {
+message GetOperationRequest {
   // The name of the operation resource.
   string name = 1 [ (google.api.field_behavior) = REQUIRED ];
 }
 
-// GetTriggerAsyncOperationResponse represents a response for a longrunning
+// GetOperationResponse represents a response for a longrunning
 // operation
-message GetTriggerAsyncOperationResponse {
+message GetOperationResponse {
   // The retrieved longrunning operation
   google.longrunning.Operation operation = 1
       [ (google.api.field_behavior) = OUTPUT_ONLY ];

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -122,12 +122,12 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name,new_pipeline_id";
   }
 
-  // TriggerSyncPipeline method receives a TriggerSyncPipelineRequest message
-  // and returns a TriggerSyncPipelineResponse.
-  rpc TriggerSyncPipeline(TriggerSyncPipelineRequest)
-      returns (TriggerSyncPipelineResponse) {
+  // TriggerPipeline method receives a TriggerPipelineRequest message
+  // and returns a TriggerPipelineResponse.
+  rpc TriggerPipeline(TriggerPipelineRequest)
+      returns (TriggerPipelineResponse) {
     option (google.api.http) = {
-      post : "/v1alpha/{name=pipelines/*}/triggerSync"
+      post : "/v1alpha/{name=pipelines/*}/trigger"
       body : "*"
     };
     option (google.api.method_signature) = "name,inputs";
@@ -155,13 +155,13 @@ service PipelinePublicService {
 
   // *Longrunning operation methods
 
-  // GetTriggerAsyncOperation method receives a
-  // GetTriggerAsyncOperationRequest message and returns a
-  // GetTriggerAsyncOperationResponse message.
-  rpc GetTriggerAsyncOperation(GetTriggerAsyncOperationRequest)
-      returns (GetTriggerAsyncOperationResponse) {
+  // GetOperation method receives a
+  // GetOperationRequest message and returns a
+  // GetOperationResponse message.
+  rpc GetOperation(GetOperationRequest)
+      returns (GetOperationResponse) {
     option (google.api.http) = {
-      get : "/v1alpha/{name=triggerAsyncOperations/*}"
+      get : "/v1alpha/{name=operations/*}"
     };
     option (google.api.method_signature) = "name";
   }


### PR DESCRIPTION
Because

- the sync/async terms are not user-friendly


This commit

- remove pipeline mode
- rename the get long running operation endpoint
- rename `triggerSync` to `trigger`
