### PR TITLE
chore(pipeline,connector): remove unused TaskOutput in pipeline, add Type in connector

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -186,7 +186,7 @@ paths:
                 title: Connector Type
                 readOnly: true
               task:
-                type: string
+                $ref: '#/definitions/connectorv1alphaTask'
                 title: Connector description
                 readOnly: true
               description:
@@ -509,7 +509,7 @@ paths:
                   Model configuration represents the configuration JSON that has been
                   validated using the `model_spec` JSON schema of a ModelDefinition
               task:
-                $ref: '#/definitions/ModelTask'
+                $ref: '#/definitions/v1alphaModelTask'
                 title: Model task
                 readOnly: true
               state:
@@ -3220,30 +3220,6 @@ definitions:
        - SERVING_STATUS_SERVING: Serving status: SERVING
        - SERVING_STATUS_NOT_SERVING: Serving status: NOT SERVING
     title: ServingStatus enumerates the status of a queried service
-  ModelTask:
-    type: string
-    enum:
-      - TASK_UNSPECIFIED
-      - TASK_CLASSIFICATION
-      - TASK_DETECTION
-      - TASK_KEYPOINT
-      - TASK_OCR
-      - TASK_INSTANCE_SEGMENTATION
-      - TASK_SEMANTIC_SEGMENTATION
-      - TASK_TEXT_TO_IMAGE
-      - TASK_TEXT_GENERATION
-    default: TASK_UNSPECIFIED
-    description: |-
-      - TASK_UNSPECIFIED: Task: UNSPECIFIED
-       - TASK_CLASSIFICATION: Task: CLASSIFICATION
-       - TASK_DETECTION: Task: DETECTION
-       - TASK_KEYPOINT: Task: KEYPOINT
-       - TASK_OCR: Task: OCR
-       - TASK_INSTANCE_SEGMENTATION: Task: INSTANCE SEGMENTATION
-       - TASK_SEMANTIC_SEGMENTATION: Task: SEMANTIC SEGMENTATION
-       - TASK_TEXT_TO_IMAGE: Task: TEXT TO IMAGE
-       - TASK_TEXT_GENERATION: Task: TEXT Generation
-    title: Task enumerates the task type of a model
   PipelineDataPayloadUnstructuredData:
     type: object
     properties:
@@ -3316,6 +3292,34 @@ definitions:
         $ref: '#/definitions/v1alphaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
+  connectorv1alphaTask:
+    type: string
+    enum:
+      - TASK_UNSPECIFIED
+      - TASK_CLASSIFICATION
+      - TASK_DETECTION
+      - TASK_KEYPOINT
+      - TASK_OCR
+      - TASK_INSTANCE_SEGMENTATION
+      - TASK_SEMANTIC_SEGMENTATION
+      - TASK_TEXT_TO_IMAGE
+      - TASK_TEXT_GENERATION
+      - TASK_IMAGE_TO_IMAGE
+      - TASK_TEXT_EMBEDDINGS
+    default: TASK_UNSPECIFIED
+    description: |-
+      - TASK_UNSPECIFIED: Task: UNSPECIFIED
+       - TASK_CLASSIFICATION: Task: CLASSIFICATION
+       - TASK_DETECTION: Task: DETECTION
+       - TASK_KEYPOINT: Task: KEYPOINT
+       - TASK_OCR: Task: OCR
+       - TASK_INSTANCE_SEGMENTATION: Task: INSTANCE SEGMENTATION
+       - TASK_SEMANTIC_SEGMENTATION: Task: SEMANTIC SEGMENTATION
+       - TASK_TEXT_TO_IMAGE: Task: TEXT TO IMAGE
+       - TASK_TEXT_GENERATION: Task: TEXT GENERATION
+       - TASK_IMAGE_TO_IMAGE: Task: IMAGE TO IMAGE
+       - TASK_TEXT_EMBEDDINGS: Task: TEXT EMBEDDINGS
+    title: Task enumerates the task type of a connector
   googlelongrunningOperation:
     type: object
     properties:
@@ -3421,46 +3425,6 @@ definitions:
         $ref: '#/definitions/v1alphaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
-  modelmodelv1alphaTaskOutput:
-    type: object
-    properties:
-      classification:
-        $ref: '#/definitions/v1alphaClassificationOutput'
-        title: The classification output
-        readOnly: true
-      detection:
-        $ref: '#/definitions/v1alphaDetectionOutput'
-        title: The detection output
-        readOnly: true
-      keypoint:
-        $ref: '#/definitions/v1alphaKeypointOutput'
-        title: The keypoint output
-        readOnly: true
-      ocr:
-        $ref: '#/definitions/v1alphaOcrOutput'
-        title: The ocr output
-        readOnly: true
-      instance_segmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
-        title: The instance segmentation output
-        readOnly: true
-      semantic_segmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
-        title: The semantic segmentation output
-        readOnly: true
-      text_to_image:
-        $ref: '#/definitions/v1alphaTextToImageOutput'
-        title: The text to image output
-        readOnly: true
-      text_generation:
-        $ref: '#/definitions/v1alphaTextGenerationOutput'
-        title: The text generation output
-        readOnly: true
-      unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedOutput'
-        title: The unspecified task output
-        readOnly: true
-    title: TaskOutput represents the output of a CV Task result from a model
   modelmodelv1alphaView:
     type: string
     enum:
@@ -3864,7 +3828,7 @@ definitions:
         title: Connector Type
         readOnly: true
       task:
-        type: string
+        $ref: '#/definitions/connectorv1alphaTask'
         title: Connector description
         readOnly: true
       description:
@@ -5215,7 +5179,7 @@ definitions:
           Model configuration represents the configuration JSON that has been
           validated using the `model_spec` JSON schema of a ModelDefinition
       task:
-        $ref: '#/definitions/ModelTask'
+        $ref: '#/definitions/v1alphaModelTask'
         title: Model task
         readOnly: true
       state:
@@ -5368,6 +5332,30 @@ definitions:
        - STATE_ONLINE: State: ONLINE
        - STATE_ERROR: State: ERROR
     title: State enumerates a model state
+  v1alphaModelTask:
+    type: string
+    enum:
+      - TASK_UNSPECIFIED
+      - TASK_CLASSIFICATION
+      - TASK_DETECTION
+      - TASK_KEYPOINT
+      - TASK_OCR
+      - TASK_INSTANCE_SEGMENTATION
+      - TASK_SEMANTIC_SEGMENTATION
+      - TASK_TEXT_TO_IMAGE
+      - TASK_TEXT_GENERATION
+    default: TASK_UNSPECIFIED
+    description: |-
+      - TASK_UNSPECIFIED: Task: UNSPECIFIED
+       - TASK_CLASSIFICATION: Task: CLASSIFICATION
+       - TASK_DETECTION: Task: DETECTION
+       - TASK_KEYPOINT: Task: KEYPOINT
+       - TASK_OCR: Task: OCR
+       - TASK_INSTANCE_SEGMENTATION: Task: INSTANCE SEGMENTATION
+       - TASK_SEMANTIC_SEGMENTATION: Task: SEMANTIC SEGMENTATION
+       - TASK_TEXT_TO_IMAGE: Task: TEXT TO IMAGE
+       - TASK_TEXT_GENERATION: Task: TEXT Generation
+    title: Task enumerates the task type of a model
   v1alphaModelUsageData:
     type: object
     properties:
@@ -5402,7 +5390,7 @@ definitions:
       tasks:
         type: array
         items:
-          $ref: '#/definitions/ModelTask'
+          $ref: '#/definitions/v1alphaModelTask'
         description: |-
           Tasks of the models. Element in the list should not be
           duplicated.
@@ -6139,6 +6127,46 @@ definitions:
         $ref: '#/definitions/v1alphaUnspecifiedInput'
         title: The unspecified task input
     title: TaskInputStream represents the input to trigger a model with stream method
+  v1alphaTaskOutput:
+    type: object
+    properties:
+      classification:
+        $ref: '#/definitions/v1alphaClassificationOutput'
+        title: The classification output
+        readOnly: true
+      detection:
+        $ref: '#/definitions/v1alphaDetectionOutput'
+        title: The detection output
+        readOnly: true
+      keypoint:
+        $ref: '#/definitions/v1alphaKeypointOutput'
+        title: The keypoint output
+        readOnly: true
+      ocr:
+        $ref: '#/definitions/v1alphaOcrOutput'
+        title: The ocr output
+        readOnly: true
+      instance_segmentation:
+        $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
+        title: The instance segmentation output
+        readOnly: true
+      semantic_segmentation:
+        $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
+        title: The semantic segmentation output
+        readOnly: true
+      text_to_image:
+        $ref: '#/definitions/v1alphaTextToImageOutput'
+        title: The text to image output
+        readOnly: true
+      text_generation:
+        $ref: '#/definitions/v1alphaTextGenerationOutput'
+        title: The text generation output
+        readOnly: true
+      unspecified:
+        $ref: '#/definitions/v1alphaUnspecifiedOutput'
+        title: The unspecified task output
+        readOnly: true
+    title: TaskOutput represents the output of a CV Task result from a model
   v1alphaTestConnectorResponse:
     type: object
     properties:
@@ -6152,13 +6180,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelTask'
+        $ref: '#/definitions/v1alphaModelTask'
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: '#/definitions/modelmodelv1alphaTaskOutput'
+          $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
       TestModelBinaryFileUploadResponse represents a response for the
@@ -6170,13 +6198,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelTask'
+        $ref: '#/definitions/v1alphaModelTask'
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: '#/definitions/modelmodelv1alphaTaskOutput'
+          $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
       TestModelResponse represents a response for the output for
@@ -6283,13 +6311,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelTask'
+        $ref: '#/definitions/v1alphaModelTask'
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: '#/definitions/modelmodelv1alphaTaskOutput'
+          $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
       TriggerModelBinaryFileUploadResponse represents a response for the
@@ -6301,13 +6329,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/ModelTask'
+        $ref: '#/definitions/v1alphaModelTask'
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: '#/definitions/modelmodelv1alphaTaskOutput'
+          $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
       TriggerModelResponse represents a response for the output for

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -41,6 +41,32 @@ message ReadinessResponse {
   common.healthcheck.v1alpha.HealthCheckResponse health_check_response = 1;
 }
 
+// Task enumerates the task type of a connector
+enum Task {
+  // Task: UNSPECIFIED
+  TASK_UNSPECIFIED = 0;
+  // Task: CLASSIFICATION
+  TASK_CLASSIFICATION = 1;
+  // Task: DETECTION
+  TASK_DETECTION = 2;
+  // Task: KEYPOINT
+  TASK_KEYPOINT = 3;
+  // Task: OCR
+  TASK_OCR = 4;
+  // Task: INSTANCE SEGMENTATION
+  TASK_INSTANCE_SEGMENTATION = 5;
+  // Task: SEMANTIC SEGMENTATION
+  TASK_SEMANTIC_SEGMENTATION = 6;
+  // Task: TEXT TO IMAGE
+  TASK_TEXT_TO_IMAGE = 7;
+  // Task: TEXT GENERATION
+  TASK_TEXT_GENERATION = 8;
+  // Task: IMAGE TO IMAGE
+  TASK_IMAGE_TO_IMAGE = 9;
+  // Task: TEXT EMBEDDINGS
+  TASK_TEXT_EMBEDDINGS = 10;
+}
+
 // Connector represents a connector data model
 message Connector {
 
@@ -91,7 +117,7 @@ message Connector {
   // Connector Type
   ConnectorType connector_type = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Connector description
-  string task = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+  Task task = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
   // Connector description
   optional string description = 7 [ (google.api.field_behavior) = OPTIONAL ];
   // Connector configuration in JSON format

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -14,15 +14,6 @@ import "google/api/field_behavior.proto";
 import "google/longrunning/operations.proto";
 
 import "common/healthcheck/v1alpha/healthcheck.proto";
-import "model/model/v1alpha/task_classification.proto";
-import "model/model/v1alpha/task_detection.proto";
-import "model/model/v1alpha/task_keypoint.proto";
-import "model/model/v1alpha/task_ocr.proto";
-import "model/model/v1alpha/task_instance_segmentation.proto";
-import "model/model/v1alpha/task_semantic_segmentation.proto";
-import "model/model/v1alpha/task_text_to_image.proto";
-import "model/model/v1alpha/task_text_generation.proto";
-import "model/model/v1alpha/task_unspecified.proto";
 
 // LivenessRequest represents a request to check a service liveness status
 message LivenessRequest {
@@ -297,50 +288,6 @@ message RenamePipelineResponse {
   Pipeline pipeline = 1;
 }
 
-////////////////////////////////////
-//  Trigger methods
-////////////////////////////////////
-
-// TaskOutput represents the output of a CV Task result from a
-// model, extended from model.v1alpha.TaskOutput.
-// Here we don't use a model.v1alpha.TaskOutput type field but explicitly use
-// the replicated oneof field because we want the CV Task output to be at the
-// same message layer like the trigger output of model.
-// This message is deprecated, will be removed soon
-message TaskOutput {
-  // The index of input data in a batch
-  string index = 1 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  // The inference task output
-  oneof output {
-    // The classification output
-    model.model.v1alpha.ClassificationOutput classification = 2
-        [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // The detection output
-    model.model.v1alpha.DetectionOutput detection = 3
-        [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // The keypoint output
-    model.model.v1alpha.KeypointOutput keypoint = 4
-        [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // The ocr output
-    model.model.v1alpha.OcrOutput ocr = 5
-        [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // The instance segmentation output
-    model.model.v1alpha.InstanceSegmentationOutput instance_segmentation = 6
-        [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // The semantic segmentation output
-    model.model.v1alpha.SemanticSegmentationOutput semantic_segmentation = 7
-        [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // The text to image output
-    model.model.v1alpha.TextToImageOutput text_to_image = 8
-        [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // The text generation
-    model.model.v1alpha.TextGenerationOutput text_generation = 9
-        [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // The unspecified task output
-    model.model.v1alpha.UnspecifiedOutput unspecified = 10
-        [ (google.api.field_behavior) = OUTPUT_ONLY ];
-  }
-}
 
 // PipelineDataPayload is a data structure for pipeline input
 message PipelineDataPayload {


### PR DESCRIPTION
Because

- we should add a connector `Task` enums to define the available `Task` for our connectors. The `Task` will be not only AI task, but also other tasks such as data task, blockchain task...etc

This commit

- remove unused `TaskOutput` in pipeline
- add `Type` in connector
