### PR TITLE
chore(metric): add connector and chart metric methods

### DIFF
--- a/base/mgmt/v1alpha/metric.proto
+++ b/base/mgmt/v1alpha/metric.proto
@@ -8,6 +8,8 @@ import "google/protobuf/timestamp.proto";
 // Google API
 import "google/api/field_behavior.proto";
 
+// ========== Pipeline endpoints
+
 // Mode enumerates the pipeline modes
 enum Mode {
     // Mode: UNSPECIFIED
@@ -18,22 +20,90 @@ enum Mode {
     MODE_ASYNC = 2;
 }
 
+// Status enumerates the final status of a pipeline trigger
+enum Status {
+    // Status: UNSPECIFIED
+    STATUS_UNSPECIFIED = 0;
+    // Status: COMPLETED
+    STATUS_COMPLETED = 1;
+    // Status: ERRORED
+    STATUS_ERRORED = 2;
+}
+
 // PipelineTriggerRecord represents a record for pipeline trigger
 message PipelineTriggerRecord {
     // Timestamp for the pipeline trigger time
     google.protobuf.Timestamp trigger_time = 1;
-    // Unique uuid for each pipeline trigger
+    // UID for each pipeline trigger
     string pipeline_trigger_id = 2;
     // ID for the triggered pipeline
     string pipeline_id = 3;
     // UID for the triggered pipeline
     string pipeline_uid = 4;
-    // Pipeline mode
-    Mode pipeline_mode = 5;
+    // Trigger mode
+    Mode trigger_mode = 5;
     // Total compute time duration for this pipeline trigger
     float compute_time_duration = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // Final status for pipeline trigger
-    string status = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    Status status = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+// PipelineTriggerChartRecord represents a aggregated chart record for pipeline trigger
+message PipelineTriggerChartRecord {
+    // ID for the triggered pipeline
+    string pipeline_id = 1;
+    // UID for the triggered pipeline
+    string pipeline_uid = 2;
+    // Trigger mode
+    Mode trigger_mode = 3;
+    // Status of pipeline trigger
+    Status status = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Time buckets
+    repeated google.protobuf.Timestamp time_buckets = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Aggregated trigger count in each time bucket
+    repeated int64 trigger_counts = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Total compute time duration in each time bucket
+    repeated float compute_time_duration = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+// ConnectorExecuteRecord represents a record for connector execution
+message ConnectorExecuteRecord {
+    // Timestamp for the connector execution time
+    google.protobuf.Timestamp execute_time = 1;
+    // UID for connector execution
+    string connector_execute_id = 2;
+    // ID for the executed connector
+    string connector_id = 3;
+    // UID for the executed connector
+    string connector_uid = 4;
+    // UID for the executed connector definition
+    string connector_definition_uid = 5;
+    // ID for the pipeline this connector belong to
+    string pipeline_id = 6;
+    // UID for the pipeline this connector belong to
+    string pipeline_uid = 7;
+    // UID for the trigger id of the pipeline this connector belong to
+    string pipeline_trigger_id = 8;
+    // Total compute time duration for this execution
+    float compute_time_duration = 9 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Final status for the connector execution
+    Status status = 10 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+// ConnectorExecuteChartRecord represents a aggregated chart record for connector execute
+message ConnectorExecuteChartRecord {
+    // ID for the executed connector
+    string connector_id = 1;
+    // UID for the executed connector
+    string connector_uid = 2;
+    // Status of connector execution
+    Status status = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Time buckets
+    repeated google.protobuf.Timestamp time_buckets = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Aggregated execute count in each time bucket
+    repeated int64 execute_counts = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Total compute time duration in each time bucket
+    repeated float compute_time_duration = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // ListPipelineTriggerRecordsRequest represents a request to list
@@ -58,4 +128,62 @@ message ListPipelineTriggerRecordsResponse {
     string next_page_token = 2;
     // Total count of pipeline trigger records
     int64 total_size = 3;
+}
+
+// ListPipelineTriggerChartRecordsRequest represents a request to list
+// pipeline trigger chart record
+message ListPipelineTriggerChartRecordsRequest {
+    // Aggregation window in nanoseconds
+    int64 aggregation_window = 1;
+    // Filter expression to list chart record
+    optional string filter = 2 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// ListPipelineTriggerChartRecordsResponse represents a response for a list
+// of pipeline trigger chart record
+message ListPipelineTriggerChartRecordsResponse {
+    // A list of pipeline trigger records
+    repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
+}
+
+// ========== Connector endpoints
+
+// ListConnectorExecuteRecordsRequest represents a request to list
+// connector execute record
+message ListConnectorExecuteRecordsRequest {
+    // The maximum number of connector execution record to return. The service may return
+    // fewer than this value. If unspecified, at most 100 record will be returned. The
+    // maximum value is 1000; values above 1000 will be coerced to 1000.
+    optional int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
+    // Page token
+    optional string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
+    // Filter expression to list record
+    optional string filter = 3 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// ListConnectorExecuteRecordsResponse represents a response for a list
+// of connector execute record
+message ListConnectorExecuteRecordsResponse {
+    // A list of connector execute records
+    repeated ConnectorExecuteRecord connector_execute_records = 1;
+    // Next page token
+    string next_page_token = 2;
+    // Total count of connector execute records
+    int64 total_size = 3;
+}
+
+// ListConnectorExecuteChartRecordsRequest represents a request to list
+// connector execute chart record
+message ListConnectorExecuteChartRecordsRequest {
+    // Aggregation window in nanoseconds
+    int64 aggregation_window = 1;
+    // Filter expression to list chart record
+    optional string filter = 2 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// ListConnectorExecuteChartRecordsResponse represents a response for a list
+// of connector execute chart record
+message ListConnectorExecuteChartRecordsResponse {
+    // A list of connector execute records
+    repeated ConnectorExecuteChartRecord connector_execute_chart_records = 1;
 }

--- a/base/mgmt/v1alpha/mgmt_public_service.proto
+++ b/base/mgmt/v1alpha/mgmt_public_service.proto
@@ -98,11 +98,37 @@ service MgmtPublicService {
     option (google.api.method_signature) = "name";
   }
 
+  // ========== Metric endpoints
+
   // ListPipelineTriggerRecords method receives a ListPipelineTriggerRecordsRequest message and returns a
   // ListPipelineTriggerRecordsResponse message.
   rpc ListPipelineTriggerRecords(ListPipelineTriggerRecordsRequest) returns (ListPipelineTriggerRecordsResponse) {
     option (google.api.http) = {
       get : "/v1alpha/metrics/vdp/pipeline/triggers"
+    };
+  }
+
+  // ListPipelineTriggerChartRecords method receives a ListPipelineTriggerChartRecordsRequest message and returns a
+  // ListPipelineTriggerChartRecordsResponse message.
+  rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/metrics/vdp/pipeline/charts"
+    };
+  }
+
+  // ListConnectorExecuteRecords method receives a ListConnectorExecuteRecordsRequest message and returns a
+  // ListConnectorExecuteRecordsResponse message.
+  rpc ListConnectorExecuteRecords(ListConnectorExecuteRecordsRequest) returns (ListConnectorExecuteRecordsResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/metrics/vdp/connector/executes"
+    };
+  }
+
+  // ListConnectorExecuteChartRecords method receives a ListConnectorExecuteChartRecordsRequest message and returns a
+  // ListConnectorExecuteChartRecordsResponse message.
+  rpc ListConnectorExecuteChartRecords(ListConnectorExecuteChartRecordsRequest) returns (ListConnectorExecuteChartRecordsResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/metrics/vdp/connector/charts"
     };
   }
 }

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -36,7 +36,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -60,7 +60,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -83,7 +83,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -124,7 +124,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -150,7 +150,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -250,7 +250,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -277,7 +277,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -304,7 +304,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector_definition.name
           description: |-
@@ -346,7 +346,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name/readme
           description: |-
@@ -372,7 +372,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name/watch
           description: |-
@@ -398,7 +398,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name
           description: |-
@@ -440,7 +440,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name
           description: |-
@@ -465,7 +465,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name
           description: |-
@@ -560,7 +560,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_definition.name
           description: |-
@@ -605,7 +605,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: The name of the operation resource.
@@ -630,7 +630,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: |-
@@ -673,7 +673,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -712,7 +712,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_2
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -753,7 +753,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: The name of the operation resource.
@@ -796,7 +796,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -829,7 +829,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -865,7 +865,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -893,7 +893,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -928,7 +928,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -963,7 +963,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -1004,7 +1004,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -1034,7 +1034,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: Resource name for the model to be renamed.
@@ -1070,7 +1070,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -1112,7 +1112,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -1153,7 +1153,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1190,7 +1190,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -1224,7 +1224,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -1257,7 +1257,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_1
           description: |-
@@ -1298,7 +1298,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_2
           description: |-
@@ -1339,7 +1339,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink
           description: |-
@@ -1382,7 +1382,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name/watch
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1406,7 +1406,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1444,7 +1444,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1467,7 +1467,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "pipelines/*"
@@ -1540,7 +1540,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink_1
           description: |-
@@ -1565,7 +1565,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink_1
           description: |-
@@ -1590,7 +1590,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink_1
           description: |-
@@ -1642,7 +1642,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -1667,7 +1667,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -1692,7 +1692,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -1741,7 +1741,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: token.name
           description: API tokens resource name. It must have the format of "tokens/*"
@@ -1764,7 +1764,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: token.name
           description: API token resource name. It must have the format of "tokens/*"
@@ -1788,7 +1788,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user.name
           description: |-
@@ -1814,7 +1814,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector_permalink
           description: |-
@@ -1840,7 +1840,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_permalink
           description: |-
@@ -1864,7 +1864,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_permalink
           description: |-
@@ -1894,7 +1894,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_permalink
           description: |-
@@ -1928,7 +1928,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_1
           description: |-
@@ -1972,7 +1972,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_2
           description: |-
@@ -2013,7 +2013,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_3
           description: |-
@@ -2054,7 +2054,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink
           description: |-
@@ -2095,7 +2095,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user.name
           description: |-
@@ -2135,7 +2135,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user.name
           description: |-
@@ -2160,7 +2160,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user.name
           description: |-
@@ -2265,7 +2265,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2317,7 +2317,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2367,7 +2367,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2419,7 +2419,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2471,7 +2471,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user
           description: |-
@@ -2502,7 +2502,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2556,7 +2556,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2608,7 +2608,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector
           description: Connector resource
@@ -2635,7 +2635,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2659,7 +2659,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2683,7 +2683,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2707,7 +2707,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2731,7 +2731,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2755,7 +2755,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -2764,6 +2764,101 @@ paths:
           type: string
       tags:
         - UsageService
+  /v1alpha/metrics/vdp/connector/charts:
+    get:
+      summary: |-
+        ListConnectorExecuteChartRecords method receives a ListConnectorExecuteChartRecordsRequest message and returns a
+        ListConnectorExecuteChartRecordsResponse message.
+      operationId: MgmtPublicService_ListConnectorExecuteChartRecords
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListConnectorExecuteChartRecordsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: aggregation_window
+          description: Aggregation window in nanoseconds
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: filter
+          description: Filter expression to list chart record
+          in: query
+          required: false
+          type: string
+      tags:
+        - MgmtPublicService
+  /v1alpha/metrics/vdp/connector/executes:
+    get:
+      summary: |-
+        ListConnectorExecuteRecords method receives a ListConnectorExecuteRecordsRequest message and returns a
+        ListConnectorExecuteRecordsResponse message.
+      operationId: MgmtPublicService_ListConnectorExecuteRecords
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListConnectorExecuteRecordsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of connector execution record to return. The service may return
+            fewer than this value. If unspecified, at most 100 record will be returned. The
+            maximum value is 1000; values above 1000 will be coerced to 1000.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: filter
+          description: Filter expression to list record
+          in: query
+          required: false
+          type: string
+      tags:
+        - MgmtPublicService
+  /v1alpha/metrics/vdp/pipeline/charts:
+    get:
+      summary: |-
+        ListPipelineTriggerChartRecords method receives a ListPipelineTriggerChartRecordsRequest message and returns a
+        ListPipelineTriggerChartRecordsResponse message.
+      operationId: MgmtPublicService_ListPipelineTriggerChartRecords
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListPipelineTriggerChartRecordsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: aggregation_window
+          description: Aggregation window in nanoseconds
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: filter
+          description: Filter expression to list chart record
+          in: query
+          required: false
+          type: string
+      tags:
+        - MgmtPublicService
   /v1alpha/metrics/vdp/pipeline/triggers:
     get:
       summary: |-
@@ -2778,7 +2873,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2815,7 +2910,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2866,7 +2961,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2915,7 +3010,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model
           description: |-
@@ -2945,7 +3040,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -2996,7 +3091,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline
           description: A pipeline resource to create
@@ -3023,7 +3118,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -3047,7 +3142,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -3070,7 +3165,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: report
           description: A report resource to create
@@ -3096,7 +3191,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: session
           description: A session resource to create
@@ -3122,7 +3217,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -3153,7 +3248,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: token
           description: A token resource to create
@@ -3179,7 +3274,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       tags:
         - MgmtPublicService
     patch:
@@ -3195,7 +3290,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user
           description: The user to update
@@ -3343,7 +3438,7 @@ definitions:
           If `true`, the operation is completed, and either `error` or `response` is
           available.
       error:
-        $ref: '#/definitions/rpcStatus'
+        $ref: '#/definitions/googlerpcStatus'
         description: The error result of the operation in case of failure or cancellation.
       response:
         $ref: '#/definitions/protobufAny'
@@ -3359,6 +3454,50 @@ definitions:
     description: |-
       This resource represents a long-running operation that is the result of a
       network API call.
+  googlerpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+        description: |-
+          The status code, which should be an enum value of
+          [google.rpc.Code][google.rpc.Code].
+      message:
+        type: string
+        description: |-
+          A developer-facing error message, which should be in English. Any
+          user-facing error message should be localized and sent in the
+          [google.rpc.Status.details][google.rpc.Status.details] field, or localized
+          by the client.
+      details:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/protobufAny'
+        description: |-
+          A list of messages that carry the error details.  There is a common set of
+          message types for APIs to use.
+    description: |-
+      The `Status` type defines a logical error model that is suitable for
+      different programming environments, including REST APIs and RPC APIs. It is
+      used by [gRPC](https://github.com/grpc). Each `Status` message contains
+      three pieces of data: error code, error message, and error details.
+
+      You can find out more about this error model and how to work with it in the
+      [API Design Guide](https://cloud.google.com/apis/design/errors).
+  mgmtv1alphaStatus:
+    type: string
+    enum:
+      - STATUS_UNSPECIFIED
+      - STATUS_COMPLETED
+      - STATUS_ERRORED
+    default: STATUS_UNSPECIFIED
+    description: |-
+      - STATUS_UNSPECIFIED: Status: UNSPECIFIED
+       - STATUS_COMPLETED: Status: COMPLETED
+       - STATUS_ERRORED: Status: ERRORED
+    title: Status enumerates the final status of a pipeline trigger
   modelcontrollerv1alphaDeleteResourceResponse:
     type: object
     title: DeleteResourceResponse represents an empty response
@@ -3572,38 +3711,6 @@ definitions:
        The JSON representation for `NullValue` is JSON `null`.
 
        - NULL_VALUE: Null value.
-  rpcStatus:
-    type: object
-    properties:
-      code:
-        type: integer
-        format: int32
-        description: |-
-          The status code, which should be an enum value of
-          [google.rpc.Code][google.rpc.Code].
-      message:
-        type: string
-        description: |-
-          A developer-facing error message, which should be in English. Any
-          user-facing error message should be localized and sent in the
-          [google.rpc.Status.details][google.rpc.Status.details] field, or localized
-          by the client.
-      details:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/protobufAny'
-        description: |-
-          A list of messages that carry the error details.  There is a common set of
-          message types for APIs to use.
-    description: |-
-      The `Status` type defines a logical error model that is suitable for
-      different programming environments, including REST APIs and RPC APIs. It is
-      used by [gRPC](https://github.com/grpc). Each `Status` message contains
-      three pieces of data: error code, error message, and error details.
-
-      You can find out more about this error model and how to work with it in the
-      [API Design Guide](https://cloud.google.com/apis/design/errors).
   v1alphaActivatePipelineResponse:
     type: object
     properties:
@@ -3949,6 +4056,79 @@ definitions:
         title: ConnectorDefinition vendorAttributes, i.e. the vendor-specific attributes
         readOnly: true
     title: ConnectorDefinition represents the connector definition data model
+  v1alphaConnectorExecuteChartRecord:
+    type: object
+    properties:
+      connector_id:
+        type: string
+        title: ID for the executed connector
+      connector_uid:
+        type: string
+        title: UID for the executed connector
+      status:
+        $ref: '#/definitions/mgmtv1alphaStatus'
+        title: Status of connector execution
+        readOnly: true
+      time_buckets:
+        type: array
+        items:
+          type: string
+          format: date-time
+        title: Time buckets
+        readOnly: true
+      execute_counts:
+        type: array
+        items:
+          type: string
+          format: int64
+        title: Aggregated execute count in each time bucket
+        readOnly: true
+      compute_time_duration:
+        type: array
+        items:
+          type: number
+          format: float
+        title: Total compute time duration in each time bucket
+        readOnly: true
+    title: ConnectorExecuteChartRecord represents a aggregated chart record for connector execute
+  v1alphaConnectorExecuteRecord:
+    type: object
+    properties:
+      execute_time:
+        type: string
+        format: date-time
+        title: Timestamp for the connector execution time
+      connector_execute_id:
+        type: string
+        title: UID for connector execution
+      connector_id:
+        type: string
+        title: ID for the executed connector
+      connector_uid:
+        type: string
+        title: UID for the executed connector
+      connector_definition_uid:
+        type: string
+        title: UID for the executed connector definition
+      pipeline_id:
+        type: string
+        title: ID for the pipeline this connector belong to
+      pipeline_uid:
+        type: string
+        title: UID for the pipeline this connector belong to
+      pipeline_trigger_id:
+        type: string
+        title: UID for the trigger id of the pipeline this connector belong to
+      compute_time_duration:
+        type: number
+        format: float
+        title: Total compute time duration for this execution
+        readOnly: true
+      status:
+        $ref: '#/definitions/mgmtv1alphaStatus'
+        title: Final status for the connector execution
+        readOnly: true
+    title: ConnectorExecuteRecord represents a record for connector execution
   v1alphaConnectorState:
     type: string
     enum:
@@ -4891,6 +5071,37 @@ definitions:
     title: |-
       ListConnectorDefinitionsResponse represents a response for a list
       of ConnectorDefinitions
+  v1alphaListConnectorExecuteChartRecordsResponse:
+    type: object
+    properties:
+      connector_execute_chart_records:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaConnectorExecuteChartRecord'
+        title: A list of connector execute records
+    title: |-
+      ListConnectorExecuteChartRecordsResponse represents a response for a list
+      of connector execute chart record
+  v1alphaListConnectorExecuteRecordsResponse:
+    type: object
+    properties:
+      connector_execute_records:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaConnectorExecuteRecord'
+        title: A list of connector execute records
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of connector execute records
+    title: |-
+      ListConnectorExecuteRecordsResponse represents a response for a list
+      of connector execute record
   v1alphaListConnectorsAdminResponse:
     type: object
     properties:
@@ -4982,6 +5193,18 @@ definitions:
         format: int64
         title: Total count of models
     title: ListModelsResponse represents a response for a list of models
+  v1alphaListPipelineTriggerChartRecordsResponse:
+    type: object
+    properties:
+      pipeline_trigger_chart_records:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaPipelineTriggerChartRecord'
+        title: A list of pipeline trigger records
+    title: |-
+      ListPipelineTriggerChartRecordsResponse represents a response for a list
+      of pipeline trigger chart record
   v1alphaListPipelineTriggerRecordsResponse:
     type: object
     properties:
@@ -5629,6 +5852,44 @@ definitions:
        - STATE_ACTIVE: State ACTIVE indicates the pipeline is active
        - STATE_ERROR: State ERROR indicates the pipeline has error
     title: State enumerates the state of a pipeline
+  v1alphaPipelineTriggerChartRecord:
+    type: object
+    properties:
+      pipeline_id:
+        type: string
+        title: ID for the triggered pipeline
+      pipeline_uid:
+        type: string
+        title: UID for the triggered pipeline
+      trigger_mode:
+        $ref: '#/definitions/v1alphaMode'
+        title: Trigger mode
+      status:
+        $ref: '#/definitions/mgmtv1alphaStatus'
+        title: Status of pipeline trigger
+        readOnly: true
+      time_buckets:
+        type: array
+        items:
+          type: string
+          format: date-time
+        title: Time buckets
+        readOnly: true
+      trigger_counts:
+        type: array
+        items:
+          type: string
+          format: int64
+        title: Aggregated trigger count in each time bucket
+        readOnly: true
+      compute_time_duration:
+        type: array
+        items:
+          type: number
+          format: float
+        title: Total compute time duration in each time bucket
+        readOnly: true
+    title: PipelineTriggerChartRecord represents a aggregated chart record for pipeline trigger
   v1alphaPipelineTriggerRecord:
     type: object
     properties:
@@ -5638,23 +5899,23 @@ definitions:
         title: Timestamp for the pipeline trigger time
       pipeline_trigger_id:
         type: string
-        title: Unique uuid for each pipeline trigger
+        title: UID for each pipeline trigger
       pipeline_id:
         type: string
         title: ID for the triggered pipeline
       pipeline_uid:
         type: string
         title: UID for the triggered pipeline
-      pipeline_mode:
+      trigger_mode:
         $ref: '#/definitions/v1alphaMode'
-        title: Pipeline mode
+        title: Trigger mode
       compute_time_duration:
         type: number
         format: float
         title: Total compute time duration for this pipeline trigger
         readOnly: true
       status:
-        type: string
+        $ref: '#/definitions/mgmtv1alphaStatus'
         title: Final status for pipeline trigger
         readOnly: true
     title: PipelineTriggerRecord represents a record for pipeline trigger


### PR DESCRIPTION
Because

- support aggregation time bucket methods for dashboard chart render
- support connector dashboard

This commit

- add connector metric methods
- add list chart method for pipeline trigger