### PR TITLE
chore(mgmt): add list table metric endpoints

### DIFF
--- a/base/mgmt/v1alpha/metric.proto
+++ b/base/mgmt/v1alpha/metric.proto
@@ -8,8 +8,6 @@ import "google/protobuf/timestamp.proto";
 // Google API
 import "google/api/field_behavior.proto";
 
-// ========== Pipeline endpoints
-
 // Mode enumerates the pipeline modes
 enum Mode {
     // Mode: UNSPECIFIED
@@ -30,6 +28,8 @@ enum Status {
     STATUS_ERRORED = 2;
 }
 
+// ========== Pipeline endpoints
+
 // PipelineTriggerRecord represents a record for pipeline trigger
 message PipelineTriggerRecord {
     // Timestamp for the pipeline trigger time
@@ -48,6 +48,18 @@ message PipelineTriggerRecord {
     Status status = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
+// PipelineTriggerTableRecord represents a aggregated table record for pipeline trigger
+message PipelineTriggerTableRecord {
+    // ID for the triggered pipeline
+    string pipeline_id = 1;
+    // UID for the triggered pipeline
+    string pipeline_uid = 2;
+    // Trigger count with STATUS_COMPLETED
+    int64 trigger_count_completed = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Trigger count with STATUS_ERRORED
+    int64 trigger_count_errored = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
 // PipelineTriggerChartRecord represents a aggregated chart record for pipeline trigger
 message PipelineTriggerChartRecord {
     // ID for the triggered pipeline
@@ -64,46 +76,6 @@ message PipelineTriggerChartRecord {
     repeated int64 trigger_counts = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
     // Total compute time duration in each time bucket
     repeated float compute_time_duration = 7 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-}
-
-// ConnectorExecuteRecord represents a record for connector execution
-message ConnectorExecuteRecord {
-    // Timestamp for the connector execution time
-    google.protobuf.Timestamp execute_time = 1;
-    // UID for connector execution
-    string connector_execute_id = 2;
-    // ID for the executed connector
-    string connector_id = 3;
-    // UID for the executed connector
-    string connector_uid = 4;
-    // UID for the executed connector definition
-    string connector_definition_uid = 5;
-    // ID for the pipeline this connector belong to
-    string pipeline_id = 6;
-    // UID for the pipeline this connector belong to
-    string pipeline_uid = 7;
-    // UID for the trigger id of the pipeline this connector belong to
-    string pipeline_trigger_id = 8;
-    // Total compute time duration for this execution
-    float compute_time_duration = 9 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // Final status for the connector execution
-    Status status = 10 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-}
-
-// ConnectorExecuteChartRecord represents a aggregated chart record for connector execute
-message ConnectorExecuteChartRecord {
-    // ID for the executed connector
-    string connector_id = 1;
-    // UID for the executed connector
-    string connector_uid = 2;
-    // Status of connector execution
-    Status status = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // Time buckets
-    repeated google.protobuf.Timestamp time_buckets = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // Aggregated execute count in each time bucket
-    repeated int64 execute_counts = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
-    // Total compute time duration in each time bucket
-    repeated float compute_time_duration = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
 }
 
 // ListPipelineTriggerRecordsRequest represents a request to list
@@ -130,6 +102,30 @@ message ListPipelineTriggerRecordsResponse {
     int64 total_size = 3;
 }
 
+// ListPipelineTriggerTableRecordsRequest represents a request to list
+// pipeline trigger table record
+message ListPipelineTriggerTableRecordsRequest {
+    // The maximum number of pipeline trigger record to return. The service may return
+    // fewer than this value. If unspecified, at most 100 record will be returned. The
+    // maximum value is 1000; values above 1000 will be coerced to 1000.
+    optional int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
+    // Page token
+    optional string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
+    // Filter expression to list record
+    optional string filter = 3 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// ListPipelineTriggerTableRecordsResponse represents a response for a list
+// of pipeline trigger table record
+message ListPipelineTriggerTableRecordsResponse {
+    // A list of pipeline trigger table records
+    repeated PipelineTriggerTableRecord pipeline_trigger_table_records = 1;
+    // Next page token
+    string next_page_token = 2;
+    // Total count of pipeline trigger records
+    int64 total_size = 3;
+}
+
 // ListPipelineTriggerChartRecordsRequest represents a request to list
 // pipeline trigger chart record
 message ListPipelineTriggerChartRecordsRequest {
@@ -147,6 +143,59 @@ message ListPipelineTriggerChartRecordsResponse {
 }
 
 // ========== Connector endpoints
+
+// ConnectorExecuteRecord represents a record for connector execution
+message ConnectorExecuteRecord {
+    // Timestamp for the connector execution time
+    google.protobuf.Timestamp execute_time = 1;
+    // UID for connector execution
+    string connector_execute_id = 2;
+    // ID for the executed connector
+    string connector_id = 3;
+    // UID for the executed connector
+    string connector_uid = 4;
+    // UID for the executed connector definition
+    string connector_definition_uid = 5;
+    // ID for the pipeline this connector belong to
+    string pipeline_id = 6;
+    // UID for the pipeline this connector belong to
+    string pipeline_uid = 7;
+    // UID for the trigger id of the pipeline this connector belong to
+    string pipeline_trigger_id = 8;
+    // Total compute time duration for this execution
+    float compute_time_duration = 9 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Final status for the connector execution
+    Status status = 10 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+// ConnectorExecuteTableRecord represents a aggregated table record for connector execute
+message ConnectorExecuteTableRecord {
+    // ID for the executed connector
+    string connector_id = 1;
+    // UID for the executed connector
+    string connector_uid = 2;
+    // Execute count with STATUS_COMPLETED
+    int64 execute_count_completed = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Execute count with STATUS_ERRORED
+    int64 execute_count_errored = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
+// ConnectorExecuteChartRecord represents a aggregated chart record for connector execute
+message ConnectorExecuteChartRecord {
+    // ID for the executed connector
+    string connector_id = 1;
+    // UID for the executed connector
+    string connector_uid = 2;
+    // Status of connector execution
+    Status status = 3 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Time buckets
+    repeated google.protobuf.Timestamp time_buckets = 4 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Aggregated execute count in each time bucket
+    repeated int64 execute_counts = 5 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+    // Total compute time duration in each time bucket
+    repeated float compute_time_duration = 6 [ (google.api.field_behavior) = OUTPUT_ONLY ];
+}
+
 
 // ListConnectorExecuteRecordsRequest represents a request to list
 // connector execute record
@@ -166,6 +215,30 @@ message ListConnectorExecuteRecordsRequest {
 message ListConnectorExecuteRecordsResponse {
     // A list of connector execute records
     repeated ConnectorExecuteRecord connector_execute_records = 1;
+    // Next page token
+    string next_page_token = 2;
+    // Total count of connector execute records
+    int64 total_size = 3;
+}
+
+// ListConnectorExecuteTableRecordsRequest represents a request to list
+// connector execute table record
+message ListConnectorExecuteTableRecordsRequest {
+    // The maximum number of connector execution table record to return. The service may return
+    // fewer than this value. If unspecified, at most 100 record will be returned. The
+    // maximum value is 1000; values above 1000 will be coerced to 1000.
+    optional int64 page_size = 1 [ (google.api.field_behavior) = OPTIONAL ];
+    // Page token
+    optional string page_token = 2 [ (google.api.field_behavior) = OPTIONAL ];
+    // Filter expression to list record
+    optional string filter = 3 [ (google.api.field_behavior) = OPTIONAL ];
+}
+
+// ListConnectorExecuteTableRecordsResponse represents a response for a list
+// of connector execute table record
+message ListConnectorExecuteTableRecordsResponse {
+    // A list of connector execute records
+    repeated ConnectorExecuteTableRecord connector_execute_table_records = 1;
     // Next page token
     string next_page_token = 2;
     // Total count of connector execute records

--- a/base/mgmt/v1alpha/mgmt_public_service.proto
+++ b/base/mgmt/v1alpha/mgmt_public_service.proto
@@ -108,6 +108,14 @@ service MgmtPublicService {
     };
   }
 
+  // ListPipelineTriggerTableRecords method receives a ListPipelineTriggerTableRecordsRequest message and returns a
+  // ListPipelineTriggerTableRecordsResponse message.
+  rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/metrics/vdp/pipeline/tables"
+    };
+  }
+
   // ListPipelineTriggerChartRecords method receives a ListPipelineTriggerChartRecordsRequest message and returns a
   // ListPipelineTriggerChartRecordsResponse message.
   rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
@@ -121,6 +129,14 @@ service MgmtPublicService {
   rpc ListConnectorExecuteRecords(ListConnectorExecuteRecordsRequest) returns (ListConnectorExecuteRecordsResponse) {
     option (google.api.http) = {
       get : "/v1alpha/metrics/vdp/connector/executes"
+    };
+  }
+
+  // ListConnectorExecuteTableRecords method receives a ListConnectorExecuteTableRecordsRequest message and returns a
+  // ListConnectorExecuteTableRecordsResponse message.
+  rpc ListConnectorExecuteTableRecords(ListConnectorExecuteTableRecordsRequest) returns (ListConnectorExecuteTableRecordsResponse) {
+    option (google.api.http) = {
+      get : "/v1alpha/metrics/vdp/connector/tables"
     };
   }
 

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2830,6 +2830,43 @@ paths:
           type: string
       tags:
         - MgmtPublicService
+  /v1alpha/metrics/vdp/connector/tables:
+    get:
+      summary: |-
+        ListConnectorExecuteTableRecords method receives a ListConnectorExecuteTableRecordsRequest message and returns a
+        ListConnectorExecuteTableRecordsResponse message.
+      operationId: MgmtPublicService_ListConnectorExecuteTableRecords
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListConnectorExecuteTableRecordsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of connector execution table record to return. The service may return
+            fewer than this value. If unspecified, at most 100 record will be returned. The
+            maximum value is 1000; values above 1000 will be coerced to 1000.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: filter
+          description: Filter expression to list record
+          in: query
+          required: false
+          type: string
+      tags:
+        - MgmtPublicService
   /v1alpha/metrics/vdp/pipeline/charts:
     get:
       summary: |-
@@ -2854,6 +2891,43 @@ paths:
           format: int64
         - name: filter
           description: Filter expression to list chart record
+          in: query
+          required: false
+          type: string
+      tags:
+        - MgmtPublicService
+  /v1alpha/metrics/vdp/pipeline/tables:
+    get:
+      summary: |-
+        ListPipelineTriggerTableRecords method receives a ListPipelineTriggerTableRecordsRequest message and returns a
+        ListPipelineTriggerTableRecordsResponse message.
+      operationId: MgmtPublicService_ListPipelineTriggerTableRecords
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListPipelineTriggerTableRecordsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of pipeline trigger record to return. The service may return
+            fewer than this value. If unspecified, at most 100 record will be returned. The
+            maximum value is 1000; values above 1000 will be coerced to 1000.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: filter
+          description: Filter expression to list record
           in: query
           required: false
           type: string
@@ -4129,6 +4203,26 @@ definitions:
         title: Final status for the connector execution
         readOnly: true
     title: ConnectorExecuteRecord represents a record for connector execution
+  v1alphaConnectorExecuteTableRecord:
+    type: object
+    properties:
+      connector_id:
+        type: string
+        title: ID for the executed connector
+      connector_uid:
+        type: string
+        title: UID for the executed connector
+      execute_count_completed:
+        type: string
+        format: int64
+        title: Execute count with STATUS_COMPLETED
+        readOnly: true
+      execute_count_errored:
+        type: string
+        format: int64
+        title: Execute count with STATUS_ERRORED
+        readOnly: true
+    title: ConnectorExecuteTableRecord represents a aggregated table record for connector execute
   v1alphaConnectorState:
     type: string
     enum:
@@ -5108,6 +5202,25 @@ definitions:
     title: |-
       ListConnectorExecuteRecordsResponse represents a response for a list
       of connector execute record
+  v1alphaListConnectorExecuteTableRecordsResponse:
+    type: object
+    properties:
+      connector_execute_table_records:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaConnectorExecuteTableRecord'
+        title: A list of connector execute records
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of connector execute records
+    title: |-
+      ListConnectorExecuteTableRecordsResponse represents a response for a list
+      of connector execute table record
   v1alphaListConnectorsAdminResponse:
     type: object
     properties:
@@ -5230,6 +5343,25 @@ definitions:
     title: |-
       ListPipelineTriggerRecordsResponse represents a response for a list
       of pipeline trigger record
+  v1alphaListPipelineTriggerTableRecordsResponse:
+    type: object
+    properties:
+      pipeline_trigger_table_records:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaPipelineTriggerTableRecord'
+        title: A list of pipeline trigger table records
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of pipeline trigger records
+    title: |-
+      ListPipelineTriggerTableRecordsResponse represents a response for a list
+      of pipeline trigger table record
   v1alphaListPipelinesAdminResponse:
     type: object
     properties:
@@ -5931,6 +6063,26 @@ definitions:
         title: Final status for pipeline trigger
         readOnly: true
     title: PipelineTriggerRecord represents a record for pipeline trigger
+  v1alphaPipelineTriggerTableRecord:
+    type: object
+    properties:
+      pipeline_id:
+        type: string
+        title: ID for the triggered pipeline
+      pipeline_uid:
+        type: string
+        title: UID for the triggered pipeline
+      trigger_count_completed:
+        type: string
+        format: int64
+        title: Trigger count with STATUS_COMPLETED
+        readOnly: true
+      trigger_count_errored:
+        type: string
+        format: int64
+        title: Trigger count with STATUS_ERRORED
+        readOnly: true
+    title: PipelineTriggerTableRecord represents a aggregated table record for pipeline trigger
   v1alphaPipelineUsageData:
     type: object
     properties:


### PR DESCRIPTION
Because

- support table view with pagination for pipeline/connector

This commit

- add list table records endpoints for pipeline and connector
