### PR TITLE
chore(usage): add trigger/execute metadata in usage report

### DIFF
--- a/base/usage/v1alpha/usage.proto
+++ b/base/usage/v1alpha/usage.proto
@@ -111,12 +111,8 @@ message ConnectorUsageData {
     }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
-    // Number of connectors with 'connected' state
-    int64 connector_connected_state_num = 2 [(google.api.field_behavior) = REQUIRED];
-    // Number of connectors with 'disconneceted' state
-    int64 connector_disconnected_state_num = 3 [(google.api.field_behavior) = REQUIRED];
     // Execution data for each user
-    repeated ConnectorExecuteData connector_execute_data = 4 [(google.api.field_behavior) = REQUIRED];
+    repeated ConnectorExecuteData connector_execute_data = 2 [(google.api.field_behavior) = REQUIRED];
   }
   // Usage data of all users in the connector service
   repeated UserUsageData usages = 1;
@@ -143,12 +139,8 @@ message ModelUsageData {
     }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
-    // Number of 'online' models
-    int64 model_online_state_num = 2 [(google.api.field_behavior) = REQUIRED];
-    // Number of 'offline' models
-    int64 model_offline_state_num = 3 [(google.api.field_behavior) = REQUIRED];
     // Trigger data for each user
-    repeated ModelTriggerData model_trigger_data = 4 [(google.api.field_behavior) = REQUIRED];
+    repeated ModelTriggerData model_trigger_data = 2 [(google.api.field_behavior) = REQUIRED];
   }
   // Usage data of all users in the model service
   repeated UserUsageData usages = 1;
@@ -173,12 +165,8 @@ message PipelineUsageData {
     }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
-    // Number of pipelines with 'active' state
-    int64 pipeline_active_state_num = 2 [(google.api.field_behavior) = REQUIRED];
-    // Number of pipelines with 'inactive' state
-    int64 pipeline_inactive_state_num = 3 [(google.api.field_behavior) = REQUIRED];
     // Trigger data for each user
-    repeated PipelineTriggerData pipeline_trigger_data = 4 [(google.api.field_behavior) = REQUIRED];
+    repeated PipelineTriggerData pipeline_trigger_data = 2 [(google.api.field_behavior) = REQUIRED];
   }
   // Usage data of all users in the pipeline service
   repeated UserUsageData usages = 1;

--- a/base/usage/v1alpha/usage.proto
+++ b/base/usage/v1alpha/usage.proto
@@ -9,6 +9,10 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 // Protobuf standard
 import "google/protobuf/timestamp.proto";
+
+import "common/healthcheck/v1alpha/healthcheck.proto";
+import "base/mgmt/v1alpha/mgmt.proto";
+import "base/mgmt/v1alpha/metric.proto";
 import "model/model/v1alpha/model.proto";
 
 // LivenessRequest represents a request to check a service liveness status
@@ -95,22 +99,28 @@ message MgmtUsageData {
 message ConnectorUsageData {
   // Per user usage data in the connector service
   message UserUsageData {
+    // Per execute usage metadata
+    message ConnectorExecuteData {
+      // UID for the executed connector
+      string connector_uid = 1 [ (google.api.field_behavior) = REQUIRED ];
+      // UID for the trigger log
+      string execute_uid = 2 [ (google.api.field_behavior) = REQUIRED ];
+      // Timestamp for the execution
+      google.protobuf.Timestamp execute_time = 3 [ (google.api.field_behavior) = REQUIRED ];
+      // Definition ID of the connector
+      string connector_definition_id = 4 [ (google.api.field_behavior) = REQUIRED ];
+    }
     // User UUID
-    string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
-    // Number of source connectors with 'connected' state
-    int64 source_connector_connected_state_num = 2 [(google.api.field_behavior) = REQUIRED];
-    // Number of source connectors with 'disconneceted' state
-    int64 source_connector_disconnected_state_num = 3 [(google.api.field_behavior) = REQUIRED];
-    // Definition IDs of the source connectors. Element in the list
-    // should not be duplicated.
-    repeated string source_connector_definition_ids = 4 [(google.api.field_behavior) = REQUIRED];
-    // Number of destination connectors with 'connected' state
-    int64 destination_connector_connected_state_num = 5 [(google.api.field_behavior) = REQUIRED];
-    // Number of destination connectors with 'disconnected' state
-    int64 destination_connector_disconnected_state_num = 6 [(google.api.field_behavior) = REQUIRED];
-    // Definition IDs of the destination connectors. Element in the
-    // list should not be duplicated.
-    repeated string destination_connector_definition_ids = 7 [(google.api.field_behavior) = REQUIRED];
+    string user_uid = 1 [ (google.api.field_behavior) = REQUIRED ];
+    // Number of connectors with 'connected' state
+    int64 connector_connected_state_num = 2
+        [ (google.api.field_behavior) = REQUIRED ];
+    // Number of connectors with 'disconneceted' state
+    int64 connector_disconnected_state_num = 3
+        [ (google.api.field_behavior) = REQUIRED ];
+    // Execution data for each user
+    repeated ConnectorExecuteData connector_execute_data = 4
+        [ (google.api.field_behavior) = REQUIRED ];
   }
   // Usage data of all users in the connector service
   repeated UserUsageData usages = 1;
@@ -120,20 +130,28 @@ message ConnectorUsageData {
 message ModelUsageData {
   // Per user usage data in the model service
   message UserUsageData {
+    // Per trigger usage metadata
+    message ModelTriggerData {
+      // UID for the trigged model
+      string model_uid = 1 [ (google.api.field_behavior) = REQUIRED ];
+      // UID for the trigger log
+      string trigger_uid = 2 [ (google.api.field_behavior) = REQUIRED ];
+      // Timestamp for the trigger
+      google.protobuf.Timestamp trigger_time = 3 [ (google.api.field_behavior) = REQUIRED ];
+      // Definition ID of the model
+      string model_definition_id = 4 [ (google.api.field_behavior) = REQUIRED ];
+      // Task of the model
+      model.model.v1alpha.Model.Task model_task = 5 [ (google.api.field_behavior) = REQUIRED ];
+    }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
     // Number of 'online' models
     int64 model_online_state_num = 2 [(google.api.field_behavior) = REQUIRED];
     // Number of 'offline' models
-    int64 model_offline_state_num = 3 [(google.api.field_behavior) = REQUIRED];
-    // Definition IDs of the model. Element in the list
-    // should not be duplicated.
-    repeated string model_definition_ids = 4 [(google.api.field_behavior) = REQUIRED];
-    // Tasks of the models. Element in the list should not be
-    // duplicated.
-    repeated model.model.v1alpha.Model.Task tasks = 5 [(google.api.field_behavior) = REQUIRED];
-    // Number of model testing operations
-    int64 test_num = 6 [(google.api.field_behavior) = REQUIRED];
+    int64 model_offline_state_num = 3
+        [ (google.api.field_behavior) = REQUIRED ];
+    // Trigger data for each user
+    repeated ModelTriggerData model_trigger_data = 4 [ (google.api.field_behavior) = REQUIRED ];
   }
   // Usage data of all users in the model service
   repeated UserUsageData usages = 1;
@@ -143,18 +161,26 @@ message ModelUsageData {
 message PipelineUsageData {
   // Per user usage data in the pipeline service
   message UserUsageData {
+    // Per trigger usage metadata
+    message PipelineTriggerData {
+      // UID for the triggered pipeline
+      string pipeline_uid = 1  [ (google.api.field_behavior) = REQUIRED ];
+      // UID for the trigger log
+      string trigger_uid = 2  [ (google.api.field_behavior) = REQUIRED ];
+      // Timestamp for the trigger
+      google.protobuf.Timestamp trigger_time = 3 [ (google.api.field_behavior) = REQUIRED ];
+      // Trigger mode
+      base.mgmt.v1alpha.Mode trigger_mode = 4 [ (google.api.field_behavior) = REQUIRED ];
+    }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
     // Number of pipelines with 'active' state
     int64 pipeline_active_state_num = 2 [(google.api.field_behavior) = REQUIRED];
     // Number of pipelines with 'inactive' state
-    int64 pipeline_inactive_state_num = 3 [(google.api.field_behavior) = REQUIRED];
-    // Number of pipelines with 'async' mode
-    int64 pipeline_async_mode_num = 4 [(google.api.field_behavior) = REQUIRED];
-    // Number of pipelines with 'sync' mode
-    int64 pipeline_sync_mode_num = 5 [(google.api.field_behavior) = REQUIRED];
-    // Number of pipeline triggering operations
-    int64 trigger_num = 6 [(google.api.field_behavior) = REQUIRED];
+    int64 pipeline_inactive_state_num = 3
+        [ (google.api.field_behavior) = REQUIRED ];
+    // Trigger data for each user
+    repeated PipelineTriggerData pipeline_trigger_data = 4  [ (google.api.field_behavior) = REQUIRED ];
   }
   // Usage data of all users in the pipeline service
   repeated UserUsageData usages = 1;

--- a/base/usage/v1alpha/usage.proto
+++ b/base/usage/v1alpha/usage.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package base.usage.v1alpha;
 
+import "base/mgmt/v1alpha/metric.proto";
 import "base/mgmt/v1alpha/mgmt.proto";
 import "common/healthcheck/v1alpha/healthcheck.proto";
 import "google/api/field_behavior.proto";
@@ -9,10 +10,6 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 // Protobuf standard
 import "google/protobuf/timestamp.proto";
-
-import "common/healthcheck/v1alpha/healthcheck.proto";
-import "base/mgmt/v1alpha/mgmt.proto";
-import "base/mgmt/v1alpha/metric.proto";
 import "model/model/v1alpha/model.proto";
 
 // LivenessRequest represents a request to check a service liveness status
@@ -102,25 +99,22 @@ message ConnectorUsageData {
     // Per execute usage metadata
     message ConnectorExecuteData {
       // UID for the executed connector
-      string connector_uid = 1 [ (google.api.field_behavior) = REQUIRED ];
+      string connector_uid = 1 [(google.api.field_behavior) = REQUIRED];
       // UID for the trigger log
-      string execute_uid = 2 [ (google.api.field_behavior) = REQUIRED ];
+      string execute_uid = 2 [(google.api.field_behavior) = REQUIRED];
       // Timestamp for the execution
-      google.protobuf.Timestamp execute_time = 3 [ (google.api.field_behavior) = REQUIRED ];
+      google.protobuf.Timestamp execute_time = 3 [(google.api.field_behavior) = REQUIRED];
       // Definition ID of the connector
-      string connector_definition_id = 4 [ (google.api.field_behavior) = REQUIRED ];
+      string connector_definition_id = 4 [(google.api.field_behavior) = REQUIRED];
     }
     // User UUID
-    string user_uid = 1 [ (google.api.field_behavior) = REQUIRED ];
+    string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
     // Number of connectors with 'connected' state
-    int64 connector_connected_state_num = 2
-        [ (google.api.field_behavior) = REQUIRED ];
+    int64 connector_connected_state_num = 2 [(google.api.field_behavior) = REQUIRED];
     // Number of connectors with 'disconneceted' state
-    int64 connector_disconnected_state_num = 3
-        [ (google.api.field_behavior) = REQUIRED ];
+    int64 connector_disconnected_state_num = 3 [(google.api.field_behavior) = REQUIRED];
     // Execution data for each user
-    repeated ConnectorExecuteData connector_execute_data = 4
-        [ (google.api.field_behavior) = REQUIRED ];
+    repeated ConnectorExecuteData connector_execute_data = 4 [(google.api.field_behavior) = REQUIRED];
   }
   // Usage data of all users in the connector service
   repeated UserUsageData usages = 1;
@@ -133,25 +127,24 @@ message ModelUsageData {
     // Per trigger usage metadata
     message ModelTriggerData {
       // UID for the trigged model
-      string model_uid = 1 [ (google.api.field_behavior) = REQUIRED ];
+      string model_uid = 1 [(google.api.field_behavior) = REQUIRED];
       // UID for the trigger log
-      string trigger_uid = 2 [ (google.api.field_behavior) = REQUIRED ];
+      string trigger_uid = 2 [(google.api.field_behavior) = REQUIRED];
       // Timestamp for the trigger
-      google.protobuf.Timestamp trigger_time = 3 [ (google.api.field_behavior) = REQUIRED ];
+      google.protobuf.Timestamp trigger_time = 3 [(google.api.field_behavior) = REQUIRED];
       // Definition ID of the model
-      string model_definition_id = 4 [ (google.api.field_behavior) = REQUIRED ];
+      string model_definition_id = 4 [(google.api.field_behavior) = REQUIRED];
       // Task of the model
-      model.model.v1alpha.Model.Task model_task = 5 [ (google.api.field_behavior) = REQUIRED ];
+      model.model.v1alpha.Model.Task model_task = 5 [(google.api.field_behavior) = REQUIRED];
     }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
     // Number of 'online' models
     int64 model_online_state_num = 2 [(google.api.field_behavior) = REQUIRED];
     // Number of 'offline' models
-    int64 model_offline_state_num = 3
-        [ (google.api.field_behavior) = REQUIRED ];
+    int64 model_offline_state_num = 3 [(google.api.field_behavior) = REQUIRED];
     // Trigger data for each user
-    repeated ModelTriggerData model_trigger_data = 4 [ (google.api.field_behavior) = REQUIRED ];
+    repeated ModelTriggerData model_trigger_data = 4 [(google.api.field_behavior) = REQUIRED];
   }
   // Usage data of all users in the model service
   repeated UserUsageData usages = 1;
@@ -164,23 +157,22 @@ message PipelineUsageData {
     // Per trigger usage metadata
     message PipelineTriggerData {
       // UID for the triggered pipeline
-      string pipeline_uid = 1  [ (google.api.field_behavior) = REQUIRED ];
+      string pipeline_uid = 1 [(google.api.field_behavior) = REQUIRED];
       // UID for the trigger log
-      string trigger_uid = 2  [ (google.api.field_behavior) = REQUIRED ];
+      string trigger_uid = 2 [(google.api.field_behavior) = REQUIRED];
       // Timestamp for the trigger
-      google.protobuf.Timestamp trigger_time = 3 [ (google.api.field_behavior) = REQUIRED ];
+      google.protobuf.Timestamp trigger_time = 3 [(google.api.field_behavior) = REQUIRED];
       // Trigger mode
-      base.mgmt.v1alpha.Mode trigger_mode = 4 [ (google.api.field_behavior) = REQUIRED ];
+      base.mgmt.v1alpha.Mode trigger_mode = 4 [(google.api.field_behavior) = REQUIRED];
     }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
     // Number of pipelines with 'active' state
     int64 pipeline_active_state_num = 2 [(google.api.field_behavior) = REQUIRED];
     // Number of pipelines with 'inactive' state
-    int64 pipeline_inactive_state_num = 3
-        [ (google.api.field_behavior) = REQUIRED ];
+    int64 pipeline_inactive_state_num = 3 [(google.api.field_behavior) = REQUIRED];
     // Trigger data for each user
-    repeated PipelineTriggerData pipeline_trigger_data = 4  [ (google.api.field_behavior) = REQUIRED ];
+    repeated PipelineTriggerData pipeline_trigger_data = 4 [(google.api.field_behavior) = REQUIRED];
   }
   // Usage data of all users in the pipeline service
   repeated UserUsageData usages = 1;

--- a/base/usage/v1alpha/usage.proto
+++ b/base/usage/v1alpha/usage.proto
@@ -105,7 +105,9 @@ message ConnectorUsageData {
       // Timestamp for the execution
       google.protobuf.Timestamp execute_time = 3 [(google.api.field_behavior) = REQUIRED];
       // Definition ID of the connector
-      string connector_definition_id = 4 [(google.api.field_behavior) = REQUIRED];
+      string connector_definition_uid = 4 [(google.api.field_behavior) = REQUIRED];
+      // Final status of the execution
+      base.mgmt.v1alpha.Status status = 5 [(google.api.field_behavior) = REQUIRED];
     }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
@@ -136,6 +138,8 @@ message ModelUsageData {
       string model_definition_id = 4 [(google.api.field_behavior) = REQUIRED];
       // Task of the model
       model.model.v1alpha.Model.Task model_task = 5 [(google.api.field_behavior) = REQUIRED];
+      // Final status of the execution
+      base.mgmt.v1alpha.Status status = 6 [(google.api.field_behavior) = REQUIRED];
     }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];
@@ -164,6 +168,8 @@ message PipelineUsageData {
       google.protobuf.Timestamp trigger_time = 3 [(google.api.field_behavior) = REQUIRED];
       // Trigger mode
       base.mgmt.v1alpha.Mode trigger_mode = 4 [(google.api.field_behavior) = REQUIRED];
+      // Final status of the execution
+      base.mgmt.v1alpha.Status status = 5 [(google.api.field_behavior) = REQUIRED];
     }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -3431,15 +3431,19 @@ definitions:
         type: string
         format: date-time
         title: Timestamp for the execution
-      connector_definition_id:
+      connector_definition_uid:
         type: string
         title: Definition ID of the connector
+      status:
+        $ref: '#/definitions/mgmtv1alphaStatus'
+        title: Final status of the execution
     title: Per execute usage metadata
     required:
       - connector_uid
       - execute_uid
       - execute_time
-      - connector_definition_id
+      - connector_definition_uid
+      - status
   UserUsageDataModelTriggerData:
     type: object
     properties:
@@ -3459,6 +3463,9 @@ definitions:
       model_task:
         $ref: '#/definitions/v1alphaModelTask'
         title: Task of the model
+      status:
+        $ref: '#/definitions/mgmtv1alphaStatus'
+        title: Final status of the execution
     title: Per trigger usage metadata
     required:
       - model_uid
@@ -3466,6 +3473,7 @@ definitions:
       - trigger_time
       - model_definition_id
       - model_task
+      - status
   UserUsageDataPipelineTriggerData:
     type: object
     properties:
@@ -3482,12 +3490,16 @@ definitions:
       trigger_mode:
         $ref: '#/definitions/v1alphaMode'
         title: Trigger mode
+      status:
+        $ref: '#/definitions/mgmtv1alphaStatus'
+        title: Final status of the execution
     title: Per trigger usage metadata
     required:
       - pipeline_uid
       - trigger_uid
       - trigger_time
       - trigger_mode
+      - status
   basemgmtv1alphaLivenessResponse:
     type: object
     properties:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -3418,6 +3418,76 @@ definitions:
        - SERVICE_MODEL: Service: MODEL
        - SERVICE_PIPELINE: Service: PIPELINE
     title: Service enumerates the services to collect data from
+  UserUsageDataConnectorExecuteData:
+    type: object
+    properties:
+      connector_uid:
+        type: string
+        title: UID for the executed connector
+      execute_uid:
+        type: string
+        title: UID for the trigger log
+      execute_time:
+        type: string
+        format: date-time
+        title: Timestamp for the execution
+      connector_definition_id:
+        type: string
+        title: Definition ID of the connector
+    title: Per execute usage metadata
+    required:
+      - connector_uid
+      - execute_uid
+      - execute_time
+      - connector_definition_id
+  UserUsageDataModelTriggerData:
+    type: object
+    properties:
+      model_uid:
+        type: string
+        title: UID for the trigged model
+      trigger_uid:
+        type: string
+        title: UID for the trigger log
+      trigger_time:
+        type: string
+        format: date-time
+        title: Timestamp for the trigger
+      model_definition_id:
+        type: string
+        title: Definition ID of the model
+      model_task:
+        $ref: '#/definitions/v1alphaModelTask'
+        title: Task of the model
+    title: Per trigger usage metadata
+    required:
+      - model_uid
+      - trigger_uid
+      - trigger_time
+      - model_definition_id
+      - model_task
+  UserUsageDataPipelineTriggerData:
+    type: object
+    properties:
+      pipeline_uid:
+        type: string
+        title: UID for the triggered pipeline
+      trigger_uid:
+        type: string
+        title: UID for the trigger log
+      trigger_time:
+        type: string
+        format: date-time
+        title: Timestamp for the trigger
+      trigger_mode:
+        $ref: '#/definitions/v1alphaMode'
+        title: Trigger mode
+    title: Per trigger usage metadata
+    required:
+      - pipeline_uid
+      - trigger_uid
+      - trigger_time
+      - trigger_mode
   basemgmtv1alphaLivenessResponse:
     type: object
     properties:
@@ -4269,45 +4339,26 @@ definitions:
       user_uid:
         type: string
         title: User UUID
-      source_connector_connected_state_num:
+      connector_connected_state_num:
         type: string
         format: int64
-        title: Number of source connectors with 'connected' state
-      source_connector_disconnected_state_num:
+        title: Number of connectors with 'connected' state
+      connector_disconnected_state_num:
         type: string
         format: int64
-        title: Number of source connectors with 'disconneceted' state
-      source_connector_definition_ids:
+        title: Number of connectors with 'disconneceted' state
+      connector_execute_data:
         type: array
         items:
-          type: string
-        description: |-
-          Definition IDs of the source connectors. Element in the list
-          should not be duplicated.
-      destination_connector_connected_state_num:
-        type: string
-        format: int64
-        title: Number of destination connectors with 'connected' state
-      destination_connector_disconnected_state_num:
-        type: string
-        format: int64
-        title: Number of destination connectors with 'disconnected' state
-      destination_connector_definition_ids:
-        type: array
-        items:
-          type: string
-        description: |-
-          Definition IDs of the destination connectors. Element in the
-          list should not be duplicated.
+          type: object
+          $ref: '#/definitions/UserUsageDataConnectorExecuteData'
+        title: Execution data for each user
     title: Per user usage data in the connector service
     required:
       - user_uid
-      - source_connector_connected_state_num
-      - source_connector_disconnected_state_num
-      - source_connector_definition_ids
-      - destination_connector_connected_state_num
-      - destination_connector_disconnected_state_num
-      - destination_connector_definition_ids
+      - connector_connected_state_num
+      - connector_disconnected_state_num
+      - connector_execute_data
   v1alphaConnectorVisibility:
     type: string
     enum:
@@ -5741,32 +5792,18 @@ definitions:
         type: string
         format: int64
         title: Number of 'offline' models
-      model_definition_ids:
+      model_trigger_data:
         type: array
         items:
-          type: string
-        description: |-
-          Definition IDs of the model. Element in the list
-          should not be duplicated.
-      tasks:
-        type: array
-        items:
-          $ref: '#/definitions/v1alphaModelTask'
-        description: |-
-          Tasks of the models. Element in the list should not be
-          duplicated.
-      test_num:
-        type: string
-        format: int64
-        title: Number of model testing operations
+          type: object
+          $ref: '#/definitions/UserUsageDataModelTriggerData'
+        title: Trigger data for each user
     title: Per user usage data in the model service
     required:
       - user_uid
       - model_online_state_num
       - model_offline_state_num
-      - model_definition_ids
-      - tasks
-      - test_num
+      - model_trigger_data
   v1alphaModelUsageRecord:
     type: object
     properties:
@@ -6107,26 +6144,18 @@ definitions:
         type: string
         format: int64
         title: Number of pipelines with 'inactive' state
-      pipeline_async_mode_num:
-        type: string
-        format: int64
-        title: Number of pipelines with 'async' mode
-      pipeline_sync_mode_num:
-        type: string
-        format: int64
-        title: Number of pipelines with 'sync' mode
-      trigger_num:
-        type: string
-        format: int64
-        title: Number of pipeline triggering operations
+      pipeline_trigger_data:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/UserUsageDataPipelineTriggerData'
+        title: Trigger data for each user
     title: Per user usage data in the pipeline service
     required:
       - user_uid
       - pipeline_active_state_num
       - pipeline_inactive_state_num
-      - pipeline_async_mode_num
-      - pipeline_sync_mode_num
-      - trigger_num
+      - pipeline_trigger_data
   v1alphaPipelineUsageRecord:
     type: object
     properties:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4351,14 +4351,6 @@ definitions:
       user_uid:
         type: string
         title: User UUID
-      connector_connected_state_num:
-        type: string
-        format: int64
-        title: Number of connectors with 'connected' state
-      connector_disconnected_state_num:
-        type: string
-        format: int64
-        title: Number of connectors with 'disconneceted' state
       connector_execute_data:
         type: array
         items:
@@ -4368,8 +4360,6 @@ definitions:
     title: Per user usage data in the connector service
     required:
       - user_uid
-      - connector_connected_state_num
-      - connector_disconnected_state_num
       - connector_execute_data
   v1alphaConnectorVisibility:
     type: string
@@ -5796,14 +5786,6 @@ definitions:
       user_uid:
         type: string
         title: User UUID
-      model_online_state_num:
-        type: string
-        format: int64
-        title: Number of 'online' models
-      model_offline_state_num:
-        type: string
-        format: int64
-        title: Number of 'offline' models
       model_trigger_data:
         type: array
         items:
@@ -5813,8 +5795,6 @@ definitions:
     title: Per user usage data in the model service
     required:
       - user_uid
-      - model_online_state_num
-      - model_offline_state_num
       - model_trigger_data
   v1alphaModelUsageRecord:
     type: object
@@ -6148,14 +6128,6 @@ definitions:
       user_uid:
         type: string
         title: User UUID
-      pipeline_active_state_num:
-        type: string
-        format: int64
-        title: Number of pipelines with 'active' state
-      pipeline_inactive_state_num:
-        type: string
-        format: int64
-        title: Number of pipelines with 'inactive' state
       pipeline_trigger_data:
         type: array
         items:
@@ -6165,8 +6137,6 @@ definitions:
     title: Per user usage data in the pipeline service
     required:
       - user_uid
-      - pipeline_active_state_num
-      - pipeline_inactive_state_num
       - pipeline_trigger_data
   v1alphaPipelineUsageRecord:
     type: object


### PR DESCRIPTION
Because

- lack details in current usage data collection

This commit

- add model/connector/pipeline trigger/execute metadata in usage report
