### PR TITLE
chore(connector): add new ConnectorType

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4245,6 +4245,8 @@ definitions:
       - CONNECTOR_TYPE_DESTINATION
       - CONNECTOR_TYPE_AI
       - CONNECTOR_TYPE_BLOCKCHAIN
+      - CONNECTOR_TYPE_DATA
+      - CONNECTOR_TYPE_OPERATOR
     default: CONNECTOR_TYPE_UNSPECIFIED
     description: |-
       - CONNECTOR_TYPE_UNSPECIFIED: ConnectorType: UNSPECIFIED
@@ -4252,6 +4254,8 @@ definitions:
        - CONNECTOR_TYPE_DESTINATION: ConnectorType: DESTINATION
        - CONNECTOR_TYPE_AI: ConnectorType: AI
        - CONNECTOR_TYPE_BLOCKCHAIN: ConnectorType: Blockchain
+       - CONNECTOR_TYPE_DATA: ConnectorType: DATA
+       - CONNECTOR_TYPE_OPERATOR: ConnectorType: OPERATOR
     title: ConnectorType enumerates connector types
   v1alphaConnectorUsageData:
     type: object

--- a/vdp/connector/v1alpha/connector_definition.proto
+++ b/vdp/connector/v1alpha/connector_definition.proto
@@ -34,6 +34,10 @@ enum ConnectorType {
   CONNECTOR_TYPE_AI = 3;
   // ConnectorType: Blockchain
   CONNECTOR_TYPE_BLOCKCHAIN = 4;
+  // ConnectorType: DATA
+  CONNECTOR_TYPE_DATA = 5;
+  // ConnectorType: OPERATOR
+  CONNECTOR_TYPE_OPERATOR = 6;
 }
 
 // ConnectorDefinition represents the connector definition data model


### PR DESCRIPTION
Because

- We are going to merge source/destination connectors into data connectors

This commit

- add new `ConnectorType`: `CONNECTOR_TYPE_DATA` and `CONNECTOR_TYPE_OPERATOR`
