### PR TITLE
chore(connector,pipeline): retire DataPayload and PipelineDataPayload

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -691,7 +691,6 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: '#/definitions/v1alphaPipelineDataPayload'
                 title: Input to the pipeline
             title: TriggerPipelineRequest represents a request to trigger a pipeline
             required:
@@ -983,7 +982,6 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: '#/definitions/v1alphaDataPayload'
                 title: Inputs
             title: |-
               ExecuteConnectorRequest represents a private request to execution
@@ -1171,7 +1169,6 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: '#/definitions/v1alphaPipelineDataPayload'
                 title: Input to the pipeline
             title: TriggerAsyncPipelineRequest represents a request to trigger a async pipeline
             required:
@@ -3389,19 +3386,6 @@ definitions:
        - SERVING_STATUS_SERVING: Serving status: SERVING
        - SERVING_STATUS_NOT_SERVING: Serving status: NOT SERVING
     title: ServingStatus enumerates the status of a queried service
-  PipelineDataPayloadUnstructuredData:
-    type: object
-    properties:
-      blob:
-        type: string
-        format: byte
-        title: |-
-          UnstructuredData using bytes,
-          grpc-gateway will do base64 conversion for http endpoint
-      url:
-        type: string
-        title: UnstructuredData using url
-    title: UnstructuredData
   SessionService:
     type: string
     enum:
@@ -4010,14 +3994,9 @@ definitions:
         type: object
         title: A pipeline component resource detail
         readOnly: true
-      metadata:
+      configuration:
         type: object
-        title: Metadata for the pipeline component
-      dependencies:
-        type: object
-        additionalProperties:
-          type: string
-        title: Dependencies for the pipeline component
+        title: Configuration for the pipeline component
       type:
         type: string
         title: Resource Type
@@ -4402,38 +4381,6 @@ definitions:
         $ref: '#/definitions/v1alphaUser'
         title: A user resource
     title: CreateUserAdminResponse represents a response for a user response
-  v1alphaDataPayload:
-    type: object
-    properties:
-      data_mapping_index:
-        type: string
-        title: Data index corresponds to each data element
-      texts:
-        type: array
-        items:
-          type: string
-        title: 'Unstructured: text field'
-      images:
-        type: array
-        items:
-          type: string
-          format: byte
-        title: 'Unstructured: image field'
-      audios:
-        type: array
-        items:
-          type: string
-          format: byte
-        title: 'Unstructured: audio field'
-      structured_data:
-        type: object
-        title: '[semi-]structured data: structured_data field'
-      metadata:
-        type: object
-        title: Metadata
-    title: DataPayload is a data structure trasferring data in pipeline
-    required:
-      - data_mapping_index
   v1alphaDeactivatePipelineResponse:
     type: object
     properties:
@@ -4543,7 +4490,6 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaDataPayload'
         title: Outputs
     title: |-
       ExecuteConnectorResponse represents a response for execution
@@ -5928,41 +5874,6 @@ definitions:
       - uid
       - id
       - task
-  v1alphaPipelineDataPayload:
-    type: object
-    properties:
-      data_mapping_index:
-        type: string
-        title: |-
-          Data index corresponds to each data element
-          if not provided, vdp will generate a one by uild
-          ref: https://github.com/ulid/spec
-      texts:
-        type: array
-        items:
-          type: string
-        title: 'Unstructured: text field'
-      images:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/PipelineDataPayloadUnstructuredData'
-        title: 'Unstructured: image field'
-      audios:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/PipelineDataPayloadUnstructuredData'
-        title: 'Unstructured: audio field'
-      structured_data:
-        type: object
-        title: '[semi-]structured data: json field'
-      metadata:
-        type: object
-        title: Metadata
-    title: PipelineDataPayload is a data structure for pipeline input
-    required:
-      - data_mapping_index
   v1alphaPipelineState:
     type: string
     enum:
@@ -6441,18 +6352,22 @@ definitions:
   v1alphaSpec:
     type: object
     properties:
-      documentation_url:
-        type: string
-        title: Spec documentation URL
-        readOnly: true
-      connection_specification:
+      resource_specification:
         type: object
-        title: Spec connection specification
+        title: Spec resource specification
+      component_specification:
+        type: object
+        title: Spec connector specification
+      openapi_specifications:
+        type: object
+        title: Spec openapi specification
     title: |-
       //////////////////////////////////
       Spec represents a spec data model
     required:
-      - connection_specification
+      - resource_specification
+      - component_specification
+      - openapi_specifications
   v1alphaTask:
     type: string
     enum:
@@ -6765,7 +6680,6 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaPipelineDataPayload'
         title: The multiple model inference outputs
     title: |-
       TriggerPipelineResponse represents a response for the output

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -395,27 +395,6 @@ message TestConnectorResponse {
   Connector.State state = 1;
 }
 
-// DataPayload is a data structure trasferring data in pipeline
-message DataPayload {
-  // Data index corresponds to each data element
-  string data_mapping_index = 1 [(google.api.field_behavior) = REQUIRED];
-
-  // Unstructured: text field
-  repeated string texts = 2;
-  // Unstructured: image field
-  repeated bytes images = 3;
-  // Unstructured: audio field
-  repeated bytes audios = 4;
-
-  // repeated bytes videos = 5;
-
-  // [semi-]structured data: structured_data field
-  google.protobuf.Struct structured_data = 6;
-
-  // Metadata
-  google.protobuf.Struct metadata = 7;
-}
-
 // ExecuteConnectorRequest represents a private request to execution
 // connector
 message ExecuteConnectorRequest {
@@ -424,12 +403,12 @@ message ExecuteConnectorRequest {
   string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Inputs
-  repeated DataPayload inputs = 2;
+  repeated google.protobuf.Struct inputs = 2;
 }
 
 // ExecuteConnectorResponse represents a response for execution
 // output
 message ExecuteConnectorResponse {
   // Outputs
-  repeated DataPayload outputs = 1;
+  repeated google.protobuf.Struct outputs = 1;
 }

--- a/vdp/connector/v1alpha/spec.proto
+++ b/vdp/connector/v1alpha/spec.proto
@@ -10,8 +10,10 @@ import "google/protobuf/struct.proto";
 ////////////////////////////////////
 // Spec represents a spec data model
 message Spec {
-  // Spec documentation URL
-  string documentation_url = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Spec connection specification
-  google.protobuf.Struct connection_specification = 2 [(google.api.field_behavior) = REQUIRED];
+  // Spec resource specification
+  google.protobuf.Struct resource_specification = 2 [(google.api.field_behavior) = REQUIRED];
+  // Spec connector specification
+  google.protobuf.Struct component_specification = 3 [(google.api.field_behavior) = REQUIRED];
+  // Spec openapi specification
+  google.protobuf.Struct openapi_specifications = 4 [(google.api.field_behavior) = REQUIRED];
 }

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -48,10 +48,8 @@ message Component {
   ];
   // A pipeline component resource detail
   google.protobuf.Struct resource_detail = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Metadata for the pipeline component
-  google.protobuf.Struct metadata = 4;
-  // Dependencies for the pipeline component
-  map<string, string> dependencies = 5;
+  // Configuration for the pipeline component
+  google.protobuf.Struct configuration = 4;
   // Resource Type
   string type = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
@@ -279,42 +277,6 @@ message RenamePipelineResponse {
   Pipeline pipeline = 1;
 }
 
-// PipelineDataPayload is a data structure for pipeline input
-message PipelineDataPayload {
-  // UnstructuredData
-  message UnstructuredData {
-    // UnstructuredData
-    oneof unstructured_data {
-      // UnstructuredData using bytes,
-      // grpc-gateway will do base64 conversion for http endpoint
-      bytes blob = 1;
-      // UnstructuredData using url
-      string url = 2;
-    }
-  }
-
-  // Data index corresponds to each data element
-  // if not provided, vdp will generate a one by uild
-  // ref: https://github.com/ulid/spec
-  string data_mapping_index = 1 [(google.api.field_behavior) = REQUIRED];
-
-  // Unstructured: text field
-  repeated string texts = 2;
-
-  // Unstructured: image field
-  repeated UnstructuredData images = 3;
-  // Unstructured: audio field
-  repeated UnstructuredData audios = 4;
-
-  // repeated UnstructuredData videos = 5;
-
-  // [semi-]structured data: json field
-  google.protobuf.Struct structured_data = 6;
-
-  // Metadata
-  google.protobuf.Struct metadata = 7;
-}
-
 // TriggerPipelineRequest represents a request to trigger a pipeline
 message TriggerPipelineRequest {
   // Pipeline resource name. It must have the format of "pipelines/*"
@@ -323,14 +285,14 @@ message TriggerPipelineRequest {
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
   ];
   // Input to the pipeline
-  repeated PipelineDataPayload inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // TriggerPipelineResponse represents a response for the output
 // of a pipeline, i.e., the multiple model inference outputs
 message TriggerPipelineResponse {
   // The multiple model inference outputs
-  repeated PipelineDataPayload outputs = 1;
+  repeated google.protobuf.Struct outputs = 1;
 }
 
 // TriggerAsyncPipelineRequest represents a request to trigger a async pipeline
@@ -341,7 +303,7 @@ message TriggerAsyncPipelineRequest {
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
   ];
   // Input to the pipeline
-  repeated PipelineDataPayload inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // TriggerAsyncPipelineResponse represents a response for the longrunning


### PR DESCRIPTION
Because

- We want to make the data input/output format more flexible, the DataPayload and PipelineDataPayload is not need for the new component-centric design

This commit

- retire DataPayload and PipelineDataPayload
- retire dependency field in pipeline recipe component
