### PR TITLE
chore(usage): add owner_uid to session

### DIFF
--- a/base/usage/v1alpha/usage.proto
+++ b/base/usage/v1alpha/usage.proto
@@ -84,6 +84,8 @@ message Session {
   google.protobuf.Timestamp create_time = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Session update time
   google.protobuf.Timestamp update_time = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Owner UUID of the instance, can also be considered as instance UUID
+  string owner_uid = 13 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Management service usage data

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -6597,6 +6597,9 @@ definitions:
         format: date-time
         title: Session update time
         readOnly: true
+      owner_uid:
+        type: string
+        title: Owner UUID of the instance, can also be considered as instance UUID
     title: |-
       Session represents a unique session whenever a new instance of VDP service
       gets started. The usage server returns a token that should be used as part of
@@ -6609,6 +6612,7 @@ definitions:
       - os
       - uptime
       - report_time
+      - owner_uid
   v1alphaSessionReport:
     type: object
     properties:


### PR DESCRIPTION
Because

- avoid complex query requirement for usage metric

This commit

- add `owner_uid` in `session`
