### PR TITLE
chore(model): update public deploy/undeploy to change desire state only

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -336,8 +336,9 @@ message DeployModelRequest {
 
 // DeployModelResponse represents a response for a deployed model
 message DeployModelResponse {
-  // Deployed model
-  Model model = 1;
+  // Deployed model's id
+  // Format: models/{model}
+  string model_id = 1;
 }
 
 // UndeployModelRequest represents a request to undeploy a model to offline
@@ -353,8 +354,9 @@ message UndeployModelRequest {
 
 // UndeployModelResponse represents a response for a undeployed model
 message UndeployModelResponse {
-  // Undeployed model
-  Model model = 1;
+  // Undeployed model's id
+  // Format: models/{model}
+  string model_id = 1;
 }
 
 // GetModelCardRequest represents a request to query a model's README card

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -336,8 +336,8 @@ message DeployModelRequest {
 
 // DeployModelResponse represents a response for a deployed model
 message DeployModelResponse {
-  // Deploy operation message
-  google.longrunning.Operation operation = 1;
+  // Deployed model
+  Model model = 1;
 }
 
 // UndeployModelRequest represents a request to undeploy a model to offline
@@ -353,8 +353,8 @@ message UndeployModelRequest {
 
 // UndeployModelResponse represents a response for a undeployed model
 message UndeployModelResponse {
-  // Undeploy operation message
-  google.longrunning.Operation operation = 1;
+  // Undeployed model
+  Model model = 1;
 }
 
 // GetModelCardRequest represents a request to query a model's README card

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4621,9 +4621,11 @@ definitions:
   v1alphaDeployModelResponse:
     type: object
     properties:
-      model:
-        $ref: '#/definitions/v1alphaModel'
-        title: Deployed model
+      model_id:
+        type: string
+        title: |-
+          Deployed model's id
+          Format: models/{model}
     title: DeployModelResponse represents a response for a deployed model
   v1alphaDetectionInput:
     type: object
@@ -6994,9 +6996,11 @@ definitions:
   v1alphaUndeployModelResponse:
     type: object
     properties:
-      model:
-        $ref: '#/definitions/v1alphaModel'
-        title: Undeployed model
+      model_id:
+        type: string
+        title: |-
+          Undeployed model's id
+          Format: models/{model}
     title: UndeployModelResponse represents a response for a undeployed model
   v1alphaUnpublishModelResponse:
     type: object

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4621,9 +4621,9 @@ definitions:
   v1alphaDeployModelResponse:
     type: object
     properties:
-      operation:
-        $ref: '#/definitions/googlelongrunningOperation'
-        title: Deploy operation message
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: Deployed model
     title: DeployModelResponse represents a response for a deployed model
   v1alphaDetectionInput:
     type: object
@@ -6994,9 +6994,9 @@ definitions:
   v1alphaUndeployModelResponse:
     type: object
     properties:
-      operation:
-        $ref: '#/definitions/googlelongrunningOperation'
-        title: Undeploy operation message
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: Undeployed model
     title: UndeployModelResponse represents a response for a undeployed model
   v1alphaUnpublishModelResponse:
     type: object


### PR DESCRIPTION
Because

- adopt changes in `model-backend` that public deploy/undeploy only change the desire state of the model

This commit

- update public deploy/undeploy response to be `model`
