### PR TITLE
chore(pipeline): add Traces data in pipeline response

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -3583,6 +3583,15 @@ definitions:
        - SERVICE_MODEL: Service: MODEL
        - SERVICE_PIPELINE: Service: PIPELINE
     title: Service enumerates the services to collect data from
+  TriggerPipelineResponseMetadata:
+    type: object
+    properties:
+      traces:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1alphaTrace'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
+    title: The metadata
   UserUsageDataConnectorExecuteData:
     type: object
     properties:
@@ -6932,6 +6941,30 @@ definitions:
     required:
       - start_time
       - end_time
+  v1alphaTrace:
+    type: object
+    properties:
+      suceess:
+        type: boolean
+        title: Suceess or not
+      inputs:
+        type: array
+        items:
+          type: object
+        title: Inputs of the component
+      outputs:
+        type: array
+        items:
+          type: object
+        title: Outputs of the component
+      error:
+        type: object
+        title: Error of the component
+      compute_time_in_seconds:
+        type: number
+        format: float
+        title: Compute Time
+    title: Trace for the intermediate component
   v1alphaTriggerAsyncPipelineResponse:
     type: object
     properties:
@@ -6983,6 +7016,9 @@ definitions:
         items:
           type: object
         title: The multiple model inference outputs
+      metadata:
+        $ref: '#/definitions/TriggerPipelineResponseMetadata'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: |-
       TriggerPipelineResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -143,6 +143,20 @@ message Pipeline {
   google.protobuf.Timestamp update_time = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// Trace for the intermediate component
+message Trace {
+  // Suceess or not
+  bool suceess = 1;
+  // Inputs of the component
+  repeated google.protobuf.Struct inputs = 2;
+  // Outputs of the component
+  repeated google.protobuf.Struct outputs = 3;
+  // Error of the component
+  google.protobuf.Struct error = 4;
+  // Compute Time
+  float compute_time_in_seconds = 5;
+}
+
 // CreatePipelineRequest represents a request to create a pipeline
 message CreatePipelineRequest {
   // A pipeline resource to create
@@ -306,8 +320,15 @@ message TriggerPipelineRequest {
 // TriggerPipelineResponse represents a response for the output
 // of a pipeline, i.e., the multiple model inference outputs
 message TriggerPipelineResponse {
+  // The metadata
+  message Metadata {
+    // The traces of the pipeline inference, {component_id: Trace}
+    map<string, Trace> traces = 1;
+  }
   // The multiple model inference outputs
   repeated google.protobuf.Struct outputs = 1;
+  // The traces of the pipeline inference, {component_id: Trace}
+  Metadata metadata = 2;
 }
 
 // TriggerAsyncPipelineRequest represents a request to trigger a async pipeline


### PR DESCRIPTION
Because

- we need to return the trace data for each component when we want to debug the pipeline

This commit

- add `Traces` data in pipeline response
