### PR TITLE
chore(pipeline): add pipeline release endpoints

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -697,6 +697,44 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
+  /v1alpha/{name_1}/triggerAsync:
+    post:
+      summary: |-
+        TriggerAsyncPipelineRelease method receives a TriggerAsyncPipelineReleaseRequest message and
+        returns a TriggerAsyncPipelineReleaseResponse.
+      operationId: PipelinePublicService_TriggerAsyncPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerAsyncPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_1
+          description: Resource name.
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+/releases/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                title: Input to the pipeline
+            title: TriggerAsyncPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+            required:
+              - inputs
+      tags:
+        - PipelinePublicService
   /v1alpha/{name_2}/rename:
     post:
       summary: |-
@@ -735,6 +773,84 @@ paths:
               name
             required:
               - new_pipeline_id
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_2}/trigger:
+    post:
+      summary: |-
+        TriggerPipelineRelease method receives a TriggePipelineReleaseRequest message
+        and returns a TriggerPipelineReleasePipelineResponse.
+      operationId: PipelinePublicService_TriggerPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_2
+          description: Resource name.
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+/releases/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                title: Input to the pipeline
+            title: TriggerPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+            required:
+              - inputs
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_3}/rename:
+    post:
+      summary: |-
+        RenamePipelineRelease method receives a RenamePipelineReleaseRequest message and returns
+        a RenamePipelineReleaseResponse message.
+      operationId: PipelinePublicService_RenamePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRenamePipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_3
+          description: Pipeline release resource name. It must have the format of "pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+/releases/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_pipeline_release_id:
+                type: string
+                title: |-
+                  Pipeline new resource id to replace with the pipeline resource name to be
+                  "pipelines/*/releases/{new_pipeline_id}"
+            title: |-
+              RenamePipelineReleaseRequest represents a request to rename the pipeline release resource
+              name
+            required:
+              - new_pipeline_release_id
       tags:
         - PipelinePublicService
   /v1alpha/{name}:
@@ -779,38 +895,6 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ModelPublicService
-  /v1alpha/{name}/activate:
-    post:
-      summary: |-
-        Activate a pipeline.
-        The "state" of the pipeline after activating is "ACTIVE".
-        ActivatePipeline can be called on Pipelines in the state "INACTIVE";
-        Pipelines in a different state (including "ACTIVE") returns an error.
-      operationId: PipelinePublicService_ActivatePipeline
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaActivatePipelineResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: name
-          description: Pipeline resource name. It must have the format of "pipelines/*"
-          in: path
-          required: true
-          type: string
-          pattern: pipelines/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            title: ActivatePipelineRequest represents a request to activate a pipeline
-      tags:
-        - PipelinePublicService
   /v1alpha/{name}/connect:
     post:
       summary: |-
@@ -848,38 +932,6 @@ paths:
               connector_resource
       tags:
         - ConnectorPublicService
-  /v1alpha/{name}/deactivate:
-    post:
-      summary: |-
-        Deactivate a pipeline.
-        The "state" of the pipeline after inactivating is "INACTIVE".
-        DeactivatePipeline can be called on Pipelines in the state "ACTIVE";
-        Pipelines in a different state (including "INACTIVE") returns an error.
-      operationId: PipelinePublicService_DeactivatePipeline
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaDeactivatePipelineResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: name
-          description: Pipeline resource name. It must have the format of "pipelines/*"
-          in: path
-          required: true
-          type: string
-          pattern: pipelines/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            title: DeactivatePipelineRequest represents a request to deactivate a pipeline
-      tags:
-        - PipelinePublicService
   /v1alpha/{name}/deploy:
     post:
       summary: DeployModel deploy a model to online state
@@ -1054,6 +1106,54 @@ paths:
               - new_model_id
       tags:
         - ModelPublicService
+  /v1alpha/{name}/restore:
+    post:
+      summary: |-
+        RestorePipelineRelease method receives a RestorePipelineReleaseRequest message
+        and returns a RestorePipelineReleaseResponse
+      operationId: PipelinePublicService_RestorePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRestorePipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name
+          description: Pipeline resource name. It must have the format of "pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+/releases/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name}/set_default:
+    post:
+      summary: |-
+        SetDefaultPipelineRelease method receives a SetDefaultPipelineReleaseRequest message
+        and returns a SetDefaultPipelineReleaseResponse
+      operationId: PipelinePublicService_SetDefaultPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaSetDefaultPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name
+          description: Pipeline resource name. It must have the format of "pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+/releases/[^/]+
+      tags:
+        - PipelinePublicService
   /v1alpha/{name}/test:
     post:
       summary: |-
@@ -1239,6 +1339,34 @@ paths:
             title: UnpublishModelRequest represents a request to unpublish a model
       tags:
         - ModelPublicService
+  /v1alpha/{name}/validate:
+    post:
+      summary: Validate a pipeline.
+      operationId: PipelinePublicService_ValidatePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaValidatePipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name
+          description: Pipeline resource name. It must have the format of "pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: ValidatePipelineRequest represents a request to validate a pipeline
+      tags:
+        - PipelinePublicService
   /v1alpha/{operator_definition.name}:
     get:
       summary: |-
@@ -1280,6 +1408,99 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
           default: VIEW_UNSPECIFIED
+      tags:
+        - PipelinePublicService
+  /v1alpha/{parent}/releases:
+    get:
+      summary: |-
+        ListPipelineReleases method receives a ListPipelineReleasesRequest message and returns a
+        ListPipelineReleasesResponse message.
+      operationId: PipelinePublicService_ListPipelineReleases
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListPipelineReleasesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent
+          description: |-
+            The parent resource where this pipeline_release will be created.
+            Format: pipelines/{pipeline}
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: page_size
+          description: |-
+            The maximum number of pipeline_releases to return. The service may return fewer
+            than this value. If unspecified, at most 10 pipeline_release will be returned. The
+            maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list pipeline_releases
+          in: query
+          required: false
+          type: string
+      tags:
+        - PipelinePublicService
+    post:
+      summary: |-
+        CreatePipelineRelease method receives a CreatePipelineReleaseRequest message and returns
+        a CreatePipelineReleaseResponse message.
+      operationId: PipelinePublicService_CreatePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreatePipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent
+          description: |-
+            The parent resource where this pipeline_release will be created.
+            Format: pipelines/{pipeline}
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+
+        - name: release
+          description: A pipeline_release resource to create
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaPipelineRelease'
+            required:
+              - release
       tags:
         - PipelinePublicService
   /v1alpha/{permalink_1}/lookUp:
@@ -1411,25 +1632,25 @@ paths:
   /v1alpha/{pipeline.name/watch}/watch:
     get:
       summary: |-
-        WatchPipeline method receives a WatchPipelineRequest message
-        and returns a WatchPipelineResponse
-      operationId: PipelinePublicService_WatchPipeline
+        WatchPipelineRelease method receives a WatchPipelineReleaseRequest message
+        and returns a WatchPipelineReleaseResponse
+      operationId: PipelinePublicService_WatchPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaWatchPipelineResponse'
+            $ref: '#/definitions/v1alphaWatchPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name/watch
-          description: Pipeline resource name. It must have the format of "pipelines/*"
+          description: Pipeline resource name. It must have the format of "pipelines/*/releases/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: pipelines/[^/]+/releases/default
       tags:
         - PipelinePublicService
   /v1alpha/{pipeline.name}:
@@ -1539,10 +1760,6 @@ paths:
               recipe:
                 $ref: '#/definitions/v1alphaRecipe'
                 title: Pipeline recipe
-              state:
-                $ref: '#/definitions/v1alphaPipelineState'
-                title: Pipeline state
-                readOnly: true
               user:
                 type: string
                 description: |-
@@ -1564,6 +1781,126 @@ paths:
                 title: Pipeline update time
                 readOnly: true
             title: A pipeline resource to update
+      tags:
+        - PipelinePublicService
+  /v1alpha/{pipeline_release.name}:
+    get:
+      summary: |-
+        GetPipelineRelease method receives a GetPipelineReleaseRequest message and returns a
+        GetPipelineReleaseResponse message.
+      operationId: PipelinePublicService_GetPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pipeline_release.name
+          description: PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+/releases/[^/]+
+        - name: view
+          description: |-
+            PipelineRelease resource view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - PipelinePublicService
+    delete:
+      summary: |-
+        DeletePipelineRelease method receives a DeletePipelineReleaseRequest message and returns
+        a DeletePipelineReleaseResponse message.
+      operationId: PipelinePublicService_DeletePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeletePipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pipeline_release.name
+          description: PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+/releases/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1alpha/{release.name}:
+    patch:
+      summary: |-
+        UpdatePipelineRelease method receives a UpdatePipelineReleaseRequest message and returns
+        a UpdatePipelineReleaseResponse message.
+      operationId: PipelinePublicService_UpdatePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdatePipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: release.name
+          description: PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: pipelines/[^/]+/releases/[^/]+
+        - name: release
+          description: A pipeline release resource to update
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: PipelineRelease UUID
+                readOnly: true
+              id:
+                type: string
+                title: |-
+                  PipelineRelease resource ID (the last segment of the resource name) used to
+                  construct the resource name. Must be a sematic version vX.Y.Z
+              description:
+                type: string
+                title: PipelineRelease description
+              recipe:
+                $ref: '#/definitions/v1alphaRecipe'
+                title: Pipeline recipe snapshot
+                readOnly: true
+              create_time:
+                type: string
+                format: date-time
+                title: Pipeline creation time
+                readOnly: true
+              update_time:
+                type: string
+                format: date-time
+                title: Pipeline update time
+                readOnly: true
+            title: A pipeline release resource to update
       tags:
         - PipelinePublicService
   /v1alpha/{resource.resource_permalink_1}:
@@ -1648,7 +1985,7 @@ paths:
             type: object
             properties:
               pipeline_state:
-                $ref: '#/definitions/v1alphaPipelineState'
+                $ref: '#/definitions/pipelinev1alphaState'
                 title: Pipeline state
               connector_state:
                 $ref: '#/definitions/v1alphaConnectorResourceState'
@@ -2488,6 +2825,58 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaListPipelinesAdminResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            The maximum number of pipelines to return. The service may return fewer
+            than this value. If unspecified, at most 10 pipelines will be returned. The
+            maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list pipelines
+          in: query
+          required: false
+          type: string
+      tags:
+        - PipelinePrivateService
+  /v1alpha/admin/releases:
+    get:
+      summary: |-
+        ListPipelineReleasesAdmin method receives a ListPipelineReleasesAdminRequest message and
+        returns a ListPipelineReleasesAdminResponse message.
+      operationId: PipelinePrivateService_ListPipelineReleasesAdmin
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListPipelineReleasesAdminResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -3583,15 +3972,6 @@ definitions:
        - SERVICE_MODEL: Service: MODEL
        - SERVICE_PIPELINE: Service: PIPELINE
     title: Service enumerates the services to collect data from
-  TriggerPipelineResponseMetadata:
-    type: object
-    properties:
-      traces:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/v1alphaTrace'
-        title: 'The traces of the pipeline inference, {component_id: Trace}'
-    title: The metadata
   UserUsageDataConnectorExecuteData:
     type: object
     properties:
@@ -3881,6 +4261,20 @@ definitions:
        - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
        - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
        - VIEW_FULL: View: FULL, full representation of the resource
+  pipelinev1alphaState:
+    type: string
+    enum:
+      - STATE_UNSPECIFIED
+      - STATE_INACTIVE
+      - STATE_ACTIVE
+      - STATE_ERROR
+    default: STATE_UNSPECIFIED
+    description: |-
+      - STATE_UNSPECIFIED: State: UNSPECIFIED
+       - STATE_INACTIVE: State INACTIVE indicates the pipeline is inactive
+       - STATE_ACTIVE: State ACTIVE indicates the pipeline is active
+       - STATE_ERROR: State ERROR indicates the pipeline has error
+    title: State enumerates the state of a pipeline
   protobufAny:
     type: object
     properties:
@@ -4013,13 +4407,6 @@ definitions:
        The JSON representation for `NullValue` is JSON `null`.
 
        - NULL_VALUE: Null value.
-  v1alphaActivatePipelineResponse:
-    type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
-        title: A pipeline resource
-    title: ActivatePipelineResponse represents an activated pipeline
   v1alphaApiToken:
     type: object
     properties:
@@ -4570,6 +4957,13 @@ definitions:
         title: Create model operation message
         readOnly: true
     title: CreateModelResponse represents a response for a model
+  v1alphaCreatePipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: The created pipeline_release resource
+    title: CreatePipelineReleaseResponse represents a response for a pipeline_release resource
   v1alphaCreatePipelineResponse:
     type: object
     properties:
@@ -4598,19 +4992,15 @@ definitions:
         $ref: '#/definitions/v1alphaUser'
         title: A user resource
     title: CreateUserAdminResponse represents a response for a user response
-  v1alphaDeactivatePipelineResponse:
-    type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
-        title: A pipeline resource
-    title: DeactivatePipelineResponse represents an inactivated pipeline
   v1alphaDeleteConnectorResourceResponse:
     type: object
     title: DeleteConnectorResourceResponse represents an empty response
   v1alphaDeleteModelResponse:
     type: object
     title: DeleteModelResponse represents an empty response
+  v1alphaDeletePipelineReleaseResponse:
+    type: object
+    title: DeletePipelineReleaseResponse represents an empty response
   v1alphaDeletePipelineResponse:
     type: object
     title: DeletePipelineResponse represents an empty response
@@ -5070,6 +5460,13 @@ definitions:
     title: |-
       GetOperatorDefinitionResponse represents a
       Operator response
+  v1alphaGetPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A pipeline_release resource
+    title: GetPipelineReleaseResponse represents a response for a pipeline_release resource
   v1alphaGetPipelineResponse:
     type: object
     properties:
@@ -5534,6 +5931,43 @@ definitions:
     title: |-
       ListOperatorDefinitionsResponse represents a response for a list
       of OperatorDefinitions
+  v1alphaListPipelineReleasesAdminResponse:
+    type: object
+    properties:
+      releases:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A list of pipeline resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of pipeline resources
+    title: |-
+      ListPipelineReleasesAdminResponse represents a response for a list of pipeline_releases
+      The recipe returned will be permaLinks instead of resourceName temporary,
+      this will be refactored soon
+  v1alphaListPipelineReleasesResponse:
+    type: object
+    properties:
+      releases:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A list of pipeline_release resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of pipeline_release resources
+    title: ListPipelineReleasesResponse represents a response for a list of pipeline_releases
   v1alphaListPipelineTriggerChartRecordsResponse:
     type: object
     properties:
@@ -6158,10 +6592,6 @@ definitions:
       recipe:
         $ref: '#/definitions/v1alphaRecipe'
         title: Pipeline recipe
-      state:
-        $ref: '#/definitions/v1alphaPipelineState'
-        title: Pipeline state
-        readOnly: true
       user:
         type: string
         description: |-
@@ -6200,20 +6630,40 @@ definitions:
       - uid
       - id
       - task
-  v1alphaPipelineState:
-    type: string
-    enum:
-      - STATE_UNSPECIFIED
-      - STATE_INACTIVE
-      - STATE_ACTIVE
-      - STATE_ERROR
-    default: STATE_UNSPECIFIED
-    description: |-
-      - STATE_UNSPECIFIED: State: UNSPECIFIED
-       - STATE_INACTIVE: State INACTIVE indicates the pipeline is inactive
-       - STATE_ACTIVE: State ACTIVE indicates the pipeline is active
-       - STATE_ERROR: State ERROR indicates the pipeline has error
-    title: State enumerates the state of a pipeline
+  v1alphaPipelineRelease:
+    type: object
+    properties:
+      name:
+        type: string
+        title: PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+        readOnly: true
+      uid:
+        type: string
+        title: PipelineRelease UUID
+        readOnly: true
+      id:
+        type: string
+        title: |-
+          PipelineRelease resource ID (the last segment of the resource name) used to
+          construct the resource name. Must be a sematic version vX.Y.Z
+      description:
+        type: string
+        title: PipelineRelease description
+      recipe:
+        $ref: '#/definitions/v1alphaRecipe'
+        title: Pipeline recipe snapshot
+        readOnly: true
+      create_time:
+        type: string
+        format: date-time
+        title: Pipeline creation time
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        title: Pipeline update time
+        readOnly: true
+    title: PipelineRelease represents the content of a pipeline release
   v1alphaPipelineTriggerChartRecord:
     type: object
     properties:
@@ -6440,6 +6890,13 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: Renamed model
     title: RenameModelResponse represents a response for a model
+  v1alphaRenamePipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A pipeline resource
+    title: RenamePipelineReleaseResponse represents a renamed pipeline release resource
   v1alphaRenamePipelineResponse:
     type: object
     properties:
@@ -6521,6 +6978,13 @@ definitions:
     title: |-
       ReportPipelineTriggersResponse represents a respond to a
       pipeline-trigger-records reporting bulk request
+  v1alphaRestorePipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A pipeline resource
+    title: RestorePipelineReleaseResponse
   v1alphaSemanticSegmentationInput:
     type: object
     properties:
@@ -6679,6 +7143,13 @@ definitions:
       - token
       - pow
       - session
+  v1alphaSetDefaultPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A pipeline resource
+    title: SetDefaultPipelineReleaseResponse
   v1alphaTask:
     type: string
     enum:
@@ -6965,6 +7436,16 @@ definitions:
         format: float
         title: Compute Time
     title: Trace for the intermediate component
+  v1alphaTriggerAsyncPipelineReleaseResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Trigger async pipeline operation message
+        readOnly: true
+    title: |-
+      TriggerAsyncPipelineReleaseResponse represents a response for the longrunning
+      operation of a pipeline
   v1alphaTriggerAsyncPipelineResponse:
     type: object
     properties:
@@ -6975,6 +7456,15 @@ definitions:
     title: |-
       TriggerAsyncPipelineResponse represents a response for the longrunning
       operation of a pipeline
+  v1alphaTriggerMetadata:
+    type: object
+    properties:
+      traces:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1alphaTrace'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
+    title: The metadata
   v1alphaTriggerModelBinaryFileUploadResponse:
     type: object
     properties:
@@ -7008,6 +7498,20 @@ definitions:
     title: |-
       TriggerModelResponse represents a response for the output for
       triggering a model
+  v1alphaTriggerPipelineReleaseResponse:
+    type: object
+    properties:
+      outputs:
+        type: array
+        items:
+          type: object
+        title: The multiple model inference outputs
+      metadata:
+        $ref: '#/definitions/v1alphaTriggerMetadata'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
+    title: |-
+      TriggerPipelineReleaseResponse represents a response for the output
+      of a pipeline, i.e., the multiple model inference outputs
   v1alphaTriggerPipelineResponse:
     type: object
     properties:
@@ -7017,7 +7521,7 @@ definitions:
           type: object
         title: The multiple model inference outputs
       metadata:
-        $ref: '#/definitions/TriggerPipelineResponseMetadata'
+        $ref: '#/definitions/v1alphaTriggerMetadata'
         title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: |-
       TriggerPipelineResponse represents a response for the output
@@ -7080,6 +7584,13 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: The updated model
     title: UpdateModelResponse represents a response for a model
+  v1alphaUpdatePipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: An updated pipeline resource
+    title: UpdatePipelineReleaseResponse represents a response for a pipeline resource
   v1alphaUpdatePipelineResponse:
     type: object
     properties:
@@ -7195,6 +7706,13 @@ definitions:
     title: User records definition
     required:
       - uid
+  v1alphaValidatePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: ValidatePipelineResponse represents an response of validated pipeline
   v1alphaWatchConnectorResourceResponse:
     type: object
     properties:
@@ -7217,14 +7735,14 @@ definitions:
     title: |-
       WatchModelResponse represents a public response to
       fetch a model current state and longrunning progress
-  v1alphaWatchPipelineResponse:
+  v1alphaWatchPipelineReleaseResponse:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1alphaPipelineState'
+        $ref: '#/definitions/pipelinev1alphaState'
         title: Retrieved pipeline state
     title: |-
-      WatchPipelineResponse represents a response to fetch a pipeline's
+      WatchPipelineReleaseResponse represents a response to fetch a pipeline's
       current state
   vdpconnectorv1alphaLivenessResponse:
     type: object
@@ -7304,7 +7822,7 @@ definitions:
           Permalink of a resouce. For example:
           "resources/{resource_uuid}/types/{type}"
       pipeline_state:
-        $ref: '#/definitions/v1alphaPipelineState'
+        $ref: '#/definitions/pipelinev1alphaState'
         title: Pipeline state
       connector_state:
         $ref: '#/definitions/v1alphaConnectorResourceState'

--- a/vdp/controller/v1alpha/controller.proto
+++ b/vdp/controller/v1alpha/controller.proto
@@ -48,7 +48,7 @@ message Resource {
   // Resource state
   oneof state {
     // Pipeline state
-    vdp.pipeline.v1alpha.Pipeline.State pipeline_state = 3;
+    vdp.pipeline.v1alpha.State pipeline_state = 3;
     // ConnectorResource state
     vdp.connector.v1alpha.ConnectorResource.State connector_state = 4;
     // Backend service state

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -89,24 +89,24 @@ message Recipe {
   repeated Component components = 2;
 }
 
+// State enumerates the state of a pipeline
+enum State {
+  // State: UNSPECIFIED
+  STATE_UNSPECIFIED = 0;
+  // State INACTIVE indicates the pipeline is inactive
+  STATE_INACTIVE = 1;
+  // State ACTIVE indicates the pipeline is active
+  STATE_ACTIVE = 2;
+  // State ERROR indicates the pipeline has error
+  STATE_ERROR = 3;
+}
+
 // Pipeline represents the content of a pipeline
 message Pipeline {
   option (google.api.resource) = {
     type: "api.instill.tech/Pipeline"
     pattern: "pipelines/{pipeline}"
   };
-
-  // State enumerates the state of a pipeline
-  enum State {
-    // State: UNSPECIFIED
-    STATE_UNSPECIFIED = 0;
-    // State INACTIVE indicates the pipeline is inactive
-    STATE_INACTIVE = 1;
-    // State ACTIVE indicates the pipeline is active
-    STATE_ACTIVE = 2;
-    // State ERROR indicates the pipeline has error
-    STATE_ERROR = 3;
-  }
 
   // Pipeline resource name. It must have the format of "pipelines/*"
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -121,8 +121,7 @@ message Pipeline {
   optional string description = 4 [(google.api.field_behavior) = OPTIONAL];
   // Pipeline recipe
   Recipe recipe = 5 [(google.api.field_behavior) = IMMUTABLE];
-  // Pipeline state
-  State state = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+
   // Pipeline owner
   oneof owner {
     // The resource name with UUID of a user, e.g.,
@@ -143,6 +142,12 @@ message Pipeline {
   google.protobuf.Timestamp update_time = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// The metadata
+message TriggerMetadata {
+  // The traces of the pipeline inference, {component_id: Trace}
+  map<string, Trace> traces = 1;
+}
+
 // Trace for the intermediate component
 message Trace {
   // Success or not
@@ -155,6 +160,30 @@ message Trace {
   google.protobuf.Struct error = 4;
   // Compute Time
   float compute_time_in_seconds = 5;
+}
+
+// PipelineRelease represents the content of a pipeline release
+message PipelineRelease {
+  option (google.api.resource) = {
+    type: "api.instill.tech/Release"
+    pattern: "releases/{release}"
+  };
+
+  // PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // PipelineRelease UUID
+  string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // PipelineRelease resource ID (the last segment of the resource name) used to
+  // construct the resource name. Must be a sematic version vX.Y.Z
+  string id = 3 [(google.api.field_behavior) = IMMUTABLE];
+  // PipelineRelease description
+  optional string description = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline recipe snapshot
+  Recipe recipe = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Pipeline creation time
+  google.protobuf.Timestamp create_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Pipeline update time
+  google.protobuf.Timestamp update_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreatePipelineRequest represents a request to create a pipeline
@@ -257,8 +286,8 @@ message LookUpPipelineResponse {
   Pipeline pipeline = 1;
 }
 
-// ActivatePipelineRequest represents a request to activate a pipeline
-message ActivatePipelineRequest {
+// ValidatePipelineRequest represents a request to validate a pipeline
+message ValidatePipelineRequest {
   // Pipeline resource name. It must have the format of "pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -266,23 +295,8 @@ message ActivatePipelineRequest {
   ];
 }
 
-// ActivatePipelineResponse represents an activated pipeline
-message ActivatePipelineResponse {
-  // A pipeline resource
-  Pipeline pipeline = 1;
-}
-
-// DeactivatePipelineRequest represents a request to deactivate a pipeline
-message DeactivatePipelineRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
-  ];
-}
-
-// DeactivatePipelineResponse represents an inactivated pipeline
-message DeactivatePipelineResponse {
+// ValidatePipelineResponse represents an response of validated pipeline
+message ValidatePipelineResponse {
   // A pipeline resource
   Pipeline pipeline = 1;
 }
@@ -320,15 +334,10 @@ message TriggerPipelineRequest {
 // TriggerPipelineResponse represents a response for the output
 // of a pipeline, i.e., the multiple model inference outputs
 message TriggerPipelineResponse {
-  // The metadata
-  message Metadata {
-    // The traces of the pipeline inference, {component_id: Trace}
-    map<string, Trace> traces = 1;
-  }
   // The multiple model inference outputs
   repeated google.protobuf.Struct outputs = 1;
   // The traces of the pipeline inference, {component_id: Trace}
-  Metadata metadata = 2;
+  TriggerMetadata metadata = 2;
 }
 
 // TriggerAsyncPipelineRequest represents a request to trigger a async pipeline
@@ -363,26 +372,6 @@ message GetOperationResponse {
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// WatchPipelineRequest represents a public request to query
-// a pipeline's current state
-message WatchPipelineRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline.name/watch"}
-    }
-  ];
-}
-
-// WatchPipelineResponse represents a response to fetch a pipeline's
-// current state
-message WatchPipelineResponse {
-  // Retrieved pipeline state
-  Pipeline.State state = 1;
-}
-
 // ========== Private endpoints
 
 // ListPipelinesAdminRequest represents a request to list all pipelines from all
@@ -406,6 +395,33 @@ message ListPipelinesAdminRequest {
 message ListPipelinesAdminResponse {
   // A list of pipeline resources
   repeated Pipeline pipelines = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of pipeline resources
+  int64 total_size = 3;
+}
+
+// ListPipelinesReleaseAdminRequest represents a request to list all pipeline_releases from all
+// users by admin
+message ListPipelineReleasesAdminRequest {
+  // The maximum number of pipelines to return. The service may return fewer
+  // than this value. If unspecified, at most 10 pipelines will be returned. The
+  // maximum value is 100; values above 100 will be coerced to 100.
+  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // View view (default is VIEW_BASIC)
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list pipelines
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListPipelineReleasesAdminResponse represents a response for a list of pipeline_releases
+// The recipe returned will be permaLinks instead of resourceName temporary,
+// this will be refactored soon
+message ListPipelineReleasesAdminResponse {
+  // A list of pipeline resources
+  repeated PipelineRelease releases = 1;
   // Next page token
   string next_page_token = 2;
   // Total count of pipeline resources
@@ -447,4 +463,208 @@ message LookUpPipelineAdminRequest {
 message LookUpPipelineAdminResponse {
   // A pipeline resource
   Pipeline pipeline = 1;
+}
+
+// CreatePipelineReleaseRequest represents a request to create a pipeline_release
+message CreatePipelineReleaseRequest {
+  // A pipeline_release resource to create
+  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
+  // The parent resource where this pipeline_release will be created.
+  // Format: pipelines/{pipeline}
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"}
+  ];
+}
+
+// CreatePipelineReleaseResponse represents a response for a pipeline_release resource
+message CreatePipelineReleaseResponse {
+  // The created pipeline_release resource
+  PipelineRelease release = 1;
+}
+
+// ListPipelineReleasesRequest represents a request to list pipeline_releases
+message ListPipelineReleasesRequest {
+  // The maximum number of pipeline_releases to return. The service may return fewer
+  // than this value. If unspecified, at most 10 pipeline_release will be returned. The
+  // maximum value is 100; values above 100 will be coerced to 100.
+  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // View view (default is VIEW_BASIC)
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list pipeline_releases
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The parent resource where this pipeline_release will be created.
+  // Format: pipelines/{pipeline}
+  string parent = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"}
+  ];
+}
+
+// ListPipelineReleasesResponse represents a response for a list of pipeline_releases
+message ListPipelineReleasesResponse {
+  // A list of pipeline_release resources
+  repeated PipelineRelease releases = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of pipeline_release resources
+  int64 total_size = 3;
+}
+
+// GetPipelineReleaseRequest represents a request to query a pipeline_release
+message GetPipelineReleaseRequest {
+  // PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline_release.name"}
+    }
+  ];
+  // PipelineRelease resource view (default is VIEW_BASIC)
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetPipelineReleaseResponse represents a response for a pipeline_release resource
+message GetPipelineReleaseResponse {
+  // A pipeline_release resource
+  PipelineRelease release = 1;
+}
+
+// UpdatePipelineReleaseRequest represents a request to update a pipeline release
+message UpdatePipelineReleaseRequest {
+  // A pipeline release resource to update
+  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
+  // Update mask for a pipeline resource
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdatePipelineReleaseResponse represents a response for a pipeline resource
+message UpdatePipelineReleaseResponse {
+  // An updated pipeline resource
+  PipelineRelease release = 1;
+}
+
+// DeletePipelineReleaseRequest represents a request to delete a pipeline_release resource
+message DeletePipelineReleaseRequest {
+  // PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline_release.name"}
+    }
+  ];
+}
+
+// DeletePipelineReleaseResponse represents an empty response
+message DeletePipelineReleaseResponse {}
+
+// SetDefaultPipelineReleaseRequest
+message SetDefaultPipelineReleaseRequest {
+  // Pipeline resource name. It must have the format of "pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+}
+
+// SetDefaultPipelineReleaseResponse
+message SetDefaultPipelineReleaseResponse {
+  // A pipeline resource
+  PipelineRelease release = 1;
+}
+
+// RestorePipelineReleaseRequest
+message RestorePipelineReleaseRequest {
+  // Pipeline resource name. It must have the format of "pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+}
+
+// RestorePipelineReleaseResponse
+message RestorePipelineReleaseResponse {
+  // A pipeline resource
+  PipelineRelease release = 1;
+}
+
+// RenamePipelineReleaseRequest represents a request to rename the pipeline release resource
+// name
+message RenamePipelineReleaseRequest {
+  // Pipeline release resource name. It must have the format of "pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Pipeline new resource id to replace with the pipeline resource name to be
+  // "pipelines/*/releases/{new_pipeline_id}"
+  string new_pipeline_release_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RenamePipelineReleaseResponse represents a renamed pipeline release resource
+message RenamePipelineReleaseResponse {
+  // A pipeline resource
+  PipelineRelease release = 1;
+}
+
+// WatchPipelineReleaseRequest represents a public request to query
+// a pipeline's current state
+message WatchPipelineReleaseRequest {
+  // Pipeline resource name. It must have the format of "pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline.name/watch"}
+    }
+  ];
+}
+
+// WatchPipelineReleaseResponse represents a response to fetch a pipeline's
+// current state
+message WatchPipelineReleaseResponse {
+  // Retrieved pipeline state
+  State state = 1;
+}
+
+// TriggerPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+message TriggerPipelineReleaseRequest {
+  // Resource name.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Input to the pipeline
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerPipelineReleaseResponse represents a response for the output
+// of a pipeline, i.e., the multiple model inference outputs
+message TriggerPipelineReleaseResponse {
+  // The multiple model inference outputs
+  repeated google.protobuf.Struct outputs = 1;
+  // The traces of the pipeline inference, {component_id: Trace}
+  TriggerMetadata metadata = 2;
+}
+
+// TriggerAsyncPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+message TriggerAsyncPipelineReleaseRequest {
+  // Resource name.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Input to the pipeline
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerAsyncPipelineReleaseResponse represents a response for the longrunning
+// operation of a pipeline
+message TriggerAsyncPipelineReleaseResponse {
+  // Trigger async pipeline operation message
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/vdp/pipeline/v1alpha/pipeline_private_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_private_service.proto
@@ -30,4 +30,10 @@ service PipelinePrivateService {
     option (google.api.http) = {get: "/v1alpha/admin/{permalink=operator-definitions/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
   }
+
+  // ListPipelineReleasesAdmin method receives a ListPipelineReleasesAdminRequest message and
+  // returns a ListPipelineReleasesAdminResponse message.
+  rpc ListPipelineReleasesAdmin(ListPipelineReleasesAdminRequest) returns (ListPipelineReleasesAdminResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/releases"};
+  }
 }

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -92,25 +92,10 @@ service PipelinePublicService {
     option (google.api.method_signature) = "permalink";
   }
 
-  // Activate a pipeline.
-  // The "state" of the pipeline after activating is "ACTIVE".
-  // ActivatePipeline can be called on Pipelines in the state "INACTIVE";
-  // Pipelines in a different state (including "ACTIVE") returns an error.
-  rpc ActivatePipeline(ActivatePipelineRequest) returns (ActivatePipelineResponse) {
+  // Validate a pipeline.
+  rpc ValidatePipeline(ValidatePipelineRequest) returns (ValidatePipelineResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=pipelines/*}/activate"
-      body: "*"
-    };
-    option (google.api.method_signature) = "name";
-  }
-
-  // Deactivate a pipeline.
-  // The "state" of the pipeline after inactivating is "INACTIVE".
-  // DeactivatePipeline can be called on Pipelines in the state "ACTIVE";
-  // Pipelines in a different state (including "INACTIVE") returns an error.
-  rpc DeactivatePipeline(DeactivatePipelineRequest) returns (DeactivatePipelineResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/{name=pipelines/*}/deactivate"
+      post: "/v1alpha/{name=pipelines/*}/validate"
       body: "*"
     };
     option (google.api.method_signature) = "name";
@@ -146,13 +131,6 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name,inputs";
   }
 
-  // WatchPipeline method receives a WatchPipelineRequest message
-  // and returns a WatchPipelineResponse
-  rpc WatchPipeline(WatchPipelineRequest) returns (WatchPipelineResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=pipelines/*}/watch"};
-    option (google.api.method_signature) = "name";
-  }
-
   // *Longrunning operation methods
 
   // GetOperation method receives a
@@ -161,5 +139,97 @@ service PipelinePublicService {
   rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
     option (google.api.method_signature) = "name";
+  }
+
+  // CreatePipelineRelease method receives a CreatePipelineReleaseRequest message and returns
+  // a CreatePipelineReleaseResponse message.
+  rpc CreatePipelineRelease(CreatePipelineReleaseRequest) returns (CreatePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{parent=pipelines/*}/releases"
+      body: "release"
+    };
+    option (google.api.method_signature) = "parent,release";
+  }
+
+  // ListPipelineReleases method receives a ListPipelineReleasesRequest message and returns a
+  // ListPipelineReleasesResponse message.
+  rpc ListPipelineReleases(ListPipelineReleasesRequest) returns (ListPipelineReleasesResponse) {
+    option (google.api.http) = {get: "/v1alpha/{parent=pipelines/*}/releases"};
+    option (google.api.method_signature) = "pipelines";
+  }
+
+  // GetPipelineRelease method receives a GetPipelineReleaseRequest message and returns a
+  // GetPipelineReleaseResponse message.
+  rpc GetPipelineRelease(GetPipelineReleaseRequest) returns (GetPipelineReleaseResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=pipelines/*/releases/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // UpdatePipelineRelease method receives a UpdatePipelineReleaseRequest message and returns
+  // a UpdatePipelineReleaseResponse message.
+  rpc UpdatePipelineRelease(UpdatePipelineReleaseRequest) returns (UpdatePipelineReleaseResponse) {
+    option (google.api.http) = {
+      patch: "/v1alpha/{release.name=pipelines/*/releases/*}"
+      body: "release"
+    };
+    option (google.api.method_signature) = "release,update_mask";
+  }
+
+  // DeletePipelineRelease method receives a DeletePipelineReleaseRequest message and returns
+  // a DeletePipelineReleaseResponse message.
+  rpc DeletePipelineRelease(DeletePipelineReleaseRequest) returns (DeletePipelineReleaseResponse) {
+    option (google.api.http) = {delete: "/v1alpha/{name=pipelines/*/releases/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // RestorePipelineRelease method receives a RestorePipelineReleaseRequest message
+  // and returns a RestorePipelineReleaseResponse
+  rpc RestorePipelineRelease(RestorePipelineReleaseRequest) returns (RestorePipelineReleaseResponse) {
+    option (google.api.http) = {post: "/v1alpha/{name=pipelines/*/releases/*}/restore"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // SetDefaultPipelineRelease method receives a SetDefaultPipelineReleaseRequest message
+  // and returns a SetDefaultPipelineReleaseResponse
+  rpc SetDefaultPipelineRelease(SetDefaultPipelineReleaseRequest) returns (SetDefaultPipelineReleaseResponse) {
+    option (google.api.http) = {post: "/v1alpha/{name=pipelines/*/releases/*}/set_default"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // WatchPipelineRelease method receives a WatchPipelineReleaseRequest message
+  // and returns a WatchPipelineReleaseResponse
+  rpc WatchPipelineRelease(WatchPipelineReleaseRequest) returns (WatchPipelineReleaseResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=pipelines/*/releases/default}/watch"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // RenamePipelineRelease method receives a RenamePipelineReleaseRequest message and returns
+  // a RenamePipelineReleaseResponse message.
+  rpc RenamePipelineRelease(RenamePipelineReleaseRequest) returns (RenamePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=pipelines/*/releases/*}/rename"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,new_pipeline_release_id";
+  }
+
+  // TriggerPipelineRelease method receives a TriggePipelineReleaseRequest message
+  // and returns a TriggerPipelineReleasePipelineResponse.
+  rpc TriggerPipelineRelease(TriggerPipelineReleaseRequest) returns (TriggerPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=pipelines/*/releases/*}/trigger"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,inputs";
+  }
+
+  // TriggerAsyncPipelineRelease method receives a TriggerAsyncPipelineReleaseRequest message and
+  // returns a TriggerAsyncPipelineReleaseResponse.
+  rpc TriggerAsyncPipelineRelease(TriggerAsyncPipelineReleaseRequest) returns (TriggerAsyncPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=pipelines/*/releases/*}/triggerAsync"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,inputs";
   }
 }


### PR DESCRIPTION
Because

- we need to have release and version control for pipeline

This commit

- add pipeline release endpoints
