### PR TITLE
chore(pipeline,connector): add namespace for api endpoints

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -228,10 +228,6 @@ paths:
                 $ref: '#/definitions/v1alphaConnectorType'
                 title: ConnectorResource Type
                 readOnly: true
-              task:
-                $ref: '#/definitions/v1alphaTask'
-                title: ConnectorResource description
-                readOnly: true
               description:
                 type: string
                 title: ConnectorResource description
@@ -4947,10 +4943,6 @@ definitions:
       connector_type:
         $ref: '#/definitions/v1alphaConnectorType'
         title: ConnectorResource Type
-        readOnly: true
-      task:
-        $ref: '#/definitions/v1alphaTask'
-        title: ConnectorResource description
         readOnly: true
       description:
         type: string

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -115,14 +115,14 @@ paths:
   /v1alpha/{connector_resource.name}:
     get:
       summary: |-
-        GetConnectorResource method receives a GetConnectorResourceRequest
-        message and returns a GetConnectorResourceResponse message.
-      operationId: ConnectorPublicService_GetConnectorResource
+        GetUserConnectorResource method receives a GetUserConnectorResourceRequest
+        message and returns a GetUserConnectorResourceResponse message.
+      operationId: ConnectorPublicService_GetUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaGetUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -135,7 +135,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
         - name: view
           description: |-
             ConnectorResource view (default is VIEW_BASIC)
@@ -155,15 +155,15 @@ paths:
         - ConnectorPublicService
     delete:
       summary: |-
-        DeleteConnectorResource method receives a
-        DeleteConnectorResourceRequest message and returns a
-        DeleteConnectorResourceResponse message.
-      operationId: ConnectorPublicService_DeleteConnectorResource
+        DeleteUserConnectorResource method receives a
+        DeleteUserConnectorResourceRequest message and returns a
+        DeleteUserConnectorResourceResponse message.
+      operationId: ConnectorPublicService_DeleteUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeleteConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaDeleteUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -176,20 +176,20 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
       tags:
         - ConnectorPublicService
     patch:
       summary: |-
-        UpdateConnectorResource method receives a
-        UpdateConnectorResourceRequest message and returns a
-        UpdateConnectorResourceResponse message.
-      operationId: ConnectorPublicService_UpdateConnectorResource
+        UpdateUserConnectorResource method receives a
+        UpdateUserConnectorResourceRequest message and returns a
+        UpdateUserConnectorResourceResponse message.
+      operationId: ConnectorPublicService_UpdateUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdateConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaUpdateUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -202,7 +202,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
         - name: connector_resource
           description: ConnectorResource resource
           in: body
@@ -282,14 +282,14 @@ paths:
   /v1alpha/{connector_resource.name}/testConnection:
     post:
       summary: |-
-        TestConnectorResource method receives a TestConnectorResourceRequest
-        message and returns a TestConnectorResourceResponse
-      operationId: ConnectorPublicService_TestConnectorResource
+        TestUserConnectorResource method receives a TestUserConnectorResourceRequest
+        message and returns a TestUserConnectorResourceResponse
+      operationId: ConnectorPublicService_TestUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTestConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaTestUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -302,21 +302,21 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
       tags:
         - ConnectorPublicService
   /v1alpha/{connector_resource.name}/watch:
     get:
       summary: |-
-        WatchConnectorResource method receives a
-        WatchConnectorResourceRequest message and returns a
-        WatchConnectorResourceResponse
-      operationId: ConnectorPublicService_WatchConnectorResource
+        WatchUserConnectorResource method receives a
+        WatchUserConnectorResourceRequest message and returns a
+        WatchUserConnectorResourceResponse
+      operationId: ConnectorPublicService_WatchUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaWatchConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaWatchUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -329,7 +329,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
       tags:
         - ConnectorPublicService
   /v1alpha/{model.name/readme}:
@@ -618,15 +618,15 @@ paths:
   /v1alpha/{name_1}/rename:
     post:
       summary: |-
-        RenameConnectorResource method receives a
-        RenameConnectorResourceRequest message and returns a
-        RenameConnectorResourceResponse message.
-      operationId: ConnectorPublicService_RenameConnectorResource
+        RenameUserConnectorResource method receives a
+        RenameUserConnectorResourceRequest message and returns a
+        RenameUserConnectorResourceResponse message.
+      operationId: ConnectorPublicService_RenameUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRenameConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaRenameUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -639,7 +639,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
         - name: body
           in: body
           required: true
@@ -653,7 +653,7 @@ paths:
                   ConnectorResource resource name to be
                   "connector-resources/{new_connector_id}"
             title: |-
-              RenameConnectorResourceRequest represents a request to rename the
+              RenameUserConnectorResourceRequest represents a request to rename the
               ConnectorResource resource name
             required:
               - new_connector_id
@@ -662,25 +662,25 @@ paths:
   /v1alpha/{name_1}/trigger:
     post:
       summary: |-
-        TriggerPipeline method receives a TriggerPipelineRequest message
-        and returns a TriggerPipelineResponse.
-      operationId: PipelinePublicService_TriggerPipeline
+        TriggerUserPipeline method receives a TriggerUserPipelineRequest message
+        and returns a TriggerUserPipelineResponse.
+      operationId: PipelinePublicService_TriggerUserPipeline
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTriggerPipelineResponse'
+            $ref: '#/definitions/v1alphaTriggerUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
-          description: Pipeline resource name. It must have the format of "pipelines/*"
+          description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
         - name: body
           in: body
           required: true
@@ -692,7 +692,7 @@ paths:
                 items:
                   type: object
                 title: Input to the pipeline
-            title: TriggerPipelineRequest represents a request to trigger a pipeline
+            title: TriggerUserPipelineRequest represents a request to trigger a pipeline
             required:
               - inputs
       tags:
@@ -700,14 +700,14 @@ paths:
   /v1alpha/{name_1}/triggerAsync:
     post:
       summary: |-
-        TriggerAsyncPipelineRelease method receives a TriggerAsyncPipelineReleaseRequest message and
-        returns a TriggerAsyncPipelineReleaseResponse.
-      operationId: PipelinePublicService_TriggerAsyncPipelineRelease
+        TriggerAsyncUserPipelineRelease method receives a TriggerAsyncUserPipelineReleaseRequest message and
+        returns a TriggerAsyncUserPipelineReleaseResponse.
+      operationId: PipelinePublicService_TriggerAsyncUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTriggerAsyncPipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaTriggerAsyncUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -718,7 +718,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+/releases/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
         - name: body
           in: body
           required: true
@@ -730,7 +730,7 @@ paths:
                 items:
                   type: object
                 title: Input to the pipeline
-            title: TriggerAsyncPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+            title: TriggerAsyncUserPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
             required:
               - inputs
       tags:
@@ -738,25 +738,25 @@ paths:
   /v1alpha/{name_2}/rename:
     post:
       summary: |-
-        RenamePipeline method receives a RenamePipelineRequest message and returns
-        a RenamePipelineResponse message.
-      operationId: PipelinePublicService_RenamePipeline
+        RenameUserPipeline method receives a RenameUserPipelineRequest message and returns
+        a RenameUserPipelineResponse message.
+      operationId: PipelinePublicService_RenameUserPipeline
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRenamePipelineResponse'
+            $ref: '#/definitions/v1alphaRenameUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_2
-          description: Pipeline resource name. It must have the format of "pipelines/*"
+          description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
         - name: body
           in: body
           required: true
@@ -767,9 +767,9 @@ paths:
                 type: string
                 title: |-
                   Pipeline new resource id to replace with the pipeline resource name to be
-                  "pipelines/{new_pipeline_id}"
+                  "users/*/pipelines/{new_pipeline_id}"
             title: |-
-              RenamePipelineRequest represents a request to rename the pipeline resource
+              RenameUserPipelineRequest represents a request to rename the pipeline resource
               name
             required:
               - new_pipeline_id
@@ -778,14 +778,14 @@ paths:
   /v1alpha/{name_2}/trigger:
     post:
       summary: |-
-        TriggerPipelineRelease method receives a TriggePipelineReleaseRequest message
+        TriggerUserPipelineRelease method receives a TriggeUserPipelineReleaseRequest message
         and returns a TriggerPipelineReleasePipelineResponse.
-      operationId: PipelinePublicService_TriggerPipelineRelease
+      operationId: PipelinePublicService_TriggerUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTriggerPipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaTriggerUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -796,7 +796,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+/releases/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
         - name: body
           in: body
           required: true
@@ -808,7 +808,7 @@ paths:
                 items:
                   type: object
                 title: Input to the pipeline
-            title: TriggerPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+            title: TriggerUserPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
             required:
               - inputs
       tags:
@@ -816,25 +816,25 @@ paths:
   /v1alpha/{name_3}/rename:
     post:
       summary: |-
-        RenamePipelineRelease method receives a RenamePipelineReleaseRequest message and returns
-        a RenamePipelineReleaseResponse message.
-      operationId: PipelinePublicService_RenamePipelineRelease
+        RenameUserPipelineRelease method receives a RenameUserPipelineReleaseRequest message and returns
+        a RenameUserPipelineReleaseResponse message.
+      operationId: PipelinePublicService_RenameUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRenamePipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaRenameUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_3
-          description: Pipeline release resource name. It must have the format of "pipelines/*/releases/*"
+          description: Pipeline release resource name. It must have the format of "users/*/pipelines/*/releases/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+/releases/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
         - name: body
           in: body
           required: true
@@ -845,9 +845,9 @@ paths:
                 type: string
                 title: |-
                   Pipeline new resource id to replace with the pipeline resource name to be
-                  "pipelines/*/releases/{new_pipeline_id}"
+                  "users/*/pipelines/*/releases/{new_pipeline_id}"
             title: |-
-              RenamePipelineReleaseRequest represents a request to rename the pipeline release resource
+              RenameUserPipelineReleaseRequest represents a request to rename the pipeline release resource
               name
             required:
               - new_pipeline_release_id
@@ -900,15 +900,15 @@ paths:
       summary: |-
         Connect a connector resource.
         The "state" of the connector resource after connecting is "CONNECTED".
-        ConnectConnectorResource can be called on ConnectorResource in the
+        ConnectUserConnectorResource can be called on ConnectorResource in the
         state `DISCONNECTED`; ConnectorResource in a different state (including
         `CONNECTED`) returns an error.
-      operationId: ConnectorPublicService_ConnectConnectorResource
+      operationId: ConnectorPublicService_ConnectUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaConnectConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaConnectUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -921,14 +921,14 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
         - name: body
           in: body
           required: true
           schema:
             type: object
             title: |-
-              ConnectConnectorResourceRequest represents a request to connect a
+              ConnectUserConnectorResourceRequest represents a request to connect a
               connector_resource
       tags:
         - ConnectorPublicService
@@ -967,15 +967,15 @@ paths:
       summary: |-
         Disconnect a connectorResource.
         The "state" of the connectorResource after disconnecting is "DISCONNECTED".
-        DisconnectConnectorResource can be called on ConnectorResource in the
+        DisconnectUserConnectorResource can be called on ConnectorResource in the
         state `CONNECTED`; ConnectorResource in a different state (including
         `DISCONNECTED`) returns an error.
-      operationId: ConnectorPublicService_DisconnectConnectorResource
+      operationId: ConnectorPublicService_DisconnectUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDisconnectConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaDisconnectUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -988,29 +988,29 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
         - name: body
           in: body
           required: true
           schema:
             type: object
             title: |-
-              DisconnectConnectorResourceRequest represents a request to disconnect a
+              DisconnectUserConnectorResourceRequest represents a request to disconnect a
               connector_resource
       tags:
         - ConnectorPublicService
   /v1alpha/{name}/execute:
     post:
       summary: |-
-        ExecuteConnectorResource method receives a
-        ExecuteConnectorResourceRequest message and returns a
-        ExecuteConnectorResourceResponse message.
-      operationId: ConnectorPublicService_ExecuteConnectorResource
+        ExecuteUserConnectorResource method receives a
+        ExecuteUserConnectorResourceRequest message and returns a
+        ExecuteUserConnectorResourceResponse message.
+      operationId: ConnectorPublicService_ExecuteUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaExecuteConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaExecuteUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1023,7 +1023,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
         - name: body
           in: body
           required: true
@@ -1036,7 +1036,7 @@ paths:
                   type: object
                 title: Inputs
             title: |-
-              ExecuteConnectorResourceRequest represents a private request to execution
+              ExecuteUserConnectorResourceRequest represents a private request to execution
               connector_resource
       tags:
         - ConnectorPublicService
@@ -1109,49 +1109,49 @@ paths:
   /v1alpha/{name}/restore:
     post:
       summary: |-
-        RestorePipelineRelease method receives a RestorePipelineReleaseRequest message
-        and returns a RestorePipelineReleaseResponse
-      operationId: PipelinePublicService_RestorePipelineRelease
+        RestoreUserPipelineRelease method receives a RestoreUserPipelineReleaseRequest message
+        and returns a RestoreUserPipelineReleaseResponse
+      operationId: PipelinePublicService_RestoreUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRestorePipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaRestoreUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
-          description: Pipeline resource name. It must have the format of "pipelines/*/releases/*"
+          description: Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+/releases/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
   /v1alpha/{name}/set_default:
     post:
       summary: |-
-        SetDefaultPipelineRelease method receives a SetDefaultPipelineReleaseRequest message
-        and returns a SetDefaultPipelineReleaseResponse
-      operationId: PipelinePublicService_SetDefaultPipelineRelease
+        SetDefaultUserPipelineRelease method receives a SetDefaultUserPipelineReleaseRequest message
+        and returns a SetDefaultUserPipelineReleaseResponse
+      operationId: PipelinePublicService_SetDefaultUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaSetDefaultPipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaSetDefaultUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
-          description: Pipeline resource name. It must have the format of "pipelines/*/releases/*"
+          description: Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+/releases/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
   /v1alpha/{name}/test:
@@ -1240,25 +1240,25 @@ paths:
   /v1alpha/{name}/triggerAsync:
     post:
       summary: |-
-        TriggerAsyncPipeline method receives a TriggerPipelineRequest message and
-        returns a TriggerAsyncPipelineResponse.
-      operationId: PipelinePublicService_TriggerAsyncPipeline
+        TriggerAsyncUserPipeline method receives a TriggerAsyncUserPipelineRequest message and
+        returns a TriggerAsyncUserPipelineResponse.
+      operationId: PipelinePublicService_TriggerAsyncUserPipeline
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTriggerAsyncPipelineResponse'
+            $ref: '#/definitions/v1alphaTriggerAsyncUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
-          description: Pipeline resource name. It must have the format of "pipelines/*"
+          description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
         - name: body
           in: body
           required: true
@@ -1270,7 +1270,7 @@ paths:
                 items:
                   type: object
                 title: Input to the pipeline
-            title: TriggerAsyncPipelineRequest represents a request to trigger a async pipeline
+            title: TriggerAsyncUserPipelineRequest represents a request to trigger a async pipeline
             required:
               - inputs
       tags:
@@ -1342,29 +1342,29 @@ paths:
   /v1alpha/{name}/validate:
     post:
       summary: Validate a pipeline.
-      operationId: PipelinePublicService_ValidatePipeline
+      operationId: PipelinePublicService_ValidateUserPipeline
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaValidatePipelineResponse'
+            $ref: '#/definitions/v1alphaValidateUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
-          description: Pipeline resource name. It must have the format of "pipelines/*"
+          description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
         - name: body
           in: body
           required: true
           schema:
             type: object
-            title: ValidatePipelineRequest represents a request to validate a pipeline
+            title: ValidatePUseripelineRequest represents a request to validate a pipeline
       tags:
         - PipelinePublicService
   /v1alpha/{operator_definition.name}:
@@ -1410,17 +1410,205 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePublicService
-  /v1alpha/{parent}/releases:
+  /v1alpha/{parent}/connector-resources:
     get:
       summary: |-
-        ListPipelineReleases method receives a ListPipelineReleasesRequest message and returns a
-        ListPipelineReleasesResponse message.
-      operationId: PipelinePublicService_ListPipelineReleases
+        ListUserConnectorResources method receives a
+        ListUserConnectorResourcesRequest message and returns a
+        ListUserConnectorResourcesResponse message.
+      operationId: ConnectorPublicService_ListUserConnectorResources
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListPipelineReleasesResponse'
+            $ref: '#/definitions/v1alphaListUserConnectorResourcesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent
+          description: |-
+            The parent resource where this connector resource will be created.
+            Format: users/{users}
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: page_size
+          description: |-
+            The maximum number of connector-resources to return. The service may return fewer
+            than this value. If unspecified, at most 10 connector-resources will be returned.
+            The maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            ConnectorResource view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list connector-resources
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorPublicService
+    post:
+      summary: |-
+        CreateUserConnectorResource method receives a
+        CreateUserConnectorResourceRequest message and returns a
+        CreateUserConnectorResourceResponse message.
+      operationId: ConnectorPublicService_CreateUserConnectorResource
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateUserConnectorResourceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent
+          description: |-
+            The parent resource where this connector resource will be created.
+            Format: users/{users}
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: connector_resource
+          description: ConnectorResource resource
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaConnectorResource'
+            required:
+              - connector_resource
+      tags:
+        - ConnectorPublicService
+  /v1alpha/{parent}/pipelines:
+    get:
+      summary: |-
+        ListUserPipelines method receives a ListUserPipelinesRequest message and returns a
+        ListUserPipelinesResponse message.
+      operationId: PipelinePublicService_ListUserPipelines
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListUserPipelinesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent
+          description: |-
+            The parent resource where this connector resource will be created.
+            Format: users/{users}
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: page_size
+          description: |-
+            The maximum number of pipelines to return. The service may return fewer
+            than this value. If unspecified, at most 10 pipelines will be returned. The
+            maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list pipelines
+          in: query
+          required: false
+          type: string
+      tags:
+        - PipelinePublicService
+    post:
+      summary: |-
+        CreateUserPipeline method receives a CreateUserPipelineRequest message and returns
+        a CreateUserPipelineResponse message.
+      operationId: PipelinePublicService_CreateUserPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateUserPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent
+          description: |-
+            The parent resource where this connector resource will be created.
+            Format: users/{users}
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: pipeline
+          description: A pipeline resource to create
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaPipeline'
+            required:
+              - pipeline
+      tags:
+        - PipelinePublicService
+  /v1alpha/{parent}/releases:
+    get:
+      summary: |-
+        ListUserPipelineReleases method receives a ListUserPipelineReleasesRequest message and returns a
+        ListUserPipelineReleasesResponse message.
+      operationId: PipelinePublicService_ListUserPipelineReleases
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListUserPipelineReleasesResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1429,11 +1617,11 @@ paths:
         - name: parent
           description: |-
             The parent resource where this pipeline_release will be created.
-            Format: pipelines/{pipeline}
+            Format: users/{user}/pipelines/{pipeline}
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
         - name: page_size
           description: |-
             The maximum number of pipeline_releases to return. The service may return fewer
@@ -1472,14 +1660,14 @@ paths:
         - PipelinePublicService
     post:
       summary: |-
-        CreatePipelineRelease method receives a CreatePipelineReleaseRequest message and returns
-        a CreatePipelineReleaseResponse message.
-      operationId: PipelinePublicService_CreatePipelineRelease
+        CreateUserPipelineRelease method receives a CreateUserPipelineReleaseRequest message and returns
+        a CreateUserPipelineReleaseResponse message.
+      operationId: PipelinePublicService_CreateUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCreatePipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaCreateUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1488,11 +1676,11 @@ paths:
         - name: parent
           description: |-
             The parent resource where this pipeline_release will be created.
-            Format: pipelines/{pipeline}
+            Format: users/{user}/pipelines/{pipeline}
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
         - name: release
           description: A pipeline_release resource to create
           in: body
@@ -1506,15 +1694,15 @@ paths:
   /v1alpha/{permalink_1}/lookUp:
     get:
       summary: |-
-        LookUpConnectorResource method receives a
-        LookUpConnectorResourceRequest message and returns a
-        LookUpConnectorResourceResponse
-      operationId: ConnectorPublicService_LookUpConnectorResource
+        LookUpUserConnectorResource method receives a
+        LookUpUserConnectorResourceRequest message and returns a
+        LookUpUserConnectorResourceResponse
+      operationId: ConnectorPublicService_LookUpUserConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaLookUpUserConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1527,7 +1715,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: connector-resources/[^/]+
+          pattern: users/[^/]+/connector-resources/[^/]+
         - name: view
           description: |-
             ConnectorResource view (default is VIEW_BASIC)
@@ -1548,14 +1736,14 @@ paths:
   /v1alpha/{permalink_2}/lookUp:
     get:
       summary: |-
-        LookUpPipeline method receives a LookUpPipelineRequest message and returns
-        a LookUpPipelineResponse
-      operationId: PipelinePublicService_LookUpPipeline
+        LookUpUserPipeline method receives a LookUpUserPipelineRequest message and returns
+        a LookUpUserPipelineResponse
+      operationId: PipelinePublicService_LookUpUserPipeline
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpPipelineResponse'
+            $ref: '#/definitions/v1alphaLookUpUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1564,11 +1752,11 @@ paths:
         - name: permalink_2
           description: |-
             Permalink of a pipeline. For example:
-            "pipelines/{uid}"
+            "users/*/pipelines/{uid}"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
         - name: view
           description: |-
             View view (default is VIEW_BASIC)
@@ -1632,49 +1820,49 @@ paths:
   /v1alpha/{pipeline.name/watch}/watch:
     get:
       summary: |-
-        WatchPipelineRelease method receives a WatchPipelineReleaseRequest message
-        and returns a WatchPipelineReleaseResponse
-      operationId: PipelinePublicService_WatchPipelineRelease
+        WatchUserPipelineRelease method receives a WatchUserPipelineReleaseRequest message
+        and returns a WatchUserPipelineReleaseResponse
+      operationId: PipelinePublicService_WatchUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaWatchPipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaWatchUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name/watch
-          description: Pipeline resource name. It must have the format of "pipelines/*/releases/*"
+          description: Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+/releases/default
+          pattern: users/[^/]+/pipelines/[^/]+/releases/default
       tags:
         - PipelinePublicService
   /v1alpha/{pipeline.name}:
     get:
       summary: |-
-        GetPipeline method receives a GetPipelineRequest message and returns a
-        GetPipelineResponse message.
-      operationId: PipelinePublicService_GetPipeline
+        GetUserPipeline method receives a GetUserPipelineRequest message and returns a
+        GetUserPipelineResponse message.
+      operationId: PipelinePublicService_GetUserPipeline
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetPipelineResponse'
+            $ref: '#/definitions/v1alphaGetUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name
-          description: Pipeline resource name. It must have the format of "pipelines/*"
+          description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
         - name: view
           description: |-
             Pipeline resource view (default is VIEW_BASIC)
@@ -1694,48 +1882,48 @@ paths:
         - PipelinePublicService
     delete:
       summary: |-
-        DeletePipeline method receives a DeletePipelineRequest message and returns
-        a DeletePipelineResponse message.
-      operationId: PipelinePublicService_DeletePipeline
+        DeleteUserPipeline method receives a DeleteUserPipelineRequest message and returns
+        a DeleteUserPipelineResponse message.
+      operationId: PipelinePublicService_DeleteUserPipeline
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeletePipelineResponse'
+            $ref: '#/definitions/v1alphaDeleteUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name
-          description: Pipeline resource name. It must have the format of "pipelines/*"
+          description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
       tags:
         - PipelinePublicService
     patch:
       summary: |-
-        UpdatePipeline method receives a UpdatePipelineRequest message and returns
-        a UpdatePipelineResponse message.
-      operationId: PipelinePublicService_UpdatePipeline
+        UpdateUserPipeline method receives a UpdateUserPipelineRequest message and returns
+        a UpdateUserPipelineResponse message.
+      operationId: PipelinePublicService_UpdateUserPipeline
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdatePipelineResponse'
+            $ref: '#/definitions/v1alphaUpdateUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name
-          description: Pipeline resource name. It must have the format of "pipelines/*"
+          description: Pipeline resource name. It must have the format of "users/{user}/pipelines/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+          pattern: users/[^/]+pipelines/[^/]+
         - name: pipeline
           description: A pipeline resource to update
           in: body
@@ -1786,25 +1974,25 @@ paths:
   /v1alpha/{pipeline_release.name}:
     get:
       summary: |-
-        GetPipelineRelease method receives a GetPipelineReleaseRequest message and returns a
-        GetPipelineReleaseResponse message.
-      operationId: PipelinePublicService_GetPipelineRelease
+        GetUserPipelineRelease method receives a GetUserPipelineReleaseRequest message and returns a
+        GetUserPipelineReleaseResponse message.
+      operationId: PipelinePublicService_GetUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetPipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaGetUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline_release.name
-          description: PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+          description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+/releases/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
         - name: view
           description: |-
             PipelineRelease resource view (default is VIEW_BASIC)
@@ -1824,49 +2012,49 @@ paths:
         - PipelinePublicService
     delete:
       summary: |-
-        DeletePipelineRelease method receives a DeletePipelineReleaseRequest message and returns
-        a DeletePipelineReleaseResponse message.
-      operationId: PipelinePublicService_DeletePipelineRelease
+        DeleteUserPipelineRelease method receives a DeleteUserPipelineReleaseRequest message and returns
+        a DeleteUserPipelineReleaseResponse message.
+      operationId: PipelinePublicService_DeleteUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeletePipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaDeleteUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline_release.name
-          description: PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+          description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+/releases/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
   /v1alpha/{release.name}:
     patch:
       summary: |-
-        UpdatePipelineRelease method receives a UpdatePipelineReleaseRequest message and returns
-        a UpdatePipelineReleaseResponse message.
-      operationId: PipelinePublicService_UpdatePipelineRelease
+        UpdateUserPipelineRelease method receives a UpdateUserPipelineReleaseRequest message and returns
+        a UpdateUserPipelineReleaseResponse message.
+      operationId: PipelinePublicService_UpdateUserPipelineRelease
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdatePipelineReleaseResponse'
+            $ref: '#/definitions/v1alphaUpdateUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: release.name
-          description: PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+          description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+/releases/[^/]+
+          pattern: usersr/[^/]+/pipelines/[^/]+/releases/[^/]+
         - name: release
           description: A pipeline release resource to update
           in: body
@@ -3107,32 +3295,6 @@ paths:
           type: string
       tags:
         - ConnectorPublicService
-    post:
-      summary: |-
-        CreateConnectorResource method receives a
-        CreateConnectorResourceRequest message and returns a
-        CreateConnectorResourceResponse message.
-      operationId: ConnectorPublicService_CreateConnectorResource
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaCreateConnectorResourceResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: connector_resource
-          description: ConnectorResource resource
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/v1alphaConnectorResource'
-            required:
-              - connector_resource
-      tags:
-        - ConnectorPublicService
   /v1alpha/health/connector:
     get:
       summary: |-
@@ -3717,31 +3879,6 @@ paths:
           in: query
           required: false
           type: string
-      tags:
-        - PipelinePublicService
-    post:
-      summary: |-
-        CreatePipeline method receives a CreatePipelineRequest message and returns
-        a CreatePipelineResponse message.
-      operationId: PipelinePublicService_CreatePipeline
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaCreatePipelineResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: pipeline
-          description: A pipeline resource to create
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/v1alphaPipeline'
-            required:
-              - pipeline
       tags:
         - PipelinePublicService
   /v1alpha/ready/mgmt:
@@ -4609,14 +4746,14 @@ definitions:
        - COMPONENT_TYPE_CONNECTOR_BLOCKCHAIN: CONNECTOR_BLOCKCHAIN
        - COMPONENT_TYPE_OPERATOR: CONNECTOR_OPERATOR
     title: ComponentType
-  v1alphaConnectConnectorResourceResponse:
+  v1alphaConnectUserConnectorResourceResponse:
     type: object
     properties:
       connector_resource:
         $ref: '#/definitions/v1alphaConnectorResource'
         title: A ConnectorResource resource
     title: |-
-      ConnectConnectorResourceResponse represents a connected
+      ConnectUserConnectorResourceResponse represents a connected
       connector_resource
   v1alphaConnectorDefinition:
     type: object
@@ -4932,15 +5069,6 @@ definitions:
     required:
       - user_uid
       - connector_execute_data
-  v1alphaCreateConnectorResourceResponse:
-    type: object
-    properties:
-      connector_resource:
-        $ref: '#/definitions/v1alphaConnectorResource'
-        title: ConnectorResource resource
-    title: |-
-      CreateConnectorResourceResponse represents a response for a
-      ConnectorResource resource
   v1alphaCreateModelBinaryFileUploadResponse:
     type: object
     properties:
@@ -4957,20 +5085,6 @@ definitions:
         title: Create model operation message
         readOnly: true
     title: CreateModelResponse represents a response for a model
-  v1alphaCreatePipelineReleaseResponse:
-    type: object
-    properties:
-      release:
-        $ref: '#/definitions/v1alphaPipelineRelease'
-        title: The created pipeline_release resource
-    title: CreatePipelineReleaseResponse represents a response for a pipeline_release resource
-  v1alphaCreatePipelineResponse:
-    type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
-        title: The created pipeline resource
-    title: CreatePipelineResponse represents a response for a pipeline resource
   v1alphaCreateSessionResponse:
     type: object
     properties:
@@ -4992,24 +5106,47 @@ definitions:
         $ref: '#/definitions/v1alphaUser'
         title: A user resource
     title: CreateUserAdminResponse represents a response for a user response
-  v1alphaDeleteConnectorResourceResponse:
+  v1alphaCreateUserConnectorResourceResponse:
     type: object
-    title: DeleteConnectorResourceResponse represents an empty response
+    properties:
+      connector_resource:
+        $ref: '#/definitions/v1alphaConnectorResource'
+        title: ConnectorResource resource
+    title: |-
+      CreateUserConnectorResourceResponse represents a response for a
+      ConnectorResource resource
+  v1alphaCreateUserPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: The created pipeline_release resource
+    title: CreateUserPipelineReleaseResponse represents a response for a pipeline_release resource
+  v1alphaCreateUserPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: The created pipeline resource
+    title: CreateUserPipelineResponse represents a response for a pipeline resource
   v1alphaDeleteModelResponse:
     type: object
     title: DeleteModelResponse represents an empty response
-  v1alphaDeletePipelineReleaseResponse:
-    type: object
-    title: DeletePipelineReleaseResponse represents an empty response
-  v1alphaDeletePipelineResponse:
-    type: object
-    title: DeletePipelineResponse represents an empty response
   v1alphaDeleteTokenResponse:
     type: object
     title: DeleteTokenResponse represents an empty response
   v1alphaDeleteUserAdminResponse:
     type: object
     title: DeleteUserAdminResponse represents an empty response
+  v1alphaDeleteUserConnectorResourceResponse:
+    type: object
+    title: DeleteUserConnectorResourceResponse represents an empty response
+  v1alphaDeleteUserPipelineReleaseResponse:
+    type: object
+    title: DeleteUserPipelineReleaseResponse represents an empty response
+  v1alphaDeleteUserPipelineResponse:
+    type: object
+    title: DeleteUserPipelineResponse represents an empty response
   v1alphaDeployModelAdminResponse:
     type: object
     properties:
@@ -5083,16 +5220,16 @@ definitions:
         title: A list of detection objects
         readOnly: true
     title: DetectionOutput represents the output of detection task
-  v1alphaDisconnectConnectorResourceResponse:
+  v1alphaDisconnectUserConnectorResourceResponse:
     type: object
     properties:
       connector_resource:
         $ref: '#/definitions/v1alphaConnectorResource'
         title: A ConnectorResource resource
     title: |-
-      DisconnectConnectorResourceResponse represents a disconnected
+      DisconnectUserConnectorResourceResponse represents a disconnected
       connector_resource
-  v1alphaExecuteConnectorResourceResponse:
+  v1alphaExecuteUserConnectorResourceResponse:
     type: object
     properties:
       outputs:
@@ -5101,7 +5238,7 @@ definitions:
           type: object
         title: Outputs
     title: |-
-      ExecuteConnectorResourceResponse represents a response for execution
+      ExecuteUserConnectorResourceResponse represents a response for execution
       output
   v1alphaExistUsernameResponse:
     type: object
@@ -5233,15 +5370,6 @@ definitions:
     title: |-
       GetConnectorDefinitionResponse represents a
       ConnectorDefinition response
-  v1alphaGetConnectorResourceResponse:
-    type: object
-    properties:
-      connector_resource:
-        $ref: '#/definitions/v1alphaConnectorResource'
-        title: ConnectorResource resource
-    title: |-
-      GetConnectorResourceResponse represents a response for a
-      ConnectorResource resource
   v1alphaGetCumulativeModelOnlineRecordsRequest:
     type: object
     properties:
@@ -5460,20 +5588,6 @@ definitions:
     title: |-
       GetOperatorDefinitionResponse represents a
       Operator response
-  v1alphaGetPipelineReleaseResponse:
-    type: object
-    properties:
-      release:
-        $ref: '#/definitions/v1alphaPipelineRelease'
-        title: A pipeline_release resource
-    title: GetPipelineReleaseResponse represents a response for a pipeline_release resource
-  v1alphaGetPipelineResponse:
-    type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
-        title: A pipeline resource
-    title: GetPipelineResponse represents a response for a pipeline resource
   v1alphaGetPipelineTriggerPriceRequest:
     type: object
     properties:
@@ -5596,6 +5710,29 @@ definitions:
         $ref: '#/definitions/v1alphaUser'
         title: A user resource
     title: GetUserAdminResponse represents a response for a user resource
+  v1alphaGetUserConnectorResourceResponse:
+    type: object
+    properties:
+      connector_resource:
+        $ref: '#/definitions/v1alphaConnectorResource'
+        title: ConnectorResource resource
+    title: |-
+      GetUserConnectorResourceResponse represents a response for a
+      ConnectorResource resource
+  v1alphaGetUserPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A pipeline_release resource
+    title: GetUserPipelineReleaseResponse represents a response for a pipeline_release resource
+  v1alphaGetUserPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: GetUserPipelineResponse represents a response for a pipeline resource
   v1alphaHealthCheckRequest:
     type: object
     properties:
@@ -5951,23 +6088,6 @@ definitions:
       ListPipelineReleasesAdminResponse represents a response for a list of pipeline_releases
       The recipe returned will be permaLinks instead of resourceName temporary,
       this will be refactored soon
-  v1alphaListPipelineReleasesResponse:
-    type: object
-    properties:
-      releases:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaPipelineRelease'
-        title: A list of pipeline_release resources
-      next_page_token:
-        type: string
-        title: Next page token
-      total_size:
-        type: string
-        format: int64
-        title: Total count of pipeline_release resources
-    title: ListPipelineReleasesResponse represents a response for a list of pipeline_releases
   v1alphaListPipelineTriggerChartRecordsResponse:
     type: object
     properties:
@@ -6072,6 +6192,59 @@ definitions:
         format: int64
         title: Total count of API tokens resources
     title: ListTokensResponse represents a response for a list of API tokens
+  v1alphaListUserConnectorResourcesResponse:
+    type: object
+    properties:
+      connector_resources:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaConnectorResource'
+        title: A list of ConnectorResource resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of connector_resource resources
+    title: |-
+      ListUserConnectorResourcesResponse represents a response for a list of
+      ConnectorResource resources
+  v1alphaListUserPipelineReleasesResponse:
+    type: object
+    properties:
+      releases:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A list of pipeline_release resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of pipeline_release resources
+    title: ListUserPipelineReleasesResponse represents a response for a list of pipeline_releases
+  v1alphaListUserPipelinesResponse:
+    type: object
+    properties:
+      pipelines:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaPipeline'
+        title: A list of pipeline resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of pipeline resources
+    title: ListUserPipelinesResponse represents a response for a list of pipelines
   v1alphaListUsersAdminResponse:
     type: object
     properties:
@@ -6107,15 +6280,6 @@ definitions:
     title: |-
       LookUpConnectorResourceAdminResponse represents a response for a
       connector_resource
-  v1alphaLookUpConnectorResourceResponse:
-    type: object
-    properties:
-      connector_resource:
-        $ref: '#/definitions/v1alphaConnectorResource'
-        title: ConnectorResource resource
-    title: |-
-      LookUpConnectorResourceResponse represents a response for a
-      connector_resource
   v1alphaLookUpModelAdminResponse:
     type: object
     properties:
@@ -6146,13 +6310,6 @@ definitions:
         $ref: '#/definitions/v1alphaPipeline'
         title: A pipeline resource
     title: LookUpPipelineAdminResponse represents a response for a pipeline resource
-  v1alphaLookUpPipelineResponse:
-    type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
-        title: A pipeline resource
-    title: LookUpPipelineResponse represents a response for a pipeline resource
   v1alphaLookUpUserAdminResponse:
     type: object
     properties:
@@ -6160,6 +6317,22 @@ definitions:
         $ref: '#/definitions/v1alphaUser'
         title: A user resource
     title: LookUpUserAdminResponse represents a response for a user resource by admin
+  v1alphaLookUpUserConnectorResourceResponse:
+    type: object
+    properties:
+      connector_resource:
+        $ref: '#/definitions/v1alphaConnectorResource'
+        title: ConnectorResource resource
+    title: |-
+      LookUpUserConnectorResourceResponse represents a response for a
+      connector_resource
+  v1alphaLookUpUserPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: LookUpUserPipelineResponse represents a response for a pipeline resource
   v1alphaMgmtUsageData:
     type: object
     properties:
@@ -6573,7 +6746,7 @@ definitions:
     properties:
       name:
         type: string
-        title: Pipeline resource name. It must have the format of "pipelines/*"
+        title: Pipeline resource name. It must have the format of "users/{user}/pipelines/*"
         readOnly: true
       uid:
         type: string
@@ -6635,7 +6808,7 @@ definitions:
     properties:
       name:
         type: string
-        title: PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+        title: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
         readOnly: true
       uid:
         type: string
@@ -6874,15 +7047,6 @@ definitions:
        - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
        - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
     title: ReleaseStage enumerates the release stages
-  v1alphaRenameConnectorResourceResponse:
-    type: object
-    properties:
-      connector_resource:
-        $ref: '#/definitions/v1alphaConnectorResource'
-        title: A ConnectorResource resource
-    title: |-
-      RenameConnectorResourceResponse represents a renamed ConnectorResource
-      resource
   v1alphaRenameModelResponse:
     type: object
     properties:
@@ -6890,20 +7054,29 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: Renamed model
     title: RenameModelResponse represents a response for a model
-  v1alphaRenamePipelineReleaseResponse:
+  v1alphaRenameUserConnectorResourceResponse:
+    type: object
+    properties:
+      connector_resource:
+        $ref: '#/definitions/v1alphaConnectorResource'
+        title: A ConnectorResource resource
+    title: |-
+      RenameUserConnectorResourceResponse represents a renamed ConnectorResource
+      resource
+  v1alphaRenameUserPipelineReleaseResponse:
     type: object
     properties:
       release:
         $ref: '#/definitions/v1alphaPipelineRelease'
         title: A pipeline resource
-    title: RenamePipelineReleaseResponse represents a renamed pipeline release resource
-  v1alphaRenamePipelineResponse:
+    title: RenameUserPipelineReleaseResponse represents a renamed pipeline release resource
+  v1alphaRenameUserPipelineResponse:
     type: object
     properties:
       pipeline:
         $ref: '#/definitions/v1alphaPipeline'
         title: A pipeline resource
-    title: RenamePipelineResponse represents a renamed pipeline resource
+    title: RenameUserPipelineResponse represents a renamed pipeline resource
   v1alphaReportModelOnlineRequest:
     type: object
     properties:
@@ -6978,13 +7151,13 @@ definitions:
     title: |-
       ReportPipelineTriggersResponse represents a respond to a
       pipeline-trigger-records reporting bulk request
-  v1alphaRestorePipelineReleaseResponse:
+  v1alphaRestoreUserPipelineReleaseResponse:
     type: object
     properties:
       release:
         $ref: '#/definitions/v1alphaPipelineRelease'
         title: A pipeline resource
-    title: RestorePipelineReleaseResponse
+    title: RestoreUserPipelineReleaseResponse
   v1alphaSemanticSegmentationInput:
     type: object
     properties:
@@ -7143,13 +7316,13 @@ definitions:
       - token
       - pow
       - session
-  v1alphaSetDefaultPipelineReleaseResponse:
+  v1alphaSetDefaultUserPipelineReleaseResponse:
     type: object
     properties:
       release:
         $ref: '#/definitions/v1alphaPipelineRelease'
         title: A pipeline resource
-    title: SetDefaultPipelineReleaseResponse
+    title: SetDefaultUserPipelineReleaseResponse
   v1alphaTask:
     type: string
     enum:
@@ -7282,15 +7455,6 @@ definitions:
         title: The unspecified task output
         readOnly: true
     title: TaskOutput represents the output of a CV Task result from a model
-  v1alphaTestConnectorResourceResponse:
-    type: object
-    properties:
-      state:
-        $ref: '#/definitions/v1alphaConnectorResourceState'
-        title: Retrieved connector_resource state
-    title: |-
-      TestConnectorResourceResponse represents a response containing a
-      connector_resource's current state
   v1alphaTestModelBinaryFileUploadResponse:
     type: object
     properties:
@@ -7327,6 +7491,15 @@ definitions:
     required:
       - task
       - task_outputs
+  v1alphaTestUserConnectorResourceResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaConnectorResourceState'
+        title: Retrieved connector_resource state
+    title: |-
+      TestUserConnectorResourceResponse represents a response containing a
+      connector_resource's current state
   v1alphaTextGenerationInput:
     type: object
     properties:
@@ -7436,7 +7609,7 @@ definitions:
         format: float
         title: Compute Time
     title: Trace for the intermediate component
-  v1alphaTriggerAsyncPipelineReleaseResponse:
+  v1alphaTriggerAsyncUserPipelineReleaseResponse:
     type: object
     properties:
       operation:
@@ -7444,9 +7617,9 @@ definitions:
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
-      TriggerAsyncPipelineReleaseResponse represents a response for the longrunning
+      TriggerAsyncUserPipelineReleaseResponse represents a response for the longrunning
       operation of a pipeline
-  v1alphaTriggerAsyncPipelineResponse:
+  v1alphaTriggerAsyncUserPipelineResponse:
     type: object
     properties:
       operation:
@@ -7454,7 +7627,7 @@ definitions:
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
-      TriggerAsyncPipelineResponse represents a response for the longrunning
+      TriggerAsyncUserPipelineResponse represents a response for the longrunning
       operation of a pipeline
   v1alphaTriggerMetadata:
     type: object
@@ -7498,7 +7671,7 @@ definitions:
     title: |-
       TriggerModelResponse represents a response for the output for
       triggering a model
-  v1alphaTriggerPipelineReleaseResponse:
+  v1alphaTriggerUserPipelineReleaseResponse:
     type: object
     properties:
       outputs:
@@ -7510,9 +7683,9 @@ definitions:
         $ref: '#/definitions/v1alphaTriggerMetadata'
         title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: |-
-      TriggerPipelineReleaseResponse represents a response for the output
+      TriggerUserPipelineReleaseResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
-  v1alphaTriggerPipelineResponse:
+  v1alphaTriggerUserPipelineResponse:
     type: object
     properties:
       outputs:
@@ -7524,7 +7697,7 @@ definitions:
         $ref: '#/definitions/v1alphaTriggerMetadata'
         title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: |-
-      TriggerPipelineResponse represents a response for the output
+      TriggerUserPipelineResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
   v1alphaUndeployModelAdminResponse:
     type: object
@@ -7568,15 +7741,6 @@ definitions:
         title: A list of unspecified task outputs
         readOnly: true
     title: UnspecifiedOutput represents the output of unspecified task
-  v1alphaUpdateConnectorResourceResponse:
-    type: object
-    properties:
-      connector_resource:
-        $ref: '#/definitions/v1alphaConnectorResource'
-        title: ConnectorResource resource
-    title: |-
-      UpdateConnectorResourceResponse represents a response for a
-      ConnectorResource resource
   v1alphaUpdateModelResponse:
     type: object
     properties:
@@ -7584,20 +7748,6 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: The updated model
     title: UpdateModelResponse represents a response for a model
-  v1alphaUpdatePipelineReleaseResponse:
-    type: object
-    properties:
-      release:
-        $ref: '#/definitions/v1alphaPipelineRelease'
-        title: An updated pipeline resource
-    title: UpdatePipelineReleaseResponse represents a response for a pipeline resource
-  v1alphaUpdatePipelineResponse:
-    type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
-        title: An updated pipeline resource
-    title: UpdatePipelineResponse represents a response for a pipeline resource
   v1alphaUpdateUserAdminResponse:
     type: object
     properties:
@@ -7605,6 +7755,29 @@ definitions:
         $ref: '#/definitions/v1alphaUser'
         title: A user resource
     title: UpdateUserAdminResponse represents a response for a user resource
+  v1alphaUpdateUserConnectorResourceResponse:
+    type: object
+    properties:
+      connector_resource:
+        $ref: '#/definitions/v1alphaConnectorResource'
+        title: ConnectorResource resource
+    title: |-
+      UpdateUserConnectorResourceResponse represents a response for a
+      ConnectorResource resource
+  v1alphaUpdateUserPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: An updated pipeline resource
+    title: UpdateUserPipelineReleaseResponse represents a response for a pipeline resource
+  v1alphaUpdateUserPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: An updated pipeline resource
+    title: UpdateUserPipelineResponse represents a response for a pipeline resource
   v1alphaUsageSummary:
     type: object
     properties:
@@ -7706,22 +7879,13 @@ definitions:
     title: User records definition
     required:
       - uid
-  v1alphaValidatePipelineResponse:
+  v1alphaValidateUserPipelineResponse:
     type: object
     properties:
       pipeline:
         $ref: '#/definitions/v1alphaPipeline'
         title: A pipeline resource
-    title: ValidatePipelineResponse represents an response of validated pipeline
-  v1alphaWatchConnectorResourceResponse:
-    type: object
-    properties:
-      state:
-        $ref: '#/definitions/v1alphaConnectorResourceState'
-        title: Retrieved connector_resource state
-    title: |-
-      WatchConnectorResourceResponse represents a response to fetch a
-      connector_resource's current state
+    title: ValidateUserPipelineResponse represents an response of validated pipeline
   v1alphaWatchModelResponse:
     type: object
     properties:
@@ -7735,14 +7899,23 @@ definitions:
     title: |-
       WatchModelResponse represents a public response to
       fetch a model current state and longrunning progress
-  v1alphaWatchPipelineReleaseResponse:
+  v1alphaWatchUserConnectorResourceResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaConnectorResourceState'
+        title: Retrieved connector_resource state
+    title: |-
+      WatchUserConnectorResourceResponse represents a response to fetch a
+      connector_resource's current state
+  v1alphaWatchUserPipelineReleaseResponse:
     type: object
     properties:
       state:
         $ref: '#/definitions/pipelinev1alphaState'
         title: Retrieved pipeline state
     title: |-
-      WatchPipelineReleaseResponse represents a response to fetch a pipeline's
+      WatchUserPipelineReleaseResponse represents a response to fetch a pipeline's
       current state
   vdpconnectorv1alphaLivenessResponse:
     type: object

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -224,7 +224,7 @@ paths:
               connector_definition_name:
                 type: string
                 title: ConnectorDefinition resource
-              connector_type:
+              type:
                 $ref: '#/definitions/v1alphaConnectorType'
                 title: ConnectorResource Type
                 readOnly: true
@@ -1919,7 +1919,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: users/[^/]+pipelines/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+
         - name: pipeline
           description: A pipeline resource to update
           in: body
@@ -1964,6 +1964,9 @@ paths:
                 format: date-time
                 title: Pipeline update time
                 readOnly: true
+              visibility:
+                $ref: '#/definitions/pipelinev1alphaVisibility'
+                title: Visibility
             title: A pipeline resource to update
       tags:
         - PipelinePublicService
@@ -2084,6 +2087,9 @@ paths:
                 format: date-time
                 title: Pipeline update time
                 readOnly: true
+              visibility:
+                $ref: '#/definitions/pipelinev1alphaVisibility'
+                title: Visibility
             title: A pipeline release resource to update
       tags:
         - PipelinePublicService
@@ -4408,6 +4414,18 @@ definitions:
        - STATE_ACTIVE: State ACTIVE indicates the pipeline is active
        - STATE_ERROR: State ERROR indicates the pipeline has error
     title: State enumerates the state of a pipeline
+  pipelinev1alphaVisibility:
+    type: string
+    enum:
+      - VISIBILITY_UNSPECIFIED
+      - VISIBILITY_PRIVATE
+      - VISIBILITY_PUBLIC
+    default: VISIBILITY_UNSPECIFIED
+    description: |-
+      - VISIBILITY_UNSPECIFIED: Visibility: UNSPECIFIED, equivalent to PRIVATE.
+       - VISIBILITY_PRIVATE: Visibility: PRIVATE
+       - VISIBILITY_PUBLIC: Visibility: PUBLIC
+    title: ConnectorResource visibility including public or private
   protobufAny:
     type: object
     properties:
@@ -4788,7 +4806,7 @@ definitions:
         $ref: '#/definitions/vdpconnectorv1alphaSpec'
         title: ConnectorDefinition spec
         readOnly: true
-      connector_type:
+      type:
         $ref: '#/definitions/v1alphaConnectorType'
         title: Connector Type
         readOnly: true
@@ -4940,7 +4958,7 @@ definitions:
       connector_definition_name:
         type: string
         title: ConnectorDefinition resource
-      connector_type:
+      type:
         $ref: '#/definitions/v1alphaConnectorType'
         title: ConnectorResource Type
         readOnly: true
@@ -6777,6 +6795,9 @@ definitions:
         format: date-time
         title: Pipeline update time
         readOnly: true
+      visibility:
+        $ref: '#/definitions/pipelinev1alphaVisibility'
+        title: Visibility
     title: Pipeline represents the content of a pipeline
   v1alphaPipelineData:
     type: object
@@ -6828,6 +6849,9 @@ definitions:
         format: date-time
         title: Pipeline update time
         readOnly: true
+      visibility:
+        $ref: '#/definitions/pipelinev1alphaVisibility'
+        title: Visibility
     title: PipelineRelease represents the content of a pipeline release
   v1alphaPipelineTriggerChartRecord:
     type: object

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package vdp.connector.v1alpha;
 
 import "common/healthcheck/v1alpha/healthcheck.proto";
-import "common/task/v1alpha/task.proto";
 import "google/api/field_behavior.proto";
 // Google API
 import "google/api/resource.proto";
@@ -84,8 +83,6 @@ message ConnectorResource {
   ];
   // ConnectorResource Type
   ConnectorType connector_type = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // ConnectorResource description
-  common.task.v1alpha.Task task = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // ConnectorResource description
   optional string description = 7 [(google.api.field_behavior) = OPTIONAL];
   // ConnectorResource configuration in JSON format

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -82,7 +82,7 @@ message ConnectorResource {
     (google.api.resource_reference) = {type: "api.instill.tech/ConnectorDefinition"}
   ];
   // ConnectorResource Type
-  ConnectorType connector_type = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  ConnectorType type = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // ConnectorResource description
   optional string description = 7 [(google.api.field_behavior) = OPTIONAL];
   // ConnectorResource configuration in JSON format

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -122,20 +122,6 @@ message ConnectorResource {
 // RPC messages
 ///////////////////////////////////////////////////////////////////////
 
-// CreateConnectorResourceRequest represents a request to create a
-// ConnectorResource resource
-message CreateConnectorResourceRequest {
-  // ConnectorResource resource
-  ConnectorResource connector_resource = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-// CreateConnectorResourceResponse represents a response for a
-// ConnectorResource resource
-message CreateConnectorResourceResponse {
-  // ConnectorResource resource
-  ConnectorResource connector_resource = 1;
-}
-
 // ListConnectorResourcesRequest represents a request to list
 // ConnectorResource resources
 message ListConnectorResourcesRequest {
@@ -162,9 +148,61 @@ message ListConnectorResourcesResponse {
   int64 total_size = 3;
 }
 
-// GetConnectorResourceRequest represents a request to query a
+// CreateUserConnectorResourceRequest represents a request to create a
 // ConnectorResource resource
-message GetConnectorResourceRequest {
+message CreateUserConnectorResourceRequest {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1 [(google.api.field_behavior) = REQUIRED];
+  // The parent resource where this connector resource will be created.
+  // Format: users/{users}
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/ConnectorResource"}
+  ];
+}
+
+// CreateUserConnectorResourceResponse represents a response for a
+// ConnectorResource resource
+message CreateUserConnectorResourceResponse {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1;
+}
+
+// ListUserConnectorResourcesRequest represents a request to list
+// ConnectorResource resources
+message ListUserConnectorResourcesRequest {
+  // The maximum number of connector-resources to return. The service may return fewer
+  // than this value. If unspecified, at most 10 connector-resources will be returned.
+  // The maximum value is 100; values above 100 will be coerced to 100.
+  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // ConnectorResource view (default is VIEW_BASIC)
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list connector-resources
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The parent resource where this connector resource will be created.
+  // Format: users/{users}
+  string parent = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/ConnectorResource"}
+  ];
+}
+
+// ListUserConnectorResourcesResponse represents a response for a list of
+// ConnectorResource resources
+message ListUserConnectorResourcesResponse {
+  // A list of ConnectorResource resources
+  repeated ConnectorResource connector_resources = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of connector_resource resources
+  int64 total_size = 3;
+}
+
+// GetUserConnectorResourceRequest represents a request to query a
+// ConnectorResource resource
+message GetUserConnectorResourceRequest {
   // ConnectorResourceConnectorResource resource name. It must have the format of
   // "connector-resources/*"
   string name = 1 [
@@ -178,32 +216,32 @@ message GetConnectorResourceRequest {
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetConnectorResourceResponse represents a response for a
+// GetUserConnectorResourceResponse represents a response for a
 // ConnectorResource resource
-message GetConnectorResourceResponse {
+message GetUserConnectorResourceResponse {
   // ConnectorResource resource
   ConnectorResource connector_resource = 1;
 }
 
-// UpdateConnectorResourceRequest represents a request to update a
+// UpdateUserConnectorResourceRequest represents a request to update a
 // ConnectorResource resource
-message UpdateConnectorResourceRequest {
+message UpdateUserConnectorResourceRequest {
   // ConnectorResource resource
   ConnectorResource connector_resource = 1 [(google.api.field_behavior) = REQUIRED];
   // Update mask for a ConnectorResource resource
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// UpdateConnectorResourceResponse represents a response for a
+// UpdateUserConnectorResourceResponse represents a response for a
 // ConnectorResource resource
-message UpdateConnectorResourceResponse {
+message UpdateUserConnectorResourceResponse {
   // ConnectorResource resource
   ConnectorResource connector_resource = 1;
 }
 
-// DeleteConnectorResourceRequest represents a request to delete a
+// DeleteUserConnectorResourceRequest represents a request to delete a
 // ConnectorResource resource
-message DeleteConnectorResourceRequest {
+message DeleteUserConnectorResourceRequest {
   // ConnectorResource resource name. It must have the format of
   // "connector-resources/*"
   string name = 1 [
@@ -215,12 +253,12 @@ message DeleteConnectorResourceRequest {
   ];
 }
 
-// DeleteConnectorResourceResponse represents an empty response
-message DeleteConnectorResourceResponse {}
+// DeleteUserConnectorResourceResponse represents an empty response
+message DeleteUserConnectorResourceResponse {}
 
-// LookUpConnectorResourceRequest represents a request to query a
+// LookUpUserConnectorResourceRequest represents a request to query a
 // connector_resource via permalink
-message LookUpConnectorResourceRequest {
+message LookUpUserConnectorResourceRequest {
   // Permalink of a connector_resource. For example:
   // "connector-resources/{uid}"
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
@@ -228,16 +266,16 @@ message LookUpConnectorResourceRequest {
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// LookUpConnectorResourceResponse represents a response for a
+// LookUpUserConnectorResourceResponse represents a response for a
 // connector_resource
-message LookUpConnectorResourceResponse {
+message LookUpUserConnectorResourceResponse {
   // ConnectorResource resource
   ConnectorResource connector_resource = 1;
 }
 
-// ConnectConnectorResourceRequest represents a request to connect a
+// ConnectUserConnectorResourceRequest represents a request to connect a
 // connector_resource
-message ConnectConnectorResourceRequest {
+message ConnectUserConnectorResourceRequest {
   // ConnectorResource resource name. It must have the format of
   // "connector-resources/*"
   string name = 1 [
@@ -246,16 +284,16 @@ message ConnectConnectorResourceRequest {
   ];
 }
 
-// ConnectConnectorResourceResponse represents a connected
+// ConnectUserConnectorResourceResponse represents a connected
 // connector_resource
-message ConnectConnectorResourceResponse {
+message ConnectUserConnectorResourceResponse {
   // A ConnectorResource resource
   ConnectorResource connector_resource = 1;
 }
 
-// DisconnectConnectorResourceRequest represents a request to disconnect a
+// DisconnectUserConnectorResourceRequest represents a request to disconnect a
 // connector_resource
-message DisconnectConnectorResourceRequest {
+message DisconnectUserConnectorResourceRequest {
   // ConnectorResource resource name. It must have the format of
   // "connector-resources/*"
   string name = 1 [
@@ -264,16 +302,16 @@ message DisconnectConnectorResourceRequest {
   ];
 }
 
-// DisconnectConnectorResourceResponse represents a disconnected
+// DisconnectUserConnectorResourceResponse represents a disconnected
 // connector_resource
-message DisconnectConnectorResourceResponse {
+message DisconnectUserConnectorResourceResponse {
   // A ConnectorResource resource
   ConnectorResource connector_resource = 1;
 }
 
-// RenameConnectorResourceRequest represents a request to rename the
+// RenameUserConnectorResourceRequest represents a request to rename the
 // ConnectorResource resource name
-message RenameConnectorResourceRequest {
+message RenameUserConnectorResourceRequest {
   // ConnectorResource resource name. It must have the format of
   // "connector-resources/*"
   string name = 1 [
@@ -286,11 +324,71 @@ message RenameConnectorResourceRequest {
   string new_connector_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// RenameConnectorResourceResponse represents a renamed ConnectorResource
+// RenameUserConnectorResourceResponse represents a renamed ConnectorResource
 // resource
-message RenameConnectorResourceResponse {
+message RenameUserConnectorResourceResponse {
   // A ConnectorResource resource
   ConnectorResource connector_resource = 1;
+}
+
+// ExecuteUserConnectorResourceRequest represents a private request to execution
+// connector_resource
+message ExecuteUserConnectorResourceRequest {
+  // Name of a connector_resource. For example:
+  // "connector-resources/{name}"
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Inputs
+  repeated google.protobuf.Struct inputs = 2;
+}
+
+// ExecuteUserConnectorResourceResponse represents a response for execution
+// output
+message ExecuteUserConnectorResourceResponse {
+  // Outputs
+  repeated google.protobuf.Struct outputs = 1;
+}
+
+// TestUserConnectorResourceRequest represents a public request to trigger check
+// action on a connector_resource
+message TestUserConnectorResourceRequest {
+  // ConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/ConnectorResource",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "connector_resource.name"}
+    }
+  ];
+}
+
+// TestUserConnectorResourceResponse represents a response containing a
+// connector_resource's current state
+message TestUserConnectorResourceResponse {
+  // Retrieved connector_resource state
+  ConnectorResource.State state = 1;
+}
+
+// WatchUserConnectorResourceRequest represents a public request to query
+// a connector_resource's current state
+message WatchUserConnectorResourceRequest {
+  // ConnectorResource resource name. It must have the format of
+  // "connector-resources/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/ConnectorResource",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "connector_resource.name"}
+    }
+  ];
+}
+
+// WatchUserConnectorResourceResponse represents a response to fetch a
+// connector_resource's current state
+message WatchUserConnectorResourceResponse {
+  // Retrieved connector_resource state
+  ConnectorResource.State state = 1;
 }
 
 // ========== Private endpoints
@@ -338,27 +436,6 @@ message LookUpConnectorResourceAdminResponse {
   ConnectorResource connector_resource = 1;
 }
 
-// WatchConnectorResourceRequest represents a public request to query
-// a connector_resource's current state
-message WatchConnectorResourceRequest {
-  // ConnectorResource resource name. It must have the format of
-  // "connector-resources/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ConnectorResource",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "connector_resource.name"}
-    }
-  ];
-}
-
-// WatchConnectorResourceResponse represents a response to fetch a
-// connector_resource's current state
-message WatchConnectorResourceResponse {
-  // Retrieved connector_resource state
-  ConnectorResource.State state = 1;
-}
-
 // CheckConnectorResourceRequest represents a private request to query
 // a connector_resource's current state
 message CheckConnectorResourceRequest {
@@ -372,43 +449,4 @@ message CheckConnectorResourceRequest {
 message CheckConnectorResourceResponse {
   // Retrieved connector_resource state
   ConnectorResource.State state = 1;
-}
-
-// TestConnectorResourceRequest represents a public request to trigger check
-// action on a connector_resource
-message TestConnectorResourceRequest {
-  // ConnectorResource resource name. It must have the format of
-  // "connector-resources/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ConnectorResource",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "connector_resource.name"}
-    }
-  ];
-}
-
-// TestConnectorResourceResponse represents a response containing a
-// connector_resource's current state
-message TestConnectorResourceResponse {
-  // Retrieved connector_resource state
-  ConnectorResource.State state = 1;
-}
-
-// ExecuteConnectorResourceRequest represents a private request to execution
-// connector_resource
-message ExecuteConnectorResourceRequest {
-  // Name of a connector_resource. For example:
-  // "connector-resources/{name}"
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
-
-  // Inputs
-  repeated google.protobuf.Struct inputs = 2;
-}
-
-// ExecuteConnectorResourceResponse represents a response for execution
-// output
-message ExecuteConnectorResourceResponse {
-  // Outputs
-  repeated google.protobuf.Struct outputs = 1;
 }

--- a/vdp/connector/v1alpha/connector_definition.proto
+++ b/vdp/connector/v1alpha/connector_definition.proto
@@ -69,7 +69,7 @@ message ConnectorDefinition {
   // ConnectorDefinition spec
   Spec spec = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Connector Type
-  ConnectorType connector_type = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  ConnectorType type = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
   // ConnectorDefinition tombstone, i.e., if not set or false, the
   // configuration is active, or otherwise, if true, this configuration is
   // permanently off

--- a/vdp/connector/v1alpha/connector_public_service.proto
+++ b/vdp/connector/v1alpha/connector_public_service.proto
@@ -53,17 +53,6 @@ service ConnectorPublicService {
   // Connector-Resource methods
   /////////////////////////////////
 
-  // CreateConnectorResource method receives a
-  // CreateConnectorResourceRequest message and returns a
-  // CreateConnectorResourceResponse message.
-  rpc CreateConnectorResource(CreateConnectorResourceRequest) returns (CreateConnectorResourceResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/connector-resources"
-      body: "connector_resource"
-    };
-    option (google.api.method_signature) = "connector_resource";
-  }
-
   // ListConnectorResources method receives a
   // ListConnectorResourcesRequest message and returns a
   // ListConnectorResourcesResponse message.
@@ -71,48 +60,67 @@ service ConnectorPublicService {
     option (google.api.http) = {get: "/v1alpha/connector-resources"};
   }
 
-  // GetConnectorResource method receives a GetConnectorResourceRequest
-  // message and returns a GetConnectorResourceResponse message.
-  rpc GetConnectorResource(GetConnectorResourceRequest) returns (GetConnectorResourceResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=connector-resources/*}"};
+  // CreateUserConnectorResource method receives a
+  // CreateUserConnectorResourceRequest message and returns a
+  // CreateUserConnectorResourceResponse message.
+  rpc CreateUserConnectorResource(CreateUserConnectorResourceRequest) returns (CreateUserConnectorResourceResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{parent=users/*}/connector-resources"
+      body: "connector_resource"
+    };
+    option (google.api.method_signature) = "parent,connector_resource";
+  }
+
+  // ListUserConnectorResources method receives a
+  // ListUserConnectorResourcesRequest message and returns a
+  // ListUserConnectorResourcesResponse message.
+  rpc ListUserConnectorResources(ListUserConnectorResourcesRequest) returns (ListUserConnectorResourcesResponse) {
+    option (google.api.http) = {get: "/v1alpha/{parent=users/*}/connector-resources"};
+    option (google.api.method_signature) = "parent";
+  }
+
+  // GetUserConnectorResource method receives a GetUserConnectorResourceRequest
+  // message and returns a GetUserConnectorResourceResponse message.
+  rpc GetUserConnectorResource(GetUserConnectorResourceRequest) returns (GetUserConnectorResourceResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/connector-resources/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // UpdateConnectorResource method receives a
-  // UpdateConnectorResourceRequest message and returns a
-  // UpdateConnectorResourceResponse message.
-  rpc UpdateConnectorResource(UpdateConnectorResourceRequest) returns (UpdateConnectorResourceResponse) {
+  // UpdateUserConnectorResource method receives a
+  // UpdateUserConnectorResourceRequest message and returns a
+  // UpdateUserConnectorResourceResponse message.
+  rpc UpdateUserConnectorResource(UpdateUserConnectorResourceRequest) returns (UpdateUserConnectorResourceResponse) {
     option (google.api.http) = {
-      patch: "/v1alpha/{connector_resource.name=connector-resources/*}"
+      patch: "/v1alpha/{connector_resource.name=users/*/connector-resources/*}"
       body: "connector_resource"
     };
     option (google.api.method_signature) = "connector_resource,update_mask";
   }
 
-  // DeleteConnectorResource method receives a
-  // DeleteConnectorResourceRequest message and returns a
-  // DeleteConnectorResourceResponse message.
-  rpc DeleteConnectorResource(DeleteConnectorResourceRequest) returns (DeleteConnectorResourceResponse) {
-    option (google.api.http) = {delete: "/v1alpha/{name=connector-resources/*}"};
+  // DeleteUserConnectorResource method receives a
+  // DeleteUserConnectorResourceRequest message and returns a
+  // DeleteUserConnectorResourceResponse message.
+  rpc DeleteUserConnectorResource(DeleteUserConnectorResourceRequest) returns (DeleteUserConnectorResourceResponse) {
+    option (google.api.http) = {delete: "/v1alpha/{name=users/*/connector-resources/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // LookUpConnectorResource method receives a
-  // LookUpConnectorResourceRequest message and returns a
-  // LookUpConnectorResourceResponse
-  rpc LookUpConnectorResource(LookUpConnectorResourceRequest) returns (LookUpConnectorResourceResponse) {
-    option (google.api.http) = {get: "/v1alpha/{permalink=connector-resources/*}/lookUp"};
+  // LookUpUserConnectorResource method receives a
+  // LookUpUserConnectorResourceRequest message and returns a
+  // LookUpUserConnectorResourceResponse
+  rpc LookUpUserConnectorResource(LookUpUserConnectorResourceRequest) returns (LookUpUserConnectorResourceResponse) {
+    option (google.api.http) = {get: "/v1alpha/{permalink=users/*/connector-resources/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
   }
 
   // Connect a connector resource.
   // The "state" of the connector resource after connecting is "CONNECTED".
-  // ConnectConnectorResource can be called on ConnectorResource in the
+  // ConnectUserConnectorResource can be called on ConnectorResource in the
   // state `DISCONNECTED`; ConnectorResource in a different state (including
   // `CONNECTED`) returns an error.
-  rpc ConnectConnectorResource(ConnectConnectorResourceRequest) returns (ConnectConnectorResourceResponse) {
+  rpc ConnectUserConnectorResource(ConnectUserConnectorResourceRequest) returns (ConnectUserConnectorResourceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=connector-resources/*}/connect"
+      post: "/v1alpha/{name=users/*/connector-resources/*}/connect"
       body: "*"
     };
     option (google.api.method_signature) = "name";
@@ -120,51 +128,51 @@ service ConnectorPublicService {
 
   // Disconnect a connectorResource.
   // The "state" of the connectorResource after disconnecting is "DISCONNECTED".
-  // DisconnectConnectorResource can be called on ConnectorResource in the
+  // DisconnectUserConnectorResource can be called on ConnectorResource in the
   // state `CONNECTED`; ConnectorResource in a different state (including
   // `DISCONNECTED`) returns an error.
-  rpc DisconnectConnectorResource(DisconnectConnectorResourceRequest) returns (DisconnectConnectorResourceResponse) {
+  rpc DisconnectUserConnectorResource(DisconnectUserConnectorResourceRequest) returns (DisconnectUserConnectorResourceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=connector-resources/*}/disconnect"
+      post: "/v1alpha/{name=users/*/connector-resources/*}/disconnect"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // RenameConnectorResource method receives a
-  // RenameConnectorResourceRequest message and returns a
-  // RenameConnectorResourceResponse message.
-  rpc RenameConnectorResource(RenameConnectorResourceRequest) returns (RenameConnectorResourceResponse) {
+  // RenameUserConnectorResource method receives a
+  // RenameUserConnectorResourceRequest message and returns a
+  // RenameUserConnectorResourceResponse message.
+  rpc RenameUserConnectorResource(RenameUserConnectorResourceRequest) returns (RenameUserConnectorResourceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=connector-resources/*}/rename"
+      post: "/v1alpha/{name=users/*/connector-resources/*}/rename"
       body: "*"
     };
     option (google.api.method_signature) = "name,new_connector_resource_id";
   }
 
-  // ExecuteConnectorResource method receives a
-  // ExecuteConnectorResourceRequest message and returns a
-  // ExecuteConnectorResourceResponse message.
-  rpc ExecuteConnectorResource(ExecuteConnectorResourceRequest) returns (ExecuteConnectorResourceResponse) {
+  // ExecuteUserConnectorResource method receives a
+  // ExecuteUserConnectorResourceRequest message and returns a
+  // ExecuteUserConnectorResourceResponse message.
+  rpc ExecuteUserConnectorResource(ExecuteUserConnectorResourceRequest) returns (ExecuteUserConnectorResourceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=connector-resources/*}/execute"
+      post: "/v1alpha/{name=users/*/connector-resources/*}/execute"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // WatchConnectorResource method receives a
-  // WatchConnectorResourceRequest message and returns a
-  // WatchConnectorResourceResponse
-  rpc WatchConnectorResource(WatchConnectorResourceRequest) returns (WatchConnectorResourceResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=connector-resources/*}/watch"};
+  // WatchUserConnectorResource method receives a
+  // WatchUserConnectorResourceRequest message and returns a
+  // WatchUserConnectorResourceResponse
+  rpc WatchUserConnectorResource(WatchUserConnectorResourceRequest) returns (WatchUserConnectorResourceResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/connector-resources/*}/watch"};
     option (google.api.method_signature) = "name";
   }
 
-  // TestConnectorResource method receives a TestConnectorResourceRequest
-  // message and returns a TestConnectorResourceResponse
-  rpc TestConnectorResource(TestConnectorResourceRequest) returns (TestConnectorResourceResponse) {
-    option (google.api.http) = {post: "/v1alpha/{name=connector-resources/*}/testConnection"};
+  // TestUserConnectorResource method receives a TestUserConnectorResourceRequest
+  // message and returns a TestUserConnectorResourceResponse
+  rpc TestUserConnectorResource(TestUserConnectorResourceRequest) returns (TestUserConnectorResourceResponse) {
+    option (google.api.http) = {post: "/v1alpha/{name=users/*/connector-resources/*}/testConnection"};
     option (google.api.method_signature) = "name";
   }
 }

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -105,10 +105,10 @@ enum State {
 message Pipeline {
   option (google.api.resource) = {
     type: "api.instill.tech/Pipeline"
-    pattern: "pipelines/{pipeline}"
+    pattern: "users/{user}/pipelines/{pipeline}"
   };
 
-  // Pipeline resource name. It must have the format of "pipelines/*"
+  // Pipeline resource name. It must have the format of "users/{user}/pipelines/*"
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline UUID
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -169,7 +169,7 @@ message PipelineRelease {
     pattern: "releases/{release}"
   };
 
-  // PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
+  // PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // PipelineRelease UUID
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -184,18 +184,6 @@ message PipelineRelease {
   google.protobuf.Timestamp create_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline update time
   google.protobuf.Timestamp update_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
-// CreatePipelineRequest represents a request to create a pipeline
-message CreatePipelineRequest {
-  // A pipeline resource to create
-  Pipeline pipeline = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-// CreatePipelineResponse represents a response for a pipeline resource
-message CreatePipelineResponse {
-  // The created pipeline resource
-  Pipeline pipeline = 1;
 }
 
 // ListPipelinesRequest represents a request to list pipelines
@@ -222,9 +210,57 @@ message ListPipelinesResponse {
   int64 total_size = 3;
 }
 
-// GetPipelineRequest represents a request to query a pipeline
-message GetPipelineRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*"
+// CreateUserPipelineRequest represents a request to create a pipeline
+message CreateUserPipelineRequest {
+  // A pipeline resource to create
+  Pipeline pipeline = 1 [(google.api.field_behavior) = REQUIRED];
+  // The parent resource where this connector resource will be created.
+  // Format: users/{users}
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Pipeline"}
+  ];
+}
+
+// CreateUserPipelineResponse represents a response for a pipeline resource
+message CreateUserPipelineResponse {
+  // The created pipeline resource
+  Pipeline pipeline = 1;
+}
+
+// ListUserPipelinesRequest represents a request to list pipelines
+message ListUserPipelinesRequest {
+  // The maximum number of pipelines to return. The service may return fewer
+  // than this value. If unspecified, at most 10 pipelines will be returned. The
+  // maximum value is 100; values above 100 will be coerced to 100.
+  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // View view (default is VIEW_BASIC)
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list pipelines
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The parent resource where this connector resource will be created.
+  // Format: users/{users}
+  string parent = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Pipeline"}
+  ];
+}
+
+// ListUserPipelinesResponse represents a response for a list of pipelines
+message ListUserPipelinesResponse {
+  // A list of pipeline resources
+  repeated Pipeline pipelines = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of pipeline resources
+  int64 total_size = 3;
+}
+
+// GetUserPipelineRequest represents a request to query a pipeline
+message GetUserPipelineRequest {
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
@@ -236,29 +272,29 @@ message GetPipelineRequest {
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetPipelineResponse represents a response for a pipeline resource
-message GetPipelineResponse {
+// GetUserPipelineResponse represents a response for a pipeline resource
+message GetUserPipelineResponse {
   // A pipeline resource
   Pipeline pipeline = 1;
 }
 
-// UpdatePipelineRequest represents a request to update a pipeline
-message UpdatePipelineRequest {
+// UpdateUserPipelineRequest represents a request to update a pipeline
+message UpdateUserPipelineRequest {
   // A pipeline resource to update
   Pipeline pipeline = 1 [(google.api.field_behavior) = REQUIRED];
   // Update mask for a pipeline resource
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// UpdatePipelineResponse represents a response for a pipeline resource
-message UpdatePipelineResponse {
+// UpdateUserPipelineResponse represents a response for a pipeline resource
+message UpdateUserPipelineResponse {
   // An updated pipeline resource
   Pipeline pipeline = 1;
 }
 
-// DeletePipelineRequest represents a request to delete a pipeline resource
-message DeletePipelineRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*"
+// DeleteUserPipelineRequest represents a request to delete a pipeline resource
+message DeleteUserPipelineRequest {
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
@@ -268,61 +304,61 @@ message DeletePipelineRequest {
   ];
 }
 
-// DeletePipelineResponse represents an empty response
-message DeletePipelineResponse {}
+// DeleteUserPipelineResponse represents an empty response
+message DeleteUserPipelineResponse {}
 
-// LookUpPipelineRequest represents a request to query a pipeline via permalink
-message LookUpPipelineRequest {
+// LookUpUserPipelineRequest represents a request to query a pipeline via permalink
+message LookUpUserPipelineRequest {
   // Permalink of a pipeline. For example:
-  // "pipelines/{uid}"
+  // "users/*/pipelines/{uid}"
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
   // View view (default is VIEW_BASIC)
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// LookUpPipelineResponse represents a response for a pipeline resource
-message LookUpPipelineResponse {
+// LookUpUserPipelineResponse represents a response for a pipeline resource
+message LookUpUserPipelineResponse {
   // A pipeline resource
   Pipeline pipeline = 1;
 }
 
-// ValidatePipelineRequest represents a request to validate a pipeline
-message ValidatePipelineRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*"
+// ValidatePUseripelineRequest represents a request to validate a pipeline
+message ValidateUserPipelineRequest {
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
   ];
 }
 
-// ValidatePipelineResponse represents an response of validated pipeline
-message ValidatePipelineResponse {
+// ValidateUserPipelineResponse represents an response of validated pipeline
+message ValidateUserPipelineResponse {
   // A pipeline resource
   Pipeline pipeline = 1;
 }
 
-// RenamePipelineRequest represents a request to rename the pipeline resource
+// RenameUserPipelineRequest represents a request to rename the pipeline resource
 // name
-message RenamePipelineRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*"
+message RenameUserPipelineRequest {
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
   ];
   // Pipeline new resource id to replace with the pipeline resource name to be
-  // "pipelines/{new_pipeline_id}"
+  // "users/*/pipelines/{new_pipeline_id}"
   string new_pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// RenamePipelineResponse represents a renamed pipeline resource
-message RenamePipelineResponse {
+// RenameUserPipelineResponse represents a renamed pipeline resource
+message RenameUserPipelineResponse {
   // A pipeline resource
   Pipeline pipeline = 1;
 }
 
-// TriggerPipelineRequest represents a request to trigger a pipeline
-message TriggerPipelineRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*"
+// TriggerUserPipelineRequest represents a request to trigger a pipeline
+message TriggerUserPipelineRequest {
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
@@ -331,18 +367,18 @@ message TriggerPipelineRequest {
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerPipelineResponse represents a response for the output
+// TriggerUserPipelineResponse represents a response for the output
 // of a pipeline, i.e., the multiple model inference outputs
-message TriggerPipelineResponse {
+message TriggerUserPipelineResponse {
   // The multiple model inference outputs
   repeated google.protobuf.Struct outputs = 1;
   // The traces of the pipeline inference, {component_id: Trace}
   TriggerMetadata metadata = 2;
 }
 
-// TriggerAsyncPipelineRequest represents a request to trigger a async pipeline
-message TriggerAsyncPipelineRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*"
+// TriggerAsyncUserPipelineRequest represents a request to trigger a async pipeline
+message TriggerAsyncUserPipelineRequest {
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
@@ -351,9 +387,9 @@ message TriggerAsyncPipelineRequest {
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerAsyncPipelineResponse represents a response for the longrunning
+// TriggerAsyncUserPipelineResponse represents a response for the longrunning
 // operation of a pipeline
-message TriggerAsyncPipelineResponse {
+message TriggerAsyncUserPipelineResponse {
   // Trigger async pipeline operation message
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
@@ -369,6 +405,210 @@ message GetOperationRequest {
 // operation
 message GetOperationResponse {
   // The retrieved longrunning operation
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CreateUserPipelineReleaseRequest represents a request to create a pipeline_release
+message CreateUserPipelineReleaseRequest {
+  // A pipeline_release resource to create
+  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
+  // The parent resource where this pipeline_release will be created.
+  // Format: users/{user}/pipelines/{pipeline}
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"}
+  ];
+}
+
+// CreateUserPipelineReleaseResponse represents a response for a pipeline_release resource
+message CreateUserPipelineReleaseResponse {
+  // The created pipeline_release resource
+  PipelineRelease release = 1;
+}
+
+// ListUserPipelineReleasesRequest represents a request to list pipeline_releases
+message ListUserPipelineReleasesRequest {
+  // The maximum number of pipeline_releases to return. The service may return fewer
+  // than this value. If unspecified, at most 10 pipeline_release will be returned. The
+  // maximum value is 100; values above 100 will be coerced to 100.
+  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // View view (default is VIEW_BASIC)
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list pipeline_releases
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The parent resource where this pipeline_release will be created.
+  // Format: users/{user}/pipelines/{pipeline}
+  string parent = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"}
+  ];
+}
+
+// ListUserPipelineReleasesResponse represents a response for a list of pipeline_releases
+message ListUserPipelineReleasesResponse {
+  // A list of pipeline_release resources
+  repeated PipelineRelease releases = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of pipeline_release resources
+  int64 total_size = 3;
+}
+
+// GetUserPipelineReleaseRequest represents a request to query a pipeline_release
+message GetUserPipelineReleaseRequest {
+  // PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline_release.name"}
+    }
+  ];
+  // PipelineRelease resource view (default is VIEW_BASIC)
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetUserPipelineReleaseResponse represents a response for a pipeline_release resource
+message GetUserPipelineReleaseResponse {
+  // A pipeline_release resource
+  PipelineRelease release = 1;
+}
+
+// UpdateUserPipelineReleaseRequest represents a request to update a pipeline release
+message UpdateUserPipelineReleaseRequest {
+  // A pipeline release resource to update
+  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
+  // Update mask for a pipeline resource
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateUserPipelineReleaseResponse represents a response for a pipeline resource
+message UpdateUserPipelineReleaseResponse {
+  // An updated pipeline resource
+  PipelineRelease release = 1;
+}
+
+// DeleteUserPipelineReleaseRequest represents a request to delete a pipeline_release resource
+message DeleteUserPipelineReleaseRequest {
+  // PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline_release.name"}
+    }
+  ];
+}
+
+// DeleteUserPipelineReleaseResponse represents an empty response
+message DeleteUserPipelineReleaseResponse {}
+
+// SetDefaultUserPipelineReleaseRequest
+message SetDefaultUserPipelineReleaseRequest {
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+}
+
+// SetDefaultUserPipelineReleaseResponse
+message SetDefaultUserPipelineReleaseResponse {
+  // A pipeline resource
+  PipelineRelease release = 1;
+}
+
+// RestoreUserPipelineReleaseRequest
+message RestoreUserPipelineReleaseRequest {
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+}
+
+// RestoreUserPipelineReleaseResponse
+message RestoreUserPipelineReleaseResponse {
+  // A pipeline resource
+  PipelineRelease release = 1;
+}
+
+// RenameUserPipelineReleaseRequest represents a request to rename the pipeline release resource
+// name
+message RenameUserPipelineReleaseRequest {
+  // Pipeline release resource name. It must have the format of "users/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Pipeline new resource id to replace with the pipeline resource name to be
+  // "users/*/pipelines/*/releases/{new_pipeline_id}"
+  string new_pipeline_release_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RenameUserPipelineReleaseResponse represents a renamed pipeline release resource
+message RenameUserPipelineReleaseResponse {
+  // A pipeline resource
+  PipelineRelease release = 1;
+}
+
+// WatchUserPipelineReleaseRequest represents a public request to query
+// a pipeline's current state
+message WatchUserPipelineReleaseRequest {
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline.name/watch"}
+    }
+  ];
+}
+
+// WatchUserPipelineReleaseResponse represents a response to fetch a pipeline's
+// current state
+message WatchUserPipelineReleaseResponse {
+  // Retrieved pipeline state
+  State state = 1;
+}
+
+// TriggerUserPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+message TriggerUserPipelineReleaseRequest {
+  // Resource name.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Input to the pipeline
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerUserPipelineReleaseResponse represents a response for the output
+// of a pipeline, i.e., the multiple model inference outputs
+message TriggerUserPipelineReleaseResponse {
+  // The multiple model inference outputs
+  repeated google.protobuf.Struct outputs = 1;
+  // The traces of the pipeline inference, {component_id: Trace}
+  TriggerMetadata metadata = 2;
+}
+
+// TriggerAsyncUserPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+message TriggerAsyncUserPipelineReleaseRequest {
+  // Resource name.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Input to the pipeline
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerAsyncUserPipelineReleaseResponse represents a response for the longrunning
+// operation of a pipeline
+message TriggerAsyncUserPipelineReleaseResponse {
+  // Trigger async pipeline operation message
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
@@ -431,7 +671,7 @@ message ListPipelineReleasesAdminResponse {
 // GetPipelineAdminRequest represents a request to query a user's pipeline by
 // admin
 message GetPipelineAdminRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*"
+  // Pipeline resource name. It must have the format of "users/*/pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
@@ -463,208 +703,4 @@ message LookUpPipelineAdminRequest {
 message LookUpPipelineAdminResponse {
   // A pipeline resource
   Pipeline pipeline = 1;
-}
-
-// CreatePipelineReleaseRequest represents a request to create a pipeline_release
-message CreatePipelineReleaseRequest {
-  // A pipeline_release resource to create
-  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
-  // The parent resource where this pipeline_release will be created.
-  // Format: pipelines/{pipeline}
-  string parent = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"}
-  ];
-}
-
-// CreatePipelineReleaseResponse represents a response for a pipeline_release resource
-message CreatePipelineReleaseResponse {
-  // The created pipeline_release resource
-  PipelineRelease release = 1;
-}
-
-// ListPipelineReleasesRequest represents a request to list pipeline_releases
-message ListPipelineReleasesRequest {
-  // The maximum number of pipeline_releases to return. The service may return fewer
-  // than this value. If unspecified, at most 10 pipeline_release will be returned. The
-  // maximum value is 100; values above 100 will be coerced to 100.
-  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // View view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Filter expression to list pipeline_releases
-  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
-  // The parent resource where this pipeline_release will be created.
-  // Format: pipelines/{pipeline}
-  string parent = 5 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"}
-  ];
-}
-
-// ListPipelineReleasesResponse represents a response for a list of pipeline_releases
-message ListPipelineReleasesResponse {
-  // A list of pipeline_release resources
-  repeated PipelineRelease releases = 1;
-  // Next page token
-  string next_page_token = 2;
-  // Total count of pipeline_release resources
-  int64 total_size = 3;
-}
-
-// GetPipelineReleaseRequest represents a request to query a pipeline_release
-message GetPipelineReleaseRequest {
-  // PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline_release.name"}
-    }
-  ];
-  // PipelineRelease resource view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// GetPipelineReleaseResponse represents a response for a pipeline_release resource
-message GetPipelineReleaseResponse {
-  // A pipeline_release resource
-  PipelineRelease release = 1;
-}
-
-// UpdatePipelineReleaseRequest represents a request to update a pipeline release
-message UpdatePipelineReleaseRequest {
-  // A pipeline release resource to update
-  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
-  // Update mask for a pipeline resource
-  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
-}
-
-// UpdatePipelineReleaseResponse represents a response for a pipeline resource
-message UpdatePipelineReleaseResponse {
-  // An updated pipeline resource
-  PipelineRelease release = 1;
-}
-
-// DeletePipelineReleaseRequest represents a request to delete a pipeline_release resource
-message DeletePipelineReleaseRequest {
-  // PipelineRelease resource name. It must have the format of "pipelines/*/releases/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline_release.name"}
-    }
-  ];
-}
-
-// DeletePipelineReleaseResponse represents an empty response
-message DeletePipelineReleaseResponse {}
-
-// SetDefaultPipelineReleaseRequest
-message SetDefaultPipelineReleaseRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*/releases/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
-  ];
-}
-
-// SetDefaultPipelineReleaseResponse
-message SetDefaultPipelineReleaseResponse {
-  // A pipeline resource
-  PipelineRelease release = 1;
-}
-
-// RestorePipelineReleaseRequest
-message RestorePipelineReleaseRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*/releases/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
-  ];
-}
-
-// RestorePipelineReleaseResponse
-message RestorePipelineReleaseResponse {
-  // A pipeline resource
-  PipelineRelease release = 1;
-}
-
-// RenamePipelineReleaseRequest represents a request to rename the pipeline release resource
-// name
-message RenamePipelineReleaseRequest {
-  // Pipeline release resource name. It must have the format of "pipelines/*/releases/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
-  ];
-  // Pipeline new resource id to replace with the pipeline resource name to be
-  // "pipelines/*/releases/{new_pipeline_id}"
-  string new_pipeline_release_id = 2 [(google.api.field_behavior) = REQUIRED];
-}
-
-// RenamePipelineReleaseResponse represents a renamed pipeline release resource
-message RenamePipelineReleaseResponse {
-  // A pipeline resource
-  PipelineRelease release = 1;
-}
-
-// WatchPipelineReleaseRequest represents a public request to query
-// a pipeline's current state
-message WatchPipelineReleaseRequest {
-  // Pipeline resource name. It must have the format of "pipelines/*/releases/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline.name/watch"}
-    }
-  ];
-}
-
-// WatchPipelineReleaseResponse represents a response to fetch a pipeline's
-// current state
-message WatchPipelineReleaseResponse {
-  // Retrieved pipeline state
-  State state = 1;
-}
-
-// TriggerPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
-message TriggerPipelineReleaseRequest {
-  // Resource name.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
-  ];
-  // Input to the pipeline
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-}
-
-// TriggerPipelineReleaseResponse represents a response for the output
-// of a pipeline, i.e., the multiple model inference outputs
-message TriggerPipelineReleaseResponse {
-  // The multiple model inference outputs
-  repeated google.protobuf.Struct outputs = 1;
-  // The traces of the pipeline inference, {component_id: Trace}
-  TriggerMetadata metadata = 2;
-}
-
-// TriggerAsyncPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
-message TriggerAsyncPipelineReleaseRequest {
-  // Resource name.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
-  ];
-  // Input to the pipeline
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-}
-
-// TriggerAsyncPipelineReleaseResponse represents a response for the longrunning
-// operation of a pipeline
-message TriggerAsyncPipelineReleaseResponse {
-  // Trigger async pipeline operation message
-  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -41,6 +41,16 @@ message ReadinessResponse {
   common.healthcheck.v1alpha.HealthCheckResponse health_check_response = 1;
 }
 
+// ConnectorResource visibility including public or private
+enum Visibility {
+  // Visibility: UNSPECIFIED, equivalent to PRIVATE.
+  VISIBILITY_UNSPECIFIED = 0;
+  // Visibility: PRIVATE
+  VISIBILITY_PRIVATE = 1;
+  // Visibility: PUBLIC
+  VISIBILITY_PUBLIC = 2;
+}
+
 // ComponentType
 enum ComponentType {
   // TYPE_UNSPECIFIED
@@ -140,6 +150,8 @@ message Pipeline {
   google.protobuf.Timestamp create_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline update time
   google.protobuf.Timestamp update_time = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Visibility
+  Visibility visibility = 12;
 }
 
 // The metadata
@@ -184,6 +196,8 @@ message PipelineRelease {
   google.protobuf.Timestamp create_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline update time
   google.protobuf.Timestamp update_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Visibility
+  Visibility visibility = 8;
 }
 
 // ListPipelinesRequest represents a request to list pipelines

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -45,87 +45,94 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // CreatePipeline method receives a CreatePipelineRequest message and returns
-  // a CreatePipelineResponse message.
-  rpc CreatePipeline(CreatePipelineRequest) returns (CreatePipelineResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/pipelines"
-      body: "pipeline"
-    };
-    option (google.api.method_signature) = "pipeline";
-  }
-
   // ListPipelines method receives a ListPipelinesRequest message and returns a
   // ListPipelinesResponse message.
   rpc ListPipelines(ListPipelinesRequest) returns (ListPipelinesResponse) {
     option (google.api.http) = {get: "/v1alpha/pipelines"};
   }
 
-  // GetPipeline method receives a GetPipelineRequest message and returns a
-  // GetPipelineResponse message.
-  rpc GetPipeline(GetPipelineRequest) returns (GetPipelineResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=pipelines/*}"};
+  // CreateUserPipeline method receives a CreateUserPipelineRequest message and returns
+  // a CreateUserPipelineResponse message.
+  rpc CreateUserPipeline(CreateUserPipelineRequest) returns (CreateUserPipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{parent=users/*}/pipelines"
+      body: "pipeline"
+    };
+    option (google.api.method_signature) = "parent,pipeline";
+  }
+
+  // ListUserPipelines method receives a ListUserPipelinesRequest message and returns a
+  // ListUserPipelinesResponse message.
+  rpc ListUserPipelines(ListUserPipelinesRequest) returns (ListUserPipelinesResponse) {
+    option (google.api.http) = {get: "/v1alpha/{parent=users/*}/pipelines"};
+    option (google.api.method_signature) = "parent";
+  }
+
+  // GetUserPipeline method receives a GetUserPipelineRequest message and returns a
+  // GetUserPipelineResponse message.
+  rpc GetUserPipeline(GetUserPipelineRequest) returns (GetUserPipelineResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/pipelines/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // UpdatePipeline method receives a UpdatePipelineRequest message and returns
-  // a UpdatePipelineResponse message.
-  rpc UpdatePipeline(UpdatePipelineRequest) returns (UpdatePipelineResponse) {
+  // UpdateUserPipeline method receives a UpdateUserPipelineRequest message and returns
+  // a UpdateUserPipelineResponse message.
+  rpc UpdateUserPipeline(UpdateUserPipelineRequest) returns (UpdateUserPipelineResponse) {
     option (google.api.http) = {
-      patch: "/v1alpha/{pipeline.name=pipelines/*}"
+      patch: "/v1alpha/{pipeline.name=users/*pipelines/*}"
       body: "pipeline"
     };
     option (google.api.method_signature) = "pipeline,update_mask";
   }
 
-  // DeletePipeline method receives a DeletePipelineRequest message and returns
-  // a DeletePipelineResponse message.
-  rpc DeletePipeline(DeletePipelineRequest) returns (DeletePipelineResponse) {
-    option (google.api.http) = {delete: "/v1alpha/{name=pipelines/*}"};
+  // DeleteUserPipeline method receives a DeleteUserPipelineRequest message and returns
+  // a DeleteUserPipelineResponse message.
+  rpc DeleteUserPipeline(DeleteUserPipelineRequest) returns (DeleteUserPipelineResponse) {
+    option (google.api.http) = {delete: "/v1alpha/{name=users/*/pipelines/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // LookUpPipeline method receives a LookUpPipelineRequest message and returns
-  // a LookUpPipelineResponse
-  rpc LookUpPipeline(LookUpPipelineRequest) returns (LookUpPipelineResponse) {
-    option (google.api.http) = {get: "/v1alpha/{permalink=pipelines/*}/lookUp"};
+  // LookUpUserPipeline method receives a LookUpUserPipelineRequest message and returns
+  // a LookUpUserPipelineResponse
+  rpc LookUpUserPipeline(LookUpUserPipelineRequest) returns (LookUpUserPipelineResponse) {
+    option (google.api.http) = {get: "/v1alpha/{permalink=users/*/pipelines/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
   }
 
   // Validate a pipeline.
-  rpc ValidatePipeline(ValidatePipelineRequest) returns (ValidatePipelineResponse) {
+  rpc ValidateUserPipeline(ValidateUserPipelineRequest) returns (ValidateUserPipelineResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=pipelines/*}/validate"
+      post: "/v1alpha/{name=users/*/pipelines/*}/validate"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // RenamePipeline method receives a RenamePipelineRequest message and returns
-  // a RenamePipelineResponse message.
-  rpc RenamePipeline(RenamePipelineRequest) returns (RenamePipelineResponse) {
+  // RenameUserPipeline method receives a RenameUserPipelineRequest message and returns
+  // a RenameUserPipelineResponse message.
+  rpc RenameUserPipeline(RenameUserPipelineRequest) returns (RenameUserPipelineResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=pipelines/*}/rename"
+      post: "/v1alpha/{name=users/*/pipelines/*}/rename"
       body: "*"
     };
     option (google.api.method_signature) = "name,new_pipeline_id";
   }
 
-  // TriggerPipeline method receives a TriggerPipelineRequest message
-  // and returns a TriggerPipelineResponse.
-  rpc TriggerPipeline(TriggerPipelineRequest) returns (TriggerPipelineResponse) {
+  // TriggerUserPipeline method receives a TriggerUserPipelineRequest message
+  // and returns a TriggerUserPipelineResponse.
+  rpc TriggerUserPipeline(TriggerUserPipelineRequest) returns (TriggerUserPipelineResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=pipelines/*}/trigger"
+      post: "/v1alpha/{name=users/*/pipelines/*}/trigger"
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
   }
 
-  // TriggerAsyncPipeline method receives a TriggerPipelineRequest message and
-  // returns a TriggerAsyncPipelineResponse.
-  rpc TriggerAsyncPipeline(TriggerAsyncPipelineRequest) returns (TriggerAsyncPipelineResponse) {
+  // TriggerAsyncUserPipeline method receives a TriggerAsyncUserPipelineRequest message and
+  // returns a TriggerAsyncUserPipelineResponse.
+  rpc TriggerAsyncUserPipeline(TriggerAsyncUserPipelineRequest) returns (TriggerAsyncUserPipelineResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=pipelines/*}/triggerAsync"
+      post: "/v1alpha/{name=users/*/pipelines/*}/triggerAsync"
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
@@ -141,93 +148,93 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // CreatePipelineRelease method receives a CreatePipelineReleaseRequest message and returns
-  // a CreatePipelineReleaseResponse message.
-  rpc CreatePipelineRelease(CreatePipelineReleaseRequest) returns (CreatePipelineReleaseResponse) {
+  // CreateUserPipelineRelease method receives a CreateUserPipelineReleaseRequest message and returns
+  // a CreateUserPipelineReleaseResponse message.
+  rpc CreateUserPipelineRelease(CreateUserPipelineReleaseRequest) returns (CreateUserPipelineReleaseResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{parent=pipelines/*}/releases"
+      post: "/v1alpha/{parent=users/*/pipelines/*}/releases"
       body: "release"
     };
     option (google.api.method_signature) = "parent,release";
   }
 
-  // ListPipelineReleases method receives a ListPipelineReleasesRequest message and returns a
-  // ListPipelineReleasesResponse message.
-  rpc ListPipelineReleases(ListPipelineReleasesRequest) returns (ListPipelineReleasesResponse) {
-    option (google.api.http) = {get: "/v1alpha/{parent=pipelines/*}/releases"};
+  // ListUserPipelineReleases method receives a ListUserPipelineReleasesRequest message and returns a
+  // ListUserPipelineReleasesResponse message.
+  rpc ListUserPipelineReleases(ListUserPipelineReleasesRequest) returns (ListUserPipelineReleasesResponse) {
+    option (google.api.http) = {get: "/v1alpha/{parent=users/*/pipelines/*}/releases"};
     option (google.api.method_signature) = "pipelines";
   }
 
-  // GetPipelineRelease method receives a GetPipelineReleaseRequest message and returns a
-  // GetPipelineReleaseResponse message.
-  rpc GetPipelineRelease(GetPipelineReleaseRequest) returns (GetPipelineReleaseResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=pipelines/*/releases/*}"};
+  // GetUserPipelineRelease method receives a GetUserPipelineReleaseRequest message and returns a
+  // GetUserPipelineReleaseResponse message.
+  rpc GetUserPipelineRelease(GetUserPipelineReleaseRequest) returns (GetUserPipelineReleaseResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/pipelines/*/releases/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // UpdatePipelineRelease method receives a UpdatePipelineReleaseRequest message and returns
-  // a UpdatePipelineReleaseResponse message.
-  rpc UpdatePipelineRelease(UpdatePipelineReleaseRequest) returns (UpdatePipelineReleaseResponse) {
+  // UpdateUserPipelineRelease method receives a UpdateUserPipelineReleaseRequest message and returns
+  // a UpdateUserPipelineReleaseResponse message.
+  rpc UpdateUserPipelineRelease(UpdateUserPipelineReleaseRequest) returns (UpdateUserPipelineReleaseResponse) {
     option (google.api.http) = {
-      patch: "/v1alpha/{release.name=pipelines/*/releases/*}"
+      patch: "/v1alpha/{release.name=usersr/*/pipelines/*/releases/*}"
       body: "release"
     };
     option (google.api.method_signature) = "release,update_mask";
   }
 
-  // DeletePipelineRelease method receives a DeletePipelineReleaseRequest message and returns
-  // a DeletePipelineReleaseResponse message.
-  rpc DeletePipelineRelease(DeletePipelineReleaseRequest) returns (DeletePipelineReleaseResponse) {
-    option (google.api.http) = {delete: "/v1alpha/{name=pipelines/*/releases/*}"};
+  // DeleteUserPipelineRelease method receives a DeleteUserPipelineReleaseRequest message and returns
+  // a DeleteUserPipelineReleaseResponse message.
+  rpc DeleteUserPipelineRelease(DeleteUserPipelineReleaseRequest) returns (DeleteUserPipelineReleaseResponse) {
+    option (google.api.http) = {delete: "/v1alpha/{name=users/*/pipelines/*/releases/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // RestorePipelineRelease method receives a RestorePipelineReleaseRequest message
-  // and returns a RestorePipelineReleaseResponse
-  rpc RestorePipelineRelease(RestorePipelineReleaseRequest) returns (RestorePipelineReleaseResponse) {
-    option (google.api.http) = {post: "/v1alpha/{name=pipelines/*/releases/*}/restore"};
+  // RestoreUserPipelineRelease method receives a RestoreUserPipelineReleaseRequest message
+  // and returns a RestoreUserPipelineReleaseResponse
+  rpc RestoreUserPipelineRelease(RestoreUserPipelineReleaseRequest) returns (RestoreUserPipelineReleaseResponse) {
+    option (google.api.http) = {post: "/v1alpha/{name=users/*/pipelines/*/releases/*}/restore"};
     option (google.api.method_signature) = "name";
   }
 
-  // SetDefaultPipelineRelease method receives a SetDefaultPipelineReleaseRequest message
-  // and returns a SetDefaultPipelineReleaseResponse
-  rpc SetDefaultPipelineRelease(SetDefaultPipelineReleaseRequest) returns (SetDefaultPipelineReleaseResponse) {
-    option (google.api.http) = {post: "/v1alpha/{name=pipelines/*/releases/*}/set_default"};
+  // SetDefaultUserPipelineRelease method receives a SetDefaultUserPipelineReleaseRequest message
+  // and returns a SetDefaultUserPipelineReleaseResponse
+  rpc SetDefaultUserPipelineRelease(SetDefaultUserPipelineReleaseRequest) returns (SetDefaultUserPipelineReleaseResponse) {
+    option (google.api.http) = {post: "/v1alpha/{name=users/*/pipelines/*/releases/*}/set_default"};
     option (google.api.method_signature) = "name";
   }
 
-  // WatchPipelineRelease method receives a WatchPipelineReleaseRequest message
-  // and returns a WatchPipelineReleaseResponse
-  rpc WatchPipelineRelease(WatchPipelineReleaseRequest) returns (WatchPipelineReleaseResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=pipelines/*/releases/default}/watch"};
+  // WatchUserPipelineRelease method receives a WatchUserPipelineReleaseRequest message
+  // and returns a WatchUserPipelineReleaseResponse
+  rpc WatchUserPipelineRelease(WatchUserPipelineReleaseRequest) returns (WatchUserPipelineReleaseResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/pipelines/*/releases/default}/watch"};
     option (google.api.method_signature) = "name";
   }
 
-  // RenamePipelineRelease method receives a RenamePipelineReleaseRequest message and returns
-  // a RenamePipelineReleaseResponse message.
-  rpc RenamePipelineRelease(RenamePipelineReleaseRequest) returns (RenamePipelineReleaseResponse) {
+  // RenameUserPipelineRelease method receives a RenameUserPipelineReleaseRequest message and returns
+  // a RenameUserPipelineReleaseResponse message.
+  rpc RenameUserPipelineRelease(RenameUserPipelineReleaseRequest) returns (RenameUserPipelineReleaseResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=pipelines/*/releases/*}/rename"
+      post: "/v1alpha/{name=users/*/pipelines/*/releases/*}/rename"
       body: "*"
     };
     option (google.api.method_signature) = "name,new_pipeline_release_id";
   }
 
-  // TriggerPipelineRelease method receives a TriggePipelineReleaseRequest message
+  // TriggerUserPipelineRelease method receives a TriggeUserPipelineReleaseRequest message
   // and returns a TriggerPipelineReleasePipelineResponse.
-  rpc TriggerPipelineRelease(TriggerPipelineReleaseRequest) returns (TriggerPipelineReleaseResponse) {
+  rpc TriggerUserPipelineRelease(TriggerUserPipelineReleaseRequest) returns (TriggerUserPipelineReleaseResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=pipelines/*/releases/*}/trigger"
+      post: "/v1alpha/{name=users/*/pipelines/*/releases/*}/trigger"
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
   }
 
-  // TriggerAsyncPipelineRelease method receives a TriggerAsyncPipelineReleaseRequest message and
-  // returns a TriggerAsyncPipelineReleaseResponse.
-  rpc TriggerAsyncPipelineRelease(TriggerAsyncPipelineReleaseRequest) returns (TriggerAsyncPipelineReleaseResponse) {
+  // TriggerAsyncUserPipelineRelease method receives a TriggerAsyncUserPipelineReleaseRequest message and
+  // returns a TriggerAsyncUserPipelineReleaseResponse.
+  rpc TriggerAsyncUserPipelineRelease(TriggerAsyncUserPipelineReleaseRequest) returns (TriggerAsyncUserPipelineReleaseResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=pipelines/*/releases/*}/triggerAsync"
+      post: "/v1alpha/{name=users/*/pipelines/*/releases/*}/triggerAsync"
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -79,7 +79,7 @@ service PipelinePublicService {
   // a UpdateUserPipelineResponse message.
   rpc UpdateUserPipeline(UpdateUserPipelineRequest) returns (UpdateUserPipelineResponse) {
     option (google.api.http) = {
-      patch: "/v1alpha/{pipeline.name=users/*pipelines/*}"
+      patch: "/v1alpha/{pipeline.name=users/*/pipelines/*}"
       body: "pipeline"
     };
     option (google.api.method_signature) = "pipeline,update_mask";


### PR DESCRIPTION
Because

- We would like to make the resources be public or shared to other users. The current structure can not support it since the api endpoint was designed for the users' own resources.

This commit

- add namespace for api endpoints
