### PR TITLE
chore(model): add namespace for model api endpoints

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -52,7 +52,7 @@ message ReadinessResponse {
 message Model {
   option (google.api.resource) = {
     type: "api.instill.tech/Model"
-    pattern: "models/{model}"
+    pattern: "users/{user}/models/{model}"
   };
 
   // Model visibility including public or private
@@ -77,8 +77,8 @@ message Model {
     STATE_ERROR = 3;
   }
 
-  // Resource name. It must have the format of "models/{model}".
-  // For example: "models/yolov4"
+  // Resource name. It must have the format of "users/{user}/models/{model}".
+  // For example: "users/instill-ai/models/yolov4"
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model ID in UUIDv4
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -128,11 +128,11 @@ message Model {
 message ModelCard {
   option (google.api.resource) = {
     type: "api.instill.tech/ModelCard"
-    pattern: "models/{model}/readme"
+    pattern: "users/{user}/models/{model}/readme"
   };
 
   // Resource name. It must have the format of
-  // "models/{model}/readme"
+  // "users/{user}/models/{model}/readme"
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Size of the file
   int32 size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -169,42 +169,79 @@ message ListModelsResponse {
   int64 total_size = 3;
 }
 
-// CreateModelRequest represents a request to create a model
-message CreateModelRequest {
+// CreateUserModelRequest represents a request to create a model
+message CreateUserModelRequest {
   // The model to be created
   //
   // The model `name` field is used to identify the model to create.
   // Format: models/{model}
   Model model = 1 [(google.api.field_behavior) = REQUIRED];
+  // The parent resource where this connector resource will be created.
+  // Format: users/{users}
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Model"}
+  ];
 }
 
-// CreateModelResponse represents a response for a model
-message CreateModelResponse {
+// CreateUserModelResponse represents a response for a model
+message CreateUserModelResponse {
   // Create model operation message
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// CreateModelBinaryFileUploadRequest represents a request to create a model
-message CreateModelBinaryFileUploadRequest {
+// CreateUserModelBinaryFileUploadRequest represents a request to create a model
+message CreateUserModelBinaryFileUploadRequest {
   // The model to be created
   //
   // The model `name` field is used to identify the model to create.
-  // Format: models/{model}
+  // Format: users/{user}/models/{model}
   Model model = 1 [(google.api.field_behavior) = REQUIRED];
   // Model content in bytes
   bytes content = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// CreateModelBinaryFileUploadResponse represents a response for a model
-message CreateModelBinaryFileUploadResponse {
+// CreateUserModelBinaryFileUploadResponse represents a response for a model
+message CreateUserModelBinaryFileUploadResponse {
   // Create model operation message
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetModelRequest represents a request to query a model
-message GetModelRequest {
+// ListUserModelsRequest represents a request to list all models
+message ListUserModelsRequest {
+  // Page size: the maximum number of resources to return. The service may
+  // return fewer than this value. If unspecified, at most 10 models will be
+  // returned. The maximum value is 100; values above 100 will be coereced to
+  // 100.
+  optional int64 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Model view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The parent resource where this connector resource will be created.
+  // Format: users/{users}
+  string parent = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Model"}
+  ];
+}
+
+// ListUserModelsResponse represents a response for a list of models
+message ListUserModelsResponse {
+  // a list of Models
+  repeated Model models = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of models
+  int64 total_size = 3;
+}
+
+// GetUserModelRequest represents a request to query a model
+message GetUserModelRequest {
   // Resource name of the model.
-  // For example "models/{model}"
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model",
@@ -218,33 +255,30 @@ message GetModelRequest {
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetModelResponse represents a response for a model
-message GetModelResponse {
+// GetUserModelResponse represents a response for a model
+message GetUserModelResponse {
   // The retrieved model
   Model model = 1;
 }
 
-// UpdateModelRequest represents a request to update a model
-message UpdateModelRequest {
+// UpdateUserModelRequest represents a request to update a model
+message UpdateUserModelRequest {
   // The model to update
-  //
-  // The model `name` field is used to identify the model to update.
-  // Format: models/{model}
   Model model = 1 [(google.api.field_behavior) = REQUIRED];
   // Mask of fields to update.
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// UpdateModelResponse represents a response for a model
-message UpdateModelResponse {
+// UpdateUserModelResponse represents a response for a model
+message UpdateUserModelResponse {
   // The updated model
   Model model = 1;
 }
 
-// DeleteModelRequest represents a request to delete a model
-message DeleteModelRequest {
+// DeleteUserModelRequest represents a request to delete a model
+message DeleteUserModelRequest {
   // Resource name of the model.
-  // For example "models/{model}"
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model",
@@ -254,13 +288,13 @@ message DeleteModelRequest {
   ];
 }
 
-// DeleteModelResponse represents an empty response
-message DeleteModelResponse {}
+// DeleteUserModelResponse represents an empty response
+message DeleteUserModelResponse {}
 
-// LookUpModelRequest represents a request to query a model via permalink
-message LookUpModelRequest {
+// LookUpUserModelRequest represents a request to query a model via permalink
+message LookUpUserModelRequest {
   // Permalink of a model. For example:
-  // "models/{uid}"
+  // Format: users/{user}/models/{uid}
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
   // Model view (default is VIEW_BASIC)
   // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
@@ -268,101 +302,103 @@ message LookUpModelRequest {
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// LookUpModelResponse represents a response for a model
-message LookUpModelResponse {
+// LookUpUserModelResponse represents a response for a model
+message LookUpUserModelResponse {
   // A model resource
   Model model = 1;
 }
 
-// RenameModelRequest represents a request to rename a model
-message RenameModelRequest {
+// RenameUserModelRequest represents a request to rename a model
+message RenameUserModelRequest {
   // Resource name for the model to be renamed.
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
 
   // New ID of this model
+  // Format: users/{user}/models/{new_model_id}
   string new_model_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// RenameModelResponse represents a response for a model
-message RenameModelResponse {
+// RenameUserModelResponse represents a response for a model
+message RenameUserModelResponse {
   // Renamed model
   Model model = 1;
 }
 
-// PublishModelRequest represents a request to publish a model
-message PublishModelRequest {
+// PublisUserhModelRequest represents a request to publish a model
+message PublishUserModelRequest {
   // Resource name of the model.
-  // For example "models/{model}"
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
 }
 
-// PublishModelResponse represents a response for the published model
-message PublishModelResponse {
+// PublishUserModelResponse represents a response for the published model
+message PublishUserModelResponse {
   // Published model
   Model model = 1;
 }
 
-// UnpublishModelRequest represents a request to unpublish a model
-message UnpublishModelRequest {
+// UnpublishUserModelRequest represents a request to unpublish a model
+message UnpublishUserModelRequest {
   // Resource name of the model.
-  // For example "models/{model}"
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
 }
 
-// UnpublishModelResponse represents a response for the unpublished model
-message UnpublishModelResponse {
+// UnpublishUserModelResponse represents a response for the unpublished model
+message UnpublishUserModelResponse {
   // Unpublished model
   Model model = 1;
 }
 
-// DeployModelRequest represents a request to deploy a model to online state
-message DeployModelRequest {
+// DeployUserModelRequest represents a request to deploy a model to online state
+message DeployUserModelRequest {
   // Resource name for the model to be deployed.
-  // Format: models/{model}
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
 }
 
-// DeployModelResponse represents a response for a deployed model
-message DeployModelResponse {
+// DeployUserModelResponse represents a response for a deployed model
+message DeployUserModelResponse {
   // Deployed model's id
-  // Format: models/{model}
+  // Format: users/{user}/models/{model}
   string model_id = 1;
 }
 
-// UndeployModelRequest represents a request to undeploy a model to offline
+// UndeployUserModelRequest represents a request to undeploy a model to offline
 // state
-message UndeployModelRequest {
+message UndeployUserModelRequest {
   // Resource name for the model to be undeployed.
-  // Format: models/{model}
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
   ];
 }
 
-// UndeployModelResponse represents a response for a undeployed model
-message UndeployModelResponse {
+// UndeployUserModelResponse represents a response for a undeployed model
+message UndeployUserModelResponse {
   // Undeployed model's id
-  // Format: models/{model}
+  // Format: users/{user}/models/{model}
   string model_id = 1;
 }
 
-// GetModelCardRequest represents a request to query a model's README card
-message GetModelCardRequest {
+// GetUserModelCardRequest represents a request to query a model's README card
+message GetUserModelCardRequest {
   // Resource name of the model card.
-  // For example "models/{model}/readme"
+  // For example "// Format: users/{user}/models/{model}/readme"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/ModelCard",
@@ -372,17 +408,17 @@ message GetModelCardRequest {
   ];
 }
 
-// GetModelCardResponse represents a response to fetch a model's README card
-message GetModelCardResponse {
+// GetUserModelCardResponse represents a response to fetch a model's README card
+message GetUserModelCardResponse {
   // Retrieved model card
   ModelCard readme = 1;
 }
 
-// WatchModelRequest represents a public request to query
+// WatchUserModelRequest represents a public request to query
 // a model's current state and longrunning progress
-message WatchModelRequest {
+message WatchUserModelRequest {
   // Resource name of the model.
-  // For example "models/{model}"
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model",
@@ -392,9 +428,9 @@ message WatchModelRequest {
   ];
 }
 
-// WatchModelResponse represents a public response to
+// WatchUserModelResponse represents a public response to
 // fetch a model current state and longrunning progress
-message WatchModelResponse {
+message WatchUserModelResponse {
   // Retrieved model state
   Model.State state = 1;
   // Retrieved model logrunning progress
@@ -480,10 +516,10 @@ message TaskOutput {
   }
 }
 
-// TriggerModelRequest represents a request to trigger a model
-message TriggerModelRequest {
+// TriggerUserModelRequest represents a request to trigger a model
+message TriggerUserModelRequest {
   // The resource name of the model to trigger.
-  // For example "models/{model}"
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
@@ -492,20 +528,20 @@ message TriggerModelRequest {
   repeated TaskInput task_inputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerModelResponse represents a response for the output for
+// TriggerUserModelResponse represents a response for the output for
 // triggering a model
-message TriggerModelResponse {
+message TriggerUserModelResponse {
   // The task type
   common.task.v1alpha.Task task = 1;
   // The task output from a model
   repeated TaskOutput task_outputs = 2;
 }
 
-// TriggerModelBinaryFileUploadRequest represents a request to test a
+// TriggerUserModelBinaryFileUploadRequest represents a request to test a
 // model by uploading binary file
-message TriggerModelBinaryFileUploadRequest {
+message TriggerUserModelBinaryFileUploadRequest {
   // The resource name of the model to trigger.
-  // For example "models/{model}"
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
@@ -514,19 +550,19 @@ message TriggerModelBinaryFileUploadRequest {
   TaskInputStream task_input = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerModelBinaryFileUploadResponse represents a response for the
+// TriggerUserModelBinaryFileUploadResponse represents a response for the
 // output for testing a model
-message TriggerModelBinaryFileUploadResponse {
+message TriggerUserModelBinaryFileUploadResponse {
   // The task type
   common.task.v1alpha.Task task = 1 [(google.api.field_behavior) = REQUIRED];
   // The task output from a model
   repeated TaskOutput task_outputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TestModelRequest represents a request to test a model
-message TestModelRequest {
+// TestUserModelRequest represents a request to test a model
+message TestUserModelRequest {
   // The resource name of the model to trigger.
-  // For example "models/{model}"
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
@@ -535,20 +571,20 @@ message TestModelRequest {
   repeated TaskInput task_inputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TestModelResponse represents a response for the output for
+// TestUserModelResponse represents a response for the output for
 // testing a model
-message TestModelResponse {
+message TestUserModelResponse {
   // The task type
   common.task.v1alpha.Task task = 1 [(google.api.field_behavior) = REQUIRED];
   // The task output from a model
   repeated TaskOutput task_outputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TestModelBinaryFileUploadRequest represents a request to test a
+// TestUserModelBinaryFileUploadRequest represents a request to test a
 // model by uploading binary file
-message TestModelBinaryFileUploadRequest {
+message TestUserModelBinaryFileUploadRequest {
   // The resource name of the model to trigger.
-  // For example "models/{model}"
+  // Format: users/{user}/models/{model}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Model"
@@ -557,17 +593,17 @@ message TestModelBinaryFileUploadRequest {
   TaskInputStream task_input = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TestModelBinaryFileUploadResponse represents a response for the
+// TestUserModelBinaryFileUploadResponse represents a response for the
 // output for testing a model
-message TestModelBinaryFileUploadResponse {
+message TestUserModelBinaryFileUploadResponse {
   // The task type
   common.task.v1alpha.Task task = 1 [(google.api.field_behavior) = REQUIRED];
   // The task output from a model
   repeated TaskOutput task_outputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// GetModelOperationRequest represents a request to query a model operation
-message GetModelOperationRequest {
+// GetUserModelOperationRequest represents a request to query a model operation
+message GetUserModelOperationRequest {
   // The name of the operation resource.
   string name = 1 [(google.api.field_behavior) = REQUIRED];
   // View (default is VIEW_BASIC)
@@ -576,8 +612,8 @@ message GetModelOperationRequest {
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetModelOperationResponse represents a response for a model operation
-message GetModelOperationResponse {
+// GetUserModelOperationResponse represents a response for a model operation
+message GetUserModelOperationResponse {
   // The retrieved model operation
   google.longrunning.Operation operation = 1;
 }

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -174,7 +174,7 @@ message CreateUserModelRequest {
   // The model to be created
   //
   // The model `name` field is used to identify the model to create.
-  // Format: models/{model}
+  // Format: users/{user}/models/{model}
   Model model = 1 [(google.api.field_behavior) = REQUIRED];
   // The parent resource where this connector resource will be created.
   // Format: users/{users}
@@ -199,6 +199,12 @@ message CreateUserModelBinaryFileUploadRequest {
   Model model = 1 [(google.api.field_behavior) = REQUIRED];
   // Model content in bytes
   bytes content = 2 [(google.api.field_behavior) = REQUIRED];
+  // The parent resource where this connector resource will be created.
+  // Format: users/{users}
+  string parent = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Model"}
+  ];
 }
 
 // CreateUserModelBinaryFileUploadResponse represents a response for a model
@@ -602,8 +608,8 @@ message TestUserModelBinaryFileUploadResponse {
   repeated TaskOutput task_outputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// GetUserModelOperationRequest represents a request to query a model operation
-message GetUserModelOperationRequest {
+// GerModelOperationRequest represents a request to query a model operation
+message GetModelOperationRequest {
   // The name of the operation resource.
   string name = 1 [(google.api.field_behavior) = REQUIRED];
   // View (default is VIEW_BASIC)
@@ -612,8 +618,8 @@ message GetUserModelOperationRequest {
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetUserModelOperationResponse represents a response for a model operation
-message GetUserModelOperationResponse {
+// GetModelOperationResponse represents a response for a model operation
+message GetModelOperationResponse {
   // The retrieved model operation
   google.longrunning.Operation operation = 1;
 }

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -76,7 +76,7 @@ service ModelPublicService {
   //
   // Endpoint: "POST /v1alpha/users/*/models:multipart"
   rpc CreateUserModelBinaryFileUpload(stream CreateUserModelBinaryFileUploadRequest) returns (CreateUserModelBinaryFileUploadResponse) {
-    option (google.api.method_signature) = "id,model_definition,content";
+    option (google.api.method_signature) = "id,model_definition,content,parent";
   }
 
   // GetUserModel method receives a GetUserModelRequest message and returns a
@@ -106,7 +106,7 @@ service ModelPublicService {
   // LookUpUserModel method receives a LookUpUserModelRequest message and returns a
   // LookUpUserModelResponse
   rpc LookUpUserModel(LookUpUserModelRequest) returns (LookUpUserModelResponse) {
-    option (google.api.http) = {get: "/v1alpha/{permalink=musers/*/odels/*}/lookUp"};
+    option (google.api.http) = {get: "/v1alpha/{permalink=users/*/models/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
   }
 
@@ -211,11 +211,11 @@ service ModelPublicService {
     option (google.api.method_signature) = "name,file";
   }
 
-  // GetUserModelOperation method receives a
-  // GetUserModelOperationRequest message and returns a
-  // GetUserModelOperationResponse message.
-  rpc GetUserModelOperation(GetUserModelOperationRequest) returns (GetUserModelOperationResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=users/*/operations/*}"};
+  // GetModelOperation method receives a
+  // GetModelOperationRequest message and returns a
+  // GetModelOperationResponse message.
+  rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
     option (google.api.method_signature) = "name";
   }
 }

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -53,162 +53,169 @@ service ModelPublicService {
     option (google.api.http) = {get: "/v1alpha/models"};
   }
 
-  // CreateModel method receives a CreateModelRequest message and returns a
-  // CreateModelResponse
-  rpc CreateModel(CreateModelRequest) returns (CreateModelResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/models"
-      body: "model"
-    };
-    option (google.api.method_signature) = "model";
+  // LisUsertModels method receives a ListUserModelsRequest message and returns a
+  // ListUserModelsResponse
+  rpc ListUserModels(ListUserModelsRequest) returns (ListUserModelsResponse) {
+    option (google.api.http) = {get: "/v1alpha/{parent=users/*}/models"};
+    option (google.api.method_signature) = "parent";
   }
 
-  // CreateModelBinaryFileUpload method receives a
-  // CreateModelBinaryFileUploadRequest message and returns a
-  // CreateModelBinaryFileUploadResponse message.
+  // CreateUserModel method receives a CreateUserModelRequest message and returns a
+  // CreateUserModelResponse
+  rpc CreateUserModel(CreateUserModelRequest) returns (CreateUserModelResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{parent=users/*}/models"
+      body: "model"
+    };
+    option (google.api.method_signature) = "parent,model";
+  }
+
+  // CreateUserModelBinaryFileUpload method receives a
+  // CreateUserModelBinaryFileUploadRequest message and returns a
+  // CreateUserModelBinaryFileUploadResponse message.
   //
-  // Endpoint: "POST /v1alpha/models:multipart"
-  rpc CreateModelBinaryFileUpload(stream CreateModelBinaryFileUploadRequest) returns (CreateModelBinaryFileUploadResponse) {
+  // Endpoint: "POST /v1alpha/users/*/models:multipart"
+  rpc CreateUserModelBinaryFileUpload(stream CreateUserModelBinaryFileUploadRequest) returns (CreateUserModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "id,model_definition,content";
   }
 
-  // GetModel method receives a GetModelRequest message and returns a
-  // GetModelResponse
-  rpc GetModel(GetModelRequest) returns (GetModelResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=models/*}"};
+  // GetUserModel method receives a GetUserModelRequest message and returns a
+  // GetUserModelResponse
+  rpc GetUserModel(GetUserModelRequest) returns (GetUserModelResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // UpdateModel method receives a UpdateModelRequest message and returns a
-  // UpdateModelResponse
-  rpc UpdateModel(UpdateModelRequest) returns (UpdateModelResponse) {
+  // UpdateUserModel method receives a UpdateUserModelRequest message and returns a
+  // UpdateUserModelResponse
+  rpc UpdateUserModel(UpdateUserModelRequest) returns (UpdateUserModelResponse) {
     option (google.api.http) = {
-      patch: "/v1alpha/{model.name=models/*}"
+      patch: "/v1alpha/{model.name=users/*/models/*}"
       body: "model"
     };
     option (google.api.method_signature) = "model,update_mask";
   }
 
-  // DeleteModel method receives a DeleteModelRequest message and returns a
-  // DeleteModelResponse
-  rpc DeleteModel(DeleteModelRequest) returns (DeleteModelResponse) {
-    option (google.api.http) = {delete: "/v1alpha/{name=models/*}"};
+  // DeleteUserModel method receives a DeleteUserModelRequest message and returns a
+  // DeleteUserModelResponse
+  rpc DeleteUserModel(DeleteUserModelRequest) returns (DeleteUserModelResponse) {
+    option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}"};
     option (google.api.method_signature) = "name";
   }
 
-  // LookUpModel method receives a LookUpModelRequest message and returns a
-  // LookUpModelResponse
-  rpc LookUpModel(LookUpModelRequest) returns (LookUpModelResponse) {
-    option (google.api.http) = {get: "/v1alpha/{permalink=models/*}/lookUp"};
+  // LookUpUserModel method receives a LookUpUserModelRequest message and returns a
+  // LookUpUserModelResponse
+  rpc LookUpUserModel(LookUpUserModelRequest) returns (LookUpUserModelResponse) {
+    option (google.api.http) = {get: "/v1alpha/{permalink=musers/*/odels/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
   }
 
-  // RenameModel method rename a model
-  rpc RenameModel(RenameModelRequest) returns (RenameModelResponse) {
+  // RenameUserModel method rename a model
+  rpc RenameUserModel(RenameUserModelRequest) returns (RenameUserModelResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=models/*}/rename"
+      post: "/v1alpha/{name=users/*/models/*}/rename"
       body: "*"
     };
     option (google.api.method_signature) = "name,new_model_id";
   }
 
-  // PublishModel method receives a PublishModelRequest message and returns a
-  // PublishModelResponse
-  rpc PublishModel(PublishModelRequest) returns (PublishModelResponse) {
+  // PublishUserModel method receives a PublisUserhModelRequest message and returns a
+  // PublishUserModelResponse
+  rpc PublishUserModel(PublishUserModelRequest) returns (PublishUserModelResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=models/*}/publish"
+      post: "/v1alpha/{name=users/*/models/*}/publish"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // UnpublishModel method receives a UnpublishModelRequest message and returns
-  // a UnpublishModelResponse
-  rpc UnpublishModel(UnpublishModelRequest) returns (UnpublishModelResponse) {
+  // UnpublishUserModel method receives a UnpublishUserModelRequest message and returns
+  // a UnpublishUserModelResponse
+  rpc UnpublishUserModel(UnpublishUserModelRequest) returns (UnpublishUserModelResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=models/*}/unpublish"
+      post: "/v1alpha/{name=users/*/models/*}/unpublish"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // DeployModel deploy a model to online state
-  rpc DeployModel(DeployModelRequest) returns (DeployModelResponse) {
+  // DeployUserModel deploy a model to online state
+  rpc DeployUserModel(DeployUserModelRequest) returns (DeployUserModelResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=models/*}/deploy"
+      post: "/v1alpha/{name=users/*/models/*}/deploy"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // UndeployModel undeploy a model to offline state
-  rpc UndeployModel(UndeployModelRequest) returns (UndeployModelResponse) {
+  // UndeployUserModel undeploy a model to offline state
+  rpc UndeployUserModel(UndeployUserModelRequest) returns (UndeployUserModelResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=models/*}/undeploy"
+      post: "/v1alpha/{name=users/*/models/*}/undeploy"
       body: "*"
     };
     option (google.api.method_signature) = "name";
   }
 
-  // GetModelCard method receives a GetModelCardRequest message
-  // and returns a GetModelCardResponse
-  rpc GetModelCard(GetModelCardRequest) returns (GetModelCardResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=models/*/readme}"};
+  // GetUserModelCard method receives a GetUserModelCardRequest message
+  // and returns a GetUserModelCardResponseUser
+  rpc GetUserModelCard(GetUserModelCardRequest) returns (GetUserModelCardResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*/readme}"};
     option (google.api.method_signature) = "name";
   }
 
-  // WatchModel method receives a WatchModelRequest message
+  // WatchUserModel method receives a WatchUserModelRequest message
   // and returns a WatchModelResponse
-  rpc WatchModel(WatchModelRequest) returns (WatchModelResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=models/*}/watch"};
+  rpc WatchUserModel(WatchUserModelRequest) returns (WatchUserModelResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/watch"};
     option (google.api.method_signature) = "name";
   }
 
   ///////////////////////////////////////////////////////
   //
-  // TriggerModel method receives a TriggerModelRequest message
-  // and returns a TriggerModelResponse message.
-  rpc TriggerModel(TriggerModelRequest) returns (TriggerModelResponse) {
+  // TriggerUserModel method receives a TriggerUserModelRequest message
+  // and returns a TriggerUserModelResponse message.
+  rpc TriggerUserModel(TriggerUserModelRequest) returns (TriggerUserModelResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=models/*}/trigger"
+      post: "/v1alpha/{name=users/*/models/*}/trigger"
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
   }
 
-  // TriggerModelBinaryFileUpload method receives a
-  // TriggerModelBinaryFileUploadRequest message and returns a
-  // TriggerModelBinaryFileUploadResponse message.
+  // TriggerUserModelBinaryFileUpload method receives a
+  // TriggerUserModelBinaryFileUploadRequest message and returns a
+  // TriggerUserModelBinaryFileUploadResponse message.
   //
   // Endpoint: "POST/v1alpha/{name=models/*}/trigger-multipart"
-  rpc TriggerModelBinaryFileUpload(stream TriggerModelBinaryFileUploadRequest) returns (TriggerModelBinaryFileUploadResponse) {
+  rpc TriggerUserModelBinaryFileUpload(stream TriggerUserModelBinaryFileUploadRequest) returns (TriggerUserModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
   }
 
-  // TestModel method receives a TestModelRequest message
-  // and returns a TestModelResponse message.
-  rpc TestModel(TestModelRequest) returns (TestModelResponse) {
+  // TestUserModel method receives a TestUserModelRequest message
+  // and returns a TestUserModelResponse message.
+  rpc TestUserModel(TestUserModelRequest) returns (TestUserModelResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/{name=models/*}/test"
+      post: "/v1alpha/{name=users/*/models/*}/test"
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
   }
 
-  // TestModelBinaryFileUpload method receives a
-  // TestModelBinaryFileUploadRequest message and returns a
-  // TestModelBinaryFileUploadResponse message.
+  // TestUserModelBinaryFileUpload method receives a
+  // TestUserModelBinaryFileUploadRequest message and returns a
+  // TestUserModelBinaryFileUploadResponse message.
   //
-  // Endpoint: "POST/v1alpha/{name=models/*}/test-multipart"
-  rpc TestModelBinaryFileUpload(stream TestModelBinaryFileUploadRequest) returns (TestModelBinaryFileUploadResponse) {
+  // Endpoint: "POST/v1alpha/{name=users/*/models/*}/test-multipart"
+  rpc TestUserModelBinaryFileUpload(stream TestUserModelBinaryFileUploadRequest) returns (TestUserModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
   }
 
-  // GetModelOperation method receives a
-  // GetModelOperationRequest message and returns a
-  // GetModelOperationResponse message.
-  rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
+  // GetUserModelOperation method receives a
+  // GetUserModelOperationRequest message and returns a
+  // GetUserModelOperationResponse message.
+  rpc GetUserModelOperation(GetUserModelOperationRequest) returns (GetUserModelOperationResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/operations/*}"};
     option (google.api.method_signature) = "name";
   }
 }

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -331,14 +331,14 @@ paths:
   /v1alpha/{model.name/readme}:
     get:
       summary: |-
-        GetModelCard method receives a GetModelCardRequest message
-        and returns a GetModelCardResponse
-      operationId: ModelPublicService_GetModelCard
+        GetUserModelCard method receives a GetUserModelCardRequest message
+        and returns a GetUserModelCardResponseUser
+      operationId: ModelPublicService_GetUserModelCard
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelCardResponse'
+            $ref: '#/definitions/v1alphaGetUserModelCardResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -347,24 +347,24 @@ paths:
         - name: model.name/readme
           description: |-
             Resource name of the model card.
-            For example "models/{model}/readme"
+            For example "// Format: users/{user}/models/{model}/readme"
           in: path
           required: true
           type: string
-          pattern: models/[^/]+/readme
+          pattern: users/[^/]+/models/[^/]+/readme
       tags:
         - ModelPublicService
   /v1alpha/{model.name/watch}/watch:
     get:
       summary: |-
-        WatchModel method receives a WatchModelRequest message
+        WatchUserModel method receives a WatchUserModelRequest message
         and returns a WatchModelResponse
-      operationId: ModelPublicService_WatchModel
+      operationId: ModelPublicService_WatchUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaWatchModelResponse'
+            $ref: '#/definitions/v1alphaWatchUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -373,24 +373,24 @@ paths:
         - name: model.name/watch
           description: |-
             Resource name of the model.
-            For example "models/{model}"
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
       tags:
         - ModelPublicService
   /v1alpha/{model.name}:
     get:
       summary: |-
-        GetModel method receives a GetModelRequest message and returns a
-        GetModelResponse
-      operationId: ModelPublicService_GetModel
+        GetUserModel method receives a GetUserModelRequest message and returns a
+        GetUserModelResponse
+      operationId: ModelPublicService_GetUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelResponse'
+            $ref: '#/definitions/v1alphaGetUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -399,11 +399,11 @@ paths:
         - name: model.name
           description: |-
             Resource name of the model.
-            For example "models/{model}"
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: view
           description: |-
             Model view (default is VIEW_BASIC)
@@ -425,14 +425,14 @@ paths:
         - ModelPublicService
     delete:
       summary: |-
-        DeleteModel method receives a DeleteModelRequest message and returns a
-        DeleteModelResponse
-      operationId: ModelPublicService_DeleteModel
+        DeleteUserModel method receives a DeleteUserModelRequest message and returns a
+        DeleteUserModelResponse
+      operationId: ModelPublicService_DeleteUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeleteModelResponse'
+            $ref: '#/definitions/v1alphaDeleteUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -441,23 +441,23 @@ paths:
         - name: model.name
           description: |-
             Resource name of the model.
-            For example "models/{model}"
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
       tags:
         - ModelPublicService
     patch:
       summary: |-
-        UpdateModel method receives a UpdateModelRequest message and returns a
-        UpdateModelResponse
-      operationId: ModelPublicService_UpdateModel
+        UpdateUserModel method receives a UpdateUserModelRequest message and returns a
+        UpdateUserModelResponse
+      operationId: ModelPublicService_UpdateUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdateModelResponse'
+            $ref: '#/definitions/v1alphaUpdateUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -465,18 +465,14 @@ paths:
       parameters:
         - name: model.name
           description: |-
-            Resource name. It must have the format of "models/{model}".
-            For example: "models/yolov4"
+            Resource name. It must have the format of "users/{user}/models/{model}".
+            For example: "users/instill-ai/models/yolov4"
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: model
-          description: |-
-            The model to update
-
-            The model `name` field is used to identify the model to update.
-            Format: models/{model}
+          description: The model to update
           in: body
           required: true
           schema:
@@ -536,9 +532,6 @@ paths:
                 format: date-time
                 title: Model update time
                 readOnly: true
-            description: |-
-              The model `name` field is used to identify the model to update.
-              Format: models/{model}
             title: The model to update
       tags:
         - ModelPublicService
@@ -852,15 +845,15 @@ paths:
   /v1alpha/{name}:
     get:
       summary: |-
-        GetModelOperation method receives a
-        GetModelOperationRequest message and returns a
-        GetModelOperationResponse message.
-      operationId: ModelPublicService_GetModelOperation
+        GetUserModelOperation method receives a
+        GetUserModelOperationRequest message and returns a
+        GetUserModelOperationResponse message.
+      operationId: ModelPublicService_GetUserModelOperation
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelOperationResponse'
+            $ref: '#/definitions/v1alphaGetUserModelOperationResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -871,7 +864,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: operations/[^/]+
+          pattern: users/[^/]+/operations/[^/]+
         - name: view
           description: |-
             View (default is VIEW_BASIC)
@@ -930,13 +923,13 @@ paths:
         - ConnectorPublicService
   /v1alpha/{name}/deploy:
     post:
-      summary: DeployModel deploy a model to online state
-      operationId: ModelPublicService_DeployModel
+      summary: DeployUserModel deploy a model to online state
+      operationId: ModelPublicService_DeployUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeployModelResponse'
+            $ref: '#/definitions/v1alphaDeployUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -945,17 +938,17 @@ paths:
         - name: name
           description: |-
             Resource name for the model to be deployed.
-            Format: models/{model}
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: body
           in: body
           required: true
           schema:
             type: object
-            title: DeployModelRequest represents a request to deploy a model to online state
+            title: DeployUserModelRequest represents a request to deploy a model to online state
       tags:
         - ModelPublicService
   /v1alpha/{name}/disconnect:
@@ -1039,14 +1032,14 @@ paths:
   /v1alpha/{name}/publish:
     post:
       summary: |-
-        PublishModel method receives a PublishModelRequest message and returns a
-        PublishModelResponse
-      operationId: ModelPublicService_PublishModel
+        PublishUserModel method receives a PublisUserhModelRequest message and returns a
+        PublishUserModelResponse
+      operationId: ModelPublicService_PublishUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaPublishModelResponse'
+            $ref: '#/definitions/v1alphaPublishUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1055,39 +1048,41 @@ paths:
         - name: name
           description: |-
             Resource name of the model.
-            For example "models/{model}"
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: body
           in: body
           required: true
           schema:
             type: object
-            title: PublishModelRequest represents a request to publish a model
+            title: PublisUserhModelRequest represents a request to publish a model
       tags:
         - ModelPublicService
   /v1alpha/{name}/rename:
     post:
-      summary: RenameModel method rename a model
-      operationId: ModelPublicService_RenameModel
+      summary: RenameUserModel method rename a model
+      operationId: ModelPublicService_RenameUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRenameModelResponse'
+            $ref: '#/definitions/v1alphaRenameUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
-          description: Resource name for the model to be renamed.
+          description: |-
+            Resource name for the model to be renamed.
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: body
           in: body
           required: true
@@ -1096,8 +1091,10 @@ paths:
             properties:
               new_model_id:
                 type: string
-                title: New ID of this model
-            title: RenameModelRequest represents a request to rename a model
+                title: |-
+                  New ID of this model
+                  Format: users/{user}/models/{new_model_id}
+            title: RenameUserModelRequest represents a request to rename a model
             required:
               - new_model_id
       tags:
@@ -1153,14 +1150,14 @@ paths:
   /v1alpha/{name}/test:
     post:
       summary: |-
-        TestModel method receives a TestModelRequest message
-        and returns a TestModelResponse message.
-      operationId: ModelPublicService_TestModel
+        TestUserModel method receives a TestUserModelRequest message
+        and returns a TestUserModelResponse message.
+      operationId: ModelPublicService_TestUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTestModelResponse'
+            $ref: '#/definitions/v1alphaTestUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1169,11 +1166,11 @@ paths:
         - name: name
           description: |-
             The resource name of the model to trigger.
-            For example "models/{model}"
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: body
           in: body
           required: true
@@ -1186,7 +1183,7 @@ paths:
                   type: object
                   $ref: '#/definitions/v1alphaTaskInput'
                 title: Input to trigger the model
-            title: TestModelRequest represents a request to test a model
+            title: TestUserModelRequest represents a request to test a model
             required:
               - task_inputs
       tags:
@@ -1195,14 +1192,14 @@ paths:
     post:
       summary: /////////////////////////////////////////////////////
       description: |-
-        TriggerModel method receives a TriggerModelRequest message
-        and returns a TriggerModelResponse message.
-      operationId: ModelPublicService_TriggerModel
+        TriggerUserModel method receives a TriggerUserModelRequest message
+        and returns a TriggerUserModelResponse message.
+      operationId: ModelPublicService_TriggerUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTriggerModelResponse'
+            $ref: '#/definitions/v1alphaTriggerUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1211,11 +1208,11 @@ paths:
         - name: name
           description: |-
             The resource name of the model to trigger.
-            For example "models/{model}"
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: body
           in: body
           required: true
@@ -1228,7 +1225,7 @@ paths:
                   type: object
                   $ref: '#/definitions/v1alphaTaskInput'
                 title: Input to trigger the model
-            title: TriggerModelRequest represents a request to trigger a model
+            title: TriggerUserModelRequest represents a request to trigger a model
             required:
               - task_inputs
       tags:
@@ -1273,13 +1270,13 @@ paths:
         - PipelinePublicService
   /v1alpha/{name}/undeploy:
     post:
-      summary: UndeployModel undeploy a model to offline state
-      operationId: ModelPublicService_UndeployModel
+      summary: UndeployUserModel undeploy a model to offline state
+      operationId: ModelPublicService_UndeployUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUndeployModelResponse'
+            $ref: '#/definitions/v1alphaUndeployUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1288,32 +1285,32 @@ paths:
         - name: name
           description: |-
             Resource name for the model to be undeployed.
-            Format: models/{model}
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: body
           in: body
           required: true
           schema:
             type: object
             title: |-
-              UndeployModelRequest represents a request to undeploy a model to offline
+              UndeployUserModelRequest represents a request to undeploy a model to offline
               state
       tags:
         - ModelPublicService
   /v1alpha/{name}/unpublish:
     post:
       summary: |-
-        UnpublishModel method receives a UnpublishModelRequest message and returns
-        a UnpublishModelResponse
-      operationId: ModelPublicService_UnpublishModel
+        UnpublishUserModel method receives a UnpublishUserModelRequest message and returns
+        a UnpublishUserModelResponse
+      operationId: ModelPublicService_UnpublishUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUnpublishModelResponse'
+            $ref: '#/definitions/v1alphaUnpublishUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1322,17 +1319,17 @@ paths:
         - name: name
           description: |-
             Resource name of the model.
-            For example "models/{model}"
+            Format: users/{user}/models/{model}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: body
           in: body
           required: true
           schema:
             type: object
-            title: UnpublishModelRequest represents a request to unpublish a model
+            title: UnpublishUserModelRequest represents a request to unpublish a model
       tags:
         - ModelPublicService
   /v1alpha/{name}/validate:
@@ -1501,6 +1498,101 @@ paths:
               - connector_resource
       tags:
         - ConnectorPublicService
+  /v1alpha/{parent}/models:
+    get:
+      summary: |-
+        LisUsertModels method receives a ListUserModelsRequest message and returns a
+        ListUserModelsResponse
+      operationId: ModelPublicService_ListUserModels
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListUserModelsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent
+          description: |-
+            The parent resource where this connector resource will be created.
+            Format: users/{users}
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: page_size
+          description: |-
+            Page size: the maximum number of resources to return. The service may
+            return fewer than this value. If unspecified, at most 10 models will be
+            returned. The maximum value is 100; values above 100 will be coereced to
+            100.
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            Model view (default is VIEW_BASIC)
+            VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+            VIEW_FULL: show full information
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC, server response only include basic information of the resource
+             - VIEW_FULL: View: FULL, full representation of the resource
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - ModelPublicService
+    post:
+      summary: |-
+        CreateUserModel method receives a CreateUserModelRequest message and returns a
+        CreateUserModelResponse
+      operationId: ModelPublicService_CreateUserModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateUserModelResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent
+          description: |-
+            The parent resource where this connector resource will be created.
+            Format: users/{users}
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: model
+          description: |-
+            The model to be created
+
+            The model `name` field is used to identify the model to create.
+            Format: models/{model}
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaModel'
+            required:
+              - model
+      tags:
+        - ModelPublicService
   /v1alpha/{parent}/pipelines:
     get:
       summary: |-
@@ -1773,14 +1865,14 @@ paths:
   /v1alpha/{permalink}/lookUp:
     get:
       summary: |-
-        LookUpModel method receives a LookUpModelRequest message and returns a
-        LookUpModelResponse
-      operationId: ModelPublicService_LookUpModel
+        LookUpUserModel method receives a LookUpUserModelRequest message and returns a
+        LookUpUserModelResponse
+      operationId: ModelPublicService_LookUpUserModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpModelResponse'
+            $ref: '#/definitions/v1alphaLookUpUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1789,11 +1881,11 @@ paths:
         - name: permalink
           description: |-
             Permalink of a model. For example:
-            "models/{uid}"
+            Format: users/{user}/models/{uid}
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+          pattern: musers/[^/]+/odels/[^/]+
         - name: view
           description: |-
             Model view (default is VIEW_BASIC)
@@ -3748,35 +3840,6 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ModelPublicService
-    post:
-      summary: |-
-        CreateModel method receives a CreateModelRequest message and returns a
-        CreateModelResponse
-      operationId: ModelPublicService_CreateModel
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaCreateModelResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: model
-          description: |-
-            The model to be created
-
-            The model `name` field is used to identify the model to create.
-            Format: models/{model}
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/v1alphaModel'
-            required:
-              - model
-      tags:
-        - ModelPublicService
   /v1alpha/operator-definitions:
     get:
       summary: |-
@@ -5079,22 +5142,6 @@ definitions:
     required:
       - user_uid
       - connector_execute_data
-  v1alphaCreateModelBinaryFileUploadResponse:
-    type: object
-    properties:
-      operation:
-        $ref: '#/definitions/googlelongrunningOperation'
-        title: Create model operation message
-        readOnly: true
-    title: CreateModelBinaryFileUploadResponse represents a response for a model
-  v1alphaCreateModelResponse:
-    type: object
-    properties:
-      operation:
-        $ref: '#/definitions/googlelongrunningOperation'
-        title: Create model operation message
-        readOnly: true
-    title: CreateModelResponse represents a response for a model
   v1alphaCreateSessionResponse:
     type: object
     properties:
@@ -5125,6 +5172,22 @@ definitions:
     title: |-
       CreateUserConnectorResourceResponse represents a response for a
       ConnectorResource resource
+  v1alphaCreateUserModelBinaryFileUploadResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Create model operation message
+        readOnly: true
+    title: CreateUserModelBinaryFileUploadResponse represents a response for a model
+  v1alphaCreateUserModelResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Create model operation message
+        readOnly: true
+    title: CreateUserModelResponse represents a response for a model
   v1alphaCreateUserPipelineReleaseResponse:
     type: object
     properties:
@@ -5139,9 +5202,6 @@ definitions:
         $ref: '#/definitions/v1alphaPipeline'
         title: The created pipeline resource
     title: CreateUserPipelineResponse represents a response for a pipeline resource
-  v1alphaDeleteModelResponse:
-    type: object
-    title: DeleteModelResponse represents an empty response
   v1alphaDeleteTokenResponse:
     type: object
     title: DeleteTokenResponse represents an empty response
@@ -5151,6 +5211,9 @@ definitions:
   v1alphaDeleteUserConnectorResourceResponse:
     type: object
     title: DeleteUserConnectorResourceResponse represents an empty response
+  v1alphaDeleteUserModelResponse:
+    type: object
+    title: DeleteUserModelResponse represents an empty response
   v1alphaDeleteUserPipelineReleaseResponse:
     type: object
     title: DeleteUserPipelineReleaseResponse represents an empty response
@@ -5164,15 +5227,15 @@ definitions:
         $ref: '#/definitions/googlelongrunningOperation'
         title: Deploy operation message
     title: DeployModelAdminResponse represents a response for a deployed model
-  v1alphaDeployModelResponse:
+  v1alphaDeployUserModelResponse:
     type: object
     properties:
       model_id:
         type: string
         title: |-
           Deployed model's id
-          Format: models/{model}
-    title: DeployModelResponse represents a response for a deployed model
+          Format: users/{user}/models/{model}
+    title: DeployUserModelResponse represents a response for a deployed model
   v1alphaDetectionInput:
     type: object
     properties:
@@ -5445,13 +5508,6 @@ definitions:
       GetCumulativePipelineTriggerRecordsRequest
     required:
       - cumulative_records
-  v1alphaGetModelCardResponse:
-    type: object
-    properties:
-      readme:
-        $ref: '#/definitions/v1alphaModelCard'
-        title: Retrieved model card
-    title: GetModelCardResponse represents a response to fetch a model's README card
   v1alphaGetModelDefinitionResponse:
     type: object
     properties:
@@ -5553,20 +5609,6 @@ definitions:
       GetModelOnlineSummaryRequest
     required:
       - summary
-  v1alphaGetModelOperationResponse:
-    type: object
-    properties:
-      operation:
-        $ref: '#/definitions/googlelongrunningOperation'
-        title: The retrieved model operation
-    title: GetModelOperationResponse represents a response for a model operation
-  v1alphaGetModelResponse:
-    type: object
-    properties:
-      model:
-        $ref: '#/definitions/v1alphaModel'
-        title: The retrieved model
-    title: GetModelResponse represents a response for a model
   v1alphaGetModelsResponse:
     type: object
     properties:
@@ -5729,6 +5771,27 @@ definitions:
     title: |-
       GetUserConnectorResourceResponse represents a response for a
       ConnectorResource resource
+  v1alphaGetUserModelCardResponse:
+    type: object
+    properties:
+      readme:
+        $ref: '#/definitions/v1alphaModelCard'
+        title: Retrieved model card
+    title: GetUserModelCardResponse represents a response to fetch a model's README card
+  v1alphaGetUserModelOperationResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: The retrieved model operation
+    title: GetUserModelOperationResponse represents a response for a model operation
+  v1alphaGetUserModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: The retrieved model
+    title: GetUserModelResponse represents a response for a model
   v1alphaGetUserPipelineReleaseResponse:
     type: object
     properties:
@@ -6221,6 +6284,23 @@ definitions:
     title: |-
       ListUserConnectorResourcesResponse represents a response for a list of
       ConnectorResource resources
+  v1alphaListUserModelsResponse:
+    type: object
+    properties:
+      models:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaModel'
+        title: a list of Models
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: string
+        format: int64
+        title: Total count of models
+    title: ListUserModelsResponse represents a response for a list of models
   v1alphaListUserPipelineReleasesResponse:
     type: object
     properties:
@@ -6297,13 +6377,6 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: A model resource
     title: LookUpModelResponse represents a response for a model
-  v1alphaLookUpModelResponse:
-    type: object
-    properties:
-      model:
-        $ref: '#/definitions/v1alphaModel'
-        title: A model resource
-    title: LookUpModelResponse represents a response for a model
   v1alphaLookUpOperatorDefinitionAdminResponse:
     type: object
     properties:
@@ -6336,6 +6409,13 @@ definitions:
     title: |-
       LookUpUserConnectorResourceResponse represents a response for a
       connector_resource
+  v1alphaLookUpUserModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: A model resource
+    title: LookUpUserModelResponse represents a response for a model
   v1alphaLookUpUserPipelineResponse:
     type: object
     properties:
@@ -6371,8 +6451,8 @@ definitions:
       name:
         type: string
         title: |-
-          Resource name. It must have the format of "models/{model}".
-          For example: "models/yolov4"
+          Resource name. It must have the format of "users/{user}/models/{model}".
+          For example: "users/instill-ai/models/yolov4"
         readOnly: true
       uid:
         type: string
@@ -6436,7 +6516,7 @@ definitions:
         type: string
         title: |-
           Resource name. It must have the format of
-          "models/{model}/readme"
+          "users/{user}/models/{model}/readme"
         readOnly: true
       size:
         type: integer
@@ -7018,13 +7098,13 @@ definitions:
     title: Pricing information
     required:
       - time
-  v1alphaPublishModelResponse:
+  v1alphaPublishUserModelResponse:
     type: object
     properties:
       model:
         $ref: '#/definitions/v1alphaModel'
         title: Published model
-    title: PublishModelResponse represents a response for the published model
+    title: PublishUserModelResponse represents a response for the published model
   v1alphaQueryAuthenticatedUserResponse:
     type: object
     properties:
@@ -7063,13 +7143,6 @@ definitions:
        - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
        - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
     title: ReleaseStage enumerates the release stages
-  v1alphaRenameModelResponse:
-    type: object
-    properties:
-      model:
-        $ref: '#/definitions/v1alphaModel'
-        title: Renamed model
-    title: RenameModelResponse represents a response for a model
   v1alphaRenameUserConnectorResourceResponse:
     type: object
     properties:
@@ -7079,6 +7152,13 @@ definitions:
     title: |-
       RenameUserConnectorResourceResponse represents a renamed ConnectorResource
       resource
+  v1alphaRenameUserModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: Renamed model
+    title: RenameUserModelResponse represents a response for a model
   v1alphaRenameUserPipelineReleaseResponse:
     type: object
     properties:
@@ -7471,42 +7551,6 @@ definitions:
         title: The unspecified task output
         readOnly: true
     title: TaskOutput represents the output of a CV Task result from a model
-  v1alphaTestModelBinaryFileUploadResponse:
-    type: object
-    properties:
-      task:
-        $ref: '#/definitions/v1alphaTask'
-        title: The task type
-      task_outputs:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaTaskOutput'
-        title: The task output from a model
-    title: |-
-      TestModelBinaryFileUploadResponse represents a response for the
-      output for testing a model
-    required:
-      - task
-      - task_outputs
-  v1alphaTestModelResponse:
-    type: object
-    properties:
-      task:
-        $ref: '#/definitions/v1alphaTask'
-        title: The task type
-      task_outputs:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaTaskOutput'
-        title: The task output from a model
-    title: |-
-      TestModelResponse represents a response for the output for
-      testing a model
-    required:
-      - task
-      - task_outputs
   v1alphaTestUserConnectorResourceResponse:
     type: object
     properties:
@@ -7516,6 +7560,42 @@ definitions:
     title: |-
       TestUserConnectorResourceResponse represents a response containing a
       connector_resource's current state
+  v1alphaTestUserModelBinaryFileUploadResponse:
+    type: object
+    properties:
+      task:
+        $ref: '#/definitions/v1alphaTask'
+        title: The task type
+      task_outputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskOutput'
+        title: The task output from a model
+    title: |-
+      TestUserModelBinaryFileUploadResponse represents a response for the
+      output for testing a model
+    required:
+      - task
+      - task_outputs
+  v1alphaTestUserModelResponse:
+    type: object
+    properties:
+      task:
+        $ref: '#/definitions/v1alphaTask'
+        title: The task type
+      task_outputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskOutput'
+        title: The task output from a model
+    title: |-
+      TestUserModelResponse represents a response for the output for
+      testing a model
+    required:
+      - task
+      - task_outputs
   v1alphaTextGenerationInput:
     type: object
     properties:
@@ -7654,7 +7734,7 @@ definitions:
           $ref: '#/definitions/v1alphaTrace'
         title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: The metadata
-  v1alphaTriggerModelBinaryFileUploadResponse:
+  v1alphaTriggerUserModelBinaryFileUploadResponse:
     type: object
     properties:
       task:
@@ -7667,12 +7747,12 @@ definitions:
           $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
-      TriggerModelBinaryFileUploadResponse represents a response for the
+      TriggerUserModelBinaryFileUploadResponse represents a response for the
       output for testing a model
     required:
       - task
       - task_outputs
-  v1alphaTriggerModelResponse:
+  v1alphaTriggerUserModelResponse:
     type: object
     properties:
       task:
@@ -7685,7 +7765,7 @@ definitions:
           $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
-      TriggerModelResponse represents a response for the output for
+      TriggerUserModelResponse represents a response for the output for
       triggering a model
   v1alphaTriggerUserPipelineReleaseResponse:
     type: object
@@ -7722,22 +7802,22 @@ definitions:
         $ref: '#/definitions/googlelongrunningOperation'
         title: Undeploy operation message
     title: UndeployModelAdminResponse represents a response for a undeployed model
-  v1alphaUndeployModelResponse:
+  v1alphaUndeployUserModelResponse:
     type: object
     properties:
       model_id:
         type: string
         title: |-
           Undeployed model's id
-          Format: models/{model}
-    title: UndeployModelResponse represents a response for a undeployed model
-  v1alphaUnpublishModelResponse:
+          Format: users/{user}/models/{model}
+    title: UndeployUserModelResponse represents a response for a undeployed model
+  v1alphaUnpublishUserModelResponse:
     type: object
     properties:
       model:
         $ref: '#/definitions/v1alphaModel'
         title: Unpublished model
-    title: UnpublishModelResponse represents a response for the unpublished model
+    title: UnpublishUserModelResponse represents a response for the unpublished model
   v1alphaUnspecifiedInput:
     type: object
     properties:
@@ -7757,13 +7837,6 @@ definitions:
         title: A list of unspecified task outputs
         readOnly: true
     title: UnspecifiedOutput represents the output of unspecified task
-  v1alphaUpdateModelResponse:
-    type: object
-    properties:
-      model:
-        $ref: '#/definitions/v1alphaModel'
-        title: The updated model
-    title: UpdateModelResponse represents a response for a model
   v1alphaUpdateUserAdminResponse:
     type: object
     properties:
@@ -7780,6 +7853,13 @@ definitions:
     title: |-
       UpdateUserConnectorResourceResponse represents a response for a
       ConnectorResource resource
+  v1alphaUpdateUserModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: The updated model
+    title: UpdateUserModelResponse represents a response for a model
   v1alphaUpdateUserPipelineReleaseResponse:
     type: object
     properties:
@@ -7902,7 +7982,16 @@ definitions:
         $ref: '#/definitions/v1alphaPipeline'
         title: A pipeline resource
     title: ValidateUserPipelineResponse represents an response of validated pipeline
-  v1alphaWatchModelResponse:
+  v1alphaWatchUserConnectorResourceResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaConnectorResourceState'
+        title: Retrieved connector_resource state
+    title: |-
+      WatchUserConnectorResourceResponse represents a response to fetch a
+      connector_resource's current state
+  v1alphaWatchUserModelResponse:
     type: object
     properties:
       state:
@@ -7913,17 +8002,8 @@ definitions:
         format: int32
         title: Retrieved model logrunning progress
     title: |-
-      WatchModelResponse represents a public response to
+      WatchUserModelResponse represents a public response to
       fetch a model current state and longrunning progress
-  v1alphaWatchUserConnectorResourceResponse:
-    type: object
-    properties:
-      state:
-        $ref: '#/definitions/v1alphaConnectorResourceState'
-        title: Retrieved connector_resource state
-    title: |-
-      WatchUserConnectorResourceResponse represents a response to fetch a
-      connector_resource's current state
   v1alphaWatchUserPipelineReleaseResponse:
     type: object
     properties:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -845,15 +845,15 @@ paths:
   /v1alpha/{name}:
     get:
       summary: |-
-        GetUserModelOperation method receives a
-        GetUserModelOperationRequest message and returns a
-        GetUserModelOperationResponse message.
-      operationId: ModelPublicService_GetUserModelOperation
+        GetModelOperation method receives a
+        GetModelOperationRequest message and returns a
+        GetModelOperationResponse message.
+      operationId: ModelPublicService_GetModelOperation
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetUserModelOperationResponse'
+            $ref: '#/definitions/v1alphaGetModelOperationResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -864,7 +864,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: users/[^/]+/operations/[^/]+
+          pattern: operations/[^/]+
         - name: view
           description: |-
             View (default is VIEW_BASIC)
@@ -1584,7 +1584,7 @@ paths:
             The model to be created
 
             The model `name` field is used to identify the model to create.
-            Format: models/{model}
+            Format: users/{user}/models/{model}
           in: body
           required: true
           schema:
@@ -1885,7 +1885,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: musers/[^/]+/odels/[^/]+
+          pattern: users/[^/]+/models/[^/]+
         - name: view
           description: |-
             Model view (default is VIEW_BASIC)
@@ -5609,6 +5609,13 @@ definitions:
       GetModelOnlineSummaryRequest
     required:
       - summary
+  v1alphaGetModelOperationResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: The retrieved model operation
+    title: GetModelOperationResponse represents a response for a model operation
   v1alphaGetModelsResponse:
     type: object
     properties:
@@ -5778,13 +5785,6 @@ definitions:
         $ref: '#/definitions/v1alphaModelCard'
         title: Retrieved model card
     title: GetUserModelCardResponse represents a response to fetch a model's README card
-  v1alphaGetUserModelOperationResponse:
-    type: object
-    properties:
-      operation:
-        $ref: '#/definitions/googlelongrunningOperation'
-        title: The retrieved model operation
-    title: GetUserModelOperationResponse represents a response for a model operation
   v1alphaGetUserModelResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- We would like to make the resources be public or shared to other
users. The current structure can not support it since the api endpoint
was designed for the users' own resources.

This commit

- add namespace for model api endpoints