### PR TITLE
chore(pipeline,connector): remove namespace in lookup endpoints

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1782,15 +1782,15 @@ paths:
   /v1alpha/{permalink_1}/lookUp:
     get:
       summary: |-
-        LookUpUserConnectorResource method receives a
-        LookUpUserConnectorResourceRequest message and returns a
-        LookUpUserConnectorResourceResponse
-      operationId: ConnectorPublicService_LookUpUserConnectorResource
+        LookUpConnectorResource method receives a
+        LookUpConnectorResourceRequest message and returns a
+        LookUpConnectorResourceResponse
+      operationId: ConnectorPublicService_LookUpConnectorResource
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpUserConnectorResourceResponse'
+            $ref: '#/definitions/v1alphaLookUpConnectorResourceResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1803,7 +1803,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: users/[^/]+/connector-resources/[^/]+
+          pattern: connector-resources/[^/]+
         - name: view
           description: |-
             ConnectorResource view (default is VIEW_BASIC)
@@ -1824,14 +1824,14 @@ paths:
   /v1alpha/{permalink_2}/lookUp:
     get:
       summary: |-
-        LookUpUserPipeline method receives a LookUpUserPipelineRequest message and returns
-        a LookUpUserPipelineResponse
-      operationId: PipelinePublicService_LookUpUserPipeline
+        LookUpPipeline method receives a LookUpPipelineRequest message and returns
+        a LookUpPipelineResponse
+      operationId: PipelinePublicService_LookUpPipeline
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpUserPipelineResponse'
+            $ref: '#/definitions/v1alphaLookUpPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1840,11 +1840,11 @@ paths:
         - name: permalink_2
           description: |-
             Permalink of a pipeline. For example:
-            "users/*/pipelines/{uid}"
+            "pipelines/{uid}"
           in: path
           required: true
           type: string
-          pattern: users/[^/]+/pipelines/[^/]+
+          pattern: pipelines/[^/]+
         - name: view
           description: |-
             View view (default is VIEW_BASIC)
@@ -6370,6 +6370,15 @@ definitions:
     title: |-
       LookUpConnectorResourceAdminResponse represents a response for a
       connector_resource
+  v1alphaLookUpConnectorResourceResponse:
+    type: object
+    properties:
+      connector_resource:
+        $ref: '#/definitions/v1alphaConnectorResource'
+        title: ConnectorResource resource
+    title: |-
+      LookUpConnectorResourceResponse represents a response for a
+      connector_resource
   v1alphaLookUpModelAdminResponse:
     type: object
     properties:
@@ -6393,6 +6402,13 @@ definitions:
         $ref: '#/definitions/v1alphaPipeline'
         title: A pipeline resource
     title: LookUpPipelineAdminResponse represents a response for a pipeline resource
+  v1alphaLookUpPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: LookUpPipelineResponse represents a response for a pipeline resource
   v1alphaLookUpUserAdminResponse:
     type: object
     properties:
@@ -6400,15 +6416,6 @@ definitions:
         $ref: '#/definitions/v1alphaUser'
         title: A user resource
     title: LookUpUserAdminResponse represents a response for a user resource by admin
-  v1alphaLookUpUserConnectorResourceResponse:
-    type: object
-    properties:
-      connector_resource:
-        $ref: '#/definitions/v1alphaConnectorResource'
-        title: ConnectorResource resource
-    title: |-
-      LookUpUserConnectorResourceResponse represents a response for a
-      connector_resource
   v1alphaLookUpUserModelResponse:
     type: object
     properties:
@@ -6416,13 +6423,6 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: A model resource
     title: LookUpUserModelResponse represents a response for a model
-  v1alphaLookUpUserPipelineResponse:
-    type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1alphaPipeline'
-        title: A pipeline resource
-    title: LookUpUserPipelineResponse represents a response for a pipeline resource
   v1alphaMgmtUsageData:
     type: object
     properties:

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -145,6 +145,23 @@ message ListConnectorResourcesResponse {
   int64 total_size = 3;
 }
 
+// LookUpConnectorResourceRequest represents a request to query a
+// connector_resource via permalink
+message LookUpConnectorResourceRequest {
+  // Permalink of a connector_resource. For example:
+  // "connector-resources/{uid}"
+  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // ConnectorResource view (default is VIEW_BASIC)
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// LookUpConnectorResourceResponse represents a response for a
+// connector_resource
+message LookUpConnectorResourceResponse {
+  // ConnectorResource resource
+  ConnectorResource connector_resource = 1;
+}
+
 // CreateUserConnectorResourceRequest represents a request to create a
 // ConnectorResource resource
 message CreateUserConnectorResourceRequest {
@@ -252,23 +269,6 @@ message DeleteUserConnectorResourceRequest {
 
 // DeleteUserConnectorResourceResponse represents an empty response
 message DeleteUserConnectorResourceResponse {}
-
-// LookUpUserConnectorResourceRequest represents a request to query a
-// connector_resource via permalink
-message LookUpUserConnectorResourceRequest {
-  // Permalink of a connector_resource. For example:
-  // "connector-resources/{uid}"
-  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
-  // ConnectorResource view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// LookUpUserConnectorResourceResponse represents a response for a
-// connector_resource
-message LookUpUserConnectorResourceResponse {
-  // ConnectorResource resource
-  ConnectorResource connector_resource = 1;
-}
 
 // ConnectUserConnectorResourceRequest represents a request to connect a
 // connector_resource

--- a/vdp/connector/v1alpha/connector_public_service.proto
+++ b/vdp/connector/v1alpha/connector_public_service.proto
@@ -60,6 +60,14 @@ service ConnectorPublicService {
     option (google.api.http) = {get: "/v1alpha/connector-resources"};
   }
 
+  // LookUpConnectorResource method receives a
+  // LookUpConnectorResourceRequest message and returns a
+  // LookUpConnectorResourceResponse
+  rpc LookUpConnectorResource(LookUpConnectorResourceRequest) returns (LookUpConnectorResourceResponse) {
+    option (google.api.http) = {get: "/v1alpha/{permalink=connector-resources/*}/lookUp"};
+    option (google.api.method_signature) = "permalink";
+  }
+
   // CreateUserConnectorResource method receives a
   // CreateUserConnectorResourceRequest message and returns a
   // CreateUserConnectorResourceResponse message.
@@ -103,14 +111,6 @@ service ConnectorPublicService {
   rpc DeleteUserConnectorResource(DeleteUserConnectorResourceRequest) returns (DeleteUserConnectorResourceResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/connector-resources/*}"};
     option (google.api.method_signature) = "name";
-  }
-
-  // LookUpUserConnectorResource method receives a
-  // LookUpUserConnectorResourceRequest message and returns a
-  // LookUpUserConnectorResourceResponse
-  rpc LookUpUserConnectorResource(LookUpUserConnectorResourceRequest) returns (LookUpUserConnectorResourceResponse) {
-    option (google.api.http) = {get: "/v1alpha/{permalink=users/*/connector-resources/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
   }
 
   // Connect a connector resource.

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -272,6 +272,21 @@ message ListUserPipelinesResponse {
   int64 total_size = 3;
 }
 
+// LookUpPipelineRequest represents a request to query a pipeline via permalink
+message LookUpPipelineRequest {
+  // Permalink of a pipeline. For example:
+  // "pipelines/{uid}"
+  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // View view (default is VIEW_BASIC)
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// LookUpPipelineResponse represents a response for a pipeline resource
+message LookUpPipelineResponse {
+  // A pipeline resource
+  Pipeline pipeline = 1;
+}
+
 // GetUserPipelineRequest represents a request to query a pipeline
 message GetUserPipelineRequest {
   // Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -320,21 +335,6 @@ message DeleteUserPipelineRequest {
 
 // DeleteUserPipelineResponse represents an empty response
 message DeleteUserPipelineResponse {}
-
-// LookUpUserPipelineRequest represents a request to query a pipeline via permalink
-message LookUpUserPipelineRequest {
-  // Permalink of a pipeline. For example:
-  // "users/*/pipelines/{uid}"
-  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
-  // View view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// LookUpUserPipelineResponse represents a response for a pipeline resource
-message LookUpUserPipelineResponse {
-  // A pipeline resource
-  Pipeline pipeline = 1;
-}
 
 // ValidatePUseripelineRequest represents a request to validate a pipeline
 message ValidateUserPipelineRequest {
@@ -680,27 +680,6 @@ message ListPipelineReleasesAdminResponse {
   string next_page_token = 2;
   // Total count of pipeline resources
   int64 total_size = 3;
-}
-
-// GetPipelineAdminRequest represents a request to query a user's pipeline by
-// admin
-message GetPipelineAdminRequest {
-  // Pipeline resource name. It must have the format of "users/*/pipelines/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline.name"}
-    }
-  ];
-  // Pipeline resource view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// GetPipelineAdminResponse represents a response for a pipeline resource
-message GetPipelineAdminResponse {
-  // A pipeline resource
-  Pipeline pipeline = 1;
 }
 
 // LookUpPipelineAdminRequest represents a request to query a user's pipeline

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -51,6 +51,13 @@ service PipelinePublicService {
     option (google.api.http) = {get: "/v1alpha/pipelines"};
   }
 
+  // LookUpPipeline method receives a LookUpPipelineRequest message and returns
+  // a LookUpPipelineResponse
+  rpc LookUpPipeline(LookUpPipelineRequest) returns (LookUpPipelineResponse) {
+    option (google.api.http) = {get: "/v1alpha/{permalink=pipelines/*}/lookUp"};
+    option (google.api.method_signature) = "permalink";
+  }
+
   // CreateUserPipeline method receives a CreateUserPipelineRequest message and returns
   // a CreateUserPipelineResponse message.
   rpc CreateUserPipeline(CreateUserPipelineRequest) returns (CreateUserPipelineResponse) {
@@ -90,13 +97,6 @@ service PipelinePublicService {
   rpc DeleteUserPipeline(DeleteUserPipelineRequest) returns (DeleteUserPipelineResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/pipelines/*}"};
     option (google.api.method_signature) = "name";
-  }
-
-  // LookUpUserPipeline method receives a LookUpUserPipelineRequest message and returns
-  // a LookUpUserPipelineResponse
-  rpc LookUpUserPipeline(LookUpUserPipelineRequest) returns (LookUpUserPipelineResponse) {
-    option (google.api.http) = {get: "/v1alpha/{permalink=users/*/pipelines/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
   }
 
   // Validate a pipeline.


### PR DESCRIPTION
Because

- We use `uuid` in lookup endpoint. `uuid` is unique so we don't need the namespace. 

This commit

- remove namespace in lookup endpoints
