### PR TITLE
chore(model): remove namespace in lookup endpoint

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -191,7 +191,7 @@ message CreateUserModelRequest {
   // The model to be created
   //
   // The model `name` field is used to identify the model to create.
-  // Format:users/{user}/models/{model}
+  // Format: users/{user}/models/{model}
   Model model = 1 [(google.api.field_behavior) = REQUIRED];
   // The parent resource where this connector resource will be created.
   // Format: users/{users}

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -169,12 +169,29 @@ message ListModelsResponse {
   int64 total_size = 3;
 }
 
+// LookUpModelRequest represents a request to query a model via permalink
+message LookUpModelRequest {
+  // Permalink of a model. For example:
+  // Format: models/{uid}
+  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model view (default is VIEW_BASIC)
+  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
+  // VIEW_FULL: show full information
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// LookUpModelResponse represents a response for a model
+message LookUpModelResponse {
+  // A model resource
+  Model model = 1;
+}
+
 // CreateUserModelRequest represents a request to create a model
 message CreateUserModelRequest {
   // The model to be created
   //
   // The model `name` field is used to identify the model to create.
-  // Format: users/{user}/models/{model}
+  // Format:users/{user}/models/{model}
   Model model = 1 [(google.api.field_behavior) = REQUIRED];
   // The parent resource where this connector resource will be created.
   // Format: users/{users}
@@ -296,23 +313,6 @@ message DeleteUserModelRequest {
 
 // DeleteUserModelResponse represents an empty response
 message DeleteUserModelResponse {}
-
-// LookUpUserModelRequest represents a request to query a model via permalink
-message LookUpUserModelRequest {
-  // Permalink of a model. For example:
-  // Format: users/{user}/models/{uid}
-  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
-  // Model view (default is VIEW_BASIC)
-  // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
-  // VIEW_FULL: show full information
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// LookUpUserModelResponse represents a response for a model
-message LookUpUserModelResponse {
-  // A model resource
-  Model model = 1;
-}
 
 // RenameUserModelRequest represents a request to rename a model
 message RenameUserModelRequest {

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -53,6 +53,13 @@ service ModelPublicService {
     option (google.api.http) = {get: "/v1alpha/models"};
   }
 
+  // LookUpUodel method receives a LookUpModelRequest message and returns a
+  // LookUpModelResponse
+  rpc LookUpModel(LookUpModelRequest) returns (LookUpModelResponse) {
+    option (google.api.http) = {get: "/v1alpha/{permalink=models/*}/lookUp"};
+    option (google.api.method_signature) = "permalink";
+  }
+
   // LisUsertModels method receives a ListUserModelsRequest message and returns a
   // ListUserModelsResponse
   rpc ListUserModels(ListUserModelsRequest) returns (ListUserModelsResponse) {
@@ -101,13 +108,6 @@ service ModelPublicService {
   rpc DeleteUserModel(DeleteUserModelRequest) returns (DeleteUserModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}"};
     option (google.api.method_signature) = "name";
-  }
-
-  // LookUpUserModel method receives a LookUpUserModelRequest message and returns a
-  // LookUpUserModelResponse
-  rpc LookUpUserModel(LookUpUserModelRequest) returns (LookUpUserModelResponse) {
-    option (google.api.http) = {get: "/v1alpha/{permalink=users/*/models/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
   }
 
   // RenameUserModel method rename a model

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1584,7 +1584,7 @@ paths:
             The model to be created
 
             The model `name` field is used to identify the model to create.
-            Format:users/{user}/models/{model}
+            Format: users/{user}/models/{model}
           in: body
           required: true
           schema:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1584,7 +1584,7 @@ paths:
             The model to be created
 
             The model `name` field is used to identify the model to create.
-            Format: users/{user}/models/{model}
+            Format:users/{user}/models/{model}
           in: body
           required: true
           schema:
@@ -1865,14 +1865,14 @@ paths:
   /v1alpha/{permalink}/lookUp:
     get:
       summary: |-
-        LookUpUserModel method receives a LookUpUserModelRequest message and returns a
-        LookUpUserModelResponse
-      operationId: ModelPublicService_LookUpUserModel
+        LookUpUodel method receives a LookUpModelRequest message and returns a
+        LookUpModelResponse
+      operationId: ModelPublicService_LookUpModel
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpUserModelResponse'
+            $ref: '#/definitions/v1alphaLookUpModelResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1881,11 +1881,11 @@ paths:
         - name: permalink
           description: |-
             Permalink of a model. For example:
-            Format: users/{user}/models/{uid}
+            Format: models/{uid}
           in: path
           required: true
           type: string
-          pattern: users/[^/]+/models/[^/]+
+          pattern: models/[^/]+
         - name: view
           description: |-
             Model view (default is VIEW_BASIC)
@@ -6386,6 +6386,13 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: A model resource
     title: LookUpModelResponse represents a response for a model
+  v1alphaLookUpModelResponse:
+    type: object
+    properties:
+      model:
+        $ref: '#/definitions/v1alphaModel'
+        title: A model resource
+    title: LookUpModelResponse represents a response for a model
   v1alphaLookUpOperatorDefinitionAdminResponse:
     type: object
     properties:
@@ -6416,13 +6423,6 @@ definitions:
         $ref: '#/definitions/v1alphaUser'
         title: A user resource
     title: LookUpUserAdminResponse represents a response for a user resource by admin
-  v1alphaLookUpUserModelResponse:
-    type: object
-    properties:
-      model:
-        $ref: '#/definitions/v1alphaModel'
-        title: A model resource
-    title: LookUpUserModelResponse represents a response for a model
   v1alphaMgmtUsageData:
     type: object
     properties:


### PR DESCRIPTION
Because

- We use `uuid` in lookup endpoint. `uuid` is unique so we don't need
the namespace.

This commit

- remove namespace in lookup endpoints