### PR TITLE
chore(pipeline): add openapi_schema field in pipeline and add VIEW_RECIPE

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1393,6 +1393,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -1400,6 +1401,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePublicService
@@ -1638,6 +1640,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -1645,6 +1648,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list pipelines
@@ -1731,6 +1735,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -1738,6 +1743,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list pipeline_releases
@@ -1852,6 +1858,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -1859,6 +1866,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePublicService
@@ -1958,6 +1966,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -1965,6 +1974,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePublicService
@@ -2059,6 +2069,12 @@ paths:
               visibility:
                 $ref: '#/definitions/pipelinev1alphaVisibility'
                 title: Visibility
+              openapi_schema:
+                type: array
+                items:
+                  type: object
+                title: OpenAPI schema
+                readOnly: true
             title: A pipeline resource to update
       tags:
         - PipelinePublicService
@@ -2091,6 +2107,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -2098,6 +2115,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePublicService
@@ -2182,6 +2200,12 @@ paths:
               visibility:
                 $ref: '#/definitions/pipelinev1alphaVisibility'
                 title: Visibility
+              openapi_schema:
+                type: array
+                items:
+                  type: object
+                title: OpenAPI schema
+                readOnly: true
             title: A pipeline release resource to update
       tags:
         - PipelinePublicService
@@ -2705,6 +2729,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -2712,6 +2737,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePrivateService
@@ -2747,6 +2773,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -2754,6 +2781,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePrivateService
@@ -3133,6 +3161,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -3140,6 +3169,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list pipelines
@@ -3185,6 +3215,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -3192,6 +3223,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list pipelines
@@ -3879,6 +3911,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -3886,6 +3919,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list operator definitions
@@ -3931,6 +3965,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
           in: query
           required: false
           type: string
@@ -3938,6 +3973,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_RECIPE
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list pipelines
@@ -6878,6 +6914,12 @@ definitions:
       visibility:
         $ref: '#/definitions/pipelinev1alphaVisibility'
         title: Visibility
+      openapi_schema:
+        type: array
+        items:
+          type: object
+        title: OpenAPI schema
+        readOnly: true
     title: Pipeline represents the content of a pipeline
   v1alphaPipelineData:
     type: object
@@ -6932,6 +6974,12 @@ definitions:
       visibility:
         $ref: '#/definitions/pipelinev1alphaVisibility'
         title: Visibility
+      openapi_schema:
+        type: array
+        items:
+          type: object
+        title: OpenAPI schema
+        readOnly: true
     title: PipelineRelease represents the content of a pipeline release
   v1alphaPipelineTriggerChartRecord:
     type: object
@@ -8142,6 +8190,7 @@ definitions:
       - VIEW_UNSPECIFIED
       - VIEW_BASIC
       - VIEW_FULL
+      - VIEW_RECIPE
     default: VIEW_UNSPECIFIED
     description: |-
       View represents a view of any resource. The resource view is implemented by
@@ -8151,3 +8200,4 @@ definitions:
        - VIEW_UNSPECIFIED: View: UNSPECIFIED
        - VIEW_BASIC: View: BASIC
        - VIEW_FULL: View: FULL
+       - VIEW_RECIPE: View: RECIPE: will return recipe

--- a/vdp/pipeline/v1alpha/common.proto
+++ b/vdp/pipeline/v1alpha/common.proto
@@ -12,4 +12,6 @@ enum View {
   VIEW_BASIC = 1;
   // View: FULL
   VIEW_FULL = 2;
+  // View: RECIPE: will return recipe
+  VIEW_RECIPE = 3;
 }

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -152,6 +152,8 @@ message Pipeline {
   google.protobuf.Timestamp update_time = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Visibility
   Visibility visibility = 12;
+  // OpenAPI schema
+  repeated google.protobuf.Struct openapi_schema = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // The metadata
@@ -198,6 +200,8 @@ message PipelineRelease {
   google.protobuf.Timestamp update_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Visibility
   Visibility visibility = 8;
+  // OpenAPI schema
+  repeated google.protobuf.Struct openapi_schema = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListPipelinesRequest represents a request to list pipelines


### PR DESCRIPTION
Because

- we'll generate openapi_schema for each pipeline trigger automatically
- we need a intermediate view mode between `VIEW_BASIC` and `VIEW_FULL`

This commit

- add `openapi_schema` field in pipeline
- add `VIEW_RECIPE`
