### PR TITLE
chore(pipeline): fix openapi_schema wrong type

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2070,9 +2070,7 @@ paths:
                 $ref: '#/definitions/pipelinev1alphaVisibility'
                 title: Visibility
               openapi_schema:
-                type: array
-                items:
-                  type: object
+                type: object
                 title: OpenAPI schema
                 readOnly: true
             title: A pipeline resource to update
@@ -2201,9 +2199,7 @@ paths:
                 $ref: '#/definitions/pipelinev1alphaVisibility'
                 title: Visibility
               openapi_schema:
-                type: array
-                items:
-                  type: object
+                type: object
                 title: OpenAPI schema
                 readOnly: true
             title: A pipeline release resource to update
@@ -6915,9 +6911,7 @@ definitions:
         $ref: '#/definitions/pipelinev1alphaVisibility'
         title: Visibility
       openapi_schema:
-        type: array
-        items:
-          type: object
+        type: object
         title: OpenAPI schema
         readOnly: true
     title: Pipeline represents the content of a pipeline
@@ -6975,9 +6969,7 @@ definitions:
         $ref: '#/definitions/pipelinev1alphaVisibility'
         title: Visibility
       openapi_schema:
-        type: array
-        items:
-          type: object
+        type: object
         title: OpenAPI schema
         readOnly: true
     title: PipelineRelease represents the content of a pipeline release

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -153,7 +153,7 @@ message Pipeline {
   // Visibility
   Visibility visibility = 12;
   // OpenAPI schema
-  repeated google.protobuf.Struct openapi_schema = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Struct openapi_schema = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // The metadata
@@ -201,7 +201,7 @@ message PipelineRelease {
   // Visibility
   Visibility visibility = 8;
   // OpenAPI schema
-  repeated google.protobuf.Struct openapi_schema = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Struct openapi_schema = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListPipelinesRequest represents a request to list pipelines


### PR DESCRIPTION
Because

- the `openapi_schema` should be a struct, not array of struct

This commit

- fix `openapi_schema` wrong type
