### PR TITLE
chore(pipeline): allow watch endpoint for all pipeline releases

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1934,7 +1934,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: users/[^/]+/pipelines/[^/]+/releases/default
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
   /v1alpha/{pipeline.name}:

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -206,7 +206,7 @@ service PipelinePublicService {
   // WatchUserPipelineRelease method receives a WatchUserPipelineReleaseRequest message
   // and returns a WatchUserPipelineReleaseResponse
   rpc WatchUserPipelineRelease(WatchUserPipelineReleaseRequest) returns (WatchUserPipelineReleaseResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=users/*/pipelines/*/releases/default}/watch"};
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/pipelines/*/releases/*}/watch"};
     option (google.api.method_signature) = "name";
   }
 


### PR DESCRIPTION
Because

- remove the constraint that only default pipeline release can be watched

This commit

- allow watch endpoint for all pipeline releases
