### PR TITLE
chore(plugin): add mypy plugins

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -11,6 +11,10 @@ plugins:
     out: gen/python
   - plugin: buf.build/grpc/python:v1.55.0
     out: gen/python
+  - plugin: buf.build/community/nipunn1313-mypy:v3.5.0
+    out: gen/python
+  - plugin: buf.build/community/nipunn1313-mypy-grpc:v3.5.0
+    out: gen/python
   - plugin: buf.build/protocolbuffers/go:v1.30.0
     out: gen/go
     opt:


### PR DESCRIPTION
Because

- provide better type checking, comments as docstrings and enum type wrapper

This commit

- add mypy plugins
