### PR TITLE
chore(connector): add `VIEW_CONFIGURATION`

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -102,6 +102,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
           in: query
           required: false
           type: string
@@ -109,6 +110,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_CONFIGURATION
           default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPublicService
@@ -143,6 +145,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
           in: query
           required: false
           type: string
@@ -150,6 +153,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_CONFIGURATION
           default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPublicService
@@ -1451,6 +1455,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
           in: query
           required: false
           type: string
@@ -1458,6 +1463,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_CONFIGURATION
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list connector-resources
@@ -1817,6 +1823,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
           in: query
           required: false
           type: string
@@ -1824,6 +1831,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_CONFIGURATION
           default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPublicService
@@ -2642,6 +2650,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
           in: query
           required: false
           type: string
@@ -2649,6 +2658,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_CONFIGURATION
           default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPrivateService
@@ -2684,6 +2694,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
           in: query
           required: false
           type: string
@@ -2691,6 +2702,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_CONFIGURATION
           default: VIEW_UNSPECIFIED
       tags:
         - ConnectorPrivateService
@@ -3055,6 +3067,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
           in: query
           required: false
           type: string
@@ -3062,6 +3075,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_CONFIGURATION
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list connector-resources
@@ -3349,6 +3363,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
           in: query
           required: false
           type: string
@@ -3356,6 +3371,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_CONFIGURATION
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list connector definitions
@@ -3402,6 +3418,7 @@ paths:
              - VIEW_UNSPECIFIED: View: UNSPECIFIED
              - VIEW_BASIC: View: BASIC
              - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
           in: query
           required: false
           type: string
@@ -3409,6 +3426,7 @@ paths:
             - VIEW_UNSPECIFIED
             - VIEW_BASIC
             - VIEW_FULL
+            - VIEW_CONFIGURATION
           default: VIEW_UNSPECIFIED
         - name: filter
           description: Filter expression to list connector-resources
@@ -8092,11 +8110,13 @@ definitions:
       - VIEW_UNSPECIFIED
       - VIEW_BASIC
       - VIEW_FULL
+      - VIEW_CONFIGURATION
     default: VIEW_UNSPECIFIED
     description: |-
       - VIEW_UNSPECIFIED: View: UNSPECIFIED
        - VIEW_BASIC: View: BASIC
        - VIEW_FULL: View: FULL
+       - VIEW_CONFIGURATION: View: CONFIGURATION
     title: View enumerates the definition views
   vdpcontrollerv1alphaDeleteResourceResponse:
     type: object

--- a/vdp/connector/v1alpha/connector_definition.proto
+++ b/vdp/connector/v1alpha/connector_definition.proto
@@ -18,6 +18,8 @@ enum View {
   VIEW_BASIC = 1;
   // View: FULL
   VIEW_FULL = 2;
+  // View: CONFIGURATION
+  VIEW_CONFIGURATION = 3;
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because

- Currently `VIEW_FULL` will return both `configuration` and `connector_definition`, we need a new view mode to return `configuration` only

This commit

- Add `VIEW_CONFIGURATION`
