### PR TITLE
chore(pipeline): fix case for set_default endpoint

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1127,7 +1127,7 @@ paths:
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
-  /v1alpha/{name}/set_default:
+  /v1alpha/{name}/setDefault:
     post:
       summary: |-
         SetDefaultUserPipelineRelease method receives a SetDefaultUserPipelineReleaseRequest message

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -199,7 +199,7 @@ service PipelinePublicService {
   // SetDefaultUserPipelineRelease method receives a SetDefaultUserPipelineReleaseRequest message
   // and returns a SetDefaultUserPipelineReleaseResponse
   rpc SetDefaultUserPipelineRelease(SetDefaultUserPipelineReleaseRequest) returns (SetDefaultUserPipelineReleaseResponse) {
-    option (google.api.http) = {post: "/v1alpha/{name=users/*/pipelines/*/releases/*}/set_default"};
+    option (google.api.http) = {post: "/v1alpha/{name=users/*/pipelines/*/releases/*}/setDefault"};
     option (google.api.method_signature) = "name";
   }
 


### PR DESCRIPTION
Because

- we should use camelCase

This commit

- fix case for set_default endpoint
