### PR TITLE
chore(mgmt): add token validation endpoint

### DIFF
--- a/base/mgmt/v1alpha/mgmt.proto
+++ b/base/mgmt/v1alpha/mgmt.proto
@@ -384,3 +384,12 @@ message DeleteTokenRequest {
 
 // DeleteTokenResponse represents an empty response
 message DeleteTokenResponse {}
+
+// Request for validating the token
+message ValidateTokenRequest {}
+
+// Response for validating the token
+message ValidateTokenResponse {
+  // user_uid
+  string user_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}

--- a/base/mgmt/v1alpha/mgmt_public_service.proto
+++ b/base/mgmt/v1alpha/mgmt_public_service.proto
@@ -87,6 +87,12 @@ service MgmtPublicService {
     option (google.api.method_signature) = "name";
   }
 
+  // ValidateToken method receives a ValidateTokenRequest message and returns
+  // a ValidateTokenResponse message.
+  rpc ValidateToken(ValidateTokenRequest) returns (ValidateTokenResponse) {
+    option (google.api.http) = {post: "/v1alpha/validate_token"};
+  }
+
   // ========== Metric endpoints
 
   // ListPipelineTriggerRecords method receives a ListPipelineTriggerRecordsRequest message and returns a

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4195,6 +4195,23 @@ paths:
               - user
       tags:
         - MgmtPublicService
+  /v1alpha/validate_token:
+    post:
+      summary: |-
+        ValidateToken method receives a ValidateTokenRequest message and returns
+        a ValidateTokenResponse message.
+      operationId: MgmtPublicService_ValidateToken
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaValidateTokenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - MgmtPublicService
 definitions:
   HealthCheckResponseServingStatus:
     type: string
@@ -8033,6 +8050,14 @@ definitions:
     title: User records definition
     required:
       - uid
+  v1alphaValidateTokenResponse:
+    type: object
+    properties:
+      user_uid:
+        type: string
+        title: user_uid
+        readOnly: true
+    title: Response for validating the token
   v1alphaValidateUserPipelineResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- we need a endpoint to validate the `api_token`

This commit

- add token validation endpoint
