### PR TITLE
chore(usage,metric): adopt pipeline release in usage and metric data

### DIFF
--- a/base/mgmt/v1alpha/metric.proto
+++ b/base/mgmt/v1alpha/metric.proto
@@ -45,6 +45,10 @@ message PipelineTriggerRecord {
   float compute_time_duration = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Final status for pipeline trigger
   Status status = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // UID for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // PipelineTriggerTableRecord represents a aggregated table record for pipeline trigger
@@ -57,6 +61,10 @@ message PipelineTriggerTableRecord {
   int64 trigger_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Trigger count with STATUS_ERRORED
   int64 trigger_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // UID for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // PipelineTriggerChartRecord represents a aggregated chart record for pipeline trigger
@@ -75,6 +83,10 @@ message PipelineTriggerChartRecord {
   repeated int64 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total compute time duration in each time bucket
   repeated float compute_time_duration = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // UID for the triggered pipeline if it is a release pipeline, else emtpy
+  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListPipelineTriggerRecordsRequest represents a request to list

--- a/base/usage/v1alpha/usage.proto
+++ b/base/usage/v1alpha/usage.proto
@@ -164,6 +164,10 @@ message PipelineUsageData {
       base.mgmt.v1alpha.Mode trigger_mode = 4 [(google.api.field_behavior) = REQUIRED];
       // Final status of the execution
       base.mgmt.v1alpha.Status status = 5 [(google.api.field_behavior) = REQUIRED];
+      // Version for the triggered release pipeline, empty string if not release
+      string pipeline_release_id = 6 [(google.api.field_behavior) = REQUIRED];
+      // UID for the triggered release pipeline, empty string if not release
+      string pipeline_release_uid = 7 [(google.api.field_behavior) = REQUIRED];
     }
     // User UUID
     string user_uid = 1 [(google.api.field_behavior) = REQUIRED];

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4316,6 +4316,12 @@ definitions:
       status:
         $ref: '#/definitions/mgmtv1alphaStatus'
         title: Final status of the execution
+      pipeline_release_id:
+        type: string
+        title: Version for the triggered release pipeline, empty string if not release
+      pipeline_release_uid:
+        type: string
+        title: UID for the triggered release pipeline, empty string if not release
     title: Per trigger usage metadata
     required:
       - pipeline_uid
@@ -4323,6 +4329,8 @@ definitions:
       - trigger_time
       - trigger_mode
       - status
+      - pipeline_release_id
+      - pipeline_release_uid
   basemgmtv1alphaLivenessResponse:
     type: object
     properties:
@@ -7045,6 +7053,14 @@ definitions:
           format: float
         title: Total compute time duration in each time bucket
         readOnly: true
+      pipeline_release_id:
+        type: string
+        title: Version for the triggered pipeline if it is a release pipeline, else emtpy
+        readOnly: true
+      pipeline_release_uid:
+        type: string
+        title: UID for the triggered pipeline if it is a release pipeline, else emtpy
+        readOnly: true
     title: PipelineTriggerChartRecord represents a aggregated chart record for pipeline trigger
   v1alphaPipelineTriggerRecord:
     type: object
@@ -7074,6 +7090,14 @@ definitions:
         $ref: '#/definitions/mgmtv1alphaStatus'
         title: Final status for pipeline trigger
         readOnly: true
+      pipeline_release_id:
+        type: string
+        title: Version for the triggered pipeline if it is a release pipeline, else emtpy
+        readOnly: true
+      pipeline_release_uid:
+        type: string
+        title: UID for the triggered pipeline if it is a release pipeline, else emtpy
+        readOnly: true
     title: PipelineTriggerRecord represents a record for pipeline trigger
   v1alphaPipelineTriggerTableRecord:
     type: object
@@ -7093,6 +7117,14 @@ definitions:
         type: string
         format: int64
         title: Trigger count with STATUS_ERRORED
+        readOnly: true
+      pipeline_release_id:
+        type: string
+        title: Version for the triggered pipeline if it is a release pipeline, else emtpy
+        readOnly: true
+      pipeline_release_uid:
+        type: string
+        title: UID for the triggered pipeline if it is a release pipeline, else emtpy
         readOnly: true
     title: PipelineTriggerTableRecord represents a aggregated table record for pipeline trigger
   v1alphaPipelineUsageData:


### PR DESCRIPTION
Because

- adopt pipeline release feature for usage and metric data

This commit

- adopt pipeline release feature for usage and metric data
