### PR TITLE
chore(pipeline,connector,model): add `show_deleted` param to return soft-deleted resources

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -121,6 +121,8 @@ message Model {
   google.protobuf.Timestamp create_time = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model update time
   google.protobuf.Timestamp update_time = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Model delete time
+  google.protobuf.Timestamp delete_time = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ModelCard represents the README card for a model. There
@@ -157,6 +159,8 @@ message ListModelsRequest {
   // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
   // VIEW_FULL: show full information
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Return soft_deleted models
+  optional bool show_deleted = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListModelsResponse represents a response for a list of models
@@ -249,6 +253,8 @@ message ListUserModelsRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Model"}
   ];
+  // Return soft_deleted models
+  optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUserModelsResponse represents a response for a list of models
@@ -640,6 +646,8 @@ message ListModelsAdminRequest {
   // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
   // VIEW_FULL: show full information
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Return soft_deleted models
+  optional bool show_deleted = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListModelsAdminResponse represents a response for a list of models

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -274,6 +274,11 @@ paths:
                 $ref: '#/definitions/v1alphaConnectorDefinition'
                 title: Embed the content of the connector_definition
                 readOnly: true
+              delete_time:
+                type: string
+                format: date-time
+                title: ConnectorResource delete time
+                readOnly: true
             title: ConnectorResource resource
             required:
               - configuration
@@ -535,6 +540,11 @@ paths:
                 type: string
                 format: date-time
                 title: Model update time
+                readOnly: true
+              delete_time:
+                type: string
+                format: date-time
+                title: Model delete time
                 readOnly: true
             title: The model to update
       tags:
@@ -1470,6 +1480,11 @@ paths:
           in: query
           required: false
           type: string
+        - name: show_deleted
+          description: Return soft_deleted connector resources
+          in: query
+          required: false
+          type: boolean
       tags:
         - ConnectorPublicService
     post:
@@ -1562,6 +1577,11 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
           default: VIEW_UNSPECIFIED
+        - name: show_deleted
+          description: Return soft_deleted models
+          in: query
+          required: false
+          type: boolean
       tags:
         - ModelPublicService
     post:
@@ -1661,6 +1681,11 @@ paths:
           in: query
           required: false
           type: string
+        - name: show_deleted
+          description: Return soft_deleted pipeline releases
+          in: query
+          required: false
+          type: boolean
       tags:
         - PipelinePublicService
     post:
@@ -1756,6 +1781,11 @@ paths:
           in: query
           required: false
           type: string
+        - name: show_deleted
+          description: Return soft_deleted pipelines
+          in: query
+          required: false
+          type: boolean
       tags:
         - PipelinePublicService
     post:
@@ -2081,6 +2111,11 @@ paths:
                 type: object
                 title: OpenAPI schema
                 readOnly: true
+              delete_time:
+                type: string
+                format: date-time
+                title: Pipeline delete time
+                readOnly: true
             title: A pipeline resource to update
       tags:
         - PipelinePublicService
@@ -2209,6 +2244,11 @@ paths:
               openapi_schema:
                 type: object
                 title: OpenAPI schema
+                readOnly: true
+              delete_time:
+                type: string
+                format: date-time
+                title: Pipeline delete time
                 readOnly: true
             title: A pipeline release resource to update
       tags:
@@ -3082,6 +3122,11 @@ paths:
           in: query
           required: false
           type: string
+        - name: show_deleted
+          description: Return soft_deleted connector resources
+          in: query
+          required: false
+          type: boolean
       tags:
         - ConnectorPrivateService
   /v1alpha/admin/models:
@@ -3132,6 +3177,11 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
           default: VIEW_UNSPECIFIED
+        - name: show_deleted
+          description: Return soft_deleted models
+          in: query
+          required: false
+          type: boolean
       tags:
         - ModelPrivateService
   /v1alpha/admin/pipelines:
@@ -3186,6 +3236,11 @@ paths:
           in: query
           required: false
           type: string
+        - name: show_deleted
+          description: Return soft_deleted pipelines
+          in: query
+          required: false
+          type: boolean
       tags:
         - PipelinePrivateService
   /v1alpha/admin/releases:
@@ -3240,6 +3295,11 @@ paths:
           in: query
           required: false
           type: string
+        - name: show_deleted
+          description: Return soft_deleted pipelines
+          in: query
+          required: false
+          type: boolean
       tags:
         - PipelinePrivateService
   /v1alpha/admin/users:
@@ -3433,6 +3493,11 @@ paths:
           in: query
           required: false
           type: string
+        - name: show_deleted
+          description: Return soft_deleted connector resources
+          in: query
+          required: false
+          type: boolean
       tags:
         - ConnectorPublicService
   /v1alpha/health/connector:
@@ -3884,6 +3949,11 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
           default: VIEW_UNSPECIFIED
+        - name: show_deleted
+          description: Return soft_deleted models
+          in: query
+          required: false
+          type: boolean
       tags:
         - ModelPublicService
   /v1alpha/operator-definitions:
@@ -3994,6 +4064,11 @@ paths:
           in: query
           required: false
           type: string
+        - name: show_deleted
+          description: Return soft_deleted pipelines
+          in: query
+          required: false
+          type: boolean
       tags:
         - PipelinePublicService
   /v1alpha/ready/mgmt:
@@ -5141,6 +5216,11 @@ definitions:
       connector_definition:
         $ref: '#/definitions/v1alphaConnectorDefinition'
         title: Embed the content of the connector_definition
+        readOnly: true
+      delete_time:
+        type: string
+        format: date-time
+        title: ConnectorResource delete time
         readOnly: true
     title: ConnectorResource represents a connector_resource data model
     required:
@@ -6583,6 +6663,11 @@ definitions:
         format: date-time
         title: Model update time
         readOnly: true
+      delete_time:
+        type: string
+        format: date-time
+        title: Model delete time
+        readOnly: true
     title: Model represents a model
   v1alphaModelCard:
     type: object
@@ -6957,6 +7042,11 @@ definitions:
         type: object
         title: OpenAPI schema
         readOnly: true
+      delete_time:
+        type: string
+        format: date-time
+        title: Pipeline delete time
+        readOnly: true
     title: Pipeline represents the content of a pipeline
   v1alphaPipelineData:
     type: object
@@ -7014,6 +7104,11 @@ definitions:
       openapi_schema:
         type: object
         title: OpenAPI schema
+        readOnly: true
+      delete_time:
+        type: string
+        format: date-time
+        title: Pipeline delete time
         readOnly: true
     title: PipelineRelease represents the content of a pipeline release
   v1alphaPipelineTriggerChartRecord:

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -113,6 +113,8 @@ message ConnectorResource {
   Visibility visibility = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Embed the content of the connector_definition
   ConnectorDefinition connector_definition = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // ConnectorResource delete time
+  google.protobuf.Timestamp delete_time = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -132,6 +134,8 @@ message ListConnectorResourcesRequest {
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list connector-resources
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Return soft_deleted connector resources
+  optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListConnectorResourcesResponse represents a response for a list of
@@ -201,6 +205,8 @@ message ListUserConnectorResourcesRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/ConnectorResource"}
   ];
+  // Return soft_deleted connector resources
+  optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUserConnectorResourcesResponse represents a response for a list of
@@ -403,6 +409,8 @@ message ListConnectorResourcesAdminRequest {
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list connector-resources
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Return soft_deleted connector resources
+  optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListConnectorResourcesAdminResponse represents a response for a list of

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -154,6 +154,8 @@ message Pipeline {
   Visibility visibility = 12;
   // OpenAPI schema
   google.protobuf.Struct openapi_schema = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Pipeline delete time
+  google.protobuf.Timestamp delete_time = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // The metadata
@@ -202,6 +204,8 @@ message PipelineRelease {
   Visibility visibility = 8;
   // OpenAPI schema
   google.protobuf.Struct openapi_schema = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Pipeline delete time
+  google.protobuf.Timestamp delete_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListPipelinesRequest represents a request to list pipelines
@@ -216,6 +220,8 @@ message ListPipelinesRequest {
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list pipelines
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Return soft_deleted pipelines
+  optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelinesResponse represents a response for a list of pipelines
@@ -264,6 +270,8 @@ message ListUserPipelinesRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Pipeline"}
   ];
+  // Return soft_deleted pipeline releases
+  optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUserPipelinesResponse represents a response for a list of pipelines
@@ -462,6 +470,8 @@ message ListUserPipelineReleasesRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"}
   ];
+  // Return soft_deleted pipelines
+  optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUserPipelineReleasesResponse represents a response for a list of pipeline_releases
@@ -645,6 +655,8 @@ message ListPipelinesAdminRequest {
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list pipelines
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Return soft_deleted pipelines
+  optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelinesAdminResponse represents a response for a list of pipelines
@@ -672,6 +684,8 @@ message ListPipelineReleasesAdminRequest {
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list pipelines
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Return soft_deleted pipelines
+  optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelineReleasesAdminResponse represents a response for a list of pipeline_releases


### PR DESCRIPTION
Because

- we need to have a way to return soft-deleted resources

This commit

- add `show_deleted` param to return soft-deleted resources
