### PR TITLE
chore(connector,pipeline): add `spec.openapi_specifications` in `operator_definitions`

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -8439,7 +8439,7 @@ definitions:
         title: Spec resource specification
       component_specification:
         type: object
-        title: Spec connector specification
+        title: Spec component specification
       openapi_specifications:
         type: object
         title: Spec openapi specification
@@ -8539,9 +8539,13 @@ definitions:
       component_specification:
         type: object
         title: Spec operator specification
+      openapi_specifications:
+        type: object
+        title: Spec openapi specification
     title: View enumerates the definition views
     required:
       - component_specification
+      - openapi_specifications
   vdppipelinev1alphaView:
     type: string
     enum:

--- a/vdp/connector/v1alpha/spec.proto
+++ b/vdp/connector/v1alpha/spec.proto
@@ -12,7 +12,7 @@ import "google/protobuf/struct.proto";
 message Spec {
   // Spec resource specification
   google.protobuf.Struct resource_specification = 2 [(google.api.field_behavior) = REQUIRED];
-  // Spec connector specification
+  // Spec component specification
   google.protobuf.Struct component_specification = 3 [(google.api.field_behavior) = REQUIRED];
   // Spec openapi specification
   google.protobuf.Struct openapi_specifications = 4 [(google.api.field_behavior) = REQUIRED];

--- a/vdp/pipeline/v1alpha/operator_definition.proto
+++ b/vdp/pipeline/v1alpha/operator_definition.proto
@@ -14,6 +14,8 @@ import "vdp/pipeline/v1alpha/common.proto";
 message Spec {
   // Spec operator specification
   google.protobuf.Struct component_specification = 1 [(google.api.field_behavior) = REQUIRED];
+  // Spec openapi specification
+  google.protobuf.Struct openapi_specifications = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because

- the `operator_definitions` also need `spec.openapi_specifications` to describe input/output format

This commit

- add `spec.openapi_specifications` in `operator_definitions`