### PR TITLE
chore(pipeline): add `alias` field into `pipeline_release` payload

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2247,6 +2247,10 @@ paths:
                 format: date-time
                 title: Pipeline delete time
                 readOnly: true
+              alias:
+                type: string
+                title: Alias
+                readOnly: true
             title: A pipeline release resource to update
       tags:
         - PipelinePublicService
@@ -7367,6 +7371,10 @@ definitions:
         type: string
         format: date-time
         title: Pipeline delete time
+        readOnly: true
+      alias:
+        type: string
+        title: Alias
         readOnly: true
     title: PipelineRelease represents the content of a pipeline release
   v1alphaPipelineTriggerChartRecord:

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -194,6 +194,8 @@ message PipelineRelease {
   google.protobuf.Struct openapi_schema = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline delete time
   google.protobuf.Timestamp delete_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Alias
+  string alias = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListPipelinesRequest represents a request to list pipelines


### PR DESCRIPTION
Because

- we need a field to indicate the `pipeline_release` alias name

This commit

- add `alias` field into pipeline_release payload
