### PR TITLE
chore(connector): add `task` field in ExecuteUserConnector request

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1038,6 +1038,9 @@ paths:
                 items:
                   type: object
                 title: Inputs
+              task:
+                type: string
+                title: Task
             title: |-
               ExecuteUserConnectorResourceRequest represents a private request to execution
               connector_resource

--- a/vdp/connector/v1alpha/connector.proto
+++ b/vdp/connector/v1alpha/connector.proto
@@ -343,6 +343,8 @@ message ExecuteUserConnectorResourceRequest {
 
   // Inputs
   repeated google.protobuf.Struct inputs = 2;
+  // Task
+  string task = 3;
 }
 
 // ExecuteUserConnectorResourceResponse represents a response for execution


### PR DESCRIPTION
Because

- the `task` field decide the input and output format, it should be outside of the `inputs` field

This commit

- add `task` field in ExecuteUserConnector request
