### PR TITLE
chore(pipeline): add `metadata` field in pipeline payload

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2119,6 +2119,9 @@ paths:
               permission:
                 $ref: '#/definitions/v1alphaPermission'
                 title: Pipeline permission
+              metadata:
+                type: object
+                title: 'Metadata: store Console-related data such as pipeline builder layout'
             title: A pipeline resource to update
       tags:
         - PipelinePublicService
@@ -2254,6 +2257,9 @@ paths:
                 type: string
                 title: Alias
                 readOnly: true
+              metadata:
+                type: object
+                title: 'Metadata: store Console-related data such as pipeline builder layout'
             title: A pipeline release resource to update
       tags:
         - PipelinePublicService
@@ -7315,6 +7321,9 @@ definitions:
       permission:
         $ref: '#/definitions/v1alphaPermission'
         title: Pipeline permission
+      metadata:
+        type: object
+        title: 'Metadata: store Console-related data such as pipeline builder layout'
     title: Pipeline represents the content of a pipeline
   v1alphaPipelineData:
     type: object
@@ -7379,6 +7388,9 @@ definitions:
         type: string
         title: Alias
         readOnly: true
+      metadata:
+        type: object
+        title: 'Metadata: store Console-related data such as pipeline builder layout'
     title: PipelineRelease represents the content of a pipeline release
   v1alphaPipelineTriggerChartRecord:
     type: object

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -146,6 +146,8 @@ message Pipeline {
   google.protobuf.Timestamp delete_time = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline permission
   Permission permission = 15;
+  // Metadata: store Console-related data such as pipeline builder layout
+  google.protobuf.Struct metadata = 16;
 }
 
 // The metadata
@@ -196,6 +198,8 @@ message PipelineRelease {
   google.protobuf.Timestamp delete_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Alias
   string alias = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Metadata: store Console-related data such as pipeline builder layout
+  google.protobuf.Struct metadata = 12;
 }
 
 // ListPipelinesRequest represents a request to list pipelines


### PR DESCRIPTION
Because

- we want to store layout of pipeline builder in backend.

This commit

- add `metadata` field in pipeline and pipeline_release payload
