### PR TITLE
chore(base,vdp): support creating pipeline/connector under organization

### DIFF
--- a/core/mgmt/v1alpha/mgmt.proto
+++ b/core/mgmt/v1alpha/mgmt.proto
@@ -145,21 +145,6 @@ message ListUsersAdminResponse {
   int32 total_size = 3;
 }
 
-// CreateUserAdminRequest represents a request to create a user by admin
-message CreateUserAdminRequest {
-  // The user to be created
-  //
-  // The user's `name` field is used to identify the user to create.
-  // Format: users/{user}
-  User user = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-// CreateUserAdminResponse represents a response for a user response
-message CreateUserAdminResponse {
-  // A user resource
-  User user = 1;
-}
-
 // GetUserAdminRequest represents a request to query a user by admin
 message GetUserAdminRequest {
   // Resource name of a user. For example:
@@ -195,6 +180,68 @@ message LookUpUserAdminRequest {
 message LookUpUserAdminResponse {
   // A user resource
   User user = 1;
+}
+
+// ListOrganizationsAdminRequest represents a request to list all organizations by admin
+message ListOrganizationsAdminRequest {
+  // Page size: the maximum number of resources to return. The service may
+  // return fewer than this value. If unspecified, at most 10 organizations will be
+  // returned. The maximum value is 100; values above 100 will be coereced to
+  // 100.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // View view (default is VIEW_BASIC)
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list organizations
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListOrganizationsAdminResponse represents a response for a list of organizations
+message ListOrganizationsAdminResponse {
+  // A list of organizations
+  repeated Organization organizations = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of organizations
+  int32 total_size = 3;
+}
+
+// GetOrganizationAdminRequest represents a request to query a organization by admin
+message GetOrganizationAdminRequest {
+  // Resource name of a organization. For example:
+  // "organizations/local-organization"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Organization",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "organization.name"}
+    }
+  ];
+  // View view (default is VIEW_BASIC)
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetOrganizationAdminResponse represents a response for a organization resource
+message GetOrganizationAdminResponse {
+  // A organization resource
+  Organization organization = 1;
+}
+
+// LookUpOrganizationAdminRequest represents a request to query a organization via permalink by
+// admin
+message LookUpOrganizationAdminRequest {
+  // Permalink of a organization. For example:
+  // "organizations/{uid}"
+  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // View view (default is VIEW_BASIC)
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// LookUpOrganizationAdminResponse represents a response for a organization resource by admin
+message LookUpOrganizationAdminResponse {
+  // A organization resource
+  Organization organization = 1;
 }
 
 // ListUsersRequest represents a request to list all users

--- a/core/mgmt/v1alpha/mgmt_private_service.proto
+++ b/core/mgmt/v1alpha/mgmt_private_service.proto
@@ -15,16 +15,6 @@ service MgmtPrivateService {
     option (google.api.http) = {get: "/v1alpha/admin/users"};
   }
 
-  // CreateUserAdmin receives a CreateUserAdminRequest message and returns a
-  // a GetUserAdminResponse
-  rpc CreateUserAdmin(CreateUserAdminRequest) returns (CreateUserAdminResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/admin/users"
-      body: "user"
-    };
-    option (google.api.method_signature) = "user";
-  }
-
   // GetUserAdmin method receives a GetUserAdminRequest message and returns
   // a GetUserAdminResponse message.
   rpc GetUserAdmin(GetUserAdminRequest) returns (GetUserAdminResponse) {
@@ -36,6 +26,26 @@ service MgmtPrivateService {
   // returns a LookUpUserAdminResponse
   rpc LookUpUserAdmin(LookUpUserAdminRequest) returns (LookUpUserAdminResponse) {
     option (google.api.http) = {get: "/v1alpha/admin/{permalink=users/*}/lookUp"};
+    option (google.api.method_signature) = "permalink";
+  }
+
+  // ListOrganizationsAdmin method receives a ListOrganizationsAdminRequest message and returns
+  // a ListOrganizationsAdminResponse message.
+  rpc ListOrganizationsAdmin(ListOrganizationsAdminRequest) returns (ListOrganizationsAdminResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/organizations"};
+  }
+
+  // GetOrganizationAdmin method receives a GetOrganizationAdminRequest message and returns
+  // a GetOrganizationAdminResponse message.
+  rpc GetOrganizationAdmin(GetOrganizationAdminRequest) returns (GetOrganizationAdminResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/{name=organizations/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // LookUpOrganizationAdmin method receives a LookUpOrganizationAdminRequest message and
+  // returns a LookUpOrganizationAdminResponse
+  rpc LookUpOrganizationAdmin(LookUpOrganizationAdminRequest) returns (LookUpOrganizationAdminResponse) {
+    option (google.api.http) = {get: "/v1alpha/admin/{permalink=organizations/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
   }
 }

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -67,6 +67,229 @@ paths:
           type: string
       tags:
         - PipelinePublicService
+  /v1alpha/{connector.name_1}:
+    get:
+      summary: |-
+        GetOrganizationConnector method receives a GetOrganizationConnectorRequest
+        message and returns a GetOrganizationConnectorResponse message.
+      operationId: PipelinePublicService_GetOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: connector.name_1
+          description: |-
+            Connectorconnector name. It must have the format of
+            "connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: view
+          description: |-
+            Connector view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_CONFIGURATION
+          default: VIEW_UNSPECIFIED
+      tags:
+        - PipelinePublicService
+    delete:
+      summary: |-
+        DeleteOrganizationConnector method receives a
+        DeleteOrganizationConnectorRequest message and returns a
+        DeleteOrganizationConnectorResponse message.
+      operationId: PipelinePublicService_DeleteOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: connector.name_1
+          description: |-
+            connector name. It must have the format of
+            "connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+      tags:
+        - PipelinePublicService
+    patch:
+      summary: |-
+        UpdateOrganizationConnector method receives a
+        UpdateOrganizationConnectorRequest message and returns a
+        UpdateOrganizationConnectorResponse message.
+      operationId: PipelinePublicService_UpdateOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: connector.name_1
+          description: |-
+            connector name. It must have the format of
+            "connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: connector
+          description: connector
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: Connector UUID
+                readOnly: true
+              id:
+                type: string
+                description: |-
+                  connector ID (the last segment of the resource name)
+                  used to construct the resource name. This conforms to RFC-1034, which
+                  restricts to letters, numbers, and hyphen, with the first character a
+                  letter, the last a letter or a number, and a 63 character maximum.
+              connector_definition_name:
+                type: string
+                title: ConnectorDefinition resource
+              type:
+                $ref: '#/definitions/v1alphaConnectorType'
+                title: Connector Type
+                readOnly: true
+              description:
+                type: string
+                title: Connector description
+              configuration:
+                type: object
+                title: Connector configuration in JSON format
+              state:
+                $ref: '#/definitions/v1alphaConnectorState'
+                title: Connector state
+                readOnly: true
+              tombstone:
+                type: boolean
+                title: Connector tombstone
+                readOnly: true
+              user:
+                type: string
+                description: |-
+                  The resource name with UUID of a user, e.g.,
+                  "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
+                readOnly: true
+              organization:
+                type: string
+                title: The resource name with UUID of an organization
+                readOnly: true
+              create_time:
+                type: string
+                format: date-time
+                title: Connector creation time
+                readOnly: true
+              update_time:
+                type: string
+                format: date-time
+                title: Connector update time
+                readOnly: true
+              visibility:
+                $ref: '#/definitions/v1alphaConnectorVisibility'
+                title: Connector visibility including public or private
+                readOnly: true
+              connector_definition:
+                $ref: '#/definitions/v1alphaConnectorDefinition'
+                title: Embed the content of the connector_definition
+                readOnly: true
+              delete_time:
+                type: string
+                format: date-time
+                title: Connector delete time
+                readOnly: true
+            title: connector
+            required:
+              - configuration
+      tags:
+        - PipelinePublicService
+  /v1alpha/{connector.name_1}/testConnection:
+    post:
+      summary: |-
+        TestOrganizationConnector method receives a TestOrganizationConnectorRequest
+        message and returns a TestOrganizationConnectorResponse
+      operationId: PipelinePublicService_TestOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTestOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: connector.name_1
+          description: |-
+            connector name. It must have the format of
+            "connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1alpha/{connector.name_1}/watch:
+    get:
+      summary: |-
+        WatchOrganizationConnector method receives a
+        WatchOrganizationConnectorRequest message and returns a
+        WatchOrganizationConnectorResponse
+      operationId: PipelinePublicService_WatchOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: connector.name_1
+          description: |-
+            connector name. It must have the format of
+            "connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+      tags:
+        - PipelinePublicService
   /v1alpha/{connector.name}:
     get:
       summary: |-
@@ -205,7 +428,7 @@ paths:
                   The resource name with UUID of a user, e.g.,
                   "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
                 readOnly: true
-              org:
+              organization:
                 type: string
                 title: The resource name with UUID of an organization
                 readOnly: true
@@ -844,6 +1067,124 @@ paths:
           pattern: operations/[^/]+
       tags:
         - PipelinePublicService
+  /v1alpha/{name_1}/connect:
+    post:
+      summary: |-
+        Connect a connector.
+        The "state" of the connector after connecting is "CONNECTED".
+        ConnectOrganizationConnector can be called on Connector in the
+        state `DISCONNECTED`; Connector in a different state (including
+        `CONNECTED`) returns an error.
+      operationId: PipelinePublicService_ConnectOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaConnectOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_1
+          description: |-
+            connector name. It must have the format of
+            "connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              ConnectOrganizationConnectorRequest represents a request to connect a
+              connector
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_1}/disconnect:
+    post:
+      summary: |-
+        Disconnect a connector.
+        The "state" of the connector after disconnecting is "DISCONNECTED".
+        DisconnectOrganizationConnector can be called on Connector in the
+        state `CONNECTED`; Connector in a different state (including
+        `DISCONNECTED`) returns an error.
+      operationId: PipelinePublicService_DisconnectOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDisconnectOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_1
+          description: |-
+            connector name. It must have the format of
+            "connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: |-
+              DisconnectOrganizationConnectorRequest represents a request to disconnect a
+              connector
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_1}/execute:
+    post:
+      summary: |-
+        ExecuteOrganizationConnector method receives a
+        ExecuteOrganizationConnectorRequest message and returns a
+        ExecuteOrganizationConnectorResponse message.
+      operationId: PipelinePublicService_ExecuteOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaExecuteOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_1
+          description: |-
+            Name of a connector. For example:
+            "connectors/{name}"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                title: Inputs
+              task:
+                type: string
+                title: Task
+            title: |-
+              ExecuteOrganizationConnectorRequest represents a private request to execution
+              connector
+      tags:
+        - PipelinePublicService
   /v1alpha/{name_1}/rename:
     post:
       summary: |-
@@ -882,6 +1223,30 @@ paths:
               name
             required:
               - new_pipeline_id
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_1}/restore:
+    post:
+      summary: |-
+        RestoreOrganizationPipelineRelease method receives a RestoreOrganizationPipelineReleaseRequest message
+        and returns a RestoreOrganizationPipelineReleaseResponse
+      operationId: PipelinePublicService_RestoreOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRestoreOrganizationPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_1
+          description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
   /v1alpha/{name_1}/trigger:
@@ -958,6 +1323,34 @@ paths:
             title: TriggerAsyncUserPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
             required:
               - inputs
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_1}/validate:
+    post:
+      summary: Validate a pipeline.
+      operationId: PipelinePublicService_ValidateOrganizationPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaValidateOrganizationPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_1
+          description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            title: ValidatePOrganizationipelineRequest represents a request to validate a pipeline
       tags:
         - PipelinePublicService
   /v1alpha/{name_2}/rename:
@@ -1038,7 +1431,239 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
+  /v1alpha/{name_2}/triggerAsync:
+    post:
+      summary: |-
+        TriggerAsyncOrganizationPipeline method receives a TriggerAsyncOrganizationPipelineRequest message and
+        returns a TriggerAsyncOrganizationPipelineResponse.
+      operationId: PipelinePublicService_TriggerAsyncOrganizationPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerAsyncOrganizationPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_2
+          description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                title: Input to the pipeline
+            title: TriggerAsyncOrganizationPipelineRequest represents a request to trigger a async pipeline
+            required:
+              - inputs
+      tags:
+        - PipelinePublicService
   /v1alpha/{name_3}/rename:
+    post:
+      summary: |-
+        RenameOrganizationPipeline method receives a RenameOrganizationPipelineRequest message and returns
+        a RenameOrganizationPipelineResponse message.
+      operationId: PipelinePublicService_RenameOrganizationPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRenameOrganizationPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_3
+          description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_pipeline_id:
+                type: string
+                title: |-
+                  Pipeline new resource id to replace with the pipeline resource name to be
+                  "organizations/*/pipelines/{new_pipeline_id}"
+            title: |-
+              RenameOrganizationPipelineRequest represents a request to rename the pipeline resource
+              name
+            required:
+              - new_pipeline_id
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_3}/trigger:
+    post:
+      summary: |-
+        TriggerOrganizationPipeline method receives a TriggerOrganizationPipelineRequest message
+        and returns a TriggerOrganizationPipelineResponse.
+      operationId: PipelinePublicService_TriggerOrganizationPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerOrganizationPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_3
+          description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                title: Input to the pipeline
+            title: TriggerOrganizationPipelineRequest represents a request to trigger a pipeline
+            required:
+              - inputs
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_3}/triggerAsync:
+    post:
+      summary: |-
+        TriggerAsyncOrganizationPipelineRelease method receives a TriggerAsyncOrganizationPipelineReleaseRequest message and
+        returns a TriggerAsyncOrganizationPipelineReleaseResponse.
+      operationId: PipelinePublicService_TriggerAsyncOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerAsyncOrganizationPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_3
+          description: Resource name.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                title: Input to the pipeline
+            title: TriggerAsyncOrganizationPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+            required:
+              - inputs
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_4}/rename:
+    post:
+      summary: |-
+        RenameOrganizationPipelineRelease method receives a RenameOrganizationPipelineReleaseRequest message and returns
+        a RenameOrganizationPipelineReleaseResponse message.
+      operationId: PipelinePublicService_RenameOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRenameOrganizationPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_4
+          description: Pipeline release resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_pipeline_release_id:
+                type: string
+                title: |-
+                  Pipeline new resource id to replace with the pipeline resource name to be
+                  "organizations/*/pipelines/*/releases/{new_pipeline_id}"
+            title: |-
+              RenameOrganizationPipelineReleaseRequest represents a request to rename the pipeline release resource
+              name
+            required:
+              - new_pipeline_release_id
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_4}/trigger:
+    post:
+      summary: |-
+        TriggerOrganizationPipelineRelease method receives a TriggeOrganizationPipelineReleaseRequest message
+        and returns a TriggerPipelineReleasePipelineResponse.
+      operationId: PipelinePublicService_TriggerOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerOrganizationPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_4
+          description: Resource name.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                title: Input to the pipeline
+            title: TriggerOrganizationPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+            required:
+              - inputs
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_5}/rename:
     post:
       summary: |-
         RenameUserConnector method receives a
@@ -1055,7 +1680,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: name_3
+        - name: name_5
           description: |-
             connector name. It must have the format of
             "connectors/*"
@@ -1077,6 +1702,50 @@ paths:
                   "connectors/{new_connector_id}"
             title: |-
               RenameUserConnectorRequest represents a request to rename the
+              connector name
+            required:
+              - new_connector_id
+      tags:
+        - PipelinePublicService
+  /v1alpha/{name_6}/rename:
+    post:
+      summary: |-
+        RenameOrganizationConnector method receives a
+        RenameOrganizationConnectorRequest message and returns a
+        RenameOrganizationConnectorResponse message.
+      operationId: PipelinePublicService_RenameOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRenameOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name_6
+          description: |-
+            connector name. It must have the format of
+            "connectors/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_connector_id:
+                type: string
+                title: |-
+                  Connector new resource id to replace with the
+                  connector name to be
+                  "connectors/{new_connector_id}"
+            title: |-
+              RenameOrganizationConnectorRequest represents a request to rename the
               connector name
             required:
               - new_connector_id
@@ -1353,30 +2022,6 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaRestoreUserPipelineReleaseResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: name
-          description: Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
-      tags:
-        - PipelinePublicService
-  /v1alpha/{name}/setDefault:
-    post:
-      summary: |-
-        SetDefaultUserPipelineRelease method receives a SetDefaultUserPipelineReleaseRequest message
-        and returns a SetDefaultUserPipelineReleaseResponse
-      operationId: PipelinePublicService_SetDefaultUserPipelineRelease
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaSetDefaultUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -1783,6 +2428,108 @@ paths:
               - id
       tags:
         - MgmtPublicService
+  /v1alpha/{parent_1}/connectors:
+    get:
+      summary: |-
+        ListOrganizationConnectors method receives a
+        ListOrganizationConnectorsRequest message and returns a
+        ListOrganizationConnectorsResponse message.
+      operationId: PipelinePublicService_ListOrganizationConnectors
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListOrganizationConnectorsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent_1
+          description: |-
+            The parent resource where this connector will be created.
+            Format: organizations/{organizations}
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+
+        - name: page_size
+          description: |-
+            The maximum number of connectors to return. The service may return fewer
+            than this value. If unspecified, at most 10 connectors will be returned.
+            The maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            Connector view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+             - VIEW_CONFIGURATION: View: CONFIGURATION
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_CONFIGURATION
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list connectors
+          in: query
+          required: false
+          type: string
+        - name: show_deleted
+          description: Return soft_deleted connectors
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - PipelinePublicService
+    post:
+      summary: |-
+        CreateOrganizationConnector method receives a
+        CreateOrganizationConnectorRequest message and returns a
+        CreateOrganizationConnectorResponse message.
+      operationId: PipelinePublicService_CreateOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateOrganizationConnectorResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent_1
+          description: |-
+            The parent resource where this connector will be created.
+            Format: organizations/{organizations}
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+
+        - name: connector
+          description: connector
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaConnector'
+            required:
+              - connector
+      tags:
+        - PipelinePublicService
   /v1alpha/{parent_1}/memberships:
     get:
       summary: |-
@@ -1809,6 +2556,206 @@ paths:
           pattern: organizations/[^/]+
       tags:
         - MgmtPublicService
+  /v1alpha/{parent_1}/pipelines:
+    get:
+      summary: |-
+        ListOrganizationPipelines method receives a ListOrganizationPipelinesRequest message and returns a
+        ListOrganizationPipelinesResponse message.
+      operationId: PipelinePublicService_ListOrganizationPipelines
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListOrganizationPipelinesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent_1
+          description: |-
+            The parent resource where this connector resource will be created.
+            Format: organizations/{organizations}
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+
+        - name: page_size
+          description: |-
+            The maximum number of pipelines to return. The service may return fewer
+            than this value. If unspecified, at most 10 pipelines will be returned. The
+            maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_RECIPE
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list pipelines
+          in: query
+          required: false
+          type: string
+        - name: show_deleted
+          description: Return soft_deleted pipeline releases
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - PipelinePublicService
+    post:
+      summary: |-
+        CreateOrganizationPipeline method receives a CreateOrganizationPipelineRequest message and returns
+        a CreateOrganizationPipelineResponse message.
+      operationId: PipelinePublicService_CreateOrganizationPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateOrganizationPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent_1
+          description: |-
+            The parent resource where this connector resource will be created.
+            Format: organizations/{organizations}
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+
+        - name: pipeline
+          description: A pipeline resource to create
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaPipeline'
+            required:
+              - pipeline
+      tags:
+        - PipelinePublicService
+  /v1alpha/{parent_1}/releases:
+    get:
+      summary: |-
+        ListOrganizationPipelineReleases method receives a ListOrganizationPipelineReleasesRequest message and returns a
+        ListOrganizationPipelineReleasesResponse message.
+      operationId: PipelinePublicService_ListOrganizationPipelineReleases
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListOrganizationPipelineReleasesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent_1
+          description: |-
+            The parent resource where this pipeline_release will be created.
+            Format: organizations/{organization}/pipelines/{pipeline}
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: page_size
+          description: |-
+            The maximum number of pipeline_releases to return. The service may return fewer
+            than this value. If unspecified, at most 10 pipeline_release will be returned. The
+            maximum value is 100; values above 100 will be coerced to 100.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_RECIPE
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list pipeline_releases
+          in: query
+          required: false
+          type: string
+        - name: show_deleted
+          description: Return soft_deleted pipelines
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - PipelinePublicService
+    post:
+      summary: |-
+        CreateOrganizationPipelineRelease method receives a CreateOrganizationPipelineReleaseRequest message and returns
+        a CreateOrganizationPipelineReleaseResponse message.
+      operationId: PipelinePublicService_CreateOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateOrganizationPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: parent_1
+          description: |-
+            The parent resource where this pipeline_release will be created.
+            Format: organizations/{organization}/pipelines/{pipeline}
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: release
+          description: A pipeline_release resource to create
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaPipelineRelease'
+            required:
+              - release
+      tags:
+        - PipelinePublicService
   /v1alpha/{parent}/connectors:
     get:
       summary: |-
@@ -2367,6 +3314,30 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ModelPublicService
+  /v1alpha/{pipeline.name/watch_1}/watch:
+    get:
+      summary: |-
+        WatchOrganizationPipelineRelease method receives a WatchOrganizationPipelineReleaseRequest message
+        and returns a WatchOrganizationPipelineReleaseResponse
+      operationId: PipelinePublicService_WatchOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchOrganizationPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pipeline.name/watch_1
+          description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
+      tags:
+        - PipelinePublicService
   /v1alpha/{pipeline.name/watch}/watch:
     get:
       summary: |-
@@ -2389,6 +3360,153 @@ paths:
           required: true
           type: string
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1alpha/{pipeline.name_1}:
+    get:
+      summary: |-
+        GetOrganizationPipeline method receives a GetOrganizationPipelineRequest message and returns a
+        GetOrganizationPipelineResponse message.
+      operationId: PipelinePublicService_GetOrganizationPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetOrganizationPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pipeline.name_1
+          description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: view
+          description: |-
+            Pipeline resource view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_RECIPE
+          default: VIEW_UNSPECIFIED
+      tags:
+        - PipelinePublicService
+    delete:
+      summary: |-
+        DeleteOrganizationPipeline method receives a DeleteOrganizationPipelineRequest message and returns
+        a DeleteOrganizationPipelineResponse message.
+      operationId: PipelinePublicService_DeleteOrganizationPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteOrganizationPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pipeline.name_1
+          description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+      tags:
+        - PipelinePublicService
+    patch:
+      summary: |-
+        UpdateOrganizationPipeline method receives a UpdateOrganizationPipelineRequest message and returns
+        a UpdateOrganizationPipelineResponse message.
+      operationId: PipelinePublicService_UpdateOrganizationPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateOrganizationPipelineResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pipeline.name_1
+          description: Pipeline resource name. It must have the format of "users/{user}/pipelines/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: pipeline
+          description: A pipeline resource to update
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: Pipeline UUID
+                readOnly: true
+              id:
+                type: string
+                description: |-
+                  Pipeline resource ID (the last segment of the resource name) used to
+                  construct the resource name. This conforms to RFC-1034, which restricts to
+                  letters, numbers, and hyphen, with the first character a letter, the last a
+                  letter or a number, and a 63 character maximum.
+              description:
+                type: string
+                title: Pipeline description
+              recipe:
+                $ref: '#/definitions/v1alphaRecipe'
+                title: Pipeline recipe
+              user:
+                type: string
+                description: |-
+                  The resource name with UUID of a user, e.g.,
+                  "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
+                readOnly: true
+              organization:
+                type: string
+                title: The resource name with UUID of an organization
+                readOnly: true
+              create_time:
+                type: string
+                format: date-time
+                title: Pipeline creation time
+                readOnly: true
+              update_time:
+                type: string
+                format: date-time
+                title: Pipeline update time
+                readOnly: true
+              openapi_schema:
+                type: object
+                title: OpenAPI schema
+                readOnly: true
+              delete_time:
+                type: string
+                format: date-time
+                title: Pipeline delete time
+                readOnly: true
+              permission:
+                $ref: '#/definitions/v1alphaPermission'
+                title: Pipeline permission
+              metadata:
+                type: object
+                title: 'Metadata: store Console-related data such as pipeline builder layout'
+            title: A pipeline resource to update
       tags:
         - PipelinePublicService
   /v1alpha/{pipeline.name}:
@@ -2506,7 +3624,7 @@ paths:
                   The resource name with UUID of a user, e.g.,
                   "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
                 readOnly: true
-              org:
+              organization:
                 type: string
                 title: The resource name with UUID of an organization
                 readOnly: true
@@ -2536,6 +3654,70 @@ paths:
                 type: object
                 title: 'Metadata: store Console-related data such as pipeline builder layout'
             title: A pipeline resource to update
+      tags:
+        - PipelinePublicService
+  /v1alpha/{pipeline_release.name_1}:
+    get:
+      summary: |-
+        GetOrganizationPipelineRelease method receives a GetOrganizationPipelineReleaseRequest message and returns a
+        GetOrganizationPipelineReleaseResponse message.
+      operationId: PipelinePublicService_GetOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetOrganizationPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pipeline_release.name_1
+          description: PipelineRelease resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
+        - name: view
+          description: |-
+            PipelineRelease resource view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+             - VIEW_RECIPE: View: RECIPE: will return recipe
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_RECIPE
+          default: VIEW_UNSPECIFIED
+      tags:
+        - PipelinePublicService
+    delete:
+      summary: |-
+        DeleteOrganizationPipelineRelease method receives a DeleteOrganizationPipelineReleaseRequest message and returns
+        a DeleteOrganizationPipelineReleaseResponse message.
+      operationId: PipelinePublicService_DeleteOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteOrganizationPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pipeline_release.name_1
+          description: PipelineRelease resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
   /v1alpha/{pipeline_release.name}:
@@ -2600,6 +3782,80 @@ paths:
           required: true
           type: string
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1alpha/{release.name_1}:
+    patch:
+      summary: |-
+        UpdateOrganizationPipelineRelease method receives a UpdateOrganizationPipelineReleaseRequest message and returns
+        a UpdateOrganizationPipelineReleaseResponse message.
+      operationId: PipelinePublicService_UpdateOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateOrganizationPipelineReleaseResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: release.name_1
+          description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
+          in: path
+          required: true
+          type: string
+          pattern: organizationsr/[^/]+/pipelines/[^/]+/releases/[^/]+
+        - name: release
+          description: A pipeline release resource to update
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              uid:
+                type: string
+                title: PipelineRelease UUID
+                readOnly: true
+              id:
+                type: string
+                title: |-
+                  PipelineRelease resource ID (the last segment of the resource name) used to
+                  construct the resource name. Must be a sematic version vX.Y.Z
+              description:
+                type: string
+                title: PipelineRelease description
+              recipe:
+                $ref: '#/definitions/v1alphaRecipe'
+                title: Pipeline recipe snapshot
+                readOnly: true
+              create_time:
+                type: string
+                format: date-time
+                title: Pipeline creation time
+                readOnly: true
+              update_time:
+                type: string
+                format: date-time
+                title: Pipeline update time
+                readOnly: true
+              openapi_schema:
+                type: object
+                title: OpenAPI schema
+                readOnly: true
+              delete_time:
+                type: string
+                format: date-time
+                title: Pipeline delete time
+                readOnly: true
+              alias:
+                type: string
+                title: Alias
+                readOnly: true
+              metadata:
+                type: object
+                title: 'Metadata: store Console-related data such as pipeline builder layout'
+            title: A pipeline release resource to update
       tags:
         - PipelinePublicService
   /v1alpha/{release.name}:
@@ -3079,7 +4335,89 @@ paths:
               state
       tags:
         - ModelPrivateService
+  /v1alpha/admin/{organization.name}:
+    get:
+      summary: |-
+        GetOrganizationAdmin method receives a GetOrganizationAdminRequest message and returns
+        a GetOrganizationAdminResponse message.
+      operationId: MgmtPrivateService_GetOrganizationAdmin
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetOrganizationAdminResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization.name
+          description: |-
+            Resource name of a organization. For example:
+            "organizations/local-organization"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - MgmtPrivateService
   /v1alpha/admin/{permalink_1}/lookUp:
+    get:
+      summary: |-
+        LookUpOrganizationAdmin method receives a LookUpOrganizationAdminRequest message and
+        returns a LookUpOrganizationAdminResponse
+      operationId: MgmtPrivateService_LookUpOrganizationAdmin
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaLookUpOrganizationAdminResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: permalink_1
+          description: |-
+            Permalink of a organization. For example:
+            "organizations/{uid}"
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+      tags:
+        - MgmtPrivateService
+  /v1alpha/admin/{permalink_2}/lookUp:
     get:
       summary: |-
         LookUpModelAdmin method receives a LookUpModelAdminRequest message and
@@ -3095,7 +4433,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: permalink_1
+        - name: permalink_2
           description: |-
             Permalink of a model. For example:
             "models/{uid}"
@@ -3122,7 +4460,7 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - ModelPrivateService
-  /v1alpha/admin/{permalink_2}/lookUp:
+  /v1alpha/admin/{permalink_3}/lookUp:
     get:
       summary: |-
         LookUpPipelineAdmin method receives a LookUpPipelineAdminRequest message
@@ -3138,7 +4476,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: permalink_2
+        - name: permalink_3
           description: |-
             Permalink of a pipeline. For example:
             "pipelines/{uid}"
@@ -3165,7 +4503,7 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePrivateService
-  /v1alpha/admin/{permalink_3}/lookUp:
+  /v1alpha/admin/{permalink_4}/lookUp:
     get:
       summary: |-
         LookUpOperatorDefinitionAdmin method receives a
@@ -3182,7 +4520,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: permalink_3
+        - name: permalink_4
           description: |-
             Permalink of a operator. For example:
             "operator-definitions/{uid}"
@@ -3207,7 +4545,7 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePrivateService
-  /v1alpha/admin/{permalink_4}/lookUp:
+  /v1alpha/admin/{permalink_5}/lookUp:
     get:
       summary: |-
         LookUpConnectorDefinitionAdmin method receives a
@@ -3224,7 +4562,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: permalink_4
+        - name: permalink_5
           description: |-
             Permalink of a connector. For example:
             "connector-definitions/{uid}"
@@ -3249,7 +4587,7 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - PipelinePrivateService
-  /v1alpha/admin/{permalink_5}/lookUp:
+  /v1alpha/admin/{permalink_6}/lookUp:
     get:
       summary: |-
         LookUpConnectorAdmin method receives a
@@ -3266,7 +4604,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: permalink_5
+        - name: permalink_6
           description: |-
             Permalink of a connector. For example:
             "connectors/{uid}"
@@ -3515,6 +4853,59 @@ paths:
           type: boolean
       tags:
         - ModelPrivateService
+  /v1alpha/admin/organizations:
+    get:
+      summary: |-
+        ListOrganizationsAdmin method receives a ListOrganizationsAdminRequest message and returns
+        a ListOrganizationsAdminResponse message.
+      operationId: MgmtPrivateService_ListOrganizationsAdmin
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListOrganizationsAdminResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: page_size
+          description: |-
+            Page size: the maximum number of resources to return. The service may
+            return fewer than this value. If unspecified, at most 10 organizations will be
+            returned. The maximum value is 100; values above 100 will be coereced to
+            100.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: page_token
+          description: Page token
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View view (default is VIEW_BASIC)
+
+             - VIEW_UNSPECIFIED: View: UNSPECIFIED, equivalent to BASIC.
+             - VIEW_BASIC: View: BASIC
+             - VIEW_FULL: View: FULL
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_UNSPECIFIED
+            - VIEW_BASIC
+            - VIEW_FULL
+          default: VIEW_UNSPECIFIED
+        - name: filter
+          description: Filter expression to list organizations
+          in: query
+          required: false
+          type: string
+      tags:
+        - MgmtPrivateService
   /v1alpha/admin/pipelines:
     get:
       summary: |-
@@ -3684,35 +5075,6 @@ paths:
           in: query
           required: false
           type: string
-      tags:
-        - MgmtPrivateService
-    post:
-      summary: |-
-        CreateUserAdmin receives a CreateUserAdminRequest message and returns a
-        a GetUserAdminResponse
-      operationId: MgmtPrivateService_CreateUserAdmin
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaCreateUserAdminResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user
-          description: |-
-            The user to be created
-
-            The user's `name` field is used to identify the user to create.
-            Format: users/{user}
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/mgmtv1alphaUser'
-            required:
-              - user
       tags:
         - MgmtPrivateService
   /v1alpha/auth/change_password:
@@ -5643,6 +7005,15 @@ definitions:
        - COMPONENT_TYPE_CONNECTOR_BLOCKCHAIN: CONNECTOR_BLOCKCHAIN
        - COMPONENT_TYPE_OPERATOR: CONNECTOR_OPERATOR
     title: ComponentType
+  v1alphaConnectOrganizationConnectorResponse:
+    type: object
+    properties:
+      connector:
+        $ref: '#/definitions/v1alphaConnector'
+        title: A connector
+    title: |-
+      ConnectOrganizationConnectorResponse represents a connected
+      connector
   v1alphaConnectUserConnectorResponse:
     type: object
     properties:
@@ -5699,7 +7070,7 @@ definitions:
           The resource name with UUID of a user, e.g.,
           "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
         readOnly: true
-      org:
+      organization:
         type: string
         title: The resource name with UUID of an organization
         readOnly: true
@@ -5802,6 +7173,18 @@ definitions:
         title: ConnectorDefinition vendorAttributes, i.e. the vendor-specific attributes
         readOnly: true
     title: ConnectorDefinition represents the connector definition data model
+  v1alphaConnectorDefinitionView:
+    type: string
+    enum:
+      - VIEW_UNSPECIFIED
+      - VIEW_BASIC
+      - VIEW_FULL
+    default: VIEW_UNSPECIFIED
+    description: |-
+      - VIEW_UNSPECIFIED: View: UNSPECIFIED
+       - VIEW_BASIC: View: BASIC
+       - VIEW_FULL: View: FULL
+    title: View enumerates the definition views
   v1alphaConnectorExecuteChartRecord:
     type: object
     properties:
@@ -5978,6 +7361,20 @@ definitions:
     required:
       - user_uid
       - connector_execute_data
+  v1alphaConnectorView:
+    type: string
+    enum:
+      - VIEW_UNSPECIFIED
+      - VIEW_BASIC
+      - VIEW_FULL
+      - VIEW_CONFIGURATION
+    default: VIEW_UNSPECIFIED
+    description: |-
+      - VIEW_UNSPECIFIED: View: UNSPECIFIED
+       - VIEW_BASIC: View: BASIC
+       - VIEW_FULL: View: FULL
+       - VIEW_CONFIGURATION: View: CONFIGURATION
+    title: View enumerates the definition views
   v1alphaConnectorVisibility:
     type: string
     enum:
@@ -5990,6 +7387,29 @@ definitions:
        - VISIBILITY_PRIVATE: Visibility: PRIVATE
        - VISIBILITY_PUBLIC: Visibility: PUBLIC
     title: Connector visibility including public or private
+  v1alphaCreateOrganizationConnectorResponse:
+    type: object
+    properties:
+      connector:
+        $ref: '#/definitions/v1alphaConnector'
+        title: connector
+    title: |-
+      CreateOrganizationConnectorResponse represents a response for a
+      connector
+  v1alphaCreateOrganizationPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: The created pipeline_release resource
+    title: CreateOrganizationPipelineReleaseResponse represents a response for a pipeline_release resource
+  v1alphaCreateOrganizationPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: The created pipeline resource
+    title: CreateOrganizationPipelineResponse represents a response for a pipeline resource
   v1alphaCreateOrganizationResponse:
     type: object
     properties:
@@ -6011,13 +7431,6 @@ definitions:
         $ref: '#/definitions/v1alphaApiToken'
         title: The created API token resource
     title: CreateTokenResponse represents a response for a API token resource
-  v1alphaCreateUserAdminResponse:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/mgmtv1alphaUser'
-        title: A user resource
-    title: CreateUserAdminResponse represents a response for a user response
   v1alphaCreateUserConnectorResponse:
     type: object
     properties:
@@ -6057,9 +7470,18 @@ definitions:
         $ref: '#/definitions/v1alphaPipeline'
         title: The created pipeline resource
     title: CreateUserPipelineResponse represents a response for a pipeline resource
+  v1alphaDeleteOrganizationConnectorResponse:
+    type: object
+    title: DeleteOrganizationConnectorResponse represents an empty response
   v1alphaDeleteOrganizationMembershipResponse:
     type: object
     title: DeleteOrganizationMembershipResponse represents an empty response
+  v1alphaDeleteOrganizationPipelineReleaseResponse:
+    type: object
+    title: DeleteOrganizationPipelineReleaseResponse represents an empty response
+  v1alphaDeleteOrganizationPipelineResponse:
+    type: object
+    title: DeleteOrganizationPipelineResponse represents an empty response
   v1alphaDeleteOrganizationResponse:
     type: object
     title: DeleteOrganizationResponse represents an empty response
@@ -6154,6 +7576,15 @@ definitions:
         title: A list of detection objects
         readOnly: true
     title: DetectionOutput represents the output of detection task
+  v1alphaDisconnectOrganizationConnectorResponse:
+    type: object
+    properties:
+      connector:
+        $ref: '#/definitions/v1alphaConnector'
+        title: A connector
+    title: |-
+      DisconnectOrganizationConnectorResponse represents a disconnected
+      connector
   v1alphaDisconnectUserConnectorResponse:
     type: object
     properties:
@@ -6163,6 +7594,17 @@ definitions:
     title: |-
       DisconnectUserConnectorResponse represents a disconnected
       connector
+  v1alphaExecuteOrganizationConnectorResponse:
+    type: object
+    properties:
+      outputs:
+        type: array
+        items:
+          type: object
+        title: Outputs
+    title: |-
+      ExecuteOrganizationConnectorResponse represents a response for execution
+      output
   v1alphaExecuteUserConnectorResponse:
     type: object
     properties:
@@ -6295,18 +7737,6 @@ definitions:
       GetBulkPipelineTriggerSummariesRequest
     required:
       - bulk_summaries
-  v1alphaGetConnectorDefinitionRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-    title: View enumerates the definition views
   v1alphaGetConnectorDefinitionResponse:
     type: object
     properties:
@@ -6511,18 +7941,6 @@ definitions:
     title: |-
       GetOperationResponse represents a response for a longrunning
       operation
-  v1alphaGetOperatorDefinitionRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-    title: Operator View
   v1alphaGetOperatorDefinitionResponse:
     type: object
     properties:
@@ -6532,6 +7950,22 @@ definitions:
     title: |-
       GetOperatorDefinitionResponse represents a
       Operator response
+  v1alphaGetOrganizationAdminResponse:
+    type: object
+    properties:
+      organization:
+        $ref: '#/definitions/v1alphaOrganization'
+        title: A organization resource
+    title: GetOrganizationAdminResponse represents a response for a organization resource
+  v1alphaGetOrganizationConnectorResponse:
+    type: object
+    properties:
+      connector:
+        $ref: '#/definitions/v1alphaConnector'
+        title: connector
+    title: |-
+      GetOrganizationConnectorResponse represents a response for a
+      connector
   v1alphaGetOrganizationMembershipResponse:
     type: object
     properties:
@@ -6539,6 +7973,20 @@ definitions:
         $ref: '#/definitions/v1alphaOrganizationMembership'
         title: A membership resource
     title: GetOrganizationMembershipResponse represents a response for a membership resource
+  v1alphaGetOrganizationPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A pipeline_release resource
+    title: GetOrganizationPipelineReleaseResponse represents a response for a pipeline_release resource
+  v1alphaGetOrganizationPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: GetOrganizationPipelineResponse represents a response for a pipeline resource
   v1alphaGetOrganizationResponse:
     type: object
     properties:
@@ -6668,20 +8116,6 @@ definitions:
         $ref: '#/definitions/mgmtv1alphaUser'
         title: A user resource
     title: GetUserAdminResponse represents a response for a user resource
-  v1alphaGetUserConnectorRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_CONFIGURATION
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_CONFIGURATION: View: CONFIGURATION
-    title: View enumerates the definition views
   v1alphaGetUserConnectorResponse:
     type: object
     properties:
@@ -6712,20 +8146,6 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: The retrieved model
     title: GetUserModelResponse represents a response for a model
-  v1alphaGetUserPipelineReleaseRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_RECIPE
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_RECIPE: View: RECIPE: will return recipe
-    title: Pipeline View
   v1alphaGetUserPipelineReleaseResponse:
     type: object
     properties:
@@ -6733,20 +8153,6 @@ definitions:
         $ref: '#/definitions/v1alphaPipelineRelease'
         title: A pipeline_release resource
     title: GetUserPipelineReleaseResponse represents a response for a pipeline_release resource
-  v1alphaGetUserPipelineRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_RECIPE
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_RECIPE: View: RECIPE: will return recipe
-    title: Pipeline View
   v1alphaGetUserPipelineResponse:
     type: object
     properties:
@@ -6917,18 +8323,6 @@ definitions:
         title: A list of keypoint objects
         readOnly: true
     title: KeypointOutput represents the output of keypoint detection task
-  v1alphaListConnectorDefinitionsRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-    title: View enumerates the definition views
   v1alphaListConnectorDefinitionsResponse:
     type: object
     properties:
@@ -6998,20 +8392,6 @@ definitions:
     title: |-
       ListConnectorExecuteTableRecordsResponse represents a response for a list
       of connector execute table record
-  v1alphaListConnectorsAdminRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_CONFIGURATION
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_CONFIGURATION: View: CONFIGURATION
-    title: View enumerates the definition views
   v1alphaListConnectorsAdminResponse:
     type: object
     properties:
@@ -7031,20 +8411,6 @@ definitions:
     title: |-
       ListConnectorsAdminResponse represents a response for a list of
       connectors
-  v1alphaListConnectorsRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_CONFIGURATION
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_CONFIGURATION: View: CONFIGURATION
-    title: View enumerates the definition views
   v1alphaListConnectorsResponse:
     type: object
     properties:
@@ -7117,18 +8483,6 @@ definitions:
         format: int32
         title: Total count of models
     title: ListModelsResponse represents a response for a list of models
-  v1alphaListOperatorDefinitionsRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-    title: Operator View
   v1alphaListOperatorDefinitionsResponse:
     type: object
     properties:
@@ -7148,6 +8502,25 @@ definitions:
     title: |-
       ListOperatorDefinitionsResponse represents a response for a list
       of OperatorDefinitions
+  v1alphaListOrganizationConnectorsResponse:
+    type: object
+    properties:
+      connectors:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaConnector'
+        title: A list of connectors
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: integer
+        format: int32
+        title: Total count of connectors
+    title: |-
+      ListOrganizationConnectorsResponse represents a response for a list of
+      connectors
   v1alphaListOrganizationMembershipsResponse:
     type: object
     properties:
@@ -7158,6 +8531,57 @@ definitions:
           $ref: '#/definitions/v1alphaOrganizationMembership'
         title: A list of memberships
     title: ListOrganizationMembershipsResponse represents a response for a list of memberships
+  v1alphaListOrganizationPipelineReleasesResponse:
+    type: object
+    properties:
+      releases:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A list of pipeline_release resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: integer
+        format: int32
+        title: Total count of pipeline_release resources
+    title: ListOrganizationPipelineReleasesResponse represents a response for a list of pipeline_releases
+  v1alphaListOrganizationPipelinesResponse:
+    type: object
+    properties:
+      pipelines:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaPipeline'
+        title: A list of pipeline resources
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: integer
+        format: int32
+        title: Total count of pipeline resources
+    title: ListOrganizationPipelinesResponse represents a response for a list of pipelines
+  v1alphaListOrganizationsAdminResponse:
+    type: object
+    properties:
+      organizations:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaOrganization'
+        title: A list of organizations
+      next_page_token:
+        type: string
+        title: Next page token
+      total_size:
+        type: integer
+        format: int32
+        title: Total count of organizations
+    title: ListOrganizationsAdminResponse represents a response for a list of organizations
   v1alphaListOrganizationsResponse:
     type: object
     properties:
@@ -7175,20 +8599,6 @@ definitions:
         format: int32
         title: Total count of organizations
     title: ListOrganizationsResponse represents a response for a list of organizations
-  v1alphaListPipelineReleasesAdminRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_RECIPE
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_RECIPE: View: RECIPE: will return recipe
-    title: Pipeline View
   v1alphaListPipelineReleasesAdminResponse:
     type: object
     properties:
@@ -7259,20 +8669,6 @@ definitions:
     title: |-
       ListPipelineTriggerTableRecordsResponse represents a response for a list
       of pipeline trigger table record
-  v1alphaListPipelinesAdminRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_RECIPE
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_RECIPE: View: RECIPE: will return recipe
-    title: Pipeline View
   v1alphaListPipelinesAdminResponse:
     type: object
     properties:
@@ -7293,20 +8689,6 @@ definitions:
       ListPipelinesAdminResponse represents a response for a list of pipelines
       The recipe returned will be permaLinks instead of resourceName temporary,
       this will be refactored soon
-  v1alphaListPipelinesRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_RECIPE
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_RECIPE: View: RECIPE: will return recipe
-    title: Pipeline View
   v1alphaListPipelinesResponse:
     type: object
     properties:
@@ -7341,20 +8723,6 @@ definitions:
         format: int32
         title: Total count of API tokens resources
     title: ListTokensResponse represents a response for a list of API tokens
-  v1alphaListUserConnectorsRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_CONFIGURATION
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_CONFIGURATION: View: CONFIGURATION
-    title: View enumerates the definition views
   v1alphaListUserConnectorsResponse:
     type: object
     properties:
@@ -7401,20 +8769,6 @@ definitions:
         format: int32
         title: Total count of models
     title: ListUserModelsResponse represents a response for a list of models
-  v1alphaListUserPipelineReleasesRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_RECIPE
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_RECIPE: View: RECIPE: will return recipe
-    title: Pipeline View
   v1alphaListUserPipelineReleasesResponse:
     type: object
     properties:
@@ -7432,20 +8786,6 @@ definitions:
         format: int32
         title: Total count of pipeline_release resources
     title: ListUserPipelineReleasesResponse represents a response for a list of pipeline_releases
-  v1alphaListUserPipelinesRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_RECIPE
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_RECIPE: View: RECIPE: will return recipe
-    title: Pipeline View
   v1alphaListUserPipelinesResponse:
     type: object
     properties:
@@ -7497,20 +8837,6 @@ definitions:
         format: int32
         title: Total count of users
     title: ListUsersResponse represents a response for a list of users
-  v1alphaLookUpConnectorAdminRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_CONFIGURATION
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_CONFIGURATION: View: CONFIGURATION
-    title: View enumerates the definition views
   v1alphaLookUpConnectorAdminResponse:
     type: object
     properties:
@@ -7520,18 +8846,6 @@ definitions:
     title: |-
       LookUpConnectorAdminResponse represents a response for a
       connector
-  v1alphaLookUpConnectorDefinitionAdminRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-    title: View enumerates the definition views
   v1alphaLookUpConnectorDefinitionAdminResponse:
     type: object
     properties:
@@ -7541,20 +8855,6 @@ definitions:
     title: |-
       LookUpConnectorDefinitionAdminResponse represents a response for a
       connector definition
-  v1alphaLookUpConnectorRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_CONFIGURATION
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_CONFIGURATION: View: CONFIGURATION
-    title: View enumerates the definition views
   v1alphaLookUpConnectorResponse:
     type: object
     properties:
@@ -7578,18 +8878,6 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         title: A model resource
     title: LookUpModelResponse represents a response for a model
-  v1alphaLookUpOperatorDefinitionAdminRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-    title: Operator View
   v1alphaLookUpOperatorDefinitionAdminResponse:
     type: object
     properties:
@@ -7599,20 +8887,13 @@ definitions:
     title: |-
       LookUpOperatorAdminResponse represents a response for a
       operator
-  v1alphaLookUpPipelineAdminRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_RECIPE
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_RECIPE: View: RECIPE: will return recipe
-    title: Pipeline View
+  v1alphaLookUpOrganizationAdminResponse:
+    type: object
+    properties:
+      organization:
+        $ref: '#/definitions/v1alphaOrganization'
+        title: A organization resource
+    title: LookUpOrganizationAdminResponse represents a response for a organization resource by admin
   v1alphaLookUpPipelineAdminResponse:
     type: object
     properties:
@@ -7620,20 +8901,6 @@ definitions:
         $ref: '#/definitions/v1alphaPipeline'
         title: A pipeline resource
     title: LookUpPipelineAdminResponse represents a response for a pipeline resource
-  v1alphaLookUpPipelineRequestView:
-    type: string
-    enum:
-      - VIEW_UNSPECIFIED
-      - VIEW_BASIC
-      - VIEW_FULL
-      - VIEW_RECIPE
-    default: VIEW_UNSPECIFIED
-    description: |-
-      - VIEW_UNSPECIFIED: View: UNSPECIFIED
-       - VIEW_BASIC: View: BASIC
-       - VIEW_FULL: View: FULL
-       - VIEW_RECIPE: View: RECIPE: will return recipe
-    title: Pipeline View
   v1alphaLookUpPipelineResponse:
     type: object
     properties:
@@ -8052,6 +9319,18 @@ definitions:
         title: Operator iconUrl
         readOnly: true
     title: Operator represents the operator definition data model
+  v1alphaOperatorDefinitionView:
+    type: string
+    enum:
+      - VIEW_UNSPECIFIED
+      - VIEW_BASIC
+      - VIEW_FULL
+    default: VIEW_UNSPECIFIED
+    description: |-
+      - VIEW_UNSPECIFIED: View: UNSPECIFIED
+       - VIEW_BASIC: View: BASIC
+       - VIEW_FULL: View: FULL
+    title: Operator View
   v1alphaOperatorSpec:
     type: object
     properties:
@@ -8192,7 +9471,7 @@ definitions:
           The resource name with UUID of a user, e.g.,
           "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
         readOnly: true
-      org:
+      organization:
         type: string
         title: The resource name with UUID of an organization
         readOnly: true
@@ -8464,6 +9743,20 @@ definitions:
       - trigger_time
       - record_time
       - value
+  v1alphaPipelineView:
+    type: string
+    enum:
+      - VIEW_UNSPECIFIED
+      - VIEW_BASIC
+      - VIEW_FULL
+      - VIEW_RECIPE
+    default: VIEW_UNSPECIFIED
+    description: |-
+      - VIEW_UNSPECIFIED: View: UNSPECIFIED
+       - VIEW_BASIC: View: BASIC
+       - VIEW_FULL: View: FULL
+       - VIEW_RECIPE: View: RECIPE: will return recipe
+    title: Pipeline View
   v1alphaPriceData:
     type: object
     properties:
@@ -8518,6 +9811,29 @@ definitions:
        - RELEASE_STAGE_GENERALLY_AVAILABLE: ReleaseStage: GENERALLY_AVAILABLE
        - RELEASE_STAGE_CUSTOM: ReleaseStage: CUSTOM
     title: ReleaseStage enumerates the release stages
+  v1alphaRenameOrganizationConnectorResponse:
+    type: object
+    properties:
+      connector:
+        $ref: '#/definitions/v1alphaConnector'
+        title: A connector
+    title: |-
+      RenameOrganizationConnectorResponse represents a renamed Connector
+      resource
+  v1alphaRenameOrganizationPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A pipeline resource
+    title: RenameOrganizationPipelineReleaseResponse represents a renamed pipeline release resource
+  v1alphaRenameOrganizationPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: RenameOrganizationPipelineResponse represents a renamed pipeline resource
   v1alphaRenameUserConnectorResponse:
     type: object
     properties:
@@ -8622,6 +9938,13 @@ definitions:
     title: |-
       ReportPipelineTriggersResponse represents a respond to a
       pipeline-trigger-records reporting bulk request
+  v1alphaRestoreOrganizationPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: A pipeline resource
+    title: RestoreOrganizationPipelineReleaseResponse
   v1alphaRestoreUserPipelineReleaseResponse:
     type: object
     properties:
@@ -8797,13 +10120,6 @@ definitions:
       - token
       - pow
       - session
-  v1alphaSetDefaultUserPipelineReleaseResponse:
-    type: object
-    properties:
-      release:
-        $ref: '#/definitions/v1alphaPipelineRelease'
-        title: A pipeline resource
-    title: SetDefaultUserPipelineReleaseResponse
   v1alphaTask:
     type: string
     enum:
@@ -8936,6 +10252,15 @@ definitions:
         title: The unspecified task output
         readOnly: true
     title: TaskOutput represents the output of a CV Task result from a model
+  v1alphaTestOrganizationConnectorResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaConnectorState'
+        title: Retrieved connector state
+    title: |-
+      TestOrganizationConnectorResponse represents a response containing a
+      connector's current state
   v1alphaTestUserConnectorResponse:
     type: object
     properties:
@@ -9109,6 +10434,26 @@ definitions:
         format: float
         title: Compute Time
     title: Trace for the intermediate component
+  v1alphaTriggerAsyncOrganizationPipelineReleaseResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Trigger async pipeline operation message
+        readOnly: true
+    title: |-
+      TriggerAsyncOrganizationPipelineReleaseResponse represents a response for the longrunning
+      operation of a pipeline
+  v1alphaTriggerAsyncOrganizationPipelineResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        title: Trigger async pipeline operation message
+        readOnly: true
+    title: |-
+      TriggerAsyncOrganizationPipelineResponse represents a response for the longrunning
+      operation of a pipeline
   v1alphaTriggerAsyncUserPipelineReleaseResponse:
     type: object
     properties:
@@ -9138,6 +10483,34 @@ definitions:
           $ref: '#/definitions/v1alphaTrace'
         title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: The metadata
+  v1alphaTriggerOrganizationPipelineReleaseResponse:
+    type: object
+    properties:
+      outputs:
+        type: array
+        items:
+          type: object
+        title: The multiple model inference outputs
+      metadata:
+        $ref: '#/definitions/v1alphaTriggerMetadata'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
+    title: |-
+      TriggerOrganizationPipelineReleaseResponse represents a response for the output
+      of a pipeline, i.e., the multiple model inference outputs
+  v1alphaTriggerOrganizationPipelineResponse:
+    type: object
+    properties:
+      outputs:
+        type: array
+        items:
+          type: object
+        title: The multiple model inference outputs
+      metadata:
+        $ref: '#/definitions/v1alphaTriggerMetadata'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
+    title: |-
+      TriggerOrganizationPipelineResponse represents a response for the output
+      of a pipeline, i.e., the multiple model inference outputs
   v1alphaTriggerUserModelBinaryFileUploadResponse:
     type: object
     properties:
@@ -9241,6 +10614,15 @@ definitions:
         title: A list of unspecified task outputs
         readOnly: true
     title: UnspecifiedOutput represents the output of unspecified task
+  v1alphaUpdateOrganizationConnectorResponse:
+    type: object
+    properties:
+      connector:
+        $ref: '#/definitions/v1alphaConnector'
+        title: connector
+    title: |-
+      UpdateOrganizationConnectorResponse represents a response for a
+      connector
   v1alphaUpdateOrganizationMembershipResponse:
     type: object
     properties:
@@ -9248,6 +10630,20 @@ definitions:
         $ref: '#/definitions/v1alphaOrganizationMembership'
         title: An updated membership resource
     title: UpdateOrganizationMembershipResponse represents a response for a membership resource
+  v1alphaUpdateOrganizationPipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        $ref: '#/definitions/v1alphaPipelineRelease'
+        title: An updated pipeline resource
+    title: UpdateOrganizationPipelineReleaseResponse represents a response for a pipeline resource
+  v1alphaUpdateOrganizationPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: An updated pipeline resource
+    title: UpdateOrganizationPipelineResponse represents a response for a pipeline resource
   v1alphaUpdateOrganizationResponse:
     type: object
     properties:
@@ -9344,6 +10740,13 @@ definitions:
     title: Membership represents the content of a membership
     required:
       - state
+  v1alphaValidateOrganizationPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1alphaPipeline'
+        title: A pipeline resource
+    title: ValidateOrganizationPipelineResponse represents an response of validated pipeline
   v1alphaValidateTokenResponse:
     type: object
     properties:
@@ -9359,6 +10762,24 @@ definitions:
         $ref: '#/definitions/v1alphaPipeline'
         title: A pipeline resource
     title: ValidateUserPipelineResponse represents an response of validated pipeline
+  v1alphaWatchOrganizationConnectorResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/v1alphaConnectorState'
+        title: Retrieved connector state
+    title: |-
+      WatchOrganizationConnectorResponse represents a response to fetch a
+      connector's current state
+  v1alphaWatchOrganizationPipelineReleaseResponse:
+    type: object
+    properties:
+      state:
+        $ref: '#/definitions/pipelinev1alphaState'
+        title: Retrieved pipeline state
+    title: |-
+      WatchOrganizationPipelineReleaseResponse represents a response to fetch a pipeline's
+      current state
   v1alphaWatchUserConnectorResponse:
     type: object
     properties:

--- a/vdp/pipeline/v1alpha/connector.proto
+++ b/vdp/pipeline/v1alpha/connector.proto
@@ -14,6 +14,18 @@ import "vdp/pipeline/v1alpha/connector_definition.proto";
 
 // Connector represents a connector data model
 message Connector {
+  // View enumerates the definition views
+  enum View {
+    // View: UNSPECIFIED
+    VIEW_UNSPECIFIED = 0;
+    // View: BASIC
+    VIEW_BASIC = 1;
+    // View: FULL
+    VIEW_FULL = 2;
+    // View: CONFIGURATION
+    VIEW_CONFIGURATION = 3;
+  }
+
   // State enumerates the connector state
   enum State {
     // State: UNSPECIFIED
@@ -75,7 +87,7 @@ message Connector {
       (google.api.field_behavior) = OUTPUT_ONLY
     ];
     // The resource name with UUID of an organization
-    string org = 12 [
+    string organization = 12 [
       (google.api.resource_reference).type = "api.instill.tech/Organization",
       (google.api.field_behavior) = OUTPUT_ONLY
     ];
@@ -99,17 +111,6 @@ message Connector {
 // ListConnectorsRequest represents a request to list
 // connectors
 message ListConnectorsRequest {
-  // View enumerates the definition views
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: CONFIGURATION
-    VIEW_CONFIGURATION = 3;
-  }
   // The maximum number of connectors to return. The service may return fewer
   // than this value. If unspecified, at most 10 connectors will be returned.
   // The maximum value is 100; values above 100 will be coerced to 100.
@@ -117,7 +118,7 @@ message ListConnectorsRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // Connector view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional Connector.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list connectors
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // Return soft_deleted connectors
@@ -138,23 +139,11 @@ message ListConnectorsResponse {
 // LookUpConnectorRequest represents a request to query a
 // connector via permalink
 message LookUpConnectorRequest {
-  // View enumerates the definition views
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: CONFIGURATION
-    VIEW_CONFIGURATION = 3;
-  }
-
   // Permalink of a connector. For example:
   // "connectors/{uid}"
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
   // Connector view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional Connector.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // LookUpConnectorResponse represents a response for a
@@ -187,17 +176,6 @@ message CreateUserConnectorResponse {
 // ListUserConnectorsRequest represents a request to list
 // connectors
 message ListUserConnectorsRequest {
-  // View enumerates the definition views
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: CONFIGURATION
-    VIEW_CONFIGURATION = 3;
-  }
   // The maximum number of connectors to return. The service may return fewer
   // than this value. If unspecified, at most 10 connectors will be returned.
   // The maximum value is 100; values above 100 will be coerced to 100.
@@ -205,7 +183,7 @@ message ListUserConnectorsRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // Connector view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional Connector.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list connectors
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // The parent resource where this connector will be created.
@@ -232,18 +210,6 @@ message ListUserConnectorsResponse {
 // GetUserConnectorRequest represents a request to query a
 // connector
 message GetUserConnectorRequest {
-  // View enumerates the definition views
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: CONFIGURATION
-    VIEW_CONFIGURATION = 3;
-  }
-
   // Connectorconnector name. It must have the format of
   // "connectors/*"
   string name = 1 [
@@ -254,7 +220,7 @@ message GetUserConnectorRequest {
     }
   ];
   // Connector view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional Connector.View view = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetUserConnectorResponse represents a response for a
@@ -417,23 +383,29 @@ message WatchUserConnectorResponse {
   Connector.State state = 1;
 }
 
-// ========== Private endpoints
+// CreateOrganizationConnectorRequest represents a request to create a
+// connector
+message CreateOrganizationConnectorRequest {
+  // connector
+  Connector connector = 1 [(google.api.field_behavior) = REQUIRED];
+  // The parent resource where this connector will be created.
+  // Format: organizations/{organizations}
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Connector"}
+  ];
+}
 
-// ListConnectorsAdminRequest represents a request to list
-// connectors from all users by admin
-message ListConnectorsAdminRequest {
-  // View enumerates the definition views
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: CONFIGURATION
-    VIEW_CONFIGURATION = 3;
-  }
+// CreateOrganizationConnectorResponse represents a response for a
+// connector
+message CreateOrganizationConnectorResponse {
+  // connector
+  Connector connector = 1;
+}
 
+// ListOrganizationConnectorsRequest represents a request to list
+// connectors
+message ListOrganizationConnectorsRequest {
   // The maximum number of connectors to return. The service may return fewer
   // than this value. If unspecified, at most 10 connectors will be returned.
   // The maximum value is 100; values above 100 will be coerced to 100.
@@ -441,7 +413,219 @@ message ListConnectorsAdminRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // Connector view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional Connector.View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list connectors
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The parent resource where this connector will be created.
+  // Format: organizations/{organizations}
+  string parent = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Connector"}
+  ];
+  // Return soft_deleted connectors
+  optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListOrganizationConnectorsResponse represents a response for a list of
+// connectors
+message ListOrganizationConnectorsResponse {
+  // A list of connectors
+  repeated Connector connectors = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of connectors
+  int32 total_size = 3;
+}
+
+// GetOrganizationConnectorRequest represents a request to query a
+// connector
+message GetOrganizationConnectorRequest {
+  // Connectorconnector name. It must have the format of
+  // "connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "connector.name"}
+    }
+  ];
+  // Connector view (default is VIEW_BASIC)
+  optional Connector.View view = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetOrganizationConnectorResponse represents a response for a
+// connector
+message GetOrganizationConnectorResponse {
+  // connector
+  Connector connector = 1;
+}
+
+// UpdateOrganizationConnectorRequest represents a request to update a
+// connector
+message UpdateOrganizationConnectorRequest {
+  // connector
+  Connector connector = 1 [(google.api.field_behavior) = REQUIRED];
+  // Update mask for a connector
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateOrganizationConnectorResponse represents a response for a
+// connector
+message UpdateOrganizationConnectorResponse {
+  // connector
+  Connector connector = 1;
+}
+
+// DeleteOrganizationConnectorRequest represents a request to delete a
+// connector
+message DeleteOrganizationConnectorRequest {
+  // connector name. It must have the format of
+  // "connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "connector.name"}
+    }
+  ];
+}
+
+// DeleteOrganizationConnectorResponse represents an empty response
+message DeleteOrganizationConnectorResponse {}
+
+// ConnectOrganizationConnectorRequest represents a request to connect a
+// connector
+message ConnectOrganizationConnectorRequest {
+  // connector name. It must have the format of
+  // "connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Connector"}
+  ];
+}
+
+// ConnectOrganizationConnectorResponse represents a connected
+// connector
+message ConnectOrganizationConnectorResponse {
+  // A connector
+  Connector connector = 1;
+}
+
+// DisconnectOrganizationConnectorRequest represents a request to disconnect a
+// connector
+message DisconnectOrganizationConnectorRequest {
+  // connector name. It must have the format of
+  // "connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Connector"}
+  ];
+}
+
+// DisconnectOrganizationConnectorResponse represents a disconnected
+// connector
+message DisconnectOrganizationConnectorResponse {
+  // A connector
+  Connector connector = 1;
+}
+
+// RenameOrganizationConnectorRequest represents a request to rename the
+// connector name
+message RenameOrganizationConnectorRequest {
+  // connector name. It must have the format of
+  // "connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Connector"}
+  ];
+  // Connector new resource id to replace with the
+  // connector name to be
+  // "connectors/{new_connector_id}"
+  string new_connector_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RenameOrganizationConnectorResponse represents a renamed Connector
+// resource
+message RenameOrganizationConnectorResponse {
+  // A connector
+  Connector connector = 1;
+}
+
+// ExecuteOrganizationConnectorRequest represents a private request to execution
+// connector
+message ExecuteOrganizationConnectorRequest {
+  // Name of a connector. For example:
+  // "connectors/{name}"
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Inputs
+  repeated google.protobuf.Struct inputs = 2;
+  // Task
+  string task = 3;
+}
+
+// ExecuteOrganizationConnectorResponse represents a response for execution
+// output
+message ExecuteOrganizationConnectorResponse {
+  // Outputs
+  repeated google.protobuf.Struct outputs = 1;
+}
+
+// TestOrganizationConnectorRequest represents a public request to trigger check
+// action on a connector
+message TestOrganizationConnectorRequest {
+  // connector name. It must have the format of
+  // "connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Connector",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "connector.name"}
+    }
+  ];
+}
+
+// TestOrganizationConnectorResponse represents a response containing a
+// connector's current state
+message TestOrganizationConnectorResponse {
+  // Retrieved connector state
+  Connector.State state = 1;
+}
+
+// WatchOrganizationConnectorRequest represents a public request to query
+// a connector's current state
+message WatchOrganizationConnectorRequest {
+  // connector name. It must have the format of
+  // "connectors/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Connector",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "connector.name"}
+    }
+  ];
+}
+
+// WatchOrganizationConnectorResponse represents a response to fetch a
+// connector's current state
+message WatchOrganizationConnectorResponse {
+  // Retrieved connector state
+  Connector.State state = 1;
+}
+
+// ========== Private endpoints
+
+// ListConnectorsAdminRequest represents a request to list
+// connectors from all users by admin
+message ListConnectorsAdminRequest {
+  // The maximum number of connectors to return. The service may return fewer
+  // than this value. If unspecified, at most 10 connectors will be returned.
+  // The maximum value is 100; values above 100 will be coerced to 100.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Connector view (default is VIEW_BASIC)
+  optional Connector.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list connectors
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // Return soft_deleted connectors
@@ -462,23 +646,11 @@ message ListConnectorsAdminResponse {
 // LookUpConnectorAdminRequest represents a request to query a
 // connector via permalink by admin
 message LookUpConnectorAdminRequest {
-  // View enumerates the definition views
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: CONFIGURATION
-    VIEW_CONFIGURATION = 3;
-  }
-
   // Permalink of a connector. For example:
   // "connectors/{uid}"
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
   // Connector view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional Connector.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // LookUpConnectorAdminResponse represents a response for a

--- a/vdp/pipeline/v1alpha/connector_definition.proto
+++ b/vdp/pipeline/v1alpha/connector_definition.proto
@@ -42,6 +42,16 @@ enum ConnectorType {
 
 // ConnectorDefinition represents the connector definition data model
 message ConnectorDefinition {
+  // View enumerates the definition views
+  enum View {
+    // View: UNSPECIFIED
+    VIEW_UNSPECIFIED = 0;
+    // View: BASIC
+    VIEW_BASIC = 1;
+    // View: FULL
+    VIEW_FULL = 2;
+  }
+
   option (google.api.resource) = {
     type: "api.instill.tech/ConnectorDefinition"
     pattern:
@@ -95,16 +105,6 @@ message ConnectorDefinition {
 // ListConnectorDefinitionsRequest represents a request to list
 // ConnectorDefinitions
 message ListConnectorDefinitionsRequest {
-  // View enumerates the definition views
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-  }
-
   // The maximum number of ConnectorDefinitions to return. The
   // service may return fewer than this value. If unspecified, at most 10
   // ConnectorDefinitions will be returned. The maximum value is 100;
@@ -113,7 +113,7 @@ message ListConnectorDefinitionsRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // Definition view (default is DEFINITION_VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional ConnectorDefinition.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list connector definitions
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
 }
@@ -132,16 +132,6 @@ message ListConnectorDefinitionsResponse {
 // GetConnectorDefinitionRequest represents a request to query a
 // ConnectorDefinition resource
 message GetConnectorDefinitionRequest {
-  // View enumerates the definition views
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-  }
-
   // ConnectorDefinition resource name. It must have the format of
   // "connector-definitions/*"
   string name = 1 [
@@ -153,7 +143,7 @@ message GetConnectorDefinitionRequest {
   ];
   // ConnectorDefinition resource view (default is
   // DEFINITION_VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional ConnectorDefinition.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetConnectorDefinitionResponse represents a
@@ -166,21 +156,11 @@ message GetConnectorDefinitionResponse {
 // LookUpConnectorDefinitionAdminRequest represents a request to query a
 // connectorDefinition via permalink by admin
 message LookUpConnectorDefinitionAdminRequest {
-  // View enumerates the definition views
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-  }
-
   // Permalink of a connector. For example:
   // "connector-definitions/{uid}"
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
   // Connector view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional ConnectorDefinition.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // LookUpConnectorDefinitionAdminResponse represents a response for a

--- a/vdp/pipeline/v1alpha/operator_definition.proto
+++ b/vdp/pipeline/v1alpha/operator_definition.proto
@@ -21,6 +21,16 @@ message OperatorSpec {
 
 // Operator represents the operator definition data model
 message OperatorDefinition {
+  // Operator View
+  enum View {
+    // View: UNSPECIFIED
+    VIEW_UNSPECIFIED = 0;
+    // View: BASIC
+    VIEW_BASIC = 1;
+    // View: FULL
+    VIEW_FULL = 2;
+  }
+
   option (google.api.resource) = {
     type: "api.instill.tech/Operator"
     pattern:
@@ -68,16 +78,6 @@ message OperatorDefinition {
 // ListOperatorDefinitionsRequest represents a request to list
 // OperatorDefinitions
 message ListOperatorDefinitionsRequest {
-  // Operator View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-  }
-
   // The maximum number of OperatorDefinitions to return. The
   // service may return fewer than this value. If unspecified, at most 10
   // OperatorDefinitions will be returned. The maximum value is 100;
@@ -86,7 +86,7 @@ message ListOperatorDefinitionsRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // Definition view (default is DEFINITION_VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional OperatorDefinition.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list operator definitions
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
 }
@@ -105,15 +105,6 @@ message ListOperatorDefinitionsResponse {
 // GetOperatorDefinitionRequest represents a request to query a
 // Operator resource
 message GetOperatorDefinitionRequest {
-  // Operator View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-  }
   // Operator resource name. It must have the format of
   // "operator-definitions/*"
   string name = 1 [
@@ -125,7 +116,7 @@ message GetOperatorDefinitionRequest {
   ];
   // Operator resource view (default is
   // DEFINITION_VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional OperatorDefinition.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetOperatorDefinitionResponse represents a
@@ -138,20 +129,11 @@ message GetOperatorDefinitionResponse {
 // LookUpOperatorDefinitionAdminRequest represents a request to query a
 // operatorDefinition via permalink by admin
 message LookUpOperatorDefinitionAdminRequest {
-  // Operator View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-  }
   // Permalink of a operator. For example:
   // "operator-definitions/{uid}"
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
   // Operator view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional OperatorDefinition.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // LookUpOperatorAdminResponse represents a response for a

--- a/vdp/pipeline/v1alpha/pipeline.proto
+++ b/vdp/pipeline/v1alpha/pipeline.proto
@@ -103,6 +103,18 @@ enum State {
 
 // Pipeline represents the content of a pipeline
 message Pipeline {
+  // Pipeline View
+  enum View {
+    // View: UNSPECIFIED
+    VIEW_UNSPECIFIED = 0;
+    // View: BASIC
+    VIEW_BASIC = 1;
+    // View: FULL
+    VIEW_FULL = 2;
+    // View: RECIPE: will return recipe
+    VIEW_RECIPE = 3;
+  }
+
   option (google.api.resource) = {
     type: "api.instill.tech/Pipeline"
     pattern: "users/{user}/pipelines/{pipeline}"
@@ -131,7 +143,7 @@ message Pipeline {
       (google.api.field_behavior) = OUTPUT_ONLY
     ];
     // The resource name with UUID of an organization
-    string org = 9 [
+    string organization = 9 [
       (google.api.resource_reference).type = "api.instill.tech/Organization",
       (google.api.field_behavior) = OUTPUT_ONLY
     ];
@@ -204,18 +216,6 @@ message PipelineRelease {
 
 // ListPipelinesRequest represents a request to list pipelines
 message ListPipelinesRequest {
-  // Pipeline View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: RECIPE: will return recipe
-    VIEW_RECIPE = 3;
-  }
-
   // The maximum number of pipelines to return. The service may return fewer
   // than this value. If unspecified, at most 10 pipelines will be returned. The
   // maximum value is 100; values above 100 will be coerced to 100.
@@ -223,7 +223,7 @@ message ListPipelinesRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional Pipeline.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list pipelines
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // Return soft_deleted pipelines
@@ -238,6 +238,21 @@ message ListPipelinesResponse {
   string next_page_token = 2;
   // Total count of pipeline resources
   int32 total_size = 3;
+}
+
+// LookUpPipelineRequest represents a request to query a pipeline via permalink
+message LookUpPipelineRequest {
+  // Permalink of a pipeline. For example:
+  // "pipelines/{uid}"
+  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // View view (default is VIEW_BASIC)
+  optional Pipeline.View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// LookUpPipelineResponse represents a response for a pipeline resource
+message LookUpPipelineResponse {
+  // A pipeline resource
+  Pipeline pipeline = 1;
 }
 
 // CreateUserPipelineRequest represents a request to create a pipeline
@@ -260,17 +275,6 @@ message CreateUserPipelineResponse {
 
 // ListUserPipelinesRequest represents a request to list pipelines
 message ListUserPipelinesRequest {
-  // Pipeline View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: RECIPE: will return recipe
-    VIEW_RECIPE = 3;
-  }
   // The maximum number of pipelines to return. The service may return fewer
   // than this value. If unspecified, at most 10 pipelines will be returned. The
   // maximum value is 100; values above 100 will be coerced to 100.
@@ -278,7 +282,7 @@ message ListUserPipelinesRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional Pipeline.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list pipelines
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // The parent resource where this connector resource will be created.
@@ -301,47 +305,8 @@ message ListUserPipelinesResponse {
   int32 total_size = 3;
 }
 
-// LookUpPipelineRequest represents a request to query a pipeline via permalink
-message LookUpPipelineRequest {
-  // Pipeline View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: RECIPE: will return recipe
-    VIEW_RECIPE = 3;
-  }
-
-  // Permalink of a pipeline. For example:
-  // "pipelines/{uid}"
-  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
-  // View view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// LookUpPipelineResponse represents a response for a pipeline resource
-message LookUpPipelineResponse {
-  // A pipeline resource
-  Pipeline pipeline = 1;
-}
-
 // GetUserPipelineRequest represents a request to query a pipeline
 message GetUserPipelineRequest {
-  // Pipeline View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: RECIPE: will return recipe
-    VIEW_RECIPE = 3;
-  }
-
   // Pipeline resource name. It must have the format of "users/*/pipelines/*"
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -351,7 +316,7 @@ message GetUserPipelineRequest {
     }
   ];
   // Pipeline resource view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional Pipeline.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetUserPipelineResponse represents a response for a pipeline resource
@@ -461,20 +426,6 @@ message TriggerAsyncUserPipelineResponse {
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetOperationRequest represents a request to query a longrunning
-// operation
-message GetOperationRequest {
-  // The name of the operation resource.
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-// GetOperationResponse represents a response for a longrunning
-// operation
-message GetOperationResponse {
-  // The retrieved longrunning operation
-  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
 // CreateUserPipelineReleaseRequest represents a request to create a pipeline_release
 message CreateUserPipelineReleaseRequest {
   // A pipeline_release resource to create
@@ -495,18 +446,6 @@ message CreateUserPipelineReleaseResponse {
 
 // ListUserPipelineReleasesRequest represents a request to list pipeline_releases
 message ListUserPipelineReleasesRequest {
-  // Pipeline View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: RECIPE: will return recipe
-    VIEW_RECIPE = 3;
-  }
-
   // The maximum number of pipeline_releases to return. The service may return fewer
   // than this value. If unspecified, at most 10 pipeline_release will be returned. The
   // maximum value is 100; values above 100 will be coerced to 100.
@@ -514,7 +453,7 @@ message ListUserPipelineReleasesRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional Pipeline.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list pipeline_releases
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // The parent resource where this pipeline_release will be created.
@@ -540,16 +479,6 @@ message ListUserPipelineReleasesResponse {
 // GetUserPipelineReleaseRequest represents a request to query a pipeline_release
 message GetUserPipelineReleaseRequest {
   // Pipeline View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: RECIPE: will return recipe
-    VIEW_RECIPE = 3;
-  }
 
   // PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
   string name = 1 [
@@ -560,7 +489,7 @@ message GetUserPipelineReleaseRequest {
     }
   ];
   // PipelineRelease resource view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional Pipeline.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetUserPipelineReleaseResponse represents a response for a pipeline_release resource
@@ -597,21 +526,6 @@ message DeleteUserPipelineReleaseRequest {
 
 // DeleteUserPipelineReleaseResponse represents an empty response
 message DeleteUserPipelineReleaseResponse {}
-
-// SetDefaultUserPipelineReleaseRequest
-message SetDefaultUserPipelineReleaseRequest {
-  // Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
-  ];
-}
-
-// SetDefaultUserPipelineReleaseResponse
-message SetDefaultUserPipelineReleaseResponse {
-  // A pipeline resource
-  PipelineRelease release = 1;
-}
 
 // RestoreUserPipelineReleaseRequest
 message RestoreUserPipelineReleaseRequest {
@@ -705,23 +619,26 @@ message TriggerAsyncUserPipelineReleaseResponse {
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ========== Private endpoints
+// CreateOrganizationPipelineRequest represents a request to create a pipeline
+message CreateOrganizationPipelineRequest {
+  // A pipeline resource to create
+  Pipeline pipeline = 1 [(google.api.field_behavior) = REQUIRED];
+  // The parent resource where this connector resource will be created.
+  // Format: organizations/{organizations}
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Pipeline"}
+  ];
+}
 
-// ListPipelinesAdminRequest represents a request to list all pipelines from all
-// users by admin
-message ListPipelinesAdminRequest {
-  // Pipeline View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: RECIPE: will return recipe
-    VIEW_RECIPE = 3;
-  }
+// CreateOrganizationPipelineResponse represents a response for a pipeline resource
+message CreateOrganizationPipelineResponse {
+  // The created pipeline resource
+  Pipeline pipeline = 1;
+}
 
+// ListOrganizationPipelinesRequest represents a request to list pipelines
+message ListOrganizationPipelinesRequest {
   // The maximum number of pipelines to return. The service may return fewer
   // than this value. If unspecified, at most 10 pipelines will be returned. The
   // maximum value is 100; values above 100 will be coerced to 100.
@@ -729,7 +646,383 @@ message ListPipelinesAdminRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional Pipeline.View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list pipelines
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The parent resource where this connector resource will be created.
+  // Format: organizations/{organizations}
+  string parent = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Pipeline"}
+  ];
+  // Return soft_deleted pipeline releases
+  optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListOrganizationPipelinesResponse represents a response for a list of pipelines
+message ListOrganizationPipelinesResponse {
+  // A list of pipeline resources
+  repeated Pipeline pipelines = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of pipeline resources
+  int32 total_size = 3;
+}
+
+// GetOrganizationPipelineRequest represents a request to query a pipeline
+message GetOrganizationPipelineRequest {
+  // Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline.name"}
+    }
+  ];
+  // Pipeline resource view (default is VIEW_BASIC)
+  optional Pipeline.View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetOrganizationPipelineResponse represents a response for a pipeline resource
+message GetOrganizationPipelineResponse {
+  // A pipeline resource
+  Pipeline pipeline = 1;
+}
+
+// UpdateOrganizationPipelineRequest represents a request to update a pipeline
+message UpdateOrganizationPipelineRequest {
+  // A pipeline resource to update
+  Pipeline pipeline = 1 [(google.api.field_behavior) = REQUIRED];
+  // Update mask for a pipeline resource
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateOrganizationPipelineResponse represents a response for a pipeline resource
+message UpdateOrganizationPipelineResponse {
+  // An updated pipeline resource
+  Pipeline pipeline = 1;
+}
+
+// DeleteOrganizationPipelineRequest represents a request to delete a pipeline resource
+message DeleteOrganizationPipelineRequest {
+  // Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline.name"}
+    }
+  ];
+}
+
+// DeleteOrganizationPipelineResponse represents an empty response
+message DeleteOrganizationPipelineResponse {}
+
+// ValidatePOrganizationipelineRequest represents a request to validate a pipeline
+message ValidateOrganizationPipelineRequest {
+  // Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+}
+
+// ValidateOrganizationPipelineResponse represents an response of validated pipeline
+message ValidateOrganizationPipelineResponse {
+  // A pipeline resource
+  Pipeline pipeline = 1;
+}
+
+// RenameOrganizationPipelineRequest represents a request to rename the pipeline resource
+// name
+message RenameOrganizationPipelineRequest {
+  // Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+  // Pipeline new resource id to replace with the pipeline resource name to be
+  // "organizations/*/pipelines/{new_pipeline_id}"
+  string new_pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RenameOrganizationPipelineResponse represents a renamed pipeline resource
+message RenameOrganizationPipelineResponse {
+  // A pipeline resource
+  Pipeline pipeline = 1;
+}
+
+// TriggerOrganizationPipelineRequest represents a request to trigger a pipeline
+message TriggerOrganizationPipelineRequest {
+  // Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+  // Input to the pipeline
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerOrganizationPipelineResponse represents a response for the output
+// of a pipeline, i.e., the multiple model inference outputs
+message TriggerOrganizationPipelineResponse {
+  // The multiple model inference outputs
+  repeated google.protobuf.Struct outputs = 1;
+  // The traces of the pipeline inference, {component_id: Trace}
+  TriggerMetadata metadata = 2;
+}
+
+// TriggerAsyncOrganizationPipelineRequest represents a request to trigger a async pipeline
+message TriggerAsyncOrganizationPipelineRequest {
+  // Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+  // Input to the pipeline
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerAsyncOrganizationPipelineResponse represents a response for the longrunning
+// operation of a pipeline
+message TriggerAsyncOrganizationPipelineResponse {
+  // Trigger async pipeline operation message
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CreateOrganizationPipelineReleaseRequest represents a request to create a pipeline_release
+message CreateOrganizationPipelineReleaseRequest {
+  // A pipeline_release resource to create
+  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
+  // The parent resource where this pipeline_release will be created.
+  // Format: organizations/{organization}/pipelines/{pipeline}
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"}
+  ];
+}
+
+// CreateOrganizationPipelineReleaseResponse represents a response for a pipeline_release resource
+message CreateOrganizationPipelineReleaseResponse {
+  // The created pipeline_release resource
+  PipelineRelease release = 1;
+}
+
+// ListOrganizationPipelineReleasesRequest represents a request to list pipeline_releases
+message ListOrganizationPipelineReleasesRequest {
+  // The maximum number of pipeline_releases to return. The service may return fewer
+  // than this value. If unspecified, at most 10 pipeline_release will be returned. The
+  // maximum value is 100; values above 100 will be coerced to 100.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // View view (default is VIEW_BASIC)
+  optional Pipeline.View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter expression to list pipeline_releases
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The parent resource where this pipeline_release will be created.
+  // Format: organizations/{organization}/pipelines/{pipeline}
+  string parent = 5 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Return soft_deleted pipelines
+  optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListOrganizationPipelineReleasesResponse represents a response for a list of pipeline_releases
+message ListOrganizationPipelineReleasesResponse {
+  // A list of pipeline_release resources
+  repeated PipelineRelease releases = 1;
+  // Next page token
+  string next_page_token = 2;
+  // Total count of pipeline_release resources
+  int32 total_size = 3;
+}
+
+// GetOrganizationPipelineReleaseRequest represents a request to query a pipeline_release
+message GetOrganizationPipelineReleaseRequest {
+  // PipelineRelease resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline_release.name"}
+    }
+  ];
+  // PipelineRelease resource view (default is VIEW_BASIC)
+  optional Pipeline.View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetOrganizationPipelineReleaseResponse represents a response for a pipeline_release resource
+message GetOrganizationPipelineReleaseResponse {
+  // A pipeline_release resource
+  PipelineRelease release = 1;
+}
+
+// UpdateOrganizationPipelineReleaseRequest represents a request to update a pipeline release
+message UpdateOrganizationPipelineReleaseRequest {
+  // A pipeline release resource to update
+  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
+  // Update mask for a pipeline resource
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateOrganizationPipelineReleaseResponse represents a response for a pipeline resource
+message UpdateOrganizationPipelineReleaseResponse {
+  // An updated pipeline resource
+  PipelineRelease release = 1;
+}
+
+// DeleteOrganizationPipelineReleaseRequest represents a request to delete a pipeline_release resource
+message DeleteOrganizationPipelineReleaseRequest {
+  // PipelineRelease resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline_release.name"}
+    }
+  ];
+}
+
+// DeleteOrganizationPipelineReleaseResponse represents an empty response
+message DeleteOrganizationPipelineReleaseResponse {}
+
+// SetDefaultOrganizationPipelineReleaseRequest
+message SetDefaultOrganizationPipelineReleaseRequest {
+  // Pipeline resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+}
+
+// SetDefaultOrganizationPipelineReleaseResponse
+message SetDefaultOrganizationPipelineReleaseResponse {
+  // A pipeline resource
+  PipelineRelease release = 1;
+}
+
+// RestoreOrganizationPipelineReleaseRequest
+message RestoreOrganizationPipelineReleaseRequest {
+  // Pipeline resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"}
+  ];
+}
+
+// RestoreOrganizationPipelineReleaseResponse
+message RestoreOrganizationPipelineReleaseResponse {
+  // A pipeline resource
+  PipelineRelease release = 1;
+}
+
+// RenameOrganizationPipelineReleaseRequest represents a request to rename the pipeline release resource
+// name
+message RenameOrganizationPipelineReleaseRequest {
+  // Pipeline release resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Pipeline new resource id to replace with the pipeline resource name to be
+  // "organizations/*/pipelines/*/releases/{new_pipeline_id}"
+  string new_pipeline_release_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RenameOrganizationPipelineReleaseResponse represents a renamed pipeline release resource
+message RenameOrganizationPipelineReleaseResponse {
+  // A pipeline resource
+  PipelineRelease release = 1;
+}
+
+// WatchOrganizationPipelineReleaseRequest represents a public request to query
+// a pipeline's current state
+message WatchOrganizationPipelineReleaseRequest {
+  // Pipeline resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline.name/watch"}
+    }
+  ];
+}
+
+// WatchOrganizationPipelineReleaseResponse represents a response to fetch a pipeline's
+// current state
+message WatchOrganizationPipelineReleaseResponse {
+  // Retrieved pipeline state
+  State state = 1;
+}
+
+// TriggerOrganizationPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+message TriggerOrganizationPipelineReleaseRequest {
+  // Resource name.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Input to the pipeline
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerOrganizationPipelineReleaseResponse represents a response for the output
+// of a pipeline, i.e., the multiple model inference outputs
+message TriggerOrganizationPipelineReleaseResponse {
+  // The multiple model inference outputs
+  repeated google.protobuf.Struct outputs = 1;
+  // The traces of the pipeline inference, {component_id: Trace}
+  TriggerMetadata metadata = 2;
+}
+
+// TriggerAsyncOrganizationPipelineReleaseRequest represents a request to trigger a pipeline_released pipeline
+message TriggerAsyncOrganizationPipelineReleaseRequest {
+  // Resource name.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"}
+  ];
+  // Input to the pipeline
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerAsyncOrganizationPipelineReleaseResponse represents a response for the longrunning
+// operation of a pipeline
+message TriggerAsyncOrganizationPipelineReleaseResponse {
+  // Trigger async pipeline operation message
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetOperationRequest represents a request to query a longrunning
+// operation
+message GetOperationRequest {
+  // The name of the operation resource.
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetOperationResponse represents a response for a longrunning
+// operation
+message GetOperationResponse {
+  // The retrieved longrunning operation
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ========== Private endpoints
+
+// ListPipelinesAdminRequest represents a request to list all pipelines from all
+// users by admin
+message ListPipelinesAdminRequest {
+  // The maximum number of pipelines to return. The service may return fewer
+  // than this value. If unspecified, at most 10 pipelines will be returned. The
+  // maximum value is 100; values above 100 will be coerced to 100.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // View view (default is VIEW_BASIC)
+  optional Pipeline.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list pipelines
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // Return soft_deleted pipelines
@@ -751,18 +1044,6 @@ message ListPipelinesAdminResponse {
 // ListPipelinesReleaseAdminRequest represents a request to list all pipeline_releases from all
 // users by admin
 message ListPipelineReleasesAdminRequest {
-  // Pipeline View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: RECIPE: will return recipe
-    VIEW_RECIPE = 3;
-  }
-
   // The maximum number of pipelines to return. The service may return fewer
   // than this value. If unspecified, at most 10 pipelines will be returned. The
   // maximum value is 100; values above 100 will be coerced to 100.
@@ -770,7 +1051,7 @@ message ListPipelineReleasesAdminRequest {
   // Page token
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View view (default is VIEW_BASIC)
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional Pipeline.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter expression to list pipelines
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // Return soft_deleted pipelines
@@ -792,23 +1073,11 @@ message ListPipelineReleasesAdminResponse {
 // LookUpPipelineAdminRequest represents a request to query a user's pipeline
 // via permalink by admin
 message LookUpPipelineAdminRequest {
-  // Pipeline View
-  enum View {
-    // View: UNSPECIFIED
-    VIEW_UNSPECIFIED = 0;
-    // View: BASIC
-    VIEW_BASIC = 1;
-    // View: FULL
-    VIEW_FULL = 2;
-    // View: RECIPE: will return recipe
-    VIEW_RECIPE = 3;
-  }
-
   // Permalink of a pipeline. For example:
   // "pipelines/{uid}"
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
   // View view (default is VIEW_BASIC)
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional Pipeline.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // LookUpPipelineAdminResponse represents a response for a pipeline resource

--- a/vdp/pipeline/v1alpha/pipeline_public_service.proto
+++ b/vdp/pipeline/v1alpha/pipeline_public_service.proto
@@ -32,21 +32,6 @@ service PipelinePublicService {
     option (google.api.http) = {get: "/v1alpha/__readiness"};
   }
 
-  // ListOperatorDefinitions method receives a
-  // ListOperatorDefinitionsRequest message and returns a
-  // ListOperatorDefinitionsResponse message.
-  rpc ListOperatorDefinitions(ListOperatorDefinitionsRequest) returns (ListOperatorDefinitionsResponse) {
-    option (google.api.http) = {get: "/v1alpha/operator-definitions"};
-  }
-
-  // GetOperatorDefinition method receives a
-  // GetOperatorDefinitionRequest message and returns a
-  // GetGetOperatorDefinitionResponse message.
-  rpc GetOperatorDefinition(GetOperatorDefinitionRequest) returns (GetOperatorDefinitionResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=operator-definitions/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
   // ListPipelines method receives a ListPipelinesRequest message and returns a
   // ListPipelinesResponse message.
   rpc ListPipelines(ListPipelinesRequest) returns (ListPipelinesResponse) {
@@ -140,16 +125,6 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name,inputs";
   }
 
-  // *Longrunning operation methods
-
-  // GetOperation method receives a
-  // GetOperationRequest message and returns a
-  // GetOperationResponse message.
-  rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
   // CreateUserPipelineRelease method receives a CreateUserPipelineReleaseRequest message and returns
   // a CreateUserPipelineReleaseResponse message.
   rpc CreateUserPipelineRelease(CreateUserPipelineReleaseRequest) returns (CreateUserPipelineReleaseResponse) {
@@ -198,13 +173,6 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // SetDefaultUserPipelineRelease method receives a SetDefaultUserPipelineReleaseRequest message
-  // and returns a SetDefaultUserPipelineReleaseResponse
-  rpc SetDefaultUserPipelineRelease(SetDefaultUserPipelineReleaseRequest) returns (SetDefaultUserPipelineReleaseResponse) {
-    option (google.api.http) = {post: "/v1alpha/{name=users/*/pipelines/*/releases/*}/setDefault"};
-    option (google.api.method_signature) = "name";
-  }
-
   // WatchUserPipelineRelease method receives a WatchUserPipelineReleaseRequest message
   // and returns a WatchUserPipelineReleaseResponse
   rpc WatchUserPipelineRelease(WatchUserPipelineReleaseRequest) returns (WatchUserPipelineReleaseResponse) {
@@ -242,6 +210,181 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name,inputs";
   }
 
+  // CreateOrganizationPipeline method receives a CreateOrganizationPipelineRequest message and returns
+  // a CreateOrganizationPipelineResponse message.
+  rpc CreateOrganizationPipeline(CreateOrganizationPipelineRequest) returns (CreateOrganizationPipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{parent=organizations/*}/pipelines"
+      body: "pipeline"
+    };
+    option (google.api.method_signature) = "parent,pipeline";
+  }
+
+  // ListOrganizationPipelines method receives a ListOrganizationPipelinesRequest message and returns a
+  // ListOrganizationPipelinesResponse message.
+  rpc ListOrganizationPipelines(ListOrganizationPipelinesRequest) returns (ListOrganizationPipelinesResponse) {
+    option (google.api.http) = {get: "/v1alpha/{parent=organizations/*}/pipelines"};
+    option (google.api.method_signature) = "parent";
+  }
+
+  // GetOrganizationPipeline method receives a GetOrganizationPipelineRequest message and returns a
+  // GetOrganizationPipelineResponse message.
+  rpc GetOrganizationPipeline(GetOrganizationPipelineRequest) returns (GetOrganizationPipelineResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=organizations/*/pipelines/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // UpdateOrganizationPipeline method receives a UpdateOrganizationPipelineRequest message and returns
+  // a UpdateOrganizationPipelineResponse message.
+  rpc UpdateOrganizationPipeline(UpdateOrganizationPipelineRequest) returns (UpdateOrganizationPipelineResponse) {
+    option (google.api.http) = {
+      patch: "/v1alpha/{pipeline.name=organizations/*/pipelines/*}"
+      body: "pipeline"
+    };
+    option (google.api.method_signature) = "pipeline,update_mask";
+  }
+
+  // DeleteOrganizationPipeline method receives a DeleteOrganizationPipelineRequest message and returns
+  // a DeleteOrganizationPipelineResponse message.
+  rpc DeleteOrganizationPipeline(DeleteOrganizationPipelineRequest) returns (DeleteOrganizationPipelineResponse) {
+    option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/pipelines/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // Validate a pipeline.
+  rpc ValidateOrganizationPipeline(ValidateOrganizationPipelineRequest) returns (ValidateOrganizationPipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/pipelines/*}/validate"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // RenameOrganizationPipeline method receives a RenameOrganizationPipelineRequest message and returns
+  // a RenameOrganizationPipelineResponse message.
+  rpc RenameOrganizationPipeline(RenameOrganizationPipelineRequest) returns (RenameOrganizationPipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/pipelines/*}/rename"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,new_pipeline_id";
+  }
+
+  // TriggerOrganizationPipeline method receives a TriggerOrganizationPipelineRequest message
+  // and returns a TriggerOrganizationPipelineResponse.
+  rpc TriggerOrganizationPipeline(TriggerOrganizationPipelineRequest) returns (TriggerOrganizationPipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/pipelines/*}/trigger"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,inputs";
+  }
+
+  // TriggerAsyncOrganizationPipeline method receives a TriggerAsyncOrganizationPipelineRequest message and
+  // returns a TriggerAsyncOrganizationPipelineResponse.
+  rpc TriggerAsyncOrganizationPipeline(TriggerAsyncOrganizationPipelineRequest) returns (TriggerAsyncOrganizationPipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/pipelines/*}/triggerAsync"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,inputs";
+  }
+
+  // CreateOrganizationPipelineRelease method receives a CreateOrganizationPipelineReleaseRequest message and returns
+  // a CreateOrganizationPipelineReleaseResponse message.
+  rpc CreateOrganizationPipelineRelease(CreateOrganizationPipelineReleaseRequest) returns (CreateOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{parent=organizations/*/pipelines/*}/releases"
+      body: "release"
+    };
+    option (google.api.method_signature) = "parent,release";
+  }
+
+  // ListOrganizationPipelineReleases method receives a ListOrganizationPipelineReleasesRequest message and returns a
+  // ListOrganizationPipelineReleasesResponse message.
+  rpc ListOrganizationPipelineReleases(ListOrganizationPipelineReleasesRequest) returns (ListOrganizationPipelineReleasesResponse) {
+    option (google.api.http) = {get: "/v1alpha/{parent=organizations/*/pipelines/*}/releases"};
+    option (google.api.method_signature) = "pipelines";
+  }
+
+  // GetOrganizationPipelineRelease method receives a GetOrganizationPipelineReleaseRequest message and returns a
+  // GetOrganizationPipelineReleaseResponse message.
+  rpc GetOrganizationPipelineRelease(GetOrganizationPipelineReleaseRequest) returns (GetOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=organizations/*/pipelines/*/releases/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // UpdateOrganizationPipelineRelease method receives a UpdateOrganizationPipelineReleaseRequest message and returns
+  // a UpdateOrganizationPipelineReleaseResponse message.
+  rpc UpdateOrganizationPipelineRelease(UpdateOrganizationPipelineReleaseRequest) returns (UpdateOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {
+      patch: "/v1alpha/{release.name=organizationsr/*/pipelines/*/releases/*}"
+      body: "release"
+    };
+    option (google.api.method_signature) = "release,update_mask";
+  }
+
+  // DeleteOrganizationPipelineRelease method receives a DeleteOrganizationPipelineReleaseRequest message and returns
+  // a DeleteOrganizationPipelineReleaseResponse message.
+  rpc DeleteOrganizationPipelineRelease(DeleteOrganizationPipelineReleaseRequest) returns (DeleteOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/pipelines/*/releases/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // RestoreOrganizationPipelineRelease method receives a RestoreOrganizationPipelineReleaseRequest message
+  // and returns a RestoreOrganizationPipelineReleaseResponse
+  rpc RestoreOrganizationPipelineRelease(RestoreOrganizationPipelineReleaseRequest) returns (RestoreOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {post: "/v1alpha/{name=organizations/*/pipelines/*/releases/*}/restore"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // WatchOrganizationPipelineRelease method receives a WatchOrganizationPipelineReleaseRequest message
+  // and returns a WatchOrganizationPipelineReleaseResponse
+  rpc WatchOrganizationPipelineRelease(WatchOrganizationPipelineReleaseRequest) returns (WatchOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=organizations/*/pipelines/*/releases/*}/watch"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // RenameOrganizationPipelineRelease method receives a RenameOrganizationPipelineReleaseRequest message and returns
+  // a RenameOrganizationPipelineReleaseResponse message.
+  rpc RenameOrganizationPipelineRelease(RenameOrganizationPipelineReleaseRequest) returns (RenameOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/pipelines/*/releases/*}/rename"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,new_pipeline_release_id";
+  }
+
+  // TriggerOrganizationPipelineRelease method receives a TriggeOrganizationPipelineReleaseRequest message
+  // and returns a TriggerPipelineReleasePipelineResponse.
+  rpc TriggerOrganizationPipelineRelease(TriggerOrganizationPipelineReleaseRequest) returns (TriggerOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/pipelines/*/releases/*}/trigger"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,inputs";
+  }
+
+  // TriggerAsyncOrganizationPipelineRelease method receives a TriggerAsyncOrganizationPipelineReleaseRequest message and
+  // returns a TriggerAsyncOrganizationPipelineReleaseResponse.
+  rpc TriggerAsyncOrganizationPipelineRelease(TriggerAsyncOrganizationPipelineReleaseRequest) returns (TriggerAsyncOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/pipelines/*/releases/*}/triggerAsync"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,inputs";
+  }
+
+  // *Longrunning operation methods
+
+  // GetOperation method receives a
+  // GetOperationRequest message and returns a
+  // GetOperationResponse message.
+  rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
   // ListConnectorDefinitions method receives a
   // ListConnectorDefinitionsRequest message and returns a
   // ListConnectorDefinitionsResponse message.
@@ -254,6 +397,21 @@ service PipelinePublicService {
   // GetGetConnectorDefinitionResponse message.
   rpc GetConnectorDefinition(GetConnectorDefinitionRequest) returns (GetConnectorDefinitionResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=connector-definitions/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // ListOperatorDefinitions method receives a
+  // ListOperatorDefinitionsRequest message and returns a
+  // ListOperatorDefinitionsResponse message.
+  rpc ListOperatorDefinitions(ListOperatorDefinitionsRequest) returns (ListOperatorDefinitionsResponse) {
+    option (google.api.http) = {get: "/v1alpha/operator-definitions"};
+  }
+
+  // GetOperatorDefinition method receives a
+  // GetOperatorDefinitionRequest message and returns a
+  // GetGetOperatorDefinitionResponse message.
+  rpc GetOperatorDefinition(GetOperatorDefinitionRequest) returns (GetOperatorDefinitionResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=operator-definitions/*}"};
     option (google.api.method_signature) = "name";
   }
 
@@ -381,6 +539,114 @@ service PipelinePublicService {
   // message and returns a TestUserConnectorResponse
   rpc TestUserConnector(TestUserConnectorRequest) returns (TestUserConnectorResponse) {
     option (google.api.http) = {post: "/v1alpha/{name=users/*/connectors/*}/testConnection"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // CreateOrganizationConnector method receives a
+  // CreateOrganizationConnectorRequest message and returns a
+  // CreateOrganizationConnectorResponse message.
+  rpc CreateOrganizationConnector(CreateOrganizationConnectorRequest) returns (CreateOrganizationConnectorResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{parent=organizations/*}/connectors"
+      body: "connector"
+    };
+    option (google.api.method_signature) = "parent,connector";
+  }
+
+  // ListOrganizationConnectors method receives a
+  // ListOrganizationConnectorsRequest message and returns a
+  // ListOrganizationConnectorsResponse message.
+  rpc ListOrganizationConnectors(ListOrganizationConnectorsRequest) returns (ListOrganizationConnectorsResponse) {
+    option (google.api.http) = {get: "/v1alpha/{parent=organizations/*}/connectors"};
+    option (google.api.method_signature) = "parent";
+  }
+
+  // GetOrganizationConnector method receives a GetOrganizationConnectorRequest
+  // message and returns a GetOrganizationConnectorResponse message.
+  rpc GetOrganizationConnector(GetOrganizationConnectorRequest) returns (GetOrganizationConnectorResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=organizations/*/connectors/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // UpdateOrganizationConnector method receives a
+  // UpdateOrganizationConnectorRequest message and returns a
+  // UpdateOrganizationConnectorResponse message.
+  rpc UpdateOrganizationConnector(UpdateOrganizationConnectorRequest) returns (UpdateOrganizationConnectorResponse) {
+    option (google.api.http) = {
+      patch: "/v1alpha/{connector.name=organizations/*/connectors/*}"
+      body: "connector"
+    };
+    option (google.api.method_signature) = "connector,update_mask";
+  }
+
+  // DeleteOrganizationConnector method receives a
+  // DeleteOrganizationConnectorRequest message and returns a
+  // DeleteOrganizationConnectorResponse message.
+  rpc DeleteOrganizationConnector(DeleteOrganizationConnectorRequest) returns (DeleteOrganizationConnectorResponse) {
+    option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/connectors/*}"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // Connect a connector.
+  // The "state" of the connector after connecting is "CONNECTED".
+  // ConnectOrganizationConnector can be called on Connector in the
+  // state `DISCONNECTED`; Connector in a different state (including
+  // `CONNECTED`) returns an error.
+  rpc ConnectOrganizationConnector(ConnectOrganizationConnectorRequest) returns (ConnectOrganizationConnectorResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/connectors/*}/connect"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Disconnect a connector.
+  // The "state" of the connector after disconnecting is "DISCONNECTED".
+  // DisconnectOrganizationConnector can be called on Connector in the
+  // state `CONNECTED`; Connector in a different state (including
+  // `DISCONNECTED`) returns an error.
+  rpc DisconnectOrganizationConnector(DisconnectOrganizationConnectorRequest) returns (DisconnectOrganizationConnectorResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/connectors/*}/disconnect"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // RenameOrganizationConnector method receives a
+  // RenameOrganizationConnectorRequest message and returns a
+  // RenameOrganizationConnectorResponse message.
+  rpc RenameOrganizationConnector(RenameOrganizationConnectorRequest) returns (RenameOrganizationConnectorResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/connectors/*}/rename"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,new_connector_id";
+  }
+
+  // ExecuteOrganizationConnector method receives a
+  // ExecuteOrganizationConnectorRequest message and returns a
+  // ExecuteOrganizationConnectorResponse message.
+  rpc ExecuteOrganizationConnector(ExecuteOrganizationConnectorRequest) returns (ExecuteOrganizationConnectorResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/{name=organizations/*/connectors/*}/execute"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // WatchOrganizationConnector method receives a
+  // WatchOrganizationConnectorRequest message and returns a
+  // WatchOrganizationConnectorResponse
+  rpc WatchOrganizationConnector(WatchOrganizationConnectorRequest) returns (WatchOrganizationConnectorResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=organizations/*/connectors/*}/watch"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // TestOrganizationConnector method receives a TestOrganizationConnectorRequest
+  // message and returns a TestOrganizationConnectorResponse
+  rpc TestOrganizationConnector(TestOrganizationConnectorRequest) returns (TestOrganizationConnectorResponse) {
+    option (google.api.http) = {post: "/v1alpha/{name=organizations/*/connectors/*}/testConnection"};
     option (google.api.method_signature) = "name";
   }
 }


### PR DESCRIPTION
Because

- we need to allow user to create pipeline/connector under organization under organization namespace

This commit

- support creating pipeline/connector under organization
- add organization admin endpoints