### PR TITLE
chore(mgmt): add profile avatar and data fields

### DIFF
--- a/core/mgmt/v1alpha/mgmt.proto
+++ b/core/mgmt/v1alpha/mgmt.proto
@@ -8,6 +8,7 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 // Protobuf standard
 import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -118,6 +119,10 @@ message User {
   bool newsletter_subscription = 13 [(google.api.field_behavior) = REQUIRED];
   // User console cookie token
   optional string cookie_token = 14 [(google.api.field_behavior) = OPTIONAL];
+  // Profile Avatar base64
+  optional string profile_avatar = 15 [(google.api.field_behavior) = OPTIONAL];
+  // Profile Data
+  optional google.protobuf.Struct profile_data = 16 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUsersAdminRequest represents a request to list all users by admin
@@ -548,6 +553,10 @@ message Organization {
   optional string org_name = 6 [(google.api.field_behavior) = OPTIONAL];
   // Stripe customer ID. This field is used in Instill Cloud.
   string customer_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Profile Avatar base64
+  optional string profile_avatar = 9 [(google.api.field_behavior) = OPTIONAL];
+  // Profile Data
+  optional google.protobuf.Struct profile_data = 10 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListOrganizationsRequest represents a request to list all organizations

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2420,6 +2420,12 @@ paths:
                 type: string
                 description: Stripe customer ID. This field is used in Instill Cloud.
                 readOnly: true
+              profile_avatar:
+                type: string
+                title: Profile Avatar base64
+              profile_data:
+                type: object
+                title: Profile Data
             description: |-
               The organization's `name` field is used to identify the organization to update.
               Format: organizations/{organization}
@@ -6525,6 +6531,12 @@ definitions:
       cookie_token:
         type: string
         title: User console cookie token
+      profile_avatar:
+        type: string
+        title: Profile Avatar base64
+      profile_data:
+        type: object
+        title: Profile Data
     title: User represents the content of a user
     required:
       - id
@@ -9382,6 +9394,12 @@ definitions:
         type: string
         description: Stripe customer ID. This field is used in Instill Cloud.
         readOnly: true
+      profile_avatar:
+        type: string
+        title: Profile Avatar base64
+      profile_data:
+        type: object
+        title: Profile Data
     title: Organization represents the content of a organization
     required:
       - id


### PR DESCRIPTION
Because

- we need to store the user avatar and profile data

This commit

- add profile avatar and data fields
