### PR TITLE
chore(vdp): add new pipeline sharing role

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -10041,10 +10041,12 @@ definitions:
     enum:
       - ROLE_UNSPECIFIED
       - ROLE_VIEWER
+      - ROLE_EXECUTOR
     default: ROLE_UNSPECIFIED
     description: |-
       - ROLE_UNSPECIFIED: ROLE: UNSPECIFIED
        - ROLE_VIEWER: Role: Viewer
+       - ROLE_EXECUTOR: Role: Executor
     title: Role
   v1alphaSemanticSegmentationInput:
     type: object

--- a/vdp/pipeline/v1alpha/common.proto
+++ b/vdp/pipeline/v1alpha/common.proto
@@ -8,6 +8,8 @@ enum Role {
   ROLE_UNSPECIFIED = 0;
   // Role: Viewer
   ROLE_VIEWER = 1;
+  // Role: Executor
+  ROLE_EXECUTOR = 2;
 }
 
 // Permission


### PR DESCRIPTION
Because

- we need a new pipeline sharing role to allow user trigger the public pipeline

This commit

- add new pipeline sharing role: `ROLE_EXECUTOR`
