### PR TITLE
chore(core): remove ExistUsername API  and add new CheckNamespace API

### DIFF
--- a/core/mgmt/v1alpha/mgmt.proto
+++ b/core/mgmt/v1alpha/mgmt.proto
@@ -311,25 +311,36 @@ message PatchAuthenticatedUserResponse {
   User user = 1;
 }
 
-// ExistUsernameRequest represents a request to verify if
-// a username has been occupied
-message ExistUsernameRequest {
-  // The resource name of the user to check,
-  // for example: "users/local-user"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/User",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
-    }
-  ];
+// CheckNamespaceRequest represents a request to verify if
+// a namespace has been occupied and know its type
+message CheckNamespaceRequest {
+  // CheckNamespaceRequestBody
+  message CheckNamespaceRequestBody {
+    // The resource id of to check,
+    string id = 1 [(google.api.field_behavior) = REQUIRED];
+  }
+  // body
+  CheckNamespaceRequestBody namespace = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
-// ExistUsernameResponse represents a response about whether
+// CheckNamespaceResponse represents a response about whether
 // the queried username has been occupied
-message ExistUsernameResponse {
+message CheckNamespaceResponse {
+  // Namespace type
+  enum Namespace {
+    // UNSPECIFIED
+    NAMESPACE_UNSPECIFIED = 0;
+    // Available
+    NAMESPACE_AVAILABLE = 1;
+    // User
+    NAMESPACE_USER = 2;
+    // Org
+    NAMESPACE_ORGANIZATION = 3;
+    // Reserved
+    NAMESPACE_RESERVED = 4;
+  }
   // A boolean value indicating whether the username has been occupied
-  bool exists = 1;
+  Namespace type = 1;
 }
 
 // ApiToken represents the content of a API token

--- a/core/mgmt/v1alpha/mgmt_public_service.proto
+++ b/core/mgmt/v1alpha/mgmt_public_service.proto
@@ -34,6 +34,15 @@ service MgmtPublicService {
     };
   }
 
+  // Check namespace
+  rpc CheckNamespace(CheckNamespaceRequest) returns (CheckNamespaceResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/check-namespace"
+      body: "namespace"
+    };
+    option (google.api.method_signature) = "namespace";
+  }
+
   // ListUsers method receives a ListUsersRequest message and returns a
   // ListUsersResponse message.
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
@@ -55,13 +64,6 @@ service MgmtPublicService {
       body: "user"
     };
     option (google.api.method_signature) = "user,update_mask";
-  }
-
-  // ExistUsername method receives a ExistUsernameRequest message and returns a
-  // ExistUsernameResponse
-  rpc ExistUsername(ExistUsernameRequest) returns (ExistUsernameResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=users/*}/exist"};
-    option (google.api.method_signature) = "name";
   }
 
   // ListUserMemberships method receives a ListUserMembershipsRequest message and returns a

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4227,32 +4227,6 @@ paths:
           default: VIEW_UNSPECIFIED
       tags:
         - MgmtPublicService
-  /v1alpha/{user.name}/exist:
-    get:
-      summary: |-
-        ExistUsername method receives a ExistUsernameRequest message and returns a
-        ExistUsernameResponse
-      operationId: MgmtPublicService_ExistUsername
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaExistUsernameResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user.name
-          description: |-
-            The resource name of the user to check,
-            for example: "users/local-user"
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+
-      tags:
-        - MgmtPublicService
   /v1alpha/admin/{model_permalink}/check:
     get:
       summary: |-
@@ -5179,6 +5153,30 @@ paths:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - MgmtPublicService
+  /v1alpha/check-namespace:
+    post:
+      summary: Check namespace
+      operationId: MgmtPublicService_CheckNamespace
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCheckNamespaceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespace
+          description: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/CheckNamespaceRequestCheckNamespaceRequestBody'
+            required:
+              - namespace
       tags:
         - MgmtPublicService
   /v1alpha/connector-definitions:
@@ -6206,6 +6204,31 @@ definitions:
         format: int32
         title: exp
     title: UnsignedAccessToken
+  CheckNamespaceRequestCheckNamespaceRequestBody:
+    type: object
+    properties:
+      id:
+        type: string
+        title: The resource id of to check,
+    title: CheckNamespaceRequestBody
+    required:
+      - id
+  CheckNamespaceResponseNamespace:
+    type: string
+    enum:
+      - NAMESPACE_UNSPECIFIED
+      - NAMESPACE_AVAILABLE
+      - NAMESPACE_USER
+      - NAMESPACE_ORGANIZATION
+      - NAMESPACE_RESERVED
+    default: NAMESPACE_UNSPECIFIED
+    description: |-
+      - NAMESPACE_UNSPECIFIED: UNSPECIFIED
+       - NAMESPACE_AVAILABLE: Available
+       - NAMESPACE_USER: User
+       - NAMESPACE_ORGANIZATION: Org
+       - NAMESPACE_RESERVED: Reserved
+    title: Namespace type
   HealthCheckResponseServingStatus:
     type: string
     enum:
@@ -6924,6 +6947,15 @@ definitions:
     title: |-
       CheckModelAdminResponse represents a response to fetch a model's
       current state and longrunning progress
+  v1alphaCheckNamespaceResponse:
+    type: object
+    properties:
+      type:
+        $ref: '#/definitions/CheckNamespaceResponseNamespace'
+        title: A boolean value indicating whether the username has been occupied
+    title: |-
+      CheckNamespaceResponse represents a response about whether
+      the queried username has been occupied
   v1alphaClassificationInput:
     type: object
     properties:
@@ -7638,15 +7670,6 @@ definitions:
     title: |-
       ExecuteUserConnectorResponse represents a response for execution
       output
-  v1alphaExistUsernameResponse:
-    type: object
-    properties:
-      exists:
-        type: boolean
-        title: A boolean value indicating whether the username has been occupied
-    title: |-
-      ExistUsernameResponse represents a response about whether
-      the queried username has been occupied
   v1alphaExtraParamObject:
     type: object
     properties:


### PR DESCRIPTION
Because

- we need an API to determine the availability of a namespace id and its type

This commit

- remove ExistUsername API  and add new CheckNamespace API
