### PR TITLE
chore(core): upgrade CheckNamespace endpoint version to v1beta

### DIFF
--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -37,7 +37,7 @@ service MgmtPublicService {
   // Check namespace
   rpc CheckNamespace(CheckNamespaceRequest) returns (CheckNamespaceResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/check-namespace"
+      post: "/v1beta/check-namespace"
       body: "namespace"
     };
     option (google.api.method_signature) = "namespace";

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -1040,30 +1040,6 @@ paths:
           type: boolean
       tags:
         - ModelPrivateService
-  /v1alpha/check-namespace:
-    post:
-      summary: Check namespace
-      operationId: MgmtPublicService_CheckNamespace
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaCheckNamespaceResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: namespace
-          description: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/CheckNamespaceRequestCheckNamespaceRequestBody'
-            required:
-              - namespace
-      tags:
-        - MgmtPublicService
   /v1alpha/health/controller:
     get:
       summary: |-
@@ -5403,6 +5379,30 @@ paths:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - MgmtPublicService
+  /v1beta/check-namespace:
+    post:
+      summary: Check namespace
+      operationId: MgmtPublicService_CheckNamespace
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCheckNamespaceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespace
+          description: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/CheckNamespaceRequestCheckNamespaceRequestBody'
+            required:
+              - namespace
       tags:
         - MgmtPublicService
   /v1beta/connector-definitions:


### PR DESCRIPTION
Because

- we are going to release beta version of Core and VDP

This commit

- upgrade CheckNamespace endpoint version to v1beta
