### PR TITLE
chore(all): embed owner profile data in pipeline, connector, model payload

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -106,26 +106,16 @@ message Model {
   State state = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model visibility including public or private
   Visibility visibility = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Model owner
-  oneof owner {
-    // The resource name with UUID of a user, e.g.,
-    // "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-    string user = 10 [
-      (google.api.resource_reference).type = "api.instill.tech/User",
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-    // The resource name with UUID of an organization
-    string org = 11 [
-      (google.api.resource_reference).type = "api.instill.tech/Organization",
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-  }
   // Model create time
   google.protobuf.Timestamp create_time = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model update time
   google.protobuf.Timestamp update_time = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model delete time
   google.protobuf.Timestamp delete_time = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Owner Name
+  string owner_name = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Owner details
+  google.protobuf.Struct owner = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ModelCard represents the README card for a model. There

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -251,16 +251,6 @@ paths:
                 $ref: '#/definitions/v1alphaModelVisibility'
                 title: Model visibility including public or private
                 readOnly: true
-              user:
-                type: string
-                description: |-
-                  The resource name with UUID of a user, e.g.,
-                  "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-                readOnly: true
-              org:
-                type: string
-                title: The resource name with UUID of an organization
-                readOnly: true
               create_time:
                 type: string
                 format: date-time
@@ -275,6 +265,14 @@ paths:
                 type: string
                 format: date-time
                 title: Model delete time
+                readOnly: true
+              owner_name:
+                type: string
+                title: Owner Name
+                readOnly: true
+              owner:
+                type: object
+                title: Owner details
                 readOnly: true
             title: The model to update
       tags:
@@ -1398,16 +1396,6 @@ paths:
                 type: boolean
                 title: Connector tombstone
                 readOnly: true
-              user:
-                type: string
-                description: |-
-                  The resource name with UUID of a user, e.g.,
-                  "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-                readOnly: true
-              organization:
-                type: string
-                title: The resource name with UUID of an organization
-                readOnly: true
               create_time:
                 type: string
                 format: date-time
@@ -1430,6 +1418,14 @@ paths:
                 type: string
                 format: date-time
                 title: Connector delete time
+                readOnly: true
+              owner_name:
+                type: string
+                title: Owner Name
+                readOnly: true
+              owner:
+                type: object
+                title: Owner details
                 readOnly: true
             title: connector
             required:
@@ -1621,16 +1617,6 @@ paths:
                 type: boolean
                 title: Connector tombstone
                 readOnly: true
-              user:
-                type: string
-                description: |-
-                  The resource name with UUID of a user, e.g.,
-                  "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-                readOnly: true
-              organization:
-                type: string
-                title: The resource name with UUID of an organization
-                readOnly: true
               create_time:
                 type: string
                 format: date-time
@@ -1653,6 +1639,14 @@ paths:
                 type: string
                 format: date-time
                 title: Connector delete time
+                readOnly: true
+              owner_name:
+                type: string
+                title: Owner Name
+                readOnly: true
+              owner:
+                type: object
+                title: Owner details
                 readOnly: true
             title: connector
             required:
@@ -3988,16 +3982,6 @@ paths:
               recipe:
                 $ref: '#/definitions/v1betaRecipe'
                 title: Pipeline recipe
-              user:
-                type: string
-                description: |-
-                  The resource name with UUID of a user, e.g.,
-                  "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-                readOnly: true
-              organization:
-                type: string
-                title: The resource name with UUID of an organization
-                readOnly: true
               create_time:
                 type: string
                 format: date-time
@@ -4023,6 +4007,21 @@ paths:
               metadata:
                 type: object
                 title: 'Metadata: store Console-related data such as pipeline builder layout'
+              owner_name:
+                type: string
+                title: Owner Name
+                readOnly: true
+              owner:
+                type: object
+                title: Owner details
+                readOnly: true
+              releases:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1betaPipelineRelease'
+                title: Releases
+                readOnly: true
             title: A pipeline resource to update
       tags:
         - PipelinePublicService
@@ -4135,16 +4134,6 @@ paths:
               recipe:
                 $ref: '#/definitions/v1betaRecipe'
                 title: Pipeline recipe
-              user:
-                type: string
-                description: |-
-                  The resource name with UUID of a user, e.g.,
-                  "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-                readOnly: true
-              organization:
-                type: string
-                title: The resource name with UUID of an organization
-                readOnly: true
               create_time:
                 type: string
                 format: date-time
@@ -4170,6 +4159,21 @@ paths:
               metadata:
                 type: object
                 title: 'Metadata: store Console-related data such as pipeline builder layout'
+              owner_name:
+                type: string
+                title: Owner Name
+                readOnly: true
+              owner:
+                type: object
+                title: Owner details
+                readOnly: true
+              releases:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1betaPipelineRelease'
+                title: Releases
+                readOnly: true
             title: A pipeline resource to update
       tags:
         - PipelinePublicService
@@ -7459,16 +7463,6 @@ definitions:
         $ref: '#/definitions/v1alphaModelVisibility'
         title: Model visibility including public or private
         readOnly: true
-      user:
-        type: string
-        description: |-
-          The resource name with UUID of a user, e.g.,
-          "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-        readOnly: true
-      org:
-        type: string
-        title: The resource name with UUID of an organization
-        readOnly: true
       create_time:
         type: string
         format: date-time
@@ -7483,6 +7477,14 @@ definitions:
         type: string
         format: date-time
         title: Model delete time
+        readOnly: true
+      owner_name:
+        type: string
+        title: Owner Name
+        readOnly: true
+      owner:
+        type: object
+        title: Owner details
         readOnly: true
     title: Model represents a model
   v1alphaModelCard:
@@ -8444,16 +8446,6 @@ definitions:
         type: boolean
         title: Connector tombstone
         readOnly: true
-      user:
-        type: string
-        description: |-
-          The resource name with UUID of a user, e.g.,
-          "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-        readOnly: true
-      organization:
-        type: string
-        title: The resource name with UUID of an organization
-        readOnly: true
       create_time:
         type: string
         format: date-time
@@ -8476,6 +8468,14 @@ definitions:
         type: string
         format: date-time
         title: Connector delete time
+        readOnly: true
+      owner_name:
+        type: string
+        title: Owner Name
+        readOnly: true
+      owner:
+        type: object
+        title: Owner details
         readOnly: true
     title: Connector represents a connector data model
     required:
@@ -10280,16 +10280,6 @@ definitions:
       recipe:
         $ref: '#/definitions/v1betaRecipe'
         title: Pipeline recipe
-      user:
-        type: string
-        description: |-
-          The resource name with UUID of a user, e.g.,
-          "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-        readOnly: true
-      organization:
-        type: string
-        title: The resource name with UUID of an organization
-        readOnly: true
       create_time:
         type: string
         format: date-time
@@ -10315,6 +10305,21 @@ definitions:
       metadata:
         type: object
         title: 'Metadata: store Console-related data such as pipeline builder layout'
+      owner_name:
+        type: string
+        title: Owner Name
+        readOnly: true
+      owner:
+        type: object
+        title: Owner details
+        readOnly: true
+      releases:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipelineRelease'
+        title: Releases
+        readOnly: true
     title: Pipeline represents the content of a pipeline
   v1betaPipelineData:
     type: object

--- a/vdp/pipeline/v1beta/connector.proto
+++ b/vdp/pipeline/v1beta/connector.proto
@@ -78,20 +78,6 @@ message Connector {
   State state = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Connector tombstone
   bool tombstone = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector owner
-  oneof owner {
-    // The resource name with UUID of a user, e.g.,
-    // "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-    string user = 11 [
-      (google.api.resource_reference).type = "api.instill.tech/User",
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-    // The resource name with UUID of an organization
-    string organization = 12 [
-      (google.api.resource_reference).type = "api.instill.tech/Organization",
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-  }
   // Connector creation time
   google.protobuf.Timestamp create_time = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Connector update time
@@ -102,6 +88,10 @@ message Connector {
   ConnectorDefinition connector_definition = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Connector delete time
   google.protobuf.Timestamp delete_time = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Owner Name
+  string owner_name = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Owner details
+  google.protobuf.Struct owner = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 ///////////////////////////////////////////////////////////////////////

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -134,20 +134,6 @@ message Pipeline {
   // Pipeline recipe
   Recipe recipe = 5 [(google.api.field_behavior) = IMMUTABLE];
 
-  // Pipeline owner
-  oneof owner {
-    // The resource name with UUID of a user, e.g.,
-    // "users/bfb978f8-78d3-4338-aa2b-a6c699cb07c5".
-    string user = 8 [
-      (google.api.resource_reference).type = "api.instill.tech/User",
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-    // The resource name with UUID of an organization
-    string organization = 9 [
-      (google.api.resource_reference).type = "api.instill.tech/Organization",
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-  }
   // Pipeline creation time
   google.protobuf.Timestamp create_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline update time
@@ -160,6 +146,12 @@ message Pipeline {
   Permission permission = 15;
   // Metadata: store Console-related data such as pipeline builder layout
   google.protobuf.Struct metadata = 16;
+  // Owner Name
+  string owner_name = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Owner details
+  google.protobuf.Struct owner = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Releases
+  repeated PipelineRelease releases = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // The metadata


### PR DESCRIPTION
Because

- we need to embed more data in response payload to reduce the API round trip

This commit

- embed owner profile data in pipeline, connector, model payload
- embed releases data in pipeline payload
