### PR TITLE
chore(vdp): add status in pipeline traces data

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -10897,9 +10897,11 @@ definitions:
   v1betaTrace:
     type: object
     properties:
-      success:
-        type: boolean
-        title: Success or not
+      statuses:
+        type: array
+        items:
+          $ref: '#/definitions/v1betaTraceStatus'
+        title: status
       inputs:
         type: array
         items:
@@ -10918,6 +10920,20 @@ definitions:
         format: float
         title: Compute Time
     title: Trace for the intermediate component
+  v1betaTraceStatus:
+    type: string
+    enum:
+      - STATUS_UNSPECIFIED
+      - STATUS_COMPLETED
+      - STATUS_SKIPPED
+      - STATUS_ERROR
+    default: STATUS_UNSPECIFIED
+    description: |-
+      - STATUS_UNSPECIFIED: UNSPECIFIED
+       - STATUS_COMPLETED: COMPLETED
+       - STATUS_SKIPPED: SKIPPED
+       - STATUS_ERROR: ERROR
+    title: Status
   v1betaTriggerAsyncOrganizationPipelineReleaseResponse:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -162,8 +162,19 @@ message TriggerMetadata {
 
 // Trace for the intermediate component
 message Trace {
-  // Success or not
-  bool success = 1;
+  // Status
+  enum Status {
+    // UNSPECIFIED
+    STATUS_UNSPECIFIED = 0;
+    // COMPLETED
+    STATUS_COMPLETED = 1;
+    // SKIPPED
+    STATUS_SKIPPED = 2;
+    // ERROR
+    STATUS_ERROR = 3;
+  }
+  // status
+  repeated Status statuses = 1;
   // Inputs of the component
   repeated google.protobuf.Struct inputs = 2;
   // Outputs of the component


### PR DESCRIPTION
Because

- we'll support conditional component, so we must show the actual status of each component

This commit

- add status in pipeline traces data
