### PR TITLE
chore(vdp): add pipeline readme field

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -4022,6 +4022,9 @@ paths:
                   $ref: '#/definitions/v1betaPipelineRelease'
                 title: Releases
                 readOnly: true
+              readme:
+                type: string
+                title: readme
             title: A pipeline resource to update
       tags:
         - PipelinePublicService
@@ -4174,6 +4177,9 @@ paths:
                   $ref: '#/definitions/v1betaPipelineRelease'
                 title: Releases
                 readOnly: true
+              readme:
+                type: string
+                title: readme
             title: A pipeline resource to update
       tags:
         - PipelinePublicService
@@ -4376,6 +4382,9 @@ paths:
               metadata:
                 type: object
                 title: 'Metadata: store Console-related data such as pipeline builder layout'
+              readme:
+                type: string
+                title: readme
             title: A pipeline release resource to update
       tags:
         - PipelinePublicService
@@ -4450,6 +4459,9 @@ paths:
               metadata:
                 type: object
                 title: 'Metadata: store Console-related data such as pipeline builder layout'
+              readme:
+                type: string
+                title: readme
             title: A pipeline release resource to update
       tags:
         - PipelinePublicService
@@ -10319,6 +10331,9 @@ definitions:
           $ref: '#/definitions/v1betaPipelineRelease'
         title: Releases
         readOnly: true
+      readme:
+        type: string
+        title: readme
     title: Pipeline represents the content of a pipeline
   v1betaPipelineData:
     type: object
@@ -10386,6 +10401,9 @@ definitions:
       metadata:
         type: object
         title: 'Metadata: store Console-related data such as pipeline builder layout'
+      readme:
+        type: string
+        title: readme
     title: PipelineRelease represents the content of a pipeline release
   v1betaPipelineTriggerChartRecord:
     type: object

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -152,6 +152,8 @@ message Pipeline {
   google.protobuf.Struct owner = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Releases
   repeated PipelineRelease releases = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // readme
+  string readme = 20 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // The metadata
@@ -215,6 +217,8 @@ message PipelineRelease {
   string alias = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Metadata: store Console-related data such as pipeline builder layout
   google.protobuf.Struct metadata = 12;
+  // readme
+  string readme = 13 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelinesRequest represents a request to list pipelines


### PR DESCRIPTION
Because

- we need to store pipeline `readme` data

This commit

- add pipeline `readme` field
