### PR TITLE
chore(mgmt): add owner field in organization payload

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -563,6 +563,8 @@ message Organization {
   optional string profile_avatar = 9 [(google.api.field_behavior) = OPTIONAL];
   // Profile Data
   optional google.protobuf.Struct profile_data = 10 [(google.api.field_behavior) = OPTIONAL];
+  // Owner
+  User owner = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListOrganizationsRequest represents a request to list all organizations

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -3074,6 +3074,10 @@ paths:
               profile_data:
                 type: object
                 title: Profile Data
+              owner:
+                $ref: '#/definitions/mgmtv1betaUser'
+                title: Owner
+                readOnly: true
             description: |-
               The organization's `name` field is used to identify the organization to update.
               Format: organizations/{organization}
@@ -10335,6 +10339,10 @@ definitions:
       profile_data:
         type: object
         title: Profile Data
+      owner:
+        $ref: '#/definitions/mgmtv1betaUser'
+        title: Owner
+        readOnly: true
     title: Organization represents the content of a organization
     required:
       - id


### PR DESCRIPTION
Because

- we need to embed owner information in the organization payload

This commit

- add owner field in organization payload
