### PR TITLE
feat(model): Update Text-Generation Task Schema to Align with OpenAI Standards

### DIFF
--- a/model/model/v1alpha/common.proto
+++ b/model/model/v1alpha/common.proto
@@ -33,3 +33,24 @@ message ConversationObject {
   // Content of the conversation
   string content = 2;
 }
+
+// Prompt Image for text generation model
+message PromptImage {
+  // Image could be either a url or base64 encoded string
+  oneof type {
+    // Image URL
+    string prompt_image_url = 1;
+    // Base64 encoded Image
+    string prompt_image_base64 = 2;
+  }
+}
+
+// Content used for chat history in text generation model
+message Content {
+  // Type of Content
+  string type = 1;
+  // Content of Text Message
+  string content = 2;
+  // Content of Image
+  PromptImage prompt_image = 3;
+}

--- a/model/model/v1alpha/common.proto
+++ b/model/model/v1alpha/common.proto
@@ -26,14 +26,6 @@ message ExtraParamObject {
   string param_value = 2;
 }
 
-// Conversation based prompt for text generation model
-message ConversationObject {
-  // Role name of the conversation
-  string role = 1;
-  // Content of the conversation
-  string content = 2;
-}
-
 // Prompt Image for text generation model
 message PromptImage {
   // Image could be either a url or base64 encoded string

--- a/model/model/v1alpha/task_image_to_image.proto
+++ b/model/model/v1alpha/task_image_to_image.proto
@@ -4,7 +4,7 @@ package model.model.v1alpha;
 
 // Google api
 import "google/api/field_behavior.proto";
-import "model/model/v1alpha/common.proto";
+import "google/protobuf/struct.proto";
 
 // ImageToImageInput represents the input of image to image task
 message ImageToImageInput {
@@ -26,7 +26,7 @@ message ImageToImageInput {
   // The number of generated samples, default is 1
   optional int32 samples = 7 [(google.api.field_behavior) = OPTIONAL];
   // The extra parameters
-  repeated ExtraParamObject extra_params = 8 [(google.api.field_behavior) = OPTIONAL];
+  google.protobuf.Struct extra_params = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ImageToImageOutput represents the output of image to image task

--- a/model/model/v1alpha/task_text_generation.proto
+++ b/model/model/v1alpha/task_text_generation.proto
@@ -4,62 +4,18 @@ package model.model.v1alpha;
 
 // Google api
 import "google/api/field_behavior.proto";
-import "model/model/v1alpha/common.proto";
-
 import "google/protobuf/struct.proto";
-
-// reference to: https://github.com/instill-ai/connector/blob/main/pkg/openai/text_generation.go#L17
-message PromptImage {
-  oneof type {
-    string prompt_image_url = 1;
-    string prompt_image_base64 = 2;
-  }
-}
-message Content {
-    string type = 1;
-    string content = 2;
-    PromptImage prompt_image = 3;
-}
-
-// type Message struct {
-// 	Role    string    `json:"role"`
-// 	Content []Content `json:"content"`
-// }
-
-// type ImageUrl struct {
-// 	Url string `json:"url"`
-// }
-
-// type Content struct {
-// 	Type     string    `json:"type"`
-// 	Text     *string   `json:"text,omitempty"`
-// 	ImageUrl *ImageUrl `json:"image_url,omitempty"`
-// }
-
-// type TextCompletionInput struct {
-// 	Prompt           string                `json:"prompt"`
-// 	Images           []string              `json:"images"`
-// 	ChatHistory      []*TextMessage        `json:"chat_history,omitempty"`
-// 	Model            string                `json:"model"`
-// 	SystemMessage    *string               `json:"system_message,omitempty"`
-// 	Temperature      *float32              `json:"temperature,omitempty"`
-// 	TopP             *float32              `json:"top_p,omitempty"`
-// 	N                *int                  `json:"n,omitempty"`
-// 	Stop             *string               `json:"stop,omitempty"`
-// 	MaxTokens        *int                  `json:"max_tokens,omitempty"`
-// 	PresencePenalty  *float32              `json:"presence_penalty,omitempty"`
-// 	FrequencyPenalty *float32              `json:"frequency_penalty,omitempty"`
-// 	ResponseFormat   *ResponseFormatStruct `json:"response_format,omitempty"`
-// }
+import "model/model/v1alpha/common.proto";
 
 // TextGenerationInput represents the input of text generation task
 message TextGenerationInput {
   // The prompt text
   string prompt = 1 [(google.api.field_behavior) = REQUIRED];
-
-  // Optional fields
+  // The prompt images
   repeated PromptImage prompt_images = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The chat history
   repeated Content chat_history = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The system message
   optional string system_message = 4 [(google.api.field_behavior) = OPTIONAL];
   // The maximum number of tokens for model to generate
   optional int32 max_new_tokens = 5 [(google.api.field_behavior) = OPTIONAL];

--- a/model/model/v1alpha/task_text_generation.proto
+++ b/model/model/v1alpha/task_text_generation.proto
@@ -6,20 +6,71 @@ package model.model.v1alpha;
 import "google/api/field_behavior.proto";
 import "model/model/v1alpha/common.proto";
 
+import "google/protobuf/struct.proto";
+
+// reference to: https://github.com/instill-ai/connector/blob/main/pkg/openai/text_generation.go#L17
+message PromptImage {
+  oneof type {
+    string prompt_image_url = 1;
+    string prompt_image_base64 = 2;
+  }
+}
+message Content {
+    string type = 1;
+    string content = 2;
+    PromptImage prompt_image = 3;
+}
+
+// type Message struct {
+// 	Role    string    `json:"role"`
+// 	Content []Content `json:"content"`
+// }
+
+// type ImageUrl struct {
+// 	Url string `json:"url"`
+// }
+
+// type Content struct {
+// 	Type     string    `json:"type"`
+// 	Text     *string   `json:"text,omitempty"`
+// 	ImageUrl *ImageUrl `json:"image_url,omitempty"`
+// }
+
+// type TextCompletionInput struct {
+// 	Prompt           string                `json:"prompt"`
+// 	Images           []string              `json:"images"`
+// 	ChatHistory      []*TextMessage        `json:"chat_history,omitempty"`
+// 	Model            string                `json:"model"`
+// 	SystemMessage    *string               `json:"system_message,omitempty"`
+// 	Temperature      *float32              `json:"temperature,omitempty"`
+// 	TopP             *float32              `json:"top_p,omitempty"`
+// 	N                *int                  `json:"n,omitempty"`
+// 	Stop             *string               `json:"stop,omitempty"`
+// 	MaxTokens        *int                  `json:"max_tokens,omitempty"`
+// 	PresencePenalty  *float32              `json:"presence_penalty,omitempty"`
+// 	FrequencyPenalty *float32              `json:"frequency_penalty,omitempty"`
+// 	ResponseFormat   *ResponseFormatStruct `json:"response_format,omitempty"`
+// }
+
 // TextGenerationInput represents the input of text generation task
 message TextGenerationInput {
   // The prompt text
   string prompt = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Optional fields
+  repeated PromptImage prompt_images = 2 [(google.api.field_behavior) = OPTIONAL];
+  repeated Content chat_history = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional string system_message = 4 [(google.api.field_behavior) = OPTIONAL];
   // The maximum number of tokens for model to generate
-  optional int32 max_new_tokens = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 max_new_tokens = 5 [(google.api.field_behavior) = OPTIONAL];
   // The temperature for sampling
-  optional float temperature = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional float temperature = 6 [(google.api.field_behavior) = OPTIONAL];
   // Top k for sampling
-  optional int32 top_k = 4 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 top_k = 7 [(google.api.field_behavior) = OPTIONAL];
   // The seed
-  optional int32 seed = 5 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 seed = 8 [(google.api.field_behavior) = OPTIONAL];
   // The extra parameters
-  repeated ExtraParamObject extra_params = 6 [(google.api.field_behavior) = OPTIONAL];
+  google.protobuf.Struct extra_params = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TextGenerationOutput represents the output of text generation task

--- a/model/model/v1alpha/task_text_generation_chat.proto
+++ b/model/model/v1alpha/task_text_generation_chat.proto
@@ -4,22 +4,29 @@ package model.model.v1alpha;
 
 // Google api
 import "google/api/field_behavior.proto";
+import "google/protobuf/struct.proto";
 import "model/model/v1alpha/common.proto";
 
 // TextGenerationChatInput represents the input of text generation chat task
 message TextGenerationChatInput {
   // The prompt text
-  repeated ConversationObject conversation = 1 [(google.api.field_behavior) = REQUIRED];
+  string prompt = 1 [(google.api.field_behavior) = REQUIRED];
+  // The prompt images
+  repeated PromptImage prompt_images = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The chat history
+  repeated Content chat_history = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The system message
+  optional string system_message = 4 [(google.api.field_behavior) = OPTIONAL];
   // The maximum number of tokens for model to generate
-  optional int32 max_new_tokens = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 max_new_tokens = 5 [(google.api.field_behavior) = OPTIONAL];
   // The temperature for sampling
-  optional float temperature = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional float temperature = 6 [(google.api.field_behavior) = OPTIONAL];
   // Top k for sampling
-  optional int32 top_k = 4 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 top_k = 7 [(google.api.field_behavior) = OPTIONAL];
   // The seed
-  optional int32 seed = 5 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 seed = 8 [(google.api.field_behavior) = OPTIONAL];
   // The extra parameters
-  repeated ExtraParamObject extra_params = 6 [(google.api.field_behavior) = OPTIONAL];
+  google.protobuf.Struct extra_params = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TextGenerationChatOutput represents the output of text generation chat task

--- a/model/model/v1alpha/task_text_to_image.proto
+++ b/model/model/v1alpha/task_text_to_image.proto
@@ -4,7 +4,7 @@ package model.model.v1alpha;
 
 // Google api
 import "google/api/field_behavior.proto";
-import "model/model/v1alpha/common.proto";
+import "google/protobuf/struct.proto";
 
 // TextToImageInput represents the input of text to image task
 message TextToImageInput {
@@ -26,7 +26,7 @@ message TextToImageInput {
   // The number of generated samples, default is 1
   optional int32 samples = 7 [(google.api.field_behavior) = OPTIONAL];
   // The extra parameters
-  repeated ExtraParamObject extra_params = 8 [(google.api.field_behavior) = OPTIONAL];
+  google.protobuf.Struct extra_params = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TextToImageOutput represents the output of text to image task

--- a/model/model/v1alpha/task_visual_question_answering.proto
+++ b/model/model/v1alpha/task_visual_question_answering.proto
@@ -4,29 +4,29 @@ package model.model.v1alpha;
 
 // Google api
 import "google/api/field_behavior.proto";
+import "google/protobuf/struct.proto";
 import "model/model/v1alpha/common.proto";
 
 // VisualQuestionAnsweringInput represents the input of visaul question answering task
 message VisualQuestionAnsweringInput {
   // The prompt text
   string prompt = 1 [(google.api.field_behavior) = REQUIRED];
-  // The Prompt Image, only for multimodal input
-  oneof type {
-    // Image type URL
-    string prompt_image_url = 2;
-    // Image type base64
-    string prompt_image_base64 = 3;
-  }
+  // The prompt images
+  repeated PromptImage prompt_images = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The chat history
+  repeated Content chat_history = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The system message
+  optional string system_message = 4 [(google.api.field_behavior) = OPTIONAL];
   // The maximum number of tokens for model to generate
-  optional int32 max_new_tokens = 4 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 max_new_tokens = 5 [(google.api.field_behavior) = OPTIONAL];
   // The temperature for sampling
-  optional float temperature = 5 [(google.api.field_behavior) = OPTIONAL];
+  optional float temperature = 6 [(google.api.field_behavior) = OPTIONAL];
   // Top k for sampling
-  optional int32 top_k = 6 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 top_k = 7 [(google.api.field_behavior) = OPTIONAL];
   // The seed
-  optional int32 seed = 7 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 seed = 8 [(google.api.field_behavior) = OPTIONAL];
   // The extra parameters
-  repeated ExtraParamObject extra_params = 8 [(google.api.field_behavior) = OPTIONAL];
+  google.protobuf.Struct extra_params = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // VisualQuestionAnsweringOutput represents the output of visaul question answering task

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -7147,16 +7147,6 @@ definitions:
         $ref: '#/definitions/v1alphaPromptImage'
         title: Content of Image
     title: Content used for chat history in text generation model
-  v1alphaConversationObject:
-    type: object
-    properties:
-      role:
-        type: string
-        title: Role name of the conversation
-      content:
-        type: string
-        title: Content of the conversation
-    title: Conversation based prompt for text generation model
   v1alphaCreateUserModelBinaryFileUploadResponse:
     type: object
     properties:
@@ -7249,18 +7239,6 @@ definitions:
         title: A list of detection objects
         readOnly: true
     title: DetectionOutput represents the output of detection task
-  v1alphaExtraParamObject:
-    type: object
-    properties:
-      param_name:
-        type: string
-        title: Name of the hyperparameter
-      param_value:
-        type: string
-        title: Value of the hyperparameter
-    title: |-
-      Additional hyperparameters for model inferences
-      or other configuration not listsed in protobuf
   v1alphaGetModelDefinitionResponse:
     type: object
     properties:
@@ -7318,10 +7296,7 @@ definitions:
         format: int32
         title: The number of generated samples, default is 1
       extra_params:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaExtraParamObject'
+        type: object
         title: The extra parameters
     title: ImageToImageInput represents the input of image to image task
     required:
@@ -8095,12 +8070,24 @@ definitions:
   v1alphaTextGenerationChatInput:
     type: object
     properties:
-      conversation:
+      prompt:
+        type: string
+        title: The prompt text
+      prompt_images:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaConversationObject'
-        title: The prompt text
+          $ref: '#/definitions/v1alphaPromptImage'
+        title: The prompt images
+      chat_history:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaContent'
+        title: The chat history
+      system_message:
+        type: string
+        title: The system message
       max_new_tokens:
         type: integer
         format: int32
@@ -8118,14 +8105,11 @@ definitions:
         format: int32
         title: The seed
       extra_params:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaExtraParamObject'
+        type: object
         title: The extra parameters
     title: TextGenerationChatInput represents the input of text generation chat task
     required:
-      - conversation
+      - prompt
   v1alphaTextGenerationChatOutput:
     type: object
     properties:
@@ -8214,10 +8198,7 @@ definitions:
         format: int32
         title: The number of generated samples, default is 1
       extra_params:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaExtraParamObject'
+        type: object
         title: The extra parameters
     title: TextToImageInput represents the input of text to image task
     required:
@@ -8320,12 +8301,21 @@ definitions:
       prompt:
         type: string
         title: The prompt text
-      prompt_image_url:
+      prompt_images:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaPromptImage'
+        title: The prompt images
+      chat_history:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaContent'
+        title: The chat history
+      system_message:
         type: string
-        title: Image type URL
-      prompt_image_base64:
-        type: string
-        title: Image type base64
+        title: The system message
       max_new_tokens:
         type: integer
         format: int32
@@ -8343,10 +8333,7 @@ definitions:
         format: int32
         title: The seed
       extra_params:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaExtraParamObject'
+        type: object
         title: The extra parameters
     title: VisualQuestionAnsweringInput represents the input of visaul question answering task
     required:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -30,11 +30,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/modelmodelv1alphaLivenessResponse'
+            $ref: "#/definitions/modelmodelv1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -54,11 +54,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/modelmodelv1alphaReadinessResponse'
+            $ref: "#/definitions/modelmodelv1alphaReadinessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -77,11 +77,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetUserModelCardResponse'
+            $ref: "#/definitions/v1alphaGetUserModelCardResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: model.name/readme
           description: |-
@@ -103,11 +103,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaWatchUserModelResponse'
+            $ref: "#/definitions/v1alphaWatchUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: model.name/watch
           description: |-
@@ -129,11 +129,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetUserModelResponse'
+            $ref: "#/definitions/v1alphaGetUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: model.name
           description: |-
@@ -171,11 +171,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeleteUserModelResponse'
+            $ref: "#/definitions/v1alphaDeleteUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: model.name
           description: |-
@@ -196,11 +196,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdateUserModelResponse'
+            $ref: "#/definitions/v1alphaUpdateUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: model.name
           description: |-
@@ -240,15 +240,15 @@ paths:
                   Model configuration represents the configuration JSON that has been
                   validated using the `model_spec` JSON schema of a ModelDefinition
               task:
-                $ref: '#/definitions/v1alphaTask'
+                $ref: "#/definitions/v1alphaTask"
                 title: Model task
                 readOnly: true
               state:
-                $ref: '#/definitions/v1alphaModelState'
+                $ref: "#/definitions/v1alphaModelState"
                 title: Model state
                 readOnly: true
               visibility:
-                $ref: '#/definitions/v1alphaModelVisibility'
+                $ref: "#/definitions/v1alphaModelVisibility"
                 title: Model visibility including public or private
                 readOnly: true
               create_time:
@@ -287,11 +287,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelDefinitionResponse'
+            $ref: "#/definitions/v1alphaGetModelDefinitionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: model_definition.name
           description: |-
@@ -332,11 +332,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaGetModelOperationResponse'
+            $ref: "#/definitions/v1alphaGetModelOperationResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: The name of the operation resource.
@@ -371,11 +371,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeployUserModelResponse'
+            $ref: "#/definitions/v1alphaDeployUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -403,11 +403,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaPublishUserModelResponse'
+            $ref: "#/definitions/v1alphaPublishUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -433,11 +433,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaRenameUserModelResponse'
+            $ref: "#/definitions/v1alphaRenameUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -473,11 +473,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTestUserModelResponse'
+            $ref: "#/definitions/v1alphaTestUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -497,7 +497,7 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: '#/definitions/v1alphaTaskInput'
+                  $ref: "#/definitions/v1alphaTaskInput"
                 title: Input to trigger the model
             title: TestUserModelRequest represents a request to test a model
             required:
@@ -515,11 +515,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaTriggerUserModelResponse'
+            $ref: "#/definitions/v1alphaTriggerUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -539,7 +539,7 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: '#/definitions/v1alphaTaskInput'
+                  $ref: "#/definitions/v1alphaTaskInput"
                 title: Input to trigger the model
             title: TriggerUserModelRequest represents a request to trigger a model
             required:
@@ -554,11 +554,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUndeployUserModelResponse'
+            $ref: "#/definitions/v1alphaUndeployUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -588,11 +588,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUnpublishUserModelResponse'
+            $ref: "#/definitions/v1alphaUnpublishUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -620,11 +620,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListUserModelsResponse'
+            $ref: "#/definitions/v1alphaListUserModelsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -682,11 +682,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCreateUserModelResponse'
+            $ref: "#/definitions/v1alphaCreateUserModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -705,7 +705,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1alphaModel'
+            $ref: "#/definitions/v1alphaModel"
             required:
               - model
       tags:
@@ -720,11 +720,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpModelResponse'
+            $ref: "#/definitions/v1alphaLookUpModelResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink
           description: |-
@@ -763,11 +763,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/controllerv1alphaGetResourceResponse'
+            $ref: "#/definitions/controllerv1alphaGetResourceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -788,11 +788,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/controllerv1alphaDeleteResourceResponse'
+            $ref: "#/definitions/controllerv1alphaDeleteResourceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -813,11 +813,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/controllerv1alphaUpdateResourceResponse'
+            $ref: "#/definitions/controllerv1alphaUpdateResourceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -835,10 +835,10 @@ paths:
             type: object
             properties:
               model_state:
-                $ref: '#/definitions/v1alphaModelState'
+                $ref: "#/definitions/v1alphaModelState"
                 title: Model state
               backend_state:
-                $ref: '#/definitions/HealthCheckResponseServingStatus'
+                $ref: "#/definitions/HealthCheckResponseServingStatus"
                 title: Backend service state
               progress:
                 type: integer
@@ -862,11 +862,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaCheckModelAdminResponse'
+            $ref: "#/definitions/v1alphaCheckModelAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: model_permalink
           description: |-
@@ -886,11 +886,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaDeployModelAdminResponse'
+            $ref: "#/definitions/v1alphaDeployModelAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: model_permalink
           description: |-
@@ -916,11 +916,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUndeployModelAdminResponse'
+            $ref: "#/definitions/v1alphaUndeployModelAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: model_permalink
           description: |-
@@ -950,11 +950,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpModelAdminResponse'
+            $ref: "#/definitions/v1alphaLookUpModelAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink
           description: |-
@@ -993,11 +993,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListModelsAdminResponse'
+            $ref: "#/definitions/v1alphaListModelsAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -1049,11 +1049,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/modelcontrollerv1alphaLivenessResponse'
+            $ref: "#/definitions/modelcontrollerv1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1073,11 +1073,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/modelmodelv1alphaLivenessResponse'
+            $ref: "#/definitions/modelmodelv1alphaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1096,11 +1096,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListModelDefinitionsResponse'
+            $ref: "#/definitions/v1alphaListModelDefinitionsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -1147,11 +1147,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListModelsResponse'
+            $ref: "#/definitions/v1alphaListModelsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -1203,11 +1203,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/modelmodelv1alphaReadinessResponse'
+            $ref: "#/definitions/modelmodelv1alphaReadinessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1227,11 +1227,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdppipelinev1betaLivenessResponse'
+            $ref: "#/definitions/vdppipelinev1betaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1251,11 +1251,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdppipelinev1betaReadinessResponse'
+            $ref: "#/definitions/vdppipelinev1betaReadinessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1274,11 +1274,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaGetOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name_1
           description: |-
@@ -1317,11 +1317,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaDeleteOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name_1
           description: |-
@@ -1343,11 +1343,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaUpdateOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name_1
           description: |-
@@ -1379,7 +1379,7 @@ paths:
                 type: string
                 title: ConnectorDefinition resource
               type:
-                $ref: '#/definitions/v1betaConnectorType'
+                $ref: "#/definitions/v1betaConnectorType"
                 title: Connector Type
                 readOnly: true
               description:
@@ -1389,7 +1389,7 @@ paths:
                 type: object
                 title: Connector configuration in JSON format
               state:
-                $ref: '#/definitions/v1betaConnectorState'
+                $ref: "#/definitions/v1betaConnectorState"
                 title: Connector state
                 readOnly: true
               tombstone:
@@ -1407,11 +1407,11 @@ paths:
                 title: Connector update time
                 readOnly: true
               visibility:
-                $ref: '#/definitions/v1betaConnectorVisibility'
+                $ref: "#/definitions/v1betaConnectorVisibility"
                 title: Connector visibility including public or private
                 readOnly: true
               connector_definition:
-                $ref: '#/definitions/v1betaConnectorDefinition'
+                $ref: "#/definitions/v1betaConnectorDefinition"
                 title: Embed the content of the connector_definition
                 readOnly: true
               delete_time:
@@ -1442,11 +1442,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTestOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaTestOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name_1
           description: |-
@@ -1469,11 +1469,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaWatchOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaWatchOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name_1
           description: |-
@@ -1495,11 +1495,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetUserConnectorResponse'
+            $ref: "#/definitions/v1betaGetUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name
           description: |-
@@ -1538,11 +1538,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteUserConnectorResponse'
+            $ref: "#/definitions/v1betaDeleteUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name
           description: |-
@@ -1564,11 +1564,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateUserConnectorResponse'
+            $ref: "#/definitions/v1betaUpdateUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name
           description: |-
@@ -1600,7 +1600,7 @@ paths:
                 type: string
                 title: ConnectorDefinition resource
               type:
-                $ref: '#/definitions/v1betaConnectorType'
+                $ref: "#/definitions/v1betaConnectorType"
                 title: Connector Type
                 readOnly: true
               description:
@@ -1610,7 +1610,7 @@ paths:
                 type: object
                 title: Connector configuration in JSON format
               state:
-                $ref: '#/definitions/v1betaConnectorState'
+                $ref: "#/definitions/v1betaConnectorState"
                 title: Connector state
                 readOnly: true
               tombstone:
@@ -1628,11 +1628,11 @@ paths:
                 title: Connector update time
                 readOnly: true
               visibility:
-                $ref: '#/definitions/v1betaConnectorVisibility'
+                $ref: "#/definitions/v1betaConnectorVisibility"
                 title: Connector visibility including public or private
                 readOnly: true
               connector_definition:
-                $ref: '#/definitions/v1betaConnectorDefinition'
+                $ref: "#/definitions/v1betaConnectorDefinition"
                 title: Embed the content of the connector_definition
                 readOnly: true
               delete_time:
@@ -1663,11 +1663,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTestUserConnectorResponse'
+            $ref: "#/definitions/v1betaTestUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name
           description: |-
@@ -1690,11 +1690,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaWatchUserConnectorResponse'
+            $ref: "#/definitions/v1betaWatchUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector.name
           description: |-
@@ -1717,11 +1717,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetConnectorDefinitionResponse'
+            $ref: "#/definitions/v1betaGetConnectorDefinitionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: connector_definition.name
           description: |-
@@ -1759,11 +1759,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOrganizationMembershipResponse'
+            $ref: "#/definitions/v1betaGetOrganizationMembershipResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: membership.name_1
           description: Membership resource name. It must have the format of "organizations/*/memberships/*"
@@ -1797,11 +1797,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteOrganizationMembershipResponse'
+            $ref: "#/definitions/v1betaDeleteOrganizationMembershipResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: membership.name_1
           description: Membership resource name. It must have the format of "organizations/*/membership/*"
@@ -1820,11 +1820,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateOrganizationMembershipResponse'
+            $ref: "#/definitions/v1betaUpdateOrganizationMembershipResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: membership.name_1
           description: Resource name. It must have the format of "organizations/*/memberships/*"
@@ -1843,15 +1843,15 @@ paths:
                 type: string
                 title: Role
               state:
-                $ref: '#/definitions/v1betaMembershipState'
+                $ref: "#/definitions/v1betaMembershipState"
                 title: State
                 readOnly: true
               user:
-                $ref: '#/definitions/mgmtv1betaUser'
+                $ref: "#/definitions/mgmtv1betaUser"
                 title: User
                 readOnly: true
               organization:
-                $ref: '#/definitions/v1betaOrganization'
+                $ref: "#/definitions/v1betaOrganization"
                 title: Organization
                 readOnly: true
             title: A membership resource to update
@@ -1874,11 +1874,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetUserMembershipResponse'
+            $ref: "#/definitions/v1betaGetUserMembershipResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: membership.name
           description: Membership resource name. It must have the format of "users/*/memberships/*"
@@ -1912,11 +1912,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteUserMembershipResponse'
+            $ref: "#/definitions/v1betaDeleteUserMembershipResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: membership.name
           description: Membership resource name. It must have the format of "users/*/membership/*"
@@ -1935,11 +1935,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateUserMembershipResponse'
+            $ref: "#/definitions/v1betaUpdateUserMembershipResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: membership.name
           description: Resource name. It must have the format of "users/*/memberships/*".
@@ -1959,14 +1959,14 @@ paths:
                 title: Role
                 readOnly: true
               state:
-                $ref: '#/definitions/v1betaMembershipState'
+                $ref: "#/definitions/v1betaMembershipState"
                 title: State
               user:
-                $ref: '#/definitions/mgmtv1betaUser'
+                $ref: "#/definitions/mgmtv1betaUser"
                 title: User
                 readOnly: true
               organization:
-                $ref: '#/definitions/v1betaOrganization'
+                $ref: "#/definitions/v1betaOrganization"
                 title: Organization
                 readOnly: true
             title: A membership resource to update
@@ -1992,11 +1992,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaConnectOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaConnectOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_1
           description: |-
@@ -2029,11 +2029,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDisconnectOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaDisconnectOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_1
           description: |-
@@ -2064,11 +2064,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaExecuteOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaExecuteOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_1
           description: |-
@@ -2107,11 +2107,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaRenameUserPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaRenameUserPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_1
           description: Pipeline release resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -2147,11 +2147,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaRestoreOrganizationPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaRestoreOrganizationPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -2171,11 +2171,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTriggerUserPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaTriggerUserPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_1
           description: Resource name.
@@ -2209,11 +2209,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTriggerAsyncUserPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaTriggerAsyncUserPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_1
           description: Resource name.
@@ -2245,11 +2245,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaValidateOrganizationPipelineResponse'
+            $ref: "#/definitions/v1betaValidateOrganizationPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -2275,11 +2275,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaRenameOrganizationPipelineResponse'
+            $ref: "#/definitions/v1betaRenameOrganizationPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_2
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -2315,11 +2315,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTriggerOrganizationPipelineResponse'
+            $ref: "#/definitions/v1betaTriggerOrganizationPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_2
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -2353,11 +2353,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTriggerAsyncOrganizationPipelineResponse'
+            $ref: "#/definitions/v1betaTriggerAsyncOrganizationPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_2
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -2391,11 +2391,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaRenameOrganizationPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaRenameOrganizationPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_3
           description: Pipeline release resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -2431,11 +2431,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTriggerOrganizationPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaTriggerOrganizationPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_3
           description: Resource name.
@@ -2469,11 +2469,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTriggerAsyncOrganizationPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaTriggerAsyncOrganizationPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_3
           description: Resource name.
@@ -2508,11 +2508,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaRenameUserConnectorResponse'
+            $ref: "#/definitions/v1betaRenameUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_4
           description: |-
@@ -2552,11 +2552,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaRenameOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaRenameOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name_5
           description: |-
@@ -2596,11 +2596,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOperationResponse'
+            $ref: "#/definitions/v1betaGetOperationResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: The name of the operation resource.
@@ -2623,11 +2623,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaConnectUserConnectorResponse'
+            $ref: "#/definitions/v1betaConnectUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -2660,11 +2660,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDisconnectUserConnectorResponse'
+            $ref: "#/definitions/v1betaDisconnectUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -2695,11 +2695,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaExecuteUserConnectorResponse'
+            $ref: "#/definitions/v1betaExecuteUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: |-
@@ -2738,11 +2738,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaRenameUserPipelineResponse'
+            $ref: "#/definitions/v1betaRenameUserPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -2778,11 +2778,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaRestoreUserPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaRestoreUserPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -2802,11 +2802,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTriggerUserPipelineResponse'
+            $ref: "#/definitions/v1betaTriggerUserPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -2840,11 +2840,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaTriggerAsyncUserPipelineResponse'
+            $ref: "#/definitions/v1betaTriggerAsyncUserPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -2876,11 +2876,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaValidateUserPipelineResponse'
+            $ref: "#/definitions/v1betaValidateUserPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -2907,11 +2907,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOperatorDefinitionResponse'
+            $ref: "#/definitions/v1betaGetOperatorDefinitionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: operator_definition.name
           description: |-
@@ -2949,11 +2949,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOrganizationResponse'
+            $ref: "#/definitions/v1betaGetOrganizationResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: organization.name
           description: |-
@@ -2989,11 +2989,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteOrganizationResponse'
+            $ref: "#/definitions/v1betaDeleteOrganizationResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: organization.name
           description: |-
@@ -3014,11 +3014,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateOrganizationResponse'
+            $ref: "#/definitions/v1betaUpdateOrganizationResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: organization.name
           description: |-
@@ -3054,7 +3054,7 @@ paths:
               create_time:
                 type: string
                 format: date-time
-                title: 'Owner type: fixed to `OWNER_TYPE_USER`'
+                title: "Owner type: fixed to `OWNER_TYPE_USER`"
                 readOnly: true
               update_time:
                 type: string
@@ -3075,7 +3075,7 @@ paths:
                 type: object
                 title: Profile Data
               owner:
-                $ref: '#/definitions/mgmtv1betaUser'
+                $ref: "#/definitions/mgmtv1betaUser"
                 title: Owner
                 readOnly: true
             description: |-
@@ -3097,11 +3097,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListOrganizationConnectorsResponse'
+            $ref: "#/definitions/v1betaListOrganizationConnectorsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent_1
           description: |-
@@ -3164,11 +3164,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateOrganizationConnectorResponse'
+            $ref: "#/definitions/v1betaCreateOrganizationConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent_1
           description: |-
@@ -3183,7 +3183,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaConnector'
+            $ref: "#/definitions/v1betaConnector"
             required:
               - connector
       tags:
@@ -3198,11 +3198,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListOrganizationMembershipsResponse'
+            $ref: "#/definitions/v1betaListOrganizationMembershipsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent_1
           description: |-
@@ -3224,11 +3224,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListOrganizationPipelinesResponse'
+            $ref: "#/definitions/v1betaListOrganizationPipelinesResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent_1
           description: |-
@@ -3290,11 +3290,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateOrganizationPipelineResponse'
+            $ref: "#/definitions/v1betaCreateOrganizationPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent_1
           description: |-
@@ -3309,7 +3309,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaPipeline'
+            $ref: "#/definitions/v1betaPipeline"
             required:
               - pipeline
       tags:
@@ -3324,11 +3324,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListOrganizationPipelineReleasesResponse'
+            $ref: "#/definitions/v1betaListOrganizationPipelineReleasesResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent_1
           description: |-
@@ -3390,11 +3390,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateOrganizationPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaCreateOrganizationPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent_1
           description: |-
@@ -3409,7 +3409,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaPipelineRelease'
+            $ref: "#/definitions/v1betaPipelineRelease"
             required:
               - release
       tags:
@@ -3422,11 +3422,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOrganizationSubscriptionResponse'
+            $ref: "#/definitions/v1betaGetOrganizationSubscriptionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent_1
           description: parent
@@ -3447,11 +3447,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListUserConnectorsResponse'
+            $ref: "#/definitions/v1betaListUserConnectorsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -3514,11 +3514,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateUserConnectorResponse'
+            $ref: "#/definitions/v1betaCreateUserConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -3533,7 +3533,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaConnector'
+            $ref: "#/definitions/v1betaConnector"
             required:
               - connector
       tags:
@@ -3548,11 +3548,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListUserMembershipsResponse'
+            $ref: "#/definitions/v1betaListUserMembershipsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -3574,11 +3574,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListUserPipelinesResponse'
+            $ref: "#/definitions/v1betaListUserPipelinesResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -3640,11 +3640,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateUserPipelineResponse'
+            $ref: "#/definitions/v1betaCreateUserPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -3659,7 +3659,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaPipeline'
+            $ref: "#/definitions/v1betaPipeline"
             required:
               - pipeline
       tags:
@@ -3674,11 +3674,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListUserPipelineReleasesResponse'
+            $ref: "#/definitions/v1betaListUserPipelineReleasesResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -3740,11 +3740,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateUserPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaCreateUserPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: |-
@@ -3759,7 +3759,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaPipelineRelease'
+            $ref: "#/definitions/v1betaPipelineRelease"
             required:
               - release
       tags:
@@ -3772,11 +3772,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetUserSubscriptionResponse'
+            $ref: "#/definitions/v1betaGetUserSubscriptionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: parent
@@ -3797,11 +3797,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaLookUpConnectorResponse'
+            $ref: "#/definitions/v1betaLookUpConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink_1
           description: |-
@@ -3840,11 +3840,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaLookUpPipelineResponse'
+            $ref: "#/definitions/v1betaLookUpPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink
           description: |-
@@ -3883,11 +3883,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaWatchOrganizationPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaWatchOrganizationPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline.name/watch_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -3907,11 +3907,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaWatchUserPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaWatchUserPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline.name/watch
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -3931,11 +3931,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOrganizationPipelineResponse'
+            $ref: "#/definitions/v1betaGetOrganizationPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline.name_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -3971,11 +3971,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteOrganizationPipelineResponse'
+            $ref: "#/definitions/v1betaDeleteOrganizationPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline.name_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -3994,11 +3994,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateOrganizationPipelineResponse'
+            $ref: "#/definitions/v1betaUpdateOrganizationPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline.name_1
           description: Pipeline resource name. It must have the format of "users/{user}/pipelines/*"
@@ -4028,7 +4028,7 @@ paths:
                 type: string
                 title: Pipeline description
               recipe:
-                $ref: '#/definitions/v1betaRecipe'
+                $ref: "#/definitions/v1betaRecipe"
                 title: Pipeline recipe
               create_time:
                 type: string
@@ -4050,11 +4050,11 @@ paths:
                 title: Pipeline delete time
                 readOnly: true
               sharing:
-                $ref: '#/definitions/v1betaSharing'
+                $ref: "#/definitions/v1betaSharing"
                 title: Pipeline sharing
               metadata:
                 type: object
-                title: 'Metadata: store Console-related data such as pipeline builder layout'
+                title: "Metadata: store Console-related data such as pipeline builder layout"
               owner_name:
                 type: string
                 title: Owner Name
@@ -4067,14 +4067,14 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: '#/definitions/v1betaPipelineRelease'
+                  $ref: "#/definitions/v1betaPipelineRelease"
                 title: Releases
                 readOnly: true
               readme:
                 type: string
                 title: readme
               permission:
-                $ref: '#/definitions/v1betaPermission'
+                $ref: "#/definitions/v1betaPermission"
                 title: Permission
                 readOnly: true
             title: A pipeline resource to update
@@ -4090,11 +4090,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetUserPipelineResponse'
+            $ref: "#/definitions/v1betaGetUserPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -4130,11 +4130,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteUserPipelineResponse'
+            $ref: "#/definitions/v1betaDeleteUserPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -4153,11 +4153,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateUserPipelineResponse'
+            $ref: "#/definitions/v1betaUpdateUserPipelineResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "users/{user}/pipelines/*"
@@ -4187,7 +4187,7 @@ paths:
                 type: string
                 title: Pipeline description
               recipe:
-                $ref: '#/definitions/v1betaRecipe'
+                $ref: "#/definitions/v1betaRecipe"
                 title: Pipeline recipe
               create_time:
                 type: string
@@ -4209,11 +4209,11 @@ paths:
                 title: Pipeline delete time
                 readOnly: true
               sharing:
-                $ref: '#/definitions/v1betaSharing'
+                $ref: "#/definitions/v1betaSharing"
                 title: Pipeline sharing
               metadata:
                 type: object
-                title: 'Metadata: store Console-related data such as pipeline builder layout'
+                title: "Metadata: store Console-related data such as pipeline builder layout"
               owner_name:
                 type: string
                 title: Owner Name
@@ -4226,14 +4226,14 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: '#/definitions/v1betaPipelineRelease'
+                  $ref: "#/definitions/v1betaPipelineRelease"
                 title: Releases
                 readOnly: true
               readme:
                 type: string
                 title: readme
               permission:
-                $ref: '#/definitions/v1betaPermission'
+                $ref: "#/definitions/v1betaPermission"
                 title: Permission
                 readOnly: true
             title: A pipeline resource to update
@@ -4249,11 +4249,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOrganizationPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaGetOrganizationPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline_release.name_1
           description: PipelineRelease resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -4289,11 +4289,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteOrganizationPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaDeleteOrganizationPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline_release.name_1
           description: PipelineRelease resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -4313,11 +4313,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetUserPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaGetUserPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline_release.name
           description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -4353,11 +4353,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteUserPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaDeleteUserPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: pipeline_release.name
           description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -4377,11 +4377,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateOrganizationPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaUpdateOrganizationPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: release.name_1
           description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -4409,7 +4409,7 @@ paths:
                 type: string
                 title: PipelineRelease description
               recipe:
-                $ref: '#/definitions/v1betaRecipe'
+                $ref: "#/definitions/v1betaRecipe"
                 title: Pipeline recipe snapshot
                 readOnly: true
               create_time:
@@ -4437,7 +4437,7 @@ paths:
                 readOnly: true
               metadata:
                 type: object
-                title: 'Metadata: store Console-related data such as pipeline builder layout'
+                title: "Metadata: store Console-related data such as pipeline builder layout"
               readme:
                 type: string
                 title: readme
@@ -4454,11 +4454,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateUserPipelineReleaseResponse'
+            $ref: "#/definitions/v1betaUpdateUserPipelineReleaseResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: release.name
           description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -4486,7 +4486,7 @@ paths:
                 type: string
                 title: PipelineRelease description
               recipe:
-                $ref: '#/definitions/v1betaRecipe'
+                $ref: "#/definitions/v1betaRecipe"
                 title: Pipeline recipe snapshot
                 readOnly: true
               create_time:
@@ -4514,7 +4514,7 @@ paths:
                 readOnly: true
               metadata:
                 type: object
-                title: 'Metadata: store Console-related data such as pipeline builder layout'
+                title: "Metadata: store Console-related data such as pipeline builder layout"
               readme:
                 type: string
                 title: readme
@@ -4531,11 +4531,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/controllerv1betaGetResourceResponse'
+            $ref: "#/definitions/controllerv1betaGetResourceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -4556,11 +4556,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/controllerv1betaDeleteResourceResponse'
+            $ref: "#/definitions/controllerv1betaDeleteResourceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -4581,11 +4581,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/controllerv1betaUpdateResourceResponse'
+            $ref: "#/definitions/controllerv1betaUpdateResourceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -4603,13 +4603,13 @@ paths:
             type: object
             properties:
               pipeline_state:
-                $ref: '#/definitions/pipelinev1betaState'
+                $ref: "#/definitions/pipelinev1betaState"
                 title: Pipeline state
               connector_state:
-                $ref: '#/definitions/v1betaConnectorState'
+                $ref: "#/definitions/v1betaConnectorState"
                 title: Connector state
               backend_state:
-                $ref: '#/definitions/HealthCheckResponseServingStatus'
+                $ref: "#/definitions/HealthCheckResponseServingStatus"
                 title: Backend service state
               progress:
                 type: integer
@@ -4633,11 +4633,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetTokenResponse'
+            $ref: "#/definitions/v1betaGetTokenResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: token.name
           description: API tokens resource name. It must have the format of "tokens/*"
@@ -4656,11 +4656,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteTokenResponse'
+            $ref: "#/definitions/v1betaDeleteTokenResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: token.name
           description: API token resource name. It must have the format of "tokens/*"
@@ -4680,11 +4680,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetUserResponse'
+            $ref: "#/definitions/v1betaGetUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: user.name
           description: |-
@@ -4721,11 +4721,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOrganizationAdminResponse'
+            $ref: "#/definitions/v1betaGetOrganizationAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: organization.name
           description: |-
@@ -4760,11 +4760,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetOrganizationSubscriptionAdminResponse'
+            $ref: "#/definitions/v1betaGetOrganizationSubscriptionAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent_1
           description: parent
@@ -4782,11 +4782,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetUserSubscriptionAdminResponse'
+            $ref: "#/definitions/v1betaGetUserSubscriptionAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: parent
           description: parent
@@ -4806,11 +4806,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaLookUpOrganizationAdminResponse'
+            $ref: "#/definitions/v1betaLookUpOrganizationAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink_1
           description: |-
@@ -4847,11 +4847,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaLookUpPipelineAdminResponse'
+            $ref: "#/definitions/v1betaLookUpPipelineAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink_2
           description: |-
@@ -4891,11 +4891,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaLookUpOperatorDefinitionAdminResponse'
+            $ref: "#/definitions/v1betaLookUpOperatorDefinitionAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink_3
           description: |-
@@ -4933,11 +4933,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaLookUpConnectorDefinitionAdminResponse'
+            $ref: "#/definitions/v1betaLookUpConnectorDefinitionAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink_4
           description: |-
@@ -4975,11 +4975,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaLookUpConnectorAdminResponse'
+            $ref: "#/definitions/v1betaLookUpConnectorAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink_5
           description: |-
@@ -5018,11 +5018,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCheckConnectorResponse'
+            $ref: "#/definitions/v1betaCheckConnectorResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink
           description: |-
@@ -5044,11 +5044,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaLookUpUserAdminResponse'
+            $ref: "#/definitions/v1betaLookUpUserAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: permalink
           description: |-
@@ -5085,11 +5085,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetUserAdminResponse'
+            $ref: "#/definitions/v1betaGetUserAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: user.name
           description: |-
@@ -5126,11 +5126,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListConnectorsAdminResponse'
+            $ref: "#/definitions/v1betaListConnectorsAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5185,11 +5185,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListOrganizationsAdminResponse'
+            $ref: "#/definitions/v1betaListOrganizationsAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5238,11 +5238,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListPipelinesAdminResponse'
+            $ref: "#/definitions/v1betaListPipelinesAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5297,11 +5297,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListPipelineReleasesAdminResponse'
+            $ref: "#/definitions/v1betaListPipelineReleasesAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5356,11 +5356,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListUsersAdminResponse'
+            $ref: "#/definitions/v1betaListUsersAdminResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5407,17 +5407,17 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaAuthChangePasswordResponse'
+            $ref: "#/definitions/v1betaAuthChangePasswordResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: body
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaAuthChangePasswordRequest'
+            $ref: "#/definitions/v1betaAuthChangePasswordRequest"
       tags:
         - MgmtPublicService
   /v1beta/auth/login:
@@ -5428,11 +5428,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaAuthLoginResponse'
+            $ref: "#/definitions/v1betaAuthLoginResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: username
           description: Username
@@ -5454,11 +5454,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaAuthLogoutResponse'
+            $ref: "#/definitions/v1betaAuthLogoutResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       tags:
         - MgmtPublicService
   /v1beta/auth/token_issuer:
@@ -5469,17 +5469,17 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaAuthTokenIssuerResponse'
+            $ref: "#/definitions/v1betaAuthTokenIssuerResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: body
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaAuthTokenIssuerRequest'
+            $ref: "#/definitions/v1betaAuthTokenIssuerRequest"
       tags:
         - MgmtPublicService
   /v1beta/auth/validate_access_token:
@@ -5490,11 +5490,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaAuthValidateAccessTokenResponse'
+            $ref: "#/definitions/v1betaAuthValidateAccessTokenResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       tags:
         - MgmtPublicService
   /v1beta/check-namespace:
@@ -5505,17 +5505,17 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCheckNamespaceResponse'
+            $ref: "#/definitions/v1betaCheckNamespaceResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: body
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaCheckNamespaceRequest'
+            $ref: "#/definitions/v1betaCheckNamespaceRequest"
       tags:
         - MgmtPublicService
   /v1beta/connector-definitions:
@@ -5529,11 +5529,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListConnectorDefinitionsResponse'
+            $ref: "#/definitions/v1betaListConnectorDefinitionsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5583,11 +5583,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListConnectorsResponse'
+            $ref: "#/definitions/v1betaListConnectorsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5643,11 +5643,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdpcontrollerv1betaLivenessResponse'
+            $ref: "#/definitions/vdpcontrollerv1betaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -5667,11 +5667,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/coremgmtv1betaLivenessResponse'
+            $ref: "#/definitions/coremgmtv1betaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -5691,11 +5691,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/vdppipelinev1betaLivenessResponse'
+            $ref: "#/definitions/vdppipelinev1betaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -5715,11 +5715,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/coreusagev1betaLivenessResponse'
+            $ref: "#/definitions/coreusagev1betaLivenessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -5739,11 +5739,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListConnectorExecuteChartRecordsResponse'
+            $ref: "#/definitions/v1betaListConnectorExecuteChartRecordsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: aggregation_window
           description: Aggregation window in nanoseconds
@@ -5769,11 +5769,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListConnectorExecuteRecordsResponse'
+            $ref: "#/definitions/v1betaListConnectorExecuteRecordsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5808,11 +5808,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListConnectorExecuteTableRecordsResponse'
+            $ref: "#/definitions/v1betaListConnectorExecuteTableRecordsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5847,11 +5847,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListPipelineTriggerChartRecordsResponse'
+            $ref: "#/definitions/v1betaListPipelineTriggerChartRecordsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: aggregation_window
           description: Aggregation window in nanoseconds
@@ -5877,11 +5877,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListPipelineTriggerTableRecordsResponse'
+            $ref: "#/definitions/v1betaListPipelineTriggerTableRecordsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5916,11 +5916,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListPipelineTriggerRecordsResponse'
+            $ref: "#/definitions/v1betaListPipelineTriggerRecordsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -5955,11 +5955,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListOperatorDefinitionsResponse'
+            $ref: "#/definitions/v1betaListOperatorDefinitionsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -6008,11 +6008,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListOrganizationsResponse'
+            $ref: "#/definitions/v1betaListOrganizationsResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -6060,11 +6060,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateOrganizationResponse'
+            $ref: "#/definitions/v1betaCreateOrganizationResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: organization
           description: |-
@@ -6075,7 +6075,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaOrganization'
+            $ref: "#/definitions/v1betaOrganization"
             required:
               - organization
       tags:
@@ -6090,11 +6090,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListPipelinesResponse'
+            $ref: "#/definitions/v1betaListPipelinesResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -6150,11 +6150,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/coremgmtv1betaReadinessResponse'
+            $ref: "#/definitions/coremgmtv1betaReadinessResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -6173,18 +6173,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaSendSessionReportResponse'
+            $ref: "#/definitions/v1betaSendSessionReportResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: report
           description: A report resource to create
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaSessionReport'
+            $ref: "#/definitions/v1betaSessionReport"
             required:
               - report
       tags:
@@ -6199,18 +6199,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateSessionResponse'
+            $ref: "#/definitions/v1betaCreateSessionResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: session
           description: A session resource to create
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaSession'
+            $ref: "#/definitions/v1betaSession"
             required:
               - session
       tags:
@@ -6225,11 +6225,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListTokensResponse'
+            $ref: "#/definitions/v1betaListTokensResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -6256,18 +6256,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateTokenResponse'
+            $ref: "#/definitions/v1betaCreateTokenResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: token
           description: A token resource to create
           in: body
           required: true
           schema:
-            $ref: '#/definitions/v1betaApiToken'
+            $ref: "#/definitions/v1betaApiToken"
             required:
               - token
       tags:
@@ -6282,11 +6282,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListUsersResponse'
+            $ref: "#/definitions/v1betaListUsersResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: page_size
           description: |-
@@ -6335,18 +6335,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaPatchAuthenticatedUserResponse'
+            $ref: "#/definitions/v1betaPatchAuthenticatedUserResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       parameters:
         - name: user
           description: The user to update
           in: body
           required: true
           schema:
-            $ref: '#/definitions/mgmtv1betaUser'
+            $ref: "#/definitions/mgmtv1betaUser"
             required:
               - user
       tags:
@@ -6361,11 +6361,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaValidateTokenResponse'
+            $ref: "#/definitions/v1betaValidateTokenResponse"
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/googlerpcStatus'
+            $ref: "#/definitions/googlerpcStatus"
       tags:
         - MgmtPublicService
 definitions:
@@ -6462,17 +6462,17 @@ definitions:
         type: boolean
         title: enabled
       role:
-        $ref: '#/definitions/v1betaRole'
+        $ref: "#/definitions/v1betaRole"
         title: role
     title: Share Code
   SubscriptionQuota:
     type: object
     properties:
       private_pipeline_trigger:
-        $ref: '#/definitions/QuotaQuotaDetail'
+        $ref: "#/definitions/QuotaQuotaDetail"
         title: pipeline trigger
       private_pipeline:
-        $ref: '#/definitions/QuotaQuotaDetail'
+        $ref: "#/definitions/QuotaQuotaDetail"
         title: private pipeline
     title: Quota
   UserUsageDataConnectorExecuteData:
@@ -6492,13 +6492,13 @@ definitions:
         type: string
         title: Definition UID of the connector
       status:
-        $ref: '#/definitions/mgmtv1betaStatus'
+        $ref: "#/definitions/mgmtv1betaStatus"
         title: Final status of the execution
       user_uid:
         type: string
         title: UUID of the user who execute the connector
       user_type:
-        $ref: '#/definitions/v1betaOwnerType'
+        $ref: "#/definitions/v1betaOwnerType"
         title: Type of the user who execute the connector
     title: Per execute usage metadata
     required:
@@ -6526,16 +6526,16 @@ definitions:
         type: string
         title: Definition UID of the model
       model_task:
-        $ref: '#/definitions/v1alphaTask'
+        $ref: "#/definitions/v1alphaTask"
         title: Task of the model
       status:
-        $ref: '#/definitions/mgmtv1betaStatus'
+        $ref: "#/definitions/mgmtv1betaStatus"
         title: Final status of the execution
       user_uid:
         type: string
         title: UUID of the user who trigger the model
       user_type:
-        $ref: '#/definitions/v1betaOwnerType'
+        $ref: "#/definitions/v1betaOwnerType"
         title: Type of the user who trigger the model
     title: Per trigger usage metadata
     required:
@@ -6561,10 +6561,10 @@ definitions:
         format: date-time
         title: Timestamp for the trigger
       trigger_mode:
-        $ref: '#/definitions/v1betaMode'
+        $ref: "#/definitions/v1betaMode"
         title: Trigger mode
       status:
-        $ref: '#/definitions/mgmtv1betaStatus'
+        $ref: "#/definitions/mgmtv1betaStatus"
         title: Final status of the execution
       pipeline_release_id:
         type: string
@@ -6576,7 +6576,7 @@ definitions:
         type: string
         title: UUID of the user who trigger the pipeline
       user_type:
-        $ref: '#/definitions/v1betaOwnerType'
+        $ref: "#/definitions/v1betaOwnerType"
         title: Type of the user who trigger the pipeline
     title: Per trigger usage metadata
     required:
@@ -6596,7 +6596,7 @@ definitions:
     type: object
     properties:
       resource:
-        $ref: '#/definitions/controllerv1alphaResource'
+        $ref: "#/definitions/controllerv1alphaResource"
         title: Retrieved resource state
     title: GetResourceResponse represents a response to fetch a resource's state
   controllerv1alphaResource:
@@ -6608,10 +6608,10 @@ definitions:
           Permalink of a resource. For example:
           "resources/{resource_uuid}/types/{type}"
       model_state:
-        $ref: '#/definitions/v1alphaModelState'
+        $ref: "#/definitions/v1alphaModelState"
         title: Model state
       backend_state:
-        $ref: '#/definitions/HealthCheckResponseServingStatus'
+        $ref: "#/definitions/HealthCheckResponseServingStatus"
         title: Backend service state
       progress:
         type: integer
@@ -6624,7 +6624,7 @@ definitions:
     type: object
     properties:
       resource:
-        $ref: '#/definitions/controllerv1alphaResource'
+        $ref: "#/definitions/controllerv1alphaResource"
         title: Updated resource state
     title: UpdateResourceResponse represents a response to update a resource's state
   controllerv1betaDeleteResourceResponse:
@@ -6634,7 +6634,7 @@ definitions:
     type: object
     properties:
       resource:
-        $ref: '#/definitions/controllerv1betaResource'
+        $ref: "#/definitions/controllerv1betaResource"
         title: Retrieved resource state
     title: GetResourceResponse represents a response to fetch a resource's state
   controllerv1betaResource:
@@ -6646,13 +6646,13 @@ definitions:
           Permalink of a resouce. For example:
           "resources/{resource_uuid}/types/{type}"
       pipeline_state:
-        $ref: '#/definitions/pipelinev1betaState'
+        $ref: "#/definitions/pipelinev1betaState"
         title: Pipeline state
       connector_state:
-        $ref: '#/definitions/v1betaConnectorState'
+        $ref: "#/definitions/v1betaConnectorState"
         title: Connector state
       backend_state:
-        $ref: '#/definitions/HealthCheckResponseServingStatus'
+        $ref: "#/definitions/HealthCheckResponseServingStatus"
         title: Backend service state
       progress:
         type: integer
@@ -6665,35 +6665,35 @@ definitions:
     type: object
     properties:
       resource:
-        $ref: '#/definitions/controllerv1betaResource'
+        $ref: "#/definitions/controllerv1betaResource"
         title: Updated resource state
     title: UpdateResourceResponse represents a response to update a resource's state
   coremgmtv1betaLivenessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   coremgmtv1betaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   coreusagev1betaLivenessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   coreusagev1betaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   googlelongrunningOperation:
@@ -6706,7 +6706,7 @@ definitions:
           originally returns it. If you use the default HTTP mapping, the
           `name` should be a resource name ending with `operations/{unique_id}`.
       metadata:
-        $ref: '#/definitions/protobufAny'
+        $ref: "#/definitions/protobufAny"
         description: |-
           Service-specific metadata associated with the operation.  It typically
           contains progress information and common metadata such as create time.
@@ -6719,10 +6719,10 @@ definitions:
           If `true`, the operation is completed, and either `error` or `response` is
           available.
       error:
-        $ref: '#/definitions/googlerpcStatus'
+        $ref: "#/definitions/googlerpcStatus"
         description: The error result of the operation in case of failure or cancellation.
       response:
-        $ref: '#/definitions/protobufAny'
+        $ref: "#/definitions/protobufAny"
         description: |-
           The normal response of the operation in case of success.  If the original
           method returns no data on success, such as `Delete`, the response is
@@ -6755,7 +6755,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/protobufAny'
+          $ref: "#/definitions/protobufAny"
         description: |-
           A list of messages that carry the error details.  There is a common set of
           message types for APIs to use.
@@ -6874,28 +6874,28 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   modelcontrollerv1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   modelmodelv1alphaLivenessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   modelmodelv1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   modelv1alphaView:
@@ -6930,7 +6930,7 @@ definitions:
   protobufAny:
     type: object
     properties:
-      '@type':
+      "@type":
         type: string
         description: |-
           A URL/resource name that uniquely identifies the type of the serialized
@@ -7087,7 +7087,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1alphaModelState'
+        $ref: "#/definitions/v1alphaModelState"
         title: Retrieved model state
     title: |-
       CheckModelAdminResponse represents a response to fetch a model's
@@ -7134,6 +7134,15 @@ definitions:
         title: Classification score
         readOnly: true
     title: ClassificationOutput represents the output of classification task
+  v1alphaContent:
+    type: object
+    properties:
+      type:
+        type: string
+      content:
+        type: string
+      prompt_image:
+        $ref: "#/definitions/v1alphaPromptImage"
   v1alphaConversationObject:
     type: object
     properties:
@@ -7148,7 +7157,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Create model operation message
         readOnly: true
     title: CreateUserModelBinaryFileUploadResponse represents a response for a model
@@ -7156,7 +7165,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Create model operation message
         readOnly: true
     title: CreateUserModelResponse represents a response for a model
@@ -7167,7 +7176,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Deploy operation message
     title: DeployModelAdminResponse represents a response for a deployed model
   v1alphaDeployUserModelResponse:
@@ -7221,7 +7230,7 @@ definitions:
         title: Detection object score
         readOnly: true
       bounding_box:
-        $ref: '#/definitions/v1alphaBoundingBox'
+        $ref: "#/definitions/v1alphaBoundingBox"
         title: Detection bounding box
         readOnly: true
     title: DetectionObject represents a predicted object
@@ -7232,7 +7241,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaDetectionObject'
+          $ref: "#/definitions/v1alphaDetectionObject"
         title: A list of detection objects
         readOnly: true
     title: DetectionOutput represents the output of detection task
@@ -7252,28 +7261,28 @@ definitions:
     type: object
     properties:
       model_definition:
-        $ref: '#/definitions/v1alphaModelDefinition'
+        $ref: "#/definitions/v1alphaModelDefinition"
         title: A model definition instance
     title: GetModelDefinitionResponse represents a response for a model definition
   v1alphaGetModelOperationResponse:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: The retrieved model operation
     title: GetModelOperationResponse represents a response for a model operation
   v1alphaGetUserModelCardResponse:
     type: object
     properties:
       readme:
-        $ref: '#/definitions/v1alphaModelCard'
+        $ref: "#/definitions/v1alphaModelCard"
         title: Retrieved model card
     title: GetUserModelCardResponse represents a response to fetch a model's README card
   v1alphaGetUserModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: The retrieved model
     title: GetUserModelResponse represents a response for a model
   v1alphaImageToImageInput:
@@ -7308,7 +7317,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaExtraParamObject'
+          $ref: "#/definitions/v1alphaExtraParamObject"
         title: The extra parameters
     title: ImageToImageInput represents the input of image to image task
     required:
@@ -7369,7 +7378,7 @@ definitions:
         title: Instance score
         readOnly: true
       bounding_box:
-        $ref: '#/definitions/v1alphaBoundingBox'
+        $ref: "#/definitions/v1alphaBoundingBox"
         title: Instance bounding box
         readOnly: true
     title: InstanceSegmentationObject corresponding to a instance segmentation object
@@ -7380,7 +7389,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaInstanceSegmentationObject'
+          $ref: "#/definitions/v1alphaInstanceSegmentationObject"
         title: A list of instance segmentation objects
         readOnly: true
     title: |-
@@ -7441,7 +7450,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaKeypoint'
+          $ref: "#/definitions/v1alphaKeypoint"
         title: Keypoints
         readOnly: true
       score:
@@ -7450,7 +7459,7 @@ definitions:
         title: Keypoint score
         readOnly: true
       bounding_box:
-        $ref: '#/definitions/v1alphaBoundingBox'
+        $ref: "#/definitions/v1alphaBoundingBox"
         title: Bounding box object
         readOnly: true
     title: KeypointObject corresponding to a person object
@@ -7461,7 +7470,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaKeypointObject'
+          $ref: "#/definitions/v1alphaKeypointObject"
         title: A list of keypoint objects
         readOnly: true
     title: KeypointOutput represents the output of keypoint detection task
@@ -7472,7 +7481,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaModelDefinition'
+          $ref: "#/definitions/v1alphaModelDefinition"
         title: a list of ModelDefinition instances
       next_page_token:
         type: string
@@ -7491,7 +7500,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaModel'
+          $ref: "#/definitions/v1alphaModel"
         title: a list of Models
       next_page_token:
         type: string
@@ -7508,7 +7517,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaModel'
+          $ref: "#/definitions/v1alphaModel"
         title: a list of Models
       next_page_token:
         type: string
@@ -7525,7 +7534,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaModel'
+          $ref: "#/definitions/v1alphaModel"
         title: a list of Models
       next_page_token:
         type: string
@@ -7539,14 +7548,14 @@ definitions:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: A model resource
     title: LookUpModelResponse represents a response for a model
   v1alphaLookUpModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: A model resource
     title: LookUpModelResponse represents a response for a model
   v1alphaModel:
@@ -7581,15 +7590,15 @@ definitions:
           Model configuration represents the configuration JSON that has been
           validated using the `model_spec` JSON schema of a ModelDefinition
       task:
-        $ref: '#/definitions/v1alphaTask'
+        $ref: "#/definitions/v1alphaTask"
         title: Model task
         readOnly: true
       state:
-        $ref: '#/definitions/v1alphaModelState'
+        $ref: "#/definitions/v1alphaModelState"
         title: Model state
         readOnly: true
       visibility:
-        $ref: '#/definitions/v1alphaModelVisibility'
+        $ref: "#/definitions/v1alphaModelVisibility"
         title: Model visibility including public or private
         readOnly: true
       create_time:
@@ -7678,7 +7687,7 @@ definitions:
         title: ModelDefinition icon
         readOnly: true
       release_stage:
-        $ref: '#/definitions/v1alphaReleaseStage'
+        $ref: "#/definitions/v1alphaReleaseStage"
         title: ModelDefinition release stage
         readOnly: true
       model_spec:
@@ -7768,7 +7777,7 @@ definitions:
         title: OCR text score
         readOnly: true
       bounding_box:
-        $ref: '#/definitions/v1alphaBoundingBox'
+        $ref: "#/definitions/v1alphaBoundingBox"
         title: OCR bounding box
         readOnly: true
     title: OcrObject represents a predicted ocr object
@@ -7779,15 +7788,23 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaOcrObject'
+          $ref: "#/definitions/v1alphaOcrObject"
         title: A list of OCR objects
         readOnly: true
     title: OcrOutput represents the output of ocr task
+  v1alphaPromptImage:
+    type: object
+    properties:
+      prompt_image_url:
+        type: string
+      prompt_image_base64:
+        type: string
+    title: "reference to: https://github.com/instill-ai/connector/blob/main/pkg/openai/text_generation.go#L17"
   v1alphaPublishUserModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: Published model
     title: PublishUserModelResponse represents a response for the published model
   v1alphaReleaseStage:
@@ -7810,7 +7827,7 @@ definitions:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: Renamed model
     title: RenameUserModelResponse represents a response for a model
   v1alphaSemanticSegmentationInput:
@@ -7849,7 +7866,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaSemanticSegmentationStuff'
+          $ref: "#/definitions/v1alphaSemanticSegmentationStuff"
         title: A list of semantic segmentation stuffs
         readOnly: true
     title: |-
@@ -7905,131 +7922,131 @@ definitions:
     type: object
     properties:
       classification:
-        $ref: '#/definitions/v1alphaClassificationInput'
+        $ref: "#/definitions/v1alphaClassificationInput"
         title: The classification input
       detection:
-        $ref: '#/definitions/v1alphaDetectionInput'
+        $ref: "#/definitions/v1alphaDetectionInput"
         title: The detection input
       keypoint:
-        $ref: '#/definitions/v1alphaKeypointInput'
+        $ref: "#/definitions/v1alphaKeypointInput"
         title: The keypoint input
       ocr:
-        $ref: '#/definitions/v1alphaOcrInput'
+        $ref: "#/definitions/v1alphaOcrInput"
         title: The ocr input
       instance_segmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationInput'
+        $ref: "#/definitions/v1alphaInstanceSegmentationInput"
         title: The instance segmentation input
       semantic_segmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationInput'
+        $ref: "#/definitions/v1alphaSemanticSegmentationInput"
         title: The semantic segmentation input
       text_to_image:
-        $ref: '#/definitions/v1alphaTextToImageInput'
+        $ref: "#/definitions/v1alphaTextToImageInput"
         title: The text to image input
       image_to_image:
-        $ref: '#/definitions/v1alphaImageToImageInput'
+        $ref: "#/definitions/v1alphaImageToImageInput"
         title: The image to image input
       text_generation:
-        $ref: '#/definitions/v1alphaTextGenerationInput'
+        $ref: "#/definitions/v1alphaTextGenerationInput"
         title: The text generation input
       text_generation_chat:
-        $ref: '#/definitions/v1alphaTextGenerationChatInput'
+        $ref: "#/definitions/v1alphaTextGenerationChatInput"
         title: The text generation chat input
       visual_question_answering:
-        $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
+        $ref: "#/definitions/v1alphaVisualQuestionAnsweringInput"
         title: The visual question answering input
       unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedInput'
+        $ref: "#/definitions/v1alphaUnspecifiedInput"
         title: The unspecified task input
     title: Input represents the input to trigger a model
   v1alphaTaskInputStream:
     type: object
     properties:
       classification:
-        $ref: '#/definitions/v1alphaClassificationInputStream'
+        $ref: "#/definitions/v1alphaClassificationInputStream"
         title: The classification input
       detection:
-        $ref: '#/definitions/v1alphaDetectionInputStream'
+        $ref: "#/definitions/v1alphaDetectionInputStream"
         title: The detection input
       keypoint:
-        $ref: '#/definitions/v1alphaKeypointInputStream'
+        $ref: "#/definitions/v1alphaKeypointInputStream"
         title: The keypoint input
       ocr:
-        $ref: '#/definitions/v1alphaOcrInputStream'
+        $ref: "#/definitions/v1alphaOcrInputStream"
         title: The ocr input
       instance_segmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationInputStream'
+        $ref: "#/definitions/v1alphaInstanceSegmentationInputStream"
         title: The instance segmentation input
       semantic_segmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationInputStream'
+        $ref: "#/definitions/v1alphaSemanticSegmentationInputStream"
         title: The semantic segmentation input
       text_to_image:
-        $ref: '#/definitions/v1alphaTextToImageInput'
+        $ref: "#/definitions/v1alphaTextToImageInput"
         title: The text to image input
       image_to_image:
-        $ref: '#/definitions/v1alphaImageToImageInput'
+        $ref: "#/definitions/v1alphaImageToImageInput"
         title: The image to image input
       text_generation:
-        $ref: '#/definitions/v1alphaTextGenerationInput'
+        $ref: "#/definitions/v1alphaTextGenerationInput"
         title: The text generation input
       text_generation_chat:
-        $ref: '#/definitions/v1alphaTextGenerationChatInput'
+        $ref: "#/definitions/v1alphaTextGenerationChatInput"
         title: The text generation chat input
       visual_question_answering:
-        $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
+        $ref: "#/definitions/v1alphaVisualQuestionAnsweringInput"
         title: The visual question answering input
       unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedInput'
+        $ref: "#/definitions/v1alphaUnspecifiedInput"
         title: The unspecified task input
     title: TaskInputStream represents the input to trigger a model with stream method
   v1alphaTaskOutput:
     type: object
     properties:
       classification:
-        $ref: '#/definitions/v1alphaClassificationOutput'
+        $ref: "#/definitions/v1alphaClassificationOutput"
         title: The classification output
         readOnly: true
       detection:
-        $ref: '#/definitions/v1alphaDetectionOutput'
+        $ref: "#/definitions/v1alphaDetectionOutput"
         title: The detection output
         readOnly: true
       keypoint:
-        $ref: '#/definitions/v1alphaKeypointOutput'
+        $ref: "#/definitions/v1alphaKeypointOutput"
         title: The keypoint output
         readOnly: true
       ocr:
-        $ref: '#/definitions/v1alphaOcrOutput'
+        $ref: "#/definitions/v1alphaOcrOutput"
         title: The ocr output
         readOnly: true
       instance_segmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
+        $ref: "#/definitions/v1alphaInstanceSegmentationOutput"
         title: The instance segmentation output
         readOnly: true
       semantic_segmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
+        $ref: "#/definitions/v1alphaSemanticSegmentationOutput"
         title: The semantic segmentation output
         readOnly: true
       text_to_image:
-        $ref: '#/definitions/v1alphaTextToImageOutput'
+        $ref: "#/definitions/v1alphaTextToImageOutput"
         title: The text to image output
         readOnly: true
       image_to_image:
-        $ref: '#/definitions/v1alphaImageToImageOutput'
+        $ref: "#/definitions/v1alphaImageToImageOutput"
         title: The image to image output
         readOnly: true
       text_generation:
-        $ref: '#/definitions/v1alphaTextGenerationOutput'
+        $ref: "#/definitions/v1alphaTextGenerationOutput"
         title: The text generation output
         readOnly: true
       text_generation_chat:
-        $ref: '#/definitions/v1alphaTextGenerationChatOutput'
+        $ref: "#/definitions/v1alphaTextGenerationChatOutput"
         title: The text generation output
         readOnly: true
       visual_question_answering:
-        $ref: '#/definitions/v1alphaVisualQuestionAnsweringOutput'
+        $ref: "#/definitions/v1alphaVisualQuestionAnsweringOutput"
         title: The text generation output
         readOnly: true
       unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedOutput'
+        $ref: "#/definitions/v1alphaUnspecifiedOutput"
         title: The unspecified task output
         readOnly: true
     title: TaskOutput represents the output of a CV Task result from a model
@@ -8037,13 +8054,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
+        $ref: "#/definitions/v1alphaTask"
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaTaskOutput'
+          $ref: "#/definitions/v1alphaTaskOutput"
         title: The task output from a model
     title: |-
       TestUserModelBinaryFileUploadResponse represents a response for the
@@ -8055,13 +8072,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
+        $ref: "#/definitions/v1alphaTask"
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaTaskOutput'
+          $ref: "#/definitions/v1alphaTaskOutput"
         title: The task output from a model
     title: |-
       TestUserModelResponse represents a response for the output for
@@ -8076,7 +8093,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaConversationObject'
+          $ref: "#/definitions/v1alphaConversationObject"
         title: The prompt text
       max_new_tokens:
         type: integer
@@ -8098,7 +8115,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaExtraParamObject'
+          $ref: "#/definitions/v1alphaExtraParamObject"
         title: The extra parameters
     title: TextGenerationChatInput represents the input of text generation chat task
     required:
@@ -8117,6 +8134,19 @@ definitions:
       prompt:
         type: string
         title: The prompt text
+      prompt_images:
+        type: array
+        items:
+          type: object
+          $ref: "#/definitions/v1alphaPromptImage"
+        title: Optional fields
+      chat_history:
+        type: array
+        items:
+          type: object
+          $ref: "#/definitions/v1alphaContent"
+      system_message:
+        type: string
       max_new_tokens:
         type: integer
         format: int32
@@ -8134,10 +8164,7 @@ definitions:
         format: int32
         title: The seed
       extra_params:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaExtraParamObject'
+        type: object
         title: The extra parameters
     title: TextGenerationInput represents the input of text generation task
     required:
@@ -8182,7 +8209,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaExtraParamObject'
+          $ref: "#/definitions/v1alphaExtraParamObject"
         title: The extra parameters
     title: TextToImageInput represents the input of text to image task
     required:
@@ -8201,13 +8228,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
+        $ref: "#/definitions/v1alphaTask"
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaTaskOutput'
+          $ref: "#/definitions/v1alphaTaskOutput"
         title: The task output from a model
     title: |-
       TriggerUserModelBinaryFileUploadResponse represents a response for the
@@ -8219,13 +8246,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
+        $ref: "#/definitions/v1alphaTask"
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaTaskOutput'
+          $ref: "#/definitions/v1alphaTaskOutput"
         title: The task output from a model
     title: |-
       TriggerUserModelResponse represents a response for the output for
@@ -8234,7 +8261,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Undeploy operation message
     title: UndeployModelAdminResponse represents a response for a undeployed model
   v1alphaUndeployUserModelResponse:
@@ -8250,7 +8277,7 @@ definitions:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: Unpublished model
     title: UnpublishUserModelResponse represents a response for the unpublished model
   v1alphaUnspecifiedInput:
@@ -8276,7 +8303,7 @@ definitions:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
+        $ref: "#/definitions/v1alphaModel"
         title: The updated model
     title: UpdateUserModelResponse represents a response for a model
   v1alphaVisualQuestionAnsweringInput:
@@ -8311,7 +8338,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alphaExtraParamObject'
+          $ref: "#/definitions/v1alphaExtraParamObject"
         title: The extra parameters
     title: VisualQuestionAnsweringInput represents the input of visaul question answering task
     required:
@@ -8328,7 +8355,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1alphaModelState'
+        $ref: "#/definitions/v1alphaModelState"
         title: Retrieved model state
       progress:
         type: integer
@@ -8374,7 +8401,7 @@ definitions:
           that issued the token.
         readOnly: true
       state:
-        $ref: '#/definitions/v1betaApiTokenState'
+        $ref: "#/definitions/v1betaApiTokenState"
         title: API token state
         readOnly: true
       token_type:
@@ -8444,7 +8471,7 @@ definitions:
     type: object
     properties:
       access_token:
-        $ref: '#/definitions/AuthTokenIssuerResponseUnsignedAccessToken'
+        $ref: "#/definitions/AuthTokenIssuerResponseUnsignedAccessToken"
         title: access_token
     title: Response for user logout
   v1betaAuthValidateAccessTokenResponse:
@@ -8454,7 +8481,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1betaConnectorState'
+        $ref: "#/definitions/v1betaConnectorState"
         title: Retrieved connector state
     title: |-
       CheckConnectorResponse represents a response to fetch a
@@ -8474,7 +8501,7 @@ definitions:
     type: object
     properties:
       type:
-        $ref: '#/definitions/CheckNamespaceResponseNamespace'
+        $ref: "#/definitions/CheckNamespaceResponseNamespace"
         title: Namespace type
     title: |-
       CheckNamespaceResponse represents a response about whether
@@ -8489,25 +8516,25 @@ definitions:
         type: string
         title: A pipeline component resource name
       resource:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: A pipeline component resource detail
         readOnly: true
       configuration:
         type: object
         title: Configuration for the pipeline component
       type:
-        $ref: '#/definitions/v1betaComponentType'
+        $ref: "#/definitions/v1betaComponentType"
         title: Resource Type
         readOnly: true
       definition_name:
         type: string
         title: A pipeline component definition name
       operator_definition:
-        $ref: '#/definitions/v1betaOperatorDefinition'
+        $ref: "#/definitions/v1betaOperatorDefinition"
         title: operator definition detail
         readOnly: true
       connector_definition:
-        $ref: '#/definitions/v1betaConnectorDefinition'
+        $ref: "#/definitions/v1betaConnectorDefinition"
         title: connector definition detail
         readOnly: true
     title: Represents a pipeline component
@@ -8534,7 +8561,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: A connector
     title: |-
       ConnectOrganizationConnectorResponse represents a connected
@@ -8543,7 +8570,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: A connector
     title: |-
       ConnectUserConnectorResponse represents a connected
@@ -8572,7 +8599,7 @@ definitions:
         type: string
         title: ConnectorDefinition resource
       type:
-        $ref: '#/definitions/v1betaConnectorType'
+        $ref: "#/definitions/v1betaConnectorType"
         title: Connector Type
         readOnly: true
       description:
@@ -8582,7 +8609,7 @@ definitions:
         type: object
         title: Connector configuration in JSON format
       state:
-        $ref: '#/definitions/v1betaConnectorState'
+        $ref: "#/definitions/v1betaConnectorState"
         title: Connector state
         readOnly: true
       tombstone:
@@ -8600,11 +8627,11 @@ definitions:
         title: Connector update time
         readOnly: true
       visibility:
-        $ref: '#/definitions/v1betaConnectorVisibility'
+        $ref: "#/definitions/v1betaConnectorVisibility"
         title: Connector visibility including public or private
         readOnly: true
       connector_definition:
-        $ref: '#/definitions/v1betaConnectorDefinition'
+        $ref: "#/definitions/v1betaConnectorDefinition"
         title: Embed the content of the connector_definition
         readOnly: true
       delete_time:
@@ -8657,11 +8684,11 @@ definitions:
         title: ConnectorDefinition icon
         readOnly: true
       spec:
-        $ref: '#/definitions/v1betaConnectorSpec'
+        $ref: "#/definitions/v1betaConnectorSpec"
         title: ConnectorDefinition spec
         readOnly: true
       type:
-        $ref: '#/definitions/v1betaConnectorType'
+        $ref: "#/definitions/v1betaConnectorType"
         title: Connector Type
         readOnly: true
       tombstone:
@@ -8718,7 +8745,7 @@ definitions:
         type: string
         title: UID for the executed connector
       status:
-        $ref: '#/definitions/mgmtv1betaStatus'
+        $ref: "#/definitions/mgmtv1betaStatus"
         title: Status of connector execution
         readOnly: true
       time_buckets:
@@ -8779,7 +8806,7 @@ definitions:
         title: Total compute time duration for this execution
         readOnly: true
       status:
-        $ref: '#/definitions/mgmtv1betaStatus'
+        $ref: "#/definitions/mgmtv1betaStatus"
         title: Final status for the connector execution
         readOnly: true
     title: ConnectorExecuteRecord represents a record for connector execution
@@ -8865,7 +8892,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaConnectorUsageDataUserUsageData'
+          $ref: "#/definitions/v1betaConnectorUsageDataUserUsageData"
         title: Usage data of all users in the connector service
     title: Connector service usage data
   v1betaConnectorUsageDataUserUsageData:
@@ -8878,10 +8905,10 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/UserUsageDataConnectorExecuteData'
+          $ref: "#/definitions/UserUsageDataConnectorExecuteData"
         title: Execution data for each user
       owner_type:
-        $ref: '#/definitions/v1betaOwnerType'
+        $ref: "#/definitions/v1betaOwnerType"
         title: Owner type
     title: Per user usage data in the connector service
     required:
@@ -8918,7 +8945,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: connector
     title: |-
       CreateOrganizationConnectorResponse represents a response for a
@@ -8927,42 +8954,42 @@ definitions:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: The created pipeline_release resource
     title: CreateOrganizationPipelineReleaseResponse represents a response for a pipeline_release resource
   v1betaCreateOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: The created pipeline resource
     title: CreateOrganizationPipelineResponse represents a response for a pipeline resource
   v1betaCreateOrganizationResponse:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
+        $ref: "#/definitions/v1betaOrganization"
         title: A organization resource
     title: CreateOrganizationResponse represents a response for a organization response
   v1betaCreateSessionResponse:
     type: object
     properties:
       session:
-        $ref: '#/definitions/v1betaSession'
+        $ref: "#/definitions/v1betaSession"
         title: A session resource
     title: CreateSessionResponse represents a response for a session response
   v1betaCreateTokenResponse:
     type: object
     properties:
       token:
-        $ref: '#/definitions/v1betaApiToken'
+        $ref: "#/definitions/v1betaApiToken"
         title: The created API token resource
     title: CreateTokenResponse represents a response for a API token resource
   v1betaCreateUserConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: connector
     title: |-
       CreateUserConnectorResponse represents a response for a
@@ -8971,14 +8998,14 @@ definitions:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: The created pipeline_release resource
     title: CreateUserPipelineReleaseResponse represents a response for a pipeline_release resource
   v1betaCreateUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: The created pipeline resource
     title: CreateUserPipelineResponse represents a response for a pipeline resource
   v1betaDeleteOrganizationConnectorResponse:
@@ -9015,7 +9042,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: A connector
     title: |-
       DisconnectOrganizationConnectorResponse represents a disconnected
@@ -9024,7 +9051,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: A connector
     title: |-
       DisconnectUserConnectorResponse represents a disconnected
@@ -9058,7 +9085,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaGetCumulativeModelOnlineRecordsResponse'
+          $ref: "#/definitions/v1betaGetCumulativeModelOnlineRecordsResponse"
         title: A list of cumulative model online record lists
     title: |-
       GetBulkCumulativeModelOnlineRecordsResponse represents a response to
@@ -9072,7 +9099,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaGetCumulativePipelineTriggerRecordsResponse'
+          $ref: "#/definitions/v1betaGetCumulativePipelineTriggerRecordsResponse"
         title: A list of cumulative pipeline trigger record lists
     title: |-
       GetBulkCumulativePipelineTriggerRecordsResponse represents a response to
@@ -9086,7 +9113,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaGetModelOnlinePriceResponse'
+          $ref: "#/definitions/v1betaGetModelOnlinePriceResponse"
         title: A list of model online price lists
     title: |-
       GetBulkModelOnlinePriceResponse represents a response to
@@ -9100,7 +9127,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaGetModelOnlineRecordsResponse'
+          $ref: "#/definitions/v1betaGetModelOnlineRecordsResponse"
         title: A list of model online record lists
     title: |-
       GetBulkModelOnlineRecordsResponse represents a response to
@@ -9114,7 +9141,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaGetModelOnlineSummaryResponse'
+          $ref: "#/definitions/v1betaGetModelOnlineSummaryResponse"
         title: A list of model online usage summaries
     title: |-
       GetBulkModelOnlineSummaryResponse represents a response to
@@ -9128,7 +9155,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaGetPipelineTriggerPriceResponse'
+          $ref: "#/definitions/v1betaGetPipelineTriggerPriceResponse"
         title: A list of pipeline trigger price lists
     title: |-
       GetBulkPipelineTriggerPriceResponse represents a response to
@@ -9142,7 +9169,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaGetPipelineTriggerRecordsResponse'
+          $ref: "#/definitions/v1betaGetPipelineTriggerRecordsResponse"
         title: A list of pipeline trigger record lists
     title: |-
       GetBulkPipelineTriggerRecordsResponse represents a response to
@@ -9156,7 +9183,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaGetPipelineTriggerSummaryResponse'
+          $ref: "#/definitions/v1betaGetPipelineTriggerSummaryResponse"
         title: A list of pipeline trigger usage summaries
     title: |-
       GetBulkPipelineTriggerSummariesResponse represents a response to
@@ -9167,7 +9194,7 @@ definitions:
     type: object
     properties:
       connector_definition:
-        $ref: '#/definitions/v1betaConnectorDefinition'
+        $ref: "#/definitions/v1betaConnectorDefinition"
         title: A ConnectorDefinition resource
     title: |-
       GetConnectorDefinitionResponse represents a
@@ -9176,13 +9203,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       model:
-        $ref: '#/definitions/v1betaModelData'
+        $ref: "#/definitions/v1betaModelData"
         title: Model information
       time_interval:
-        $ref: '#/definitions/v1betaTimeInterval'
+        $ref: "#/definitions/v1betaTimeInterval"
         title: Time interval
     title: |-
       GetCumulativeModelOnlineRecordsRequest represents a query for cumulative
@@ -9198,7 +9225,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaModelUsageRecord'
+          $ref: "#/definitions/v1betaModelUsageRecord"
         title: A list of model online records in cumulative format
     title: |-
       GetCumulativeModelOnlineRecordsResponse represents a response to
@@ -9209,13 +9236,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
+        $ref: "#/definitions/v1betaPipelineData"
         title: Pipeline information
       time_interval:
-        $ref: '#/definitions/v1betaTimeInterval'
+        $ref: "#/definitions/v1betaTimeInterval"
         title: Time interval
     title: |-
       GetCumulativePipelineTriggerRecordsRequest represents a query for cumulative
@@ -9230,7 +9257,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineUsageRecord'
+          $ref: "#/definitions/v1betaPipelineUsageRecord"
         title: Pipeline trigger records where values are in cumulative formats
     title: |-
       GetCumulativePipelineTriggerRecordsResponse represents a response to
@@ -9241,13 +9268,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       model:
-        $ref: '#/definitions/v1betaModelData'
+        $ref: "#/definitions/v1betaModelData"
         title: Pipeline information
       time_interval:
-        $ref: '#/definitions/v1betaTimeInterval'
+        $ref: "#/definitions/v1betaTimeInterval"
         title: Time interval
     title: |-
       GetPipelineTriggerPriceRequest represents a query for price data of the
@@ -9263,7 +9290,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPriceData'
+          $ref: "#/definitions/v1betaPriceData"
         title: |-
           A list of model online prices given the billing periods covered by the time
           interval
@@ -9276,13 +9303,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       model:
-        $ref: '#/definitions/v1betaModelData'
+        $ref: "#/definitions/v1betaModelData"
         title: Model information
       time_interval:
-        $ref: '#/definitions/v1betaTimeInterval'
+        $ref: "#/definitions/v1betaTimeInterval"
         title: Time interval
     title: GetModelOnlineRecordsRequest represent a query for model online records
     required:
@@ -9296,7 +9323,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaModelUsageRecord'
+          $ref: "#/definitions/v1betaModelUsageRecord"
         title: A list of model trigger records
     title: |-
       GetModelOnlineRecordsResponse represents a response to
@@ -9307,13 +9334,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       model:
-        $ref: '#/definitions/v1betaModelData'
+        $ref: "#/definitions/v1betaModelData"
         title: Pipeline information
       time_interval:
-        $ref: '#/definitions/v1betaTimeInterval'
+        $ref: "#/definitions/v1betaTimeInterval"
         title: Time interval
     title: GetModelOnlineSummaryRequest represents a query for model online summary
     required:
@@ -9324,7 +9351,7 @@ definitions:
     type: object
     properties:
       summary:
-        $ref: '#/definitions/v1betaUsageSummary'
+        $ref: "#/definitions/v1betaUsageSummary"
         title: The total model online usage in the time interval
     title: |-
       GetModelOnlineSummaryResponse represents a response to
@@ -9338,7 +9365,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaModelData'
+          $ref: "#/definitions/v1betaModelData"
         title: A list of model informations
     title: GetPipelinesResponse represents a respond to GetModelsRequest
     required:
@@ -9347,7 +9374,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: The retrieved longrunning operation
         readOnly: true
     title: |-
@@ -9357,7 +9384,7 @@ definitions:
     type: object
     properties:
       operator_definition:
-        $ref: '#/definitions/v1betaOperatorDefinition'
+        $ref: "#/definitions/v1betaOperatorDefinition"
         title: A Operator resource
     title: |-
       GetOperatorDefinitionResponse represents a
@@ -9366,14 +9393,14 @@ definitions:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
+        $ref: "#/definitions/v1betaOrganization"
         title: A organization resource
     title: GetOrganizationAdminResponse represents a response for a organization resource
   v1betaGetOrganizationConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: connector
     title: |-
       GetOrganizationConnectorResponse represents a response for a
@@ -9382,55 +9409,55 @@ definitions:
     type: object
     properties:
       membership:
-        $ref: '#/definitions/v1betaOrganizationMembership'
+        $ref: "#/definitions/v1betaOrganizationMembership"
         title: A membership resource
     title: GetOrganizationMembershipResponse represents a response for a membership resource
   v1betaGetOrganizationPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: A pipeline_release resource
     title: GetOrganizationPipelineReleaseResponse represents a response for a pipeline_release resource
   v1betaGetOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: A pipeline resource
     title: GetOrganizationPipelineResponse represents a response for a pipeline resource
   v1betaGetOrganizationResponse:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
+        $ref: "#/definitions/v1betaOrganization"
         title: A organization resource
     title: GetOrganizationResponse represents a response for a organization resource
   v1betaGetOrganizationSubscriptionAdminResponse:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaSubscription'
+        $ref: "#/definitions/v1betaSubscription"
         title: Subscription
     title: GetOrganizationSubscriptionAdminResponse
   v1betaGetOrganizationSubscriptionResponse:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaSubscription'
+        $ref: "#/definitions/v1betaSubscription"
         title: Subscription
     title: GetOrganizationSubscriptionResponse
   v1betaGetPipelineTriggerPriceRequest:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
+        $ref: "#/definitions/v1betaPipelineData"
         title: Pipeline information
       time_interval:
-        $ref: '#/definitions/v1betaTimeInterval'
+        $ref: "#/definitions/v1betaTimeInterval"
         title: Time interval
     title: |-
       GetPipelineTriggerPriceRequest represents a query for pipeline trigger prices
@@ -9446,7 +9473,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPriceData'
+          $ref: "#/definitions/v1betaPriceData"
         title: |-
           A list of pipeline trigger prices given the billing periods covered by the
           time interval
@@ -9459,13 +9486,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
+        $ref: "#/definitions/v1betaPipelineData"
         title: Pipeline information
       time_interval:
-        $ref: '#/definitions/v1betaTimeInterval'
+        $ref: "#/definitions/v1betaTimeInterval"
         title: Time interval
     title: |-
       GetPipelineTriggerRecordsRequest represents a query for pipeline trigger
@@ -9480,7 +9507,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineUsageRecord'
+          $ref: "#/definitions/v1betaPipelineUsageRecord"
         title: A list of pipeline trigger records
     title: |-
       GetPipelineTriggerRecordsResponse represents a response to
@@ -9491,13 +9518,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
+        $ref: "#/definitions/v1betaPipelineData"
         title: Pipeline information
       time_interval:
-        $ref: '#/definitions/v1betaTimeInterval'
+        $ref: "#/definitions/v1betaTimeInterval"
         title: Time interval
     title: |-
       GetPipelineTriggerSummaryRequest represents a query for pipeline trigger
@@ -9509,7 +9536,7 @@ definitions:
     type: object
     properties:
       summaries:
-        $ref: '#/definitions/v1betaUsageSummary'
+        $ref: "#/definitions/v1betaUsageSummary"
         title: The total pipeline trigger usage in the time interval
     title: |-
       GetPipelineTriggerSummaryResponse represents a response to
@@ -9523,7 +9550,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineData'
+          $ref: "#/definitions/v1betaPipelineData"
         title: A list of pipeline informations
     title: GetPipelinesResponse represents a respond to GetPipelineRequest
     required:
@@ -9532,21 +9559,21 @@ definitions:
     type: object
     properties:
       token:
-        $ref: '#/definitions/v1betaApiToken'
+        $ref: "#/definitions/v1betaApiToken"
         title: An API token resource
     title: GetTokenResponse represents a response for an API token resource
   v1betaGetUserAdminResponse:
     type: object
     properties:
       user:
-        $ref: '#/definitions/mgmtv1betaUser'
+        $ref: "#/definitions/mgmtv1betaUser"
         title: A user resource
     title: GetUserAdminResponse represents a response for a user resource
   v1betaGetUserConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: connector
     title: |-
       GetUserConnectorResponse represents a response for a
@@ -9555,42 +9582,42 @@ definitions:
     type: object
     properties:
       membership:
-        $ref: '#/definitions/v1betaUserMembership'
+        $ref: "#/definitions/v1betaUserMembership"
         title: A membership resource
     title: GetUserMembershipResponse represents a response for a membership resource
   v1betaGetUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: A pipeline_release resource
     title: GetUserPipelineReleaseResponse represents a response for a pipeline_release resource
   v1betaGetUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: A pipeline resource
     title: GetUserPipelineResponse represents a response for a pipeline resource
   v1betaGetUserResponse:
     type: object
     properties:
       user:
-        $ref: '#/definitions/mgmtv1betaUser'
+        $ref: "#/definitions/mgmtv1betaUser"
         title: A user resource
     title: GetUserResponse represents a response for a user resource
   v1betaGetUserSubscriptionAdminResponse:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaSubscription'
+        $ref: "#/definitions/v1betaSubscription"
         title: Subscription
     title: GetUserSubscriptionAdminResponse
   v1betaGetUserSubscriptionResponse:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaSubscription'
+        $ref: "#/definitions/v1betaSubscription"
         title: Subscription
     title: GetUserSubscriptionResponse
   v1betaHealthCheckRequest:
@@ -9604,7 +9631,7 @@ definitions:
     type: object
     properties:
       status:
-        $ref: '#/definitions/HealthCheckResponseServingStatus'
+        $ref: "#/definitions/HealthCheckResponseServingStatus"
         title: Status is the instance of the enum type ServingStatus
     title: HealthCheckResponse represents a response for a service heath status
   v1betaListConnectorDefinitionsResponse:
@@ -9614,7 +9641,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaConnectorDefinition'
+          $ref: "#/definitions/v1betaConnectorDefinition"
         title: A list of ConnectorDefinition resources
       next_page_token:
         type: string
@@ -9633,7 +9660,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaConnectorExecuteChartRecord'
+          $ref: "#/definitions/v1betaConnectorExecuteChartRecord"
         title: A list of connector execute records
     title: |-
       ListConnectorExecuteChartRecordsResponse represents a response for a list
@@ -9645,7 +9672,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaConnectorExecuteRecord'
+          $ref: "#/definitions/v1betaConnectorExecuteRecord"
         title: A list of connector execute records
       next_page_token:
         type: string
@@ -9664,7 +9691,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaConnectorExecuteTableRecord'
+          $ref: "#/definitions/v1betaConnectorExecuteTableRecord"
         title: A list of connector execute records
       next_page_token:
         type: string
@@ -9683,7 +9710,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaConnector'
+          $ref: "#/definitions/v1betaConnector"
         title: A list of connectors
       next_page_token:
         type: string
@@ -9702,7 +9729,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaConnector'
+          $ref: "#/definitions/v1betaConnector"
         title: A list of connectors
       next_page_token:
         type: string
@@ -9721,7 +9748,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaOperatorDefinition'
+          $ref: "#/definitions/v1betaOperatorDefinition"
         title: A list of Operator resources
       next_page_token:
         type: string
@@ -9740,7 +9767,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaConnector'
+          $ref: "#/definitions/v1betaConnector"
         title: A list of connectors
       next_page_token:
         type: string
@@ -9759,7 +9786,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaOrganizationMembership'
+          $ref: "#/definitions/v1betaOrganizationMembership"
         title: A list of memberships
     title: ListOrganizationMembershipsResponse represents a response for a list of memberships
   v1betaListOrganizationPipelineReleasesResponse:
@@ -9769,7 +9796,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineRelease'
+          $ref: "#/definitions/v1betaPipelineRelease"
         title: A list of pipeline_release resources
       next_page_token:
         type: string
@@ -9786,7 +9813,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipeline'
+          $ref: "#/definitions/v1betaPipeline"
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -9803,7 +9830,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaOrganization'
+          $ref: "#/definitions/v1betaOrganization"
         title: A list of organizations
       next_page_token:
         type: string
@@ -9820,7 +9847,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaOrganization'
+          $ref: "#/definitions/v1betaOrganization"
         title: A list of organizations
       next_page_token:
         type: string
@@ -9837,7 +9864,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineRelease'
+          $ref: "#/definitions/v1betaPipelineRelease"
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -9857,7 +9884,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineTriggerChartRecord'
+          $ref: "#/definitions/v1betaPipelineTriggerChartRecord"
         title: A list of pipeline trigger records
     title: |-
       ListPipelineTriggerChartRecordsResponse represents a response for a list
@@ -9869,7 +9896,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineTriggerRecord'
+          $ref: "#/definitions/v1betaPipelineTriggerRecord"
         title: A list of pipeline trigger records
       next_page_token:
         type: string
@@ -9888,7 +9915,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineTriggerTableRecord'
+          $ref: "#/definitions/v1betaPipelineTriggerTableRecord"
         title: A list of pipeline trigger table records
       next_page_token:
         type: string
@@ -9907,7 +9934,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipeline'
+          $ref: "#/definitions/v1betaPipeline"
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -9927,7 +9954,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipeline'
+          $ref: "#/definitions/v1betaPipeline"
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -9944,7 +9971,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaApiToken'
+          $ref: "#/definitions/v1betaApiToken"
         title: A list of API tokens resources
       next_page_token:
         type: string
@@ -9961,7 +9988,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaConnector'
+          $ref: "#/definitions/v1betaConnector"
         title: A list of connectors
       next_page_token:
         type: string
@@ -9980,7 +10007,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaUserMembership'
+          $ref: "#/definitions/v1betaUserMembership"
         title: A list of memberships
     title: ListUserMembershipsResponse represents a response for a list of memberships
   v1betaListUserPipelineReleasesResponse:
@@ -9990,7 +10017,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineRelease'
+          $ref: "#/definitions/v1betaPipelineRelease"
         title: A list of pipeline_release resources
       next_page_token:
         type: string
@@ -10007,7 +10034,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipeline'
+          $ref: "#/definitions/v1betaPipeline"
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -10024,7 +10051,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/mgmtv1betaUser'
+          $ref: "#/definitions/mgmtv1betaUser"
         title: A list of users
       next_page_token:
         type: string
@@ -10041,7 +10068,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/mgmtv1betaUser'
+          $ref: "#/definitions/mgmtv1betaUser"
         title: A list of users
       next_page_token:
         type: string
@@ -10055,7 +10082,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: connector
     title: |-
       LookUpConnectorAdminResponse represents a response for a
@@ -10064,7 +10091,7 @@ definitions:
     type: object
     properties:
       connector_definition:
-        $ref: '#/definitions/v1betaConnectorDefinition'
+        $ref: "#/definitions/v1betaConnectorDefinition"
         title: Connector resource
     title: |-
       LookUpConnectorDefinitionAdminResponse represents a response for a
@@ -10073,7 +10100,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: connector
     title: |-
       LookUpConnectorResponse represents a response for a
@@ -10082,7 +10109,7 @@ definitions:
     type: object
     properties:
       operator_definition:
-        $ref: '#/definitions/v1betaOperatorDefinition'
+        $ref: "#/definitions/v1betaOperatorDefinition"
         title: operator resource
     title: |-
       LookUpOperatorAdminResponse represents a response for a
@@ -10091,28 +10118,28 @@ definitions:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
+        $ref: "#/definitions/v1betaOrganization"
         title: A organization resource
     title: LookUpOrganizationAdminResponse represents a response for a organization resource by admin
   v1betaLookUpPipelineAdminResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: A pipeline resource
     title: LookUpPipelineAdminResponse represents a response for a pipeline resource
   v1betaLookUpPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: A pipeline resource
     title: LookUpPipelineResponse represents a response for a pipeline resource
   v1betaLookUpUserAdminResponse:
     type: object
     properties:
       user:
-        $ref: '#/definitions/mgmtv1betaUser'
+        $ref: "#/definitions/mgmtv1betaUser"
         title: A user resource
     title: LookUpUserAdminResponse represents a response for a user resource by admin
   v1betaMembershipState:
@@ -10134,7 +10161,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/mgmtv1betaUser'
+          $ref: "#/definitions/mgmtv1betaUser"
         title: Repeated user usage data
     title: Management service usage data
   v1betaMode:
@@ -10177,7 +10204,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaModelUsageDataUserUsageData'
+          $ref: "#/definitions/v1betaModelUsageDataUserUsageData"
         title: Usage data of all users in the model service
     title: Model service usage data
   v1betaModelUsageDataUserUsageData:
@@ -10190,10 +10217,10 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/UserUsageDataModelTriggerData'
+          $ref: "#/definitions/UserUsageDataModelTriggerData"
         title: Trigger data for each user
       owner_type:
-        $ref: '#/definitions/v1betaOwnerType'
+        $ref: "#/definitions/v1betaOwnerType"
         title: Owner type
     title: Per user usage data in the model service
     required:
@@ -10260,7 +10287,7 @@ definitions:
         title: Operator icon
         readOnly: true
       spec:
-        $ref: '#/definitions/v1betaOperatorSpec'
+        $ref: "#/definitions/v1betaOperatorSpec"
         title: Operator spec
         readOnly: true
       tombstone:
@@ -10336,7 +10363,7 @@ definitions:
       create_time:
         type: string
         format: date-time
-        title: 'Owner type: fixed to `OWNER_TYPE_USER`'
+        title: "Owner type: fixed to `OWNER_TYPE_USER`"
         readOnly: true
       update_time:
         type: string
@@ -10357,7 +10384,7 @@ definitions:
         type: object
         title: Profile Data
       owner:
-        $ref: '#/definitions/mgmtv1betaUser'
+        $ref: "#/definitions/mgmtv1betaUser"
         title: Owner
         readOnly: true
     title: Organization represents the content of a organization
@@ -10374,15 +10401,15 @@ definitions:
         type: string
         title: Role
       state:
-        $ref: '#/definitions/v1betaMembershipState'
+        $ref: "#/definitions/v1betaMembershipState"
         title: State
         readOnly: true
       user:
-        $ref: '#/definitions/mgmtv1betaUser'
+        $ref: "#/definitions/mgmtv1betaUser"
         title: User
         readOnly: true
       organization:
-        $ref: '#/definitions/v1betaOrganization'
+        $ref: "#/definitions/v1betaOrganization"
         title: Organization
         readOnly: true
     title: Membership represents the content of a membership
@@ -10404,7 +10431,7 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/mgmtv1betaUser'
+        $ref: "#/definitions/mgmtv1betaUser"
         title: A user resource
     title: |-
       PatchAuthenticatedUserResponse represents a response for
@@ -10441,7 +10468,7 @@ definitions:
         type: string
         title: Pipeline description
       recipe:
-        $ref: '#/definitions/v1betaRecipe'
+        $ref: "#/definitions/v1betaRecipe"
         title: Pipeline recipe
       create_time:
         type: string
@@ -10463,11 +10490,11 @@ definitions:
         title: Pipeline delete time
         readOnly: true
       sharing:
-        $ref: '#/definitions/v1betaSharing'
+        $ref: "#/definitions/v1betaSharing"
         title: Pipeline sharing
       metadata:
         type: object
-        title: 'Metadata: store Console-related data such as pipeline builder layout'
+        title: "Metadata: store Console-related data such as pipeline builder layout"
       owner_name:
         type: string
         title: Owner Name
@@ -10480,14 +10507,14 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineRelease'
+          $ref: "#/definitions/v1betaPipelineRelease"
         title: Releases
         readOnly: true
       readme:
         type: string
         title: readme
       permission:
-        $ref: '#/definitions/v1betaPermission'
+        $ref: "#/definitions/v1betaPermission"
         title: Permission
         readOnly: true
     title: Pipeline represents the content of a pipeline
@@ -10528,7 +10555,7 @@ definitions:
         type: string
         title: PipelineRelease description
       recipe:
-        $ref: '#/definitions/v1betaRecipe'
+        $ref: "#/definitions/v1betaRecipe"
         title: Pipeline recipe snapshot
         readOnly: true
       create_time:
@@ -10556,7 +10583,7 @@ definitions:
         readOnly: true
       metadata:
         type: object
-        title: 'Metadata: store Console-related data such as pipeline builder layout'
+        title: "Metadata: store Console-related data such as pipeline builder layout"
       readme:
         type: string
         title: readme
@@ -10571,10 +10598,10 @@ definitions:
         type: string
         title: UID for the triggered pipeline
       trigger_mode:
-        $ref: '#/definitions/v1betaMode'
+        $ref: "#/definitions/v1betaMode"
         title: Trigger mode
       status:
-        $ref: '#/definitions/mgmtv1betaStatus'
+        $ref: "#/definitions/mgmtv1betaStatus"
         title: Status of pipeline trigger
         readOnly: true
       time_buckets:
@@ -10626,7 +10653,7 @@ definitions:
         type: string
         title: UID for the triggered pipeline
       trigger_mode:
-        $ref: '#/definitions/v1betaMode'
+        $ref: "#/definitions/v1betaMode"
         title: Trigger mode
       compute_time_duration:
         type: number
@@ -10634,7 +10661,7 @@ definitions:
         title: Total compute time duration for this pipeline trigger
         readOnly: true
       status:
-        $ref: '#/definitions/mgmtv1betaStatus'
+        $ref: "#/definitions/mgmtv1betaStatus"
         title: Final status for pipeline trigger
         readOnly: true
       pipeline_release_id:
@@ -10683,7 +10710,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineUsageDataUserUsageData'
+          $ref: "#/definitions/v1betaPipelineUsageDataUserUsageData"
         title: Usage data of all users in the pipeline service
     title: Pipeline service usage data
   v1betaPipelineUsageDataUserUsageData:
@@ -10696,10 +10723,10 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/UserUsageDataPipelineTriggerData'
+          $ref: "#/definitions/UserUsageDataPipelineTriggerData"
         title: Trigger data for each user
       owner_type:
-        $ref: '#/definitions/v1betaOwnerType'
+        $ref: "#/definitions/v1betaOwnerType"
         title: Owner type
     title: Per user usage data in the pipeline service
     required:
@@ -10758,7 +10785,7 @@ definitions:
     type: object
     properties:
       time:
-        $ref: '#/definitions/v1betaTimeInterval'
+        $ref: "#/definitions/v1betaTimeInterval"
         title: Time when the price record is generated
       currency:
         type: string
@@ -10782,14 +10809,14 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaComponent'
+          $ref: "#/definitions/v1betaComponent"
         title: List of pipeline components
     title: Pipeline represents a pipeline recipe
   v1betaRenameOrganizationConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: A connector
     title: |-
       RenameOrganizationConnectorResponse represents a renamed Connector
@@ -10798,21 +10825,21 @@ definitions:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: A pipeline resource
     title: RenameOrganizationPipelineReleaseResponse represents a renamed pipeline release resource
   v1betaRenameOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: A pipeline resource
     title: RenameOrganizationPipelineResponse represents a renamed pipeline resource
   v1betaRenameUserConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: A connector
     title: |-
       RenameUserConnectorResponse represents a renamed Connector
@@ -10821,27 +10848,27 @@ definitions:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: A pipeline resource
     title: RenameUserPipelineReleaseResponse represents a renamed pipeline release resource
   v1betaRenameUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: A pipeline resource
     title: RenameUserPipelineResponse represents a renamed pipeline resource
   v1betaReportModelOnlineRequest:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       model:
-        $ref: '#/definitions/v1betaModelData'
+        $ref: "#/definitions/v1betaModelData"
         title: Model information
       cum_usage_record:
-        $ref: '#/definitions/v1betaModelUsageRecord'
+        $ref: "#/definitions/v1betaModelUsageRecord"
         title: Model online record
     title: |-
       ReportModelOnlineRequest represents a request for reporting a model-online
@@ -10854,7 +10881,7 @@ definitions:
     type: object
     properties:
       "null":
-        $ref: '#/definitions/v1betaNullMessage'
+        $ref: "#/definitions/v1betaNullMessage"
         title: Null message for empty response
     title: |-
       ReportModelOnlineResponse represents a respond to a model-online-record
@@ -10863,7 +10890,7 @@ definitions:
     type: object
     properties:
       "null":
-        $ref: '#/definitions/v1betaNullMessage'
+        $ref: "#/definitions/v1betaNullMessage"
         title: Null message for empty response
     title: |-
       ReportModelOnlinesResponse represents a respond to a model-online-records
@@ -10872,13 +10899,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUserData'
+        $ref: "#/definitions/v1betaUserData"
         title: User information
       pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
+        $ref: "#/definitions/v1betaPipelineData"
         title: Pipeline information
       usage_record:
-        $ref: '#/definitions/v1betaPipelineUsageRecord'
+        $ref: "#/definitions/v1betaPipelineUsageRecord"
         title: Pipeline trigger record
     title: |-
       ReportPipelineTriggerRequest represents a request for reporting a
@@ -10891,7 +10918,7 @@ definitions:
     type: object
     properties:
       "null":
-        $ref: '#/definitions/v1betaNullMessage'
+        $ref: "#/definitions/v1betaNullMessage"
         title: Null message for empty response
     title: |-
       ReportPipelineTriggerResponse represents a respond to a
@@ -10900,7 +10927,7 @@ definitions:
     type: object
     properties:
       "null":
-        $ref: '#/definitions/v1betaNullMessage'
+        $ref: "#/definitions/v1betaNullMessage"
         title: Null message for empty response
     title: |-
       ReportPipelineTriggersResponse represents a respond to a
@@ -10909,14 +10936,14 @@ definitions:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: A pipeline resource
     title: RestoreOrganizationPipelineReleaseResponse
   v1betaRestoreUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: A pipeline resource
     title: RestoreUserPipelineReleaseResponse
   v1betaRole:
@@ -10946,11 +10973,11 @@ definitions:
         title: Resource UUID
         readOnly: true
       service:
-        $ref: '#/definitions/SessionService'
+        $ref: "#/definitions/SessionService"
         title: name of the service to collect data from
       edition:
         type: string
-        title: 'Session edition, allowed values include: ''local-ce'' and ''local-ce:dev'''
+        title: "Session edition, allowed values include: 'local-ce' and 'local-ce:dev'"
       version:
         type: string
         title: Version of the service
@@ -11013,19 +11040,19 @@ definitions:
         type: string
         title: Proof-of-work See https://en.wikipedia.org/wiki/Proof_of_work
       session:
-        $ref: '#/definitions/v1betaSession'
+        $ref: "#/definitions/v1betaSession"
         title: Session
       mgmt_usage_data:
-        $ref: '#/definitions/v1betaMgmtUsageData'
+        $ref: "#/definitions/v1betaMgmtUsageData"
         title: Management service usage data
       connector_usage_data:
-        $ref: '#/definitions/v1betaConnectorUsageData'
+        $ref: "#/definitions/v1betaConnectorUsageData"
         title: Connector service usage data
       model_usage_data:
-        $ref: '#/definitions/v1betaModelUsageData'
+        $ref: "#/definitions/v1betaModelUsageData"
         title: Model service usage data
       pipeline_usage_data:
-        $ref: '#/definitions/v1betaPipelineUsageData'
+        $ref: "#/definitions/v1betaPipelineUsageData"
         title: Pipeline service usage data
     title: |-
       SessionReport represents a report to be sent to the server that includes the
@@ -11041,10 +11068,10 @@ definitions:
       users:
         type: object
         additionalProperties:
-          $ref: '#/definitions/v1betaSharingUser'
+          $ref: "#/definitions/v1betaSharingUser"
         title: users
       share_code:
-        $ref: '#/definitions/SharingShareCode'
+        $ref: "#/definitions/SharingShareCode"
         title: shared code
     title: Sharing
   v1betaSharingUser:
@@ -11054,7 +11081,7 @@ definitions:
         type: boolean
         title: enabled
       role:
-        $ref: '#/definitions/v1betaRole'
+        $ref: "#/definitions/v1betaRole"
         title: role
     title: User
   v1betaSubscription:
@@ -11064,14 +11091,14 @@ definitions:
         type: string
         title: plan
       quota:
-        $ref: '#/definitions/SubscriptionQuota'
+        $ref: "#/definitions/SubscriptionQuota"
         title: plan
     title: Subscription
   v1betaTestOrganizationConnectorResponse:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1betaConnectorState'
+        $ref: "#/definitions/v1betaConnectorState"
         title: Retrieved connector state
     title: |-
       TestOrganizationConnectorResponse represents a response containing a
@@ -11080,7 +11107,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1betaConnectorState'
+        $ref: "#/definitions/v1betaConnectorState"
         title: Retrieved connector state
     title: |-
       TestUserConnectorResponse represents a response containing a
@@ -11106,7 +11133,7 @@ definitions:
       statuses:
         type: array
         items:
-          $ref: '#/definitions/v1betaTraceStatus'
+          $ref: "#/definitions/v1betaTraceStatus"
         title: status
       inputs:
         type: array
@@ -11144,7 +11171,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
@@ -11154,7 +11181,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
@@ -11164,7 +11191,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
@@ -11174,7 +11201,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
+        $ref: "#/definitions/googlelongrunningOperation"
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
@@ -11186,8 +11213,8 @@ definitions:
       traces:
         type: object
         additionalProperties:
-          $ref: '#/definitions/v1betaTrace'
-        title: 'The traces of the pipeline inference, {component_id: Trace}'
+          $ref: "#/definitions/v1betaTrace"
+        title: "The traces of the pipeline inference, {component_id: Trace}"
     title: The metadata
   v1betaTriggerOrganizationPipelineReleaseResponse:
     type: object
@@ -11198,8 +11225,8 @@ definitions:
           type: object
         title: The multiple model inference outputs
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
-        title: 'The traces of the pipeline inference, {component_id: Trace}'
+        $ref: "#/definitions/v1betaTriggerMetadata"
+        title: "The traces of the pipeline inference, {component_id: Trace}"
     title: |-
       TriggerOrganizationPipelineReleaseResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
@@ -11212,8 +11239,8 @@ definitions:
           type: object
         title: The multiple model inference outputs
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
-        title: 'The traces of the pipeline inference, {component_id: Trace}'
+        $ref: "#/definitions/v1betaTriggerMetadata"
+        title: "The traces of the pipeline inference, {component_id: Trace}"
     title: |-
       TriggerOrganizationPipelineResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
@@ -11226,8 +11253,8 @@ definitions:
           type: object
         title: The multiple model inference outputs
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
-        title: 'The traces of the pipeline inference, {component_id: Trace}'
+        $ref: "#/definitions/v1betaTriggerMetadata"
+        title: "The traces of the pipeline inference, {component_id: Trace}"
     title: |-
       TriggerUserPipelineReleaseResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
@@ -11240,8 +11267,8 @@ definitions:
           type: object
         title: The multiple model inference outputs
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
-        title: 'The traces of the pipeline inference, {component_id: Trace}'
+        $ref: "#/definitions/v1betaTriggerMetadata"
+        title: "The traces of the pipeline inference, {component_id: Trace}"
     title: |-
       TriggerUserPipelineResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
@@ -11249,7 +11276,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: connector
     title: |-
       UpdateOrganizationConnectorResponse represents a response for a
@@ -11258,35 +11285,35 @@ definitions:
     type: object
     properties:
       membership:
-        $ref: '#/definitions/v1betaOrganizationMembership'
+        $ref: "#/definitions/v1betaOrganizationMembership"
         title: An updated membership resource
     title: UpdateOrganizationMembershipResponse represents a response for a membership resource
   v1betaUpdateOrganizationPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: An updated pipeline resource
     title: UpdateOrganizationPipelineReleaseResponse represents a response for a pipeline resource
   v1betaUpdateOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: An updated pipeline resource
     title: UpdateOrganizationPipelineResponse represents a response for a pipeline resource
   v1betaUpdateOrganizationResponse:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
+        $ref: "#/definitions/v1betaOrganization"
         title: A organization resource
     title: UpdateOrganizationResponse represents a response for a organization resource
   v1betaUpdateUserConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: '#/definitions/v1betaConnector'
+        $ref: "#/definitions/v1betaConnector"
         title: connector
     title: |-
       UpdateUserConnectorResponse represents a response for a
@@ -11295,21 +11322,21 @@ definitions:
     type: object
     properties:
       membership:
-        $ref: '#/definitions/v1betaUserMembership'
+        $ref: "#/definitions/v1betaUserMembership"
         title: An updated membership resource
     title: UpdateUserMembershipResponse represents a response for a membership resource
   v1betaUpdateUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
+        $ref: "#/definitions/v1betaPipelineRelease"
         title: An updated pipeline resource
     title: UpdateUserPipelineReleaseResponse represents a response for a pipeline resource
   v1betaUpdateUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: An updated pipeline resource
     title: UpdateUserPipelineResponse represents a response for a pipeline resource
   v1betaUsageSummary:
@@ -11351,14 +11378,14 @@ definitions:
         title: Role
         readOnly: true
       state:
-        $ref: '#/definitions/v1betaMembershipState'
+        $ref: "#/definitions/v1betaMembershipState"
         title: State
       user:
-        $ref: '#/definitions/mgmtv1betaUser'
+        $ref: "#/definitions/mgmtv1betaUser"
         title: User
         readOnly: true
       organization:
-        $ref: '#/definitions/v1betaOrganization'
+        $ref: "#/definitions/v1betaOrganization"
         title: Organization
         readOnly: true
     title: Membership represents the content of a membership
@@ -11368,7 +11395,7 @@ definitions:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: A pipeline resource
     title: ValidateOrganizationPipelineResponse represents an response of validated pipeline
   v1betaValidateTokenResponse:
@@ -11383,14 +11410,14 @@ definitions:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+        $ref: "#/definitions/v1betaPipeline"
         title: A pipeline resource
     title: ValidateUserPipelineResponse represents an response of validated pipeline
   v1betaWatchOrganizationConnectorResponse:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1betaConnectorState'
+        $ref: "#/definitions/v1betaConnectorState"
         title: Retrieved connector state
     title: |-
       WatchOrganizationConnectorResponse represents a response to fetch a
@@ -11399,7 +11426,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/pipelinev1betaState'
+        $ref: "#/definitions/pipelinev1betaState"
         title: Retrieved pipeline state
     title: |-
       WatchOrganizationPipelineReleaseResponse represents a response to fetch a pipeline's
@@ -11408,7 +11435,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/v1betaConnectorState'
+        $ref: "#/definitions/v1betaConnectorState"
         title: Retrieved connector state
     title: |-
       WatchUserConnectorResponse represents a response to fetch a
@@ -11417,7 +11444,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/pipelinev1betaState'
+        $ref: "#/definitions/pipelinev1betaState"
         title: Retrieved pipeline state
     title: |-
       WatchUserPipelineReleaseResponse represents a response to fetch a pipeline's
@@ -11426,27 +11453,27 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdpcontrollerv1betaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   vdppipelinev1betaLivenessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdppipelinev1betaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
+        $ref: "#/definitions/v1betaHealthCheckResponse"
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -30,11 +30,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/modelmodelv1alphaLivenessResponse"
+            $ref: '#/definitions/modelmodelv1alphaLivenessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -54,11 +54,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/modelmodelv1alphaReadinessResponse"
+            $ref: '#/definitions/modelmodelv1alphaReadinessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -77,11 +77,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaGetUserModelCardResponse"
+            $ref: '#/definitions/v1alphaGetUserModelCardResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name/readme
           description: |-
@@ -103,11 +103,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaWatchUserModelResponse"
+            $ref: '#/definitions/v1alphaWatchUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name/watch
           description: |-
@@ -129,11 +129,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaGetUserModelResponse"
+            $ref: '#/definitions/v1alphaGetUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name
           description: |-
@@ -171,11 +171,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaDeleteUserModelResponse"
+            $ref: '#/definitions/v1alphaDeleteUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name
           description: |-
@@ -196,11 +196,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaUpdateUserModelResponse"
+            $ref: '#/definitions/v1alphaUpdateUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model.name
           description: |-
@@ -240,15 +240,15 @@ paths:
                   Model configuration represents the configuration JSON that has been
                   validated using the `model_spec` JSON schema of a ModelDefinition
               task:
-                $ref: "#/definitions/v1alphaTask"
+                $ref: '#/definitions/v1alphaTask'
                 title: Model task
                 readOnly: true
               state:
-                $ref: "#/definitions/v1alphaModelState"
+                $ref: '#/definitions/v1alphaModelState'
                 title: Model state
                 readOnly: true
               visibility:
-                $ref: "#/definitions/v1alphaModelVisibility"
+                $ref: '#/definitions/v1alphaModelVisibility'
                 title: Model visibility including public or private
                 readOnly: true
               create_time:
@@ -287,11 +287,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaGetModelDefinitionResponse"
+            $ref: '#/definitions/v1alphaGetModelDefinitionResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_definition.name
           description: |-
@@ -332,11 +332,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaGetModelOperationResponse"
+            $ref: '#/definitions/v1alphaGetModelOperationResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: The name of the operation resource.
@@ -371,11 +371,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaDeployUserModelResponse"
+            $ref: '#/definitions/v1alphaDeployUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -403,11 +403,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaPublishUserModelResponse"
+            $ref: '#/definitions/v1alphaPublishUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -433,11 +433,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaRenameUserModelResponse"
+            $ref: '#/definitions/v1alphaRenameUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -473,11 +473,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaTestUserModelResponse"
+            $ref: '#/definitions/v1alphaTestUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -497,7 +497,7 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: "#/definitions/v1alphaTaskInput"
+                  $ref: '#/definitions/v1alphaTaskInput'
                 title: Input to trigger the model
             title: TestUserModelRequest represents a request to test a model
             required:
@@ -515,11 +515,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaTriggerUserModelResponse"
+            $ref: '#/definitions/v1alphaTriggerUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -539,7 +539,7 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: "#/definitions/v1alphaTaskInput"
+                  $ref: '#/definitions/v1alphaTaskInput'
                 title: Input to trigger the model
             title: TriggerUserModelRequest represents a request to trigger a model
             required:
@@ -554,11 +554,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaUndeployUserModelResponse"
+            $ref: '#/definitions/v1alphaUndeployUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -588,11 +588,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaUnpublishUserModelResponse"
+            $ref: '#/definitions/v1alphaUnpublishUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -620,11 +620,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaListUserModelsResponse"
+            $ref: '#/definitions/v1alphaListUserModelsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: |-
@@ -682,11 +682,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaCreateUserModelResponse"
+            $ref: '#/definitions/v1alphaCreateUserModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: |-
@@ -705,7 +705,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1alphaModel"
+            $ref: '#/definitions/v1alphaModel'
             required:
               - model
       tags:
@@ -720,11 +720,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaLookUpModelResponse"
+            $ref: '#/definitions/v1alphaLookUpModelResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink
           description: |-
@@ -763,11 +763,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/controllerv1alphaGetResourceResponse"
+            $ref: '#/definitions/controllerv1alphaGetResourceResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -788,11 +788,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/controllerv1alphaDeleteResourceResponse"
+            $ref: '#/definitions/controllerv1alphaDeleteResourceResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -813,11 +813,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/controllerv1alphaUpdateResourceResponse"
+            $ref: '#/definitions/controllerv1alphaUpdateResourceResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -835,10 +835,10 @@ paths:
             type: object
             properties:
               model_state:
-                $ref: "#/definitions/v1alphaModelState"
+                $ref: '#/definitions/v1alphaModelState'
                 title: Model state
               backend_state:
-                $ref: "#/definitions/HealthCheckResponseServingStatus"
+                $ref: '#/definitions/HealthCheckResponseServingStatus'
                 title: Backend service state
               progress:
                 type: integer
@@ -862,11 +862,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaCheckModelAdminResponse"
+            $ref: '#/definitions/v1alphaCheckModelAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_permalink
           description: |-
@@ -886,11 +886,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaDeployModelAdminResponse"
+            $ref: '#/definitions/v1alphaDeployModelAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_permalink
           description: |-
@@ -916,11 +916,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaUndeployModelAdminResponse"
+            $ref: '#/definitions/v1alphaUndeployModelAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_permalink
           description: |-
@@ -950,11 +950,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaLookUpModelAdminResponse"
+            $ref: '#/definitions/v1alphaLookUpModelAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink
           description: |-
@@ -993,11 +993,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaListModelsAdminResponse"
+            $ref: '#/definitions/v1alphaListModelsAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -1049,11 +1049,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/modelcontrollerv1alphaLivenessResponse"
+            $ref: '#/definitions/modelcontrollerv1alphaLivenessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1073,11 +1073,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/modelmodelv1alphaLivenessResponse"
+            $ref: '#/definitions/modelmodelv1alphaLivenessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1096,11 +1096,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaListModelDefinitionsResponse"
+            $ref: '#/definitions/v1alphaListModelDefinitionsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -1147,11 +1147,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1alphaListModelsResponse"
+            $ref: '#/definitions/v1alphaListModelsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -1203,11 +1203,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/modelmodelv1alphaReadinessResponse"
+            $ref: '#/definitions/modelmodelv1alphaReadinessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1227,11 +1227,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/vdppipelinev1betaLivenessResponse"
+            $ref: '#/definitions/vdppipelinev1betaLivenessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1251,11 +1251,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/vdppipelinev1betaReadinessResponse"
+            $ref: '#/definitions/vdppipelinev1betaReadinessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -1274,11 +1274,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaGetOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name_1
           description: |-
@@ -1317,11 +1317,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaDeleteOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name_1
           description: |-
@@ -1343,11 +1343,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaUpdateOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaUpdateOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name_1
           description: |-
@@ -1379,7 +1379,7 @@ paths:
                 type: string
                 title: ConnectorDefinition resource
               type:
-                $ref: "#/definitions/v1betaConnectorType"
+                $ref: '#/definitions/v1betaConnectorType'
                 title: Connector Type
                 readOnly: true
               description:
@@ -1389,7 +1389,7 @@ paths:
                 type: object
                 title: Connector configuration in JSON format
               state:
-                $ref: "#/definitions/v1betaConnectorState"
+                $ref: '#/definitions/v1betaConnectorState'
                 title: Connector state
                 readOnly: true
               tombstone:
@@ -1407,11 +1407,11 @@ paths:
                 title: Connector update time
                 readOnly: true
               visibility:
-                $ref: "#/definitions/v1betaConnectorVisibility"
+                $ref: '#/definitions/v1betaConnectorVisibility'
                 title: Connector visibility including public or private
                 readOnly: true
               connector_definition:
-                $ref: "#/definitions/v1betaConnectorDefinition"
+                $ref: '#/definitions/v1betaConnectorDefinition'
                 title: Embed the content of the connector_definition
                 readOnly: true
               delete_time:
@@ -1442,11 +1442,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTestOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaTestOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name_1
           description: |-
@@ -1469,11 +1469,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaWatchOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaWatchOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name_1
           description: |-
@@ -1495,11 +1495,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetUserConnectorResponse"
+            $ref: '#/definitions/v1betaGetUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -1538,11 +1538,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteUserConnectorResponse"
+            $ref: '#/definitions/v1betaDeleteUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -1564,11 +1564,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaUpdateUserConnectorResponse"
+            $ref: '#/definitions/v1betaUpdateUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -1600,7 +1600,7 @@ paths:
                 type: string
                 title: ConnectorDefinition resource
               type:
-                $ref: "#/definitions/v1betaConnectorType"
+                $ref: '#/definitions/v1betaConnectorType'
                 title: Connector Type
                 readOnly: true
               description:
@@ -1610,7 +1610,7 @@ paths:
                 type: object
                 title: Connector configuration in JSON format
               state:
-                $ref: "#/definitions/v1betaConnectorState"
+                $ref: '#/definitions/v1betaConnectorState'
                 title: Connector state
                 readOnly: true
               tombstone:
@@ -1628,11 +1628,11 @@ paths:
                 title: Connector update time
                 readOnly: true
               visibility:
-                $ref: "#/definitions/v1betaConnectorVisibility"
+                $ref: '#/definitions/v1betaConnectorVisibility'
                 title: Connector visibility including public or private
                 readOnly: true
               connector_definition:
-                $ref: "#/definitions/v1betaConnectorDefinition"
+                $ref: '#/definitions/v1betaConnectorDefinition'
                 title: Embed the content of the connector_definition
                 readOnly: true
               delete_time:
@@ -1663,11 +1663,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTestUserConnectorResponse"
+            $ref: '#/definitions/v1betaTestUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -1690,11 +1690,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaWatchUserConnectorResponse"
+            $ref: '#/definitions/v1betaWatchUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector.name
           description: |-
@@ -1717,11 +1717,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetConnectorDefinitionResponse"
+            $ref: '#/definitions/v1betaGetConnectorDefinitionResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: connector_definition.name
           description: |-
@@ -1759,11 +1759,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOrganizationMembershipResponse"
+            $ref: '#/definitions/v1betaGetOrganizationMembershipResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: membership.name_1
           description: Membership resource name. It must have the format of "organizations/*/memberships/*"
@@ -1797,11 +1797,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteOrganizationMembershipResponse"
+            $ref: '#/definitions/v1betaDeleteOrganizationMembershipResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: membership.name_1
           description: Membership resource name. It must have the format of "organizations/*/membership/*"
@@ -1820,11 +1820,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaUpdateOrganizationMembershipResponse"
+            $ref: '#/definitions/v1betaUpdateOrganizationMembershipResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: membership.name_1
           description: Resource name. It must have the format of "organizations/*/memberships/*"
@@ -1843,15 +1843,15 @@ paths:
                 type: string
                 title: Role
               state:
-                $ref: "#/definitions/v1betaMembershipState"
+                $ref: '#/definitions/v1betaMembershipState'
                 title: State
                 readOnly: true
               user:
-                $ref: "#/definitions/mgmtv1betaUser"
+                $ref: '#/definitions/mgmtv1betaUser'
                 title: User
                 readOnly: true
               organization:
-                $ref: "#/definitions/v1betaOrganization"
+                $ref: '#/definitions/v1betaOrganization'
                 title: Organization
                 readOnly: true
             title: A membership resource to update
@@ -1874,11 +1874,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetUserMembershipResponse"
+            $ref: '#/definitions/v1betaGetUserMembershipResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: membership.name
           description: Membership resource name. It must have the format of "users/*/memberships/*"
@@ -1912,11 +1912,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteUserMembershipResponse"
+            $ref: '#/definitions/v1betaDeleteUserMembershipResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: membership.name
           description: Membership resource name. It must have the format of "users/*/membership/*"
@@ -1935,11 +1935,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaUpdateUserMembershipResponse"
+            $ref: '#/definitions/v1betaUpdateUserMembershipResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: membership.name
           description: Resource name. It must have the format of "users/*/memberships/*".
@@ -1959,14 +1959,14 @@ paths:
                 title: Role
                 readOnly: true
               state:
-                $ref: "#/definitions/v1betaMembershipState"
+                $ref: '#/definitions/v1betaMembershipState'
                 title: State
               user:
-                $ref: "#/definitions/mgmtv1betaUser"
+                $ref: '#/definitions/mgmtv1betaUser'
                 title: User
                 readOnly: true
               organization:
-                $ref: "#/definitions/v1betaOrganization"
+                $ref: '#/definitions/v1betaOrganization'
                 title: Organization
                 readOnly: true
             title: A membership resource to update
@@ -1992,11 +1992,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaConnectOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaConnectOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: |-
@@ -2029,11 +2029,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDisconnectOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaDisconnectOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: |-
@@ -2064,11 +2064,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaExecuteOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaExecuteOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: |-
@@ -2107,11 +2107,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaRenameUserPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaRenameUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: Pipeline release resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -2147,11 +2147,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaRestoreOrganizationPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaRestoreOrganizationPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -2171,11 +2171,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTriggerUserPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaTriggerUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: Resource name.
@@ -2209,11 +2209,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTriggerAsyncUserPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaTriggerAsyncUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: Resource name.
@@ -2245,11 +2245,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaValidateOrganizationPipelineResponse"
+            $ref: '#/definitions/v1betaValidateOrganizationPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -2275,11 +2275,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaRenameOrganizationPipelineResponse"
+            $ref: '#/definitions/v1betaRenameOrganizationPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_2
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -2315,11 +2315,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTriggerOrganizationPipelineResponse"
+            $ref: '#/definitions/v1betaTriggerOrganizationPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_2
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -2353,11 +2353,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTriggerAsyncOrganizationPipelineResponse"
+            $ref: '#/definitions/v1betaTriggerAsyncOrganizationPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_2
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -2391,11 +2391,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaRenameOrganizationPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaRenameOrganizationPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_3
           description: Pipeline release resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -2431,11 +2431,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTriggerOrganizationPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaTriggerOrganizationPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_3
           description: Resource name.
@@ -2469,11 +2469,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTriggerAsyncOrganizationPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaTriggerAsyncOrganizationPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_3
           description: Resource name.
@@ -2508,11 +2508,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaRenameUserConnectorResponse"
+            $ref: '#/definitions/v1betaRenameUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_4
           description: |-
@@ -2552,11 +2552,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaRenameOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaRenameOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name_5
           description: |-
@@ -2596,11 +2596,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOperationResponse"
+            $ref: '#/definitions/v1betaGetOperationResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: The name of the operation resource.
@@ -2623,11 +2623,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaConnectUserConnectorResponse"
+            $ref: '#/definitions/v1betaConnectUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -2660,11 +2660,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDisconnectUserConnectorResponse"
+            $ref: '#/definitions/v1betaDisconnectUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -2695,11 +2695,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaExecuteUserConnectorResponse"
+            $ref: '#/definitions/v1betaExecuteUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -2738,11 +2738,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaRenameUserPipelineResponse"
+            $ref: '#/definitions/v1betaRenameUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -2778,11 +2778,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaRestoreUserPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaRestoreUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -2802,11 +2802,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTriggerUserPipelineResponse"
+            $ref: '#/definitions/v1betaTriggerUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -2840,11 +2840,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaTriggerAsyncUserPipelineResponse"
+            $ref: '#/definitions/v1betaTriggerAsyncUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -2876,11 +2876,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaValidateUserPipelineResponse"
+            $ref: '#/definitions/v1betaValidateUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -2907,11 +2907,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOperatorDefinitionResponse"
+            $ref: '#/definitions/v1betaGetOperatorDefinitionResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: operator_definition.name
           description: |-
@@ -2949,11 +2949,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOrganizationResponse"
+            $ref: '#/definitions/v1betaGetOrganizationResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization.name
           description: |-
@@ -2989,11 +2989,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteOrganizationResponse"
+            $ref: '#/definitions/v1betaDeleteOrganizationResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization.name
           description: |-
@@ -3014,11 +3014,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaUpdateOrganizationResponse"
+            $ref: '#/definitions/v1betaUpdateOrganizationResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization.name
           description: |-
@@ -3054,7 +3054,7 @@ paths:
               create_time:
                 type: string
                 format: date-time
-                title: "Owner type: fixed to `OWNER_TYPE_USER`"
+                title: 'Owner type: fixed to `OWNER_TYPE_USER`'
                 readOnly: true
               update_time:
                 type: string
@@ -3075,7 +3075,7 @@ paths:
                 type: object
                 title: Profile Data
               owner:
-                $ref: "#/definitions/mgmtv1betaUser"
+                $ref: '#/definitions/mgmtv1betaUser'
                 title: Owner
                 readOnly: true
             description: |-
@@ -3097,11 +3097,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListOrganizationConnectorsResponse"
+            $ref: '#/definitions/v1betaListOrganizationConnectorsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent_1
           description: |-
@@ -3164,11 +3164,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCreateOrganizationConnectorResponse"
+            $ref: '#/definitions/v1betaCreateOrganizationConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent_1
           description: |-
@@ -3183,7 +3183,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaConnector"
+            $ref: '#/definitions/v1betaConnector'
             required:
               - connector
       tags:
@@ -3198,11 +3198,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListOrganizationMembershipsResponse"
+            $ref: '#/definitions/v1betaListOrganizationMembershipsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent_1
           description: |-
@@ -3224,11 +3224,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListOrganizationPipelinesResponse"
+            $ref: '#/definitions/v1betaListOrganizationPipelinesResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent_1
           description: |-
@@ -3290,11 +3290,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCreateOrganizationPipelineResponse"
+            $ref: '#/definitions/v1betaCreateOrganizationPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent_1
           description: |-
@@ -3309,7 +3309,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaPipeline"
+            $ref: '#/definitions/v1betaPipeline'
             required:
               - pipeline
       tags:
@@ -3324,11 +3324,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListOrganizationPipelineReleasesResponse"
+            $ref: '#/definitions/v1betaListOrganizationPipelineReleasesResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent_1
           description: |-
@@ -3390,11 +3390,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCreateOrganizationPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaCreateOrganizationPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent_1
           description: |-
@@ -3409,7 +3409,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaPipelineRelease"
+            $ref: '#/definitions/v1betaPipelineRelease'
             required:
               - release
       tags:
@@ -3422,11 +3422,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOrganizationSubscriptionResponse"
+            $ref: '#/definitions/v1betaGetOrganizationSubscriptionResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent_1
           description: parent
@@ -3447,11 +3447,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListUserConnectorsResponse"
+            $ref: '#/definitions/v1betaListUserConnectorsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: |-
@@ -3514,11 +3514,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCreateUserConnectorResponse"
+            $ref: '#/definitions/v1betaCreateUserConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: |-
@@ -3533,7 +3533,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaConnector"
+            $ref: '#/definitions/v1betaConnector'
             required:
               - connector
       tags:
@@ -3548,11 +3548,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListUserMembershipsResponse"
+            $ref: '#/definitions/v1betaListUserMembershipsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: |-
@@ -3574,11 +3574,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListUserPipelinesResponse"
+            $ref: '#/definitions/v1betaListUserPipelinesResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: |-
@@ -3640,11 +3640,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCreateUserPipelineResponse"
+            $ref: '#/definitions/v1betaCreateUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: |-
@@ -3659,7 +3659,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaPipeline"
+            $ref: '#/definitions/v1betaPipeline'
             required:
               - pipeline
       tags:
@@ -3674,11 +3674,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListUserPipelineReleasesResponse"
+            $ref: '#/definitions/v1betaListUserPipelineReleasesResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: |-
@@ -3740,11 +3740,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCreateUserPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaCreateUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: |-
@@ -3759,7 +3759,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaPipelineRelease"
+            $ref: '#/definitions/v1betaPipelineRelease'
             required:
               - release
       tags:
@@ -3772,11 +3772,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetUserSubscriptionResponse"
+            $ref: '#/definitions/v1betaGetUserSubscriptionResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: parent
@@ -3797,11 +3797,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaLookUpConnectorResponse"
+            $ref: '#/definitions/v1betaLookUpConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_1
           description: |-
@@ -3840,11 +3840,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaLookUpPipelineResponse"
+            $ref: '#/definitions/v1betaLookUpPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink
           description: |-
@@ -3883,11 +3883,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaWatchOrganizationPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaWatchOrganizationPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name/watch_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -3907,11 +3907,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaWatchUserPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaWatchUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name/watch
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -3931,11 +3931,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOrganizationPipelineResponse"
+            $ref: '#/definitions/v1betaGetOrganizationPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -3971,11 +3971,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteOrganizationPipelineResponse"
+            $ref: '#/definitions/v1betaDeleteOrganizationPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name_1
           description: Pipeline resource name. It must have the format of "organizations/*/pipelines/*"
@@ -3994,11 +3994,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaUpdateOrganizationPipelineResponse"
+            $ref: '#/definitions/v1betaUpdateOrganizationPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name_1
           description: Pipeline resource name. It must have the format of "users/{user}/pipelines/*"
@@ -4028,7 +4028,7 @@ paths:
                 type: string
                 title: Pipeline description
               recipe:
-                $ref: "#/definitions/v1betaRecipe"
+                $ref: '#/definitions/v1betaRecipe'
                 title: Pipeline recipe
               create_time:
                 type: string
@@ -4050,11 +4050,11 @@ paths:
                 title: Pipeline delete time
                 readOnly: true
               sharing:
-                $ref: "#/definitions/v1betaSharing"
+                $ref: '#/definitions/v1betaSharing'
                 title: Pipeline sharing
               metadata:
                 type: object
-                title: "Metadata: store Console-related data such as pipeline builder layout"
+                title: 'Metadata: store Console-related data such as pipeline builder layout'
               owner_name:
                 type: string
                 title: Owner Name
@@ -4067,14 +4067,14 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: "#/definitions/v1betaPipelineRelease"
+                  $ref: '#/definitions/v1betaPipelineRelease'
                 title: Releases
                 readOnly: true
               readme:
                 type: string
                 title: readme
               permission:
-                $ref: "#/definitions/v1betaPermission"
+                $ref: '#/definitions/v1betaPermission'
                 title: Permission
                 readOnly: true
             title: A pipeline resource to update
@@ -4090,11 +4090,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetUserPipelineResponse"
+            $ref: '#/definitions/v1betaGetUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -4130,11 +4130,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteUserPipelineResponse"
+            $ref: '#/definitions/v1betaDeleteUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "users/*/pipelines/*"
@@ -4153,11 +4153,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaUpdateUserPipelineResponse"
+            $ref: '#/definitions/v1betaUpdateUserPipelineResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline.name
           description: Pipeline resource name. It must have the format of "users/{user}/pipelines/*"
@@ -4187,7 +4187,7 @@ paths:
                 type: string
                 title: Pipeline description
               recipe:
-                $ref: "#/definitions/v1betaRecipe"
+                $ref: '#/definitions/v1betaRecipe'
                 title: Pipeline recipe
               create_time:
                 type: string
@@ -4209,11 +4209,11 @@ paths:
                 title: Pipeline delete time
                 readOnly: true
               sharing:
-                $ref: "#/definitions/v1betaSharing"
+                $ref: '#/definitions/v1betaSharing'
                 title: Pipeline sharing
               metadata:
                 type: object
-                title: "Metadata: store Console-related data such as pipeline builder layout"
+                title: 'Metadata: store Console-related data such as pipeline builder layout'
               owner_name:
                 type: string
                 title: Owner Name
@@ -4226,14 +4226,14 @@ paths:
                 type: array
                 items:
                   type: object
-                  $ref: "#/definitions/v1betaPipelineRelease"
+                  $ref: '#/definitions/v1betaPipelineRelease'
                 title: Releases
                 readOnly: true
               readme:
                 type: string
                 title: readme
               permission:
-                $ref: "#/definitions/v1betaPermission"
+                $ref: '#/definitions/v1betaPermission'
                 title: Permission
                 readOnly: true
             title: A pipeline resource to update
@@ -4249,11 +4249,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOrganizationPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaGetOrganizationPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline_release.name_1
           description: PipelineRelease resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -4289,11 +4289,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteOrganizationPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaDeleteOrganizationPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline_release.name_1
           description: PipelineRelease resource name. It must have the format of "organizations/*/pipelines/*/releases/*"
@@ -4313,11 +4313,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetUserPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaGetUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline_release.name
           description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -4353,11 +4353,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteUserPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaDeleteUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pipeline_release.name
           description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -4377,11 +4377,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaUpdateOrganizationPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaUpdateOrganizationPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: release.name_1
           description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -4409,7 +4409,7 @@ paths:
                 type: string
                 title: PipelineRelease description
               recipe:
-                $ref: "#/definitions/v1betaRecipe"
+                $ref: '#/definitions/v1betaRecipe'
                 title: Pipeline recipe snapshot
                 readOnly: true
               create_time:
@@ -4437,7 +4437,7 @@ paths:
                 readOnly: true
               metadata:
                 type: object
-                title: "Metadata: store Console-related data such as pipeline builder layout"
+                title: 'Metadata: store Console-related data such as pipeline builder layout'
               readme:
                 type: string
                 title: readme
@@ -4454,11 +4454,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaUpdateUserPipelineReleaseResponse"
+            $ref: '#/definitions/v1betaUpdateUserPipelineReleaseResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: release.name
           description: PipelineRelease resource name. It must have the format of "users/*/pipelines/*/releases/*"
@@ -4486,7 +4486,7 @@ paths:
                 type: string
                 title: PipelineRelease description
               recipe:
-                $ref: "#/definitions/v1betaRecipe"
+                $ref: '#/definitions/v1betaRecipe'
                 title: Pipeline recipe snapshot
                 readOnly: true
               create_time:
@@ -4514,7 +4514,7 @@ paths:
                 readOnly: true
               metadata:
                 type: object
-                title: "Metadata: store Console-related data such as pipeline builder layout"
+                title: 'Metadata: store Console-related data such as pipeline builder layout'
               readme:
                 type: string
                 title: readme
@@ -4531,11 +4531,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/controllerv1betaGetResourceResponse"
+            $ref: '#/definitions/controllerv1betaGetResourceResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -4556,11 +4556,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/controllerv1betaDeleteResourceResponse"
+            $ref: '#/definitions/controllerv1betaDeleteResourceResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -4581,11 +4581,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/controllerv1betaUpdateResourceResponse"
+            $ref: '#/definitions/controllerv1betaUpdateResourceResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.resource_permalink
           description: |-
@@ -4603,13 +4603,13 @@ paths:
             type: object
             properties:
               pipeline_state:
-                $ref: "#/definitions/pipelinev1betaState"
+                $ref: '#/definitions/pipelinev1betaState'
                 title: Pipeline state
               connector_state:
-                $ref: "#/definitions/v1betaConnectorState"
+                $ref: '#/definitions/v1betaConnectorState'
                 title: Connector state
               backend_state:
-                $ref: "#/definitions/HealthCheckResponseServingStatus"
+                $ref: '#/definitions/HealthCheckResponseServingStatus'
                 title: Backend service state
               progress:
                 type: integer
@@ -4633,11 +4633,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetTokenResponse"
+            $ref: '#/definitions/v1betaGetTokenResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: token.name
           description: API tokens resource name. It must have the format of "tokens/*"
@@ -4656,11 +4656,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaDeleteTokenResponse"
+            $ref: '#/definitions/v1betaDeleteTokenResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: token.name
           description: API token resource name. It must have the format of "tokens/*"
@@ -4680,11 +4680,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetUserResponse"
+            $ref: '#/definitions/v1betaGetUserResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user.name
           description: |-
@@ -4721,11 +4721,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOrganizationAdminResponse"
+            $ref: '#/definitions/v1betaGetOrganizationAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization.name
           description: |-
@@ -4760,11 +4760,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetOrganizationSubscriptionAdminResponse"
+            $ref: '#/definitions/v1betaGetOrganizationSubscriptionAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent_1
           description: parent
@@ -4782,11 +4782,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetUserSubscriptionAdminResponse"
+            $ref: '#/definitions/v1betaGetUserSubscriptionAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
           description: parent
@@ -4806,11 +4806,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaLookUpOrganizationAdminResponse"
+            $ref: '#/definitions/v1betaLookUpOrganizationAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_1
           description: |-
@@ -4847,11 +4847,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaLookUpPipelineAdminResponse"
+            $ref: '#/definitions/v1betaLookUpPipelineAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_2
           description: |-
@@ -4891,11 +4891,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaLookUpOperatorDefinitionAdminResponse"
+            $ref: '#/definitions/v1betaLookUpOperatorDefinitionAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_3
           description: |-
@@ -4933,11 +4933,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaLookUpConnectorDefinitionAdminResponse"
+            $ref: '#/definitions/v1betaLookUpConnectorDefinitionAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_4
           description: |-
@@ -4975,11 +4975,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaLookUpConnectorAdminResponse"
+            $ref: '#/definitions/v1betaLookUpConnectorAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink_5
           description: |-
@@ -5018,11 +5018,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCheckConnectorResponse"
+            $ref: '#/definitions/v1betaCheckConnectorResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink
           description: |-
@@ -5044,11 +5044,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaLookUpUserAdminResponse"
+            $ref: '#/definitions/v1betaLookUpUserAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink
           description: |-
@@ -5085,11 +5085,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaGetUserAdminResponse"
+            $ref: '#/definitions/v1betaGetUserAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user.name
           description: |-
@@ -5126,11 +5126,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListConnectorsAdminResponse"
+            $ref: '#/definitions/v1betaListConnectorsAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5185,11 +5185,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListOrganizationsAdminResponse"
+            $ref: '#/definitions/v1betaListOrganizationsAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5238,11 +5238,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListPipelinesAdminResponse"
+            $ref: '#/definitions/v1betaListPipelinesAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5297,11 +5297,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListPipelineReleasesAdminResponse"
+            $ref: '#/definitions/v1betaListPipelineReleasesAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5356,11 +5356,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListUsersAdminResponse"
+            $ref: '#/definitions/v1betaListUsersAdminResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5407,17 +5407,17 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaAuthChangePasswordResponse"
+            $ref: '#/definitions/v1betaAuthChangePasswordResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: body
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaAuthChangePasswordRequest"
+            $ref: '#/definitions/v1betaAuthChangePasswordRequest'
       tags:
         - MgmtPublicService
   /v1beta/auth/login:
@@ -5428,11 +5428,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaAuthLoginResponse"
+            $ref: '#/definitions/v1betaAuthLoginResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: username
           description: Username
@@ -5454,11 +5454,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaAuthLogoutResponse"
+            $ref: '#/definitions/v1betaAuthLogoutResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       tags:
         - MgmtPublicService
   /v1beta/auth/token_issuer:
@@ -5469,17 +5469,17 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaAuthTokenIssuerResponse"
+            $ref: '#/definitions/v1betaAuthTokenIssuerResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: body
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaAuthTokenIssuerRequest"
+            $ref: '#/definitions/v1betaAuthTokenIssuerRequest'
       tags:
         - MgmtPublicService
   /v1beta/auth/validate_access_token:
@@ -5490,11 +5490,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaAuthValidateAccessTokenResponse"
+            $ref: '#/definitions/v1betaAuthValidateAccessTokenResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       tags:
         - MgmtPublicService
   /v1beta/check-namespace:
@@ -5505,17 +5505,17 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCheckNamespaceResponse"
+            $ref: '#/definitions/v1betaCheckNamespaceResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: body
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaCheckNamespaceRequest"
+            $ref: '#/definitions/v1betaCheckNamespaceRequest'
       tags:
         - MgmtPublicService
   /v1beta/connector-definitions:
@@ -5529,11 +5529,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListConnectorDefinitionsResponse"
+            $ref: '#/definitions/v1betaListConnectorDefinitionsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5583,11 +5583,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListConnectorsResponse"
+            $ref: '#/definitions/v1betaListConnectorsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5643,11 +5643,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/vdpcontrollerv1betaLivenessResponse"
+            $ref: '#/definitions/vdpcontrollerv1betaLivenessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -5667,11 +5667,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/coremgmtv1betaLivenessResponse"
+            $ref: '#/definitions/coremgmtv1betaLivenessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -5691,11 +5691,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/vdppipelinev1betaLivenessResponse"
+            $ref: '#/definitions/vdppipelinev1betaLivenessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -5715,11 +5715,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/coreusagev1betaLivenessResponse"
+            $ref: '#/definitions/coreusagev1betaLivenessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -5739,11 +5739,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListConnectorExecuteChartRecordsResponse"
+            $ref: '#/definitions/v1betaListConnectorExecuteChartRecordsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: aggregation_window
           description: Aggregation window in nanoseconds
@@ -5769,11 +5769,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListConnectorExecuteRecordsResponse"
+            $ref: '#/definitions/v1betaListConnectorExecuteRecordsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5808,11 +5808,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListConnectorExecuteTableRecordsResponse"
+            $ref: '#/definitions/v1betaListConnectorExecuteTableRecordsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5847,11 +5847,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListPipelineTriggerChartRecordsResponse"
+            $ref: '#/definitions/v1betaListPipelineTriggerChartRecordsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: aggregation_window
           description: Aggregation window in nanoseconds
@@ -5877,11 +5877,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListPipelineTriggerTableRecordsResponse"
+            $ref: '#/definitions/v1betaListPipelineTriggerTableRecordsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5916,11 +5916,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListPipelineTriggerRecordsResponse"
+            $ref: '#/definitions/v1betaListPipelineTriggerRecordsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -5955,11 +5955,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListOperatorDefinitionsResponse"
+            $ref: '#/definitions/v1betaListOperatorDefinitionsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -6008,11 +6008,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListOrganizationsResponse"
+            $ref: '#/definitions/v1betaListOrganizationsResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -6060,11 +6060,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCreateOrganizationResponse"
+            $ref: '#/definitions/v1betaCreateOrganizationResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization
           description: |-
@@ -6075,7 +6075,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaOrganization"
+            $ref: '#/definitions/v1betaOrganization'
             required:
               - organization
       tags:
@@ -6090,11 +6090,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListPipelinesResponse"
+            $ref: '#/definitions/v1betaListPipelinesResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -6150,11 +6150,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/coremgmtv1betaReadinessResponse"
+            $ref: '#/definitions/coremgmtv1betaReadinessResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: health_check_request.service
           description: Service name to check for its readiness status
@@ -6173,18 +6173,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaSendSessionReportResponse"
+            $ref: '#/definitions/v1betaSendSessionReportResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: report
           description: A report resource to create
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaSessionReport"
+            $ref: '#/definitions/v1betaSessionReport'
             required:
               - report
       tags:
@@ -6199,18 +6199,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCreateSessionResponse"
+            $ref: '#/definitions/v1betaCreateSessionResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: session
           description: A session resource to create
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaSession"
+            $ref: '#/definitions/v1betaSession'
             required:
               - session
       tags:
@@ -6225,11 +6225,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListTokensResponse"
+            $ref: '#/definitions/v1betaListTokensResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -6256,18 +6256,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaCreateTokenResponse"
+            $ref: '#/definitions/v1betaCreateTokenResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: token
           description: A token resource to create
           in: body
           required: true
           schema:
-            $ref: "#/definitions/v1betaApiToken"
+            $ref: '#/definitions/v1betaApiToken'
             required:
               - token
       tags:
@@ -6282,11 +6282,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaListUsersResponse"
+            $ref: '#/definitions/v1betaListUsersResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -6335,18 +6335,18 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaPatchAuthenticatedUserResponse"
+            $ref: '#/definitions/v1betaPatchAuthenticatedUserResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user
           description: The user to update
           in: body
           required: true
           schema:
-            $ref: "#/definitions/mgmtv1betaUser"
+            $ref: '#/definitions/mgmtv1betaUser'
             required:
               - user
       tags:
@@ -6361,11 +6361,11 @@ paths:
         "200":
           description: A successful response.
           schema:
-            $ref: "#/definitions/v1betaValidateTokenResponse"
+            $ref: '#/definitions/v1betaValidateTokenResponse'
         default:
           description: An unexpected error response.
           schema:
-            $ref: "#/definitions/googlerpcStatus"
+            $ref: '#/definitions/googlerpcStatus'
       tags:
         - MgmtPublicService
 definitions:
@@ -6462,17 +6462,17 @@ definitions:
         type: boolean
         title: enabled
       role:
-        $ref: "#/definitions/v1betaRole"
+        $ref: '#/definitions/v1betaRole'
         title: role
     title: Share Code
   SubscriptionQuota:
     type: object
     properties:
       private_pipeline_trigger:
-        $ref: "#/definitions/QuotaQuotaDetail"
+        $ref: '#/definitions/QuotaQuotaDetail'
         title: pipeline trigger
       private_pipeline:
-        $ref: "#/definitions/QuotaQuotaDetail"
+        $ref: '#/definitions/QuotaQuotaDetail'
         title: private pipeline
     title: Quota
   UserUsageDataConnectorExecuteData:
@@ -6492,13 +6492,13 @@ definitions:
         type: string
         title: Definition UID of the connector
       status:
-        $ref: "#/definitions/mgmtv1betaStatus"
+        $ref: '#/definitions/mgmtv1betaStatus'
         title: Final status of the execution
       user_uid:
         type: string
         title: UUID of the user who execute the connector
       user_type:
-        $ref: "#/definitions/v1betaOwnerType"
+        $ref: '#/definitions/v1betaOwnerType'
         title: Type of the user who execute the connector
     title: Per execute usage metadata
     required:
@@ -6526,16 +6526,16 @@ definitions:
         type: string
         title: Definition UID of the model
       model_task:
-        $ref: "#/definitions/v1alphaTask"
+        $ref: '#/definitions/v1alphaTask'
         title: Task of the model
       status:
-        $ref: "#/definitions/mgmtv1betaStatus"
+        $ref: '#/definitions/mgmtv1betaStatus'
         title: Final status of the execution
       user_uid:
         type: string
         title: UUID of the user who trigger the model
       user_type:
-        $ref: "#/definitions/v1betaOwnerType"
+        $ref: '#/definitions/v1betaOwnerType'
         title: Type of the user who trigger the model
     title: Per trigger usage metadata
     required:
@@ -6561,10 +6561,10 @@ definitions:
         format: date-time
         title: Timestamp for the trigger
       trigger_mode:
-        $ref: "#/definitions/v1betaMode"
+        $ref: '#/definitions/v1betaMode'
         title: Trigger mode
       status:
-        $ref: "#/definitions/mgmtv1betaStatus"
+        $ref: '#/definitions/mgmtv1betaStatus'
         title: Final status of the execution
       pipeline_release_id:
         type: string
@@ -6576,7 +6576,7 @@ definitions:
         type: string
         title: UUID of the user who trigger the pipeline
       user_type:
-        $ref: "#/definitions/v1betaOwnerType"
+        $ref: '#/definitions/v1betaOwnerType'
         title: Type of the user who trigger the pipeline
     title: Per trigger usage metadata
     required:
@@ -6596,7 +6596,7 @@ definitions:
     type: object
     properties:
       resource:
-        $ref: "#/definitions/controllerv1alphaResource"
+        $ref: '#/definitions/controllerv1alphaResource'
         title: Retrieved resource state
     title: GetResourceResponse represents a response to fetch a resource's state
   controllerv1alphaResource:
@@ -6608,10 +6608,10 @@ definitions:
           Permalink of a resource. For example:
           "resources/{resource_uuid}/types/{type}"
       model_state:
-        $ref: "#/definitions/v1alphaModelState"
+        $ref: '#/definitions/v1alphaModelState'
         title: Model state
       backend_state:
-        $ref: "#/definitions/HealthCheckResponseServingStatus"
+        $ref: '#/definitions/HealthCheckResponseServingStatus'
         title: Backend service state
       progress:
         type: integer
@@ -6624,7 +6624,7 @@ definitions:
     type: object
     properties:
       resource:
-        $ref: "#/definitions/controllerv1alphaResource"
+        $ref: '#/definitions/controllerv1alphaResource'
         title: Updated resource state
     title: UpdateResourceResponse represents a response to update a resource's state
   controllerv1betaDeleteResourceResponse:
@@ -6634,7 +6634,7 @@ definitions:
     type: object
     properties:
       resource:
-        $ref: "#/definitions/controllerv1betaResource"
+        $ref: '#/definitions/controllerv1betaResource'
         title: Retrieved resource state
     title: GetResourceResponse represents a response to fetch a resource's state
   controllerv1betaResource:
@@ -6646,13 +6646,13 @@ definitions:
           Permalink of a resouce. For example:
           "resources/{resource_uuid}/types/{type}"
       pipeline_state:
-        $ref: "#/definitions/pipelinev1betaState"
+        $ref: '#/definitions/pipelinev1betaState'
         title: Pipeline state
       connector_state:
-        $ref: "#/definitions/v1betaConnectorState"
+        $ref: '#/definitions/v1betaConnectorState'
         title: Connector state
       backend_state:
-        $ref: "#/definitions/HealthCheckResponseServingStatus"
+        $ref: '#/definitions/HealthCheckResponseServingStatus'
         title: Backend service state
       progress:
         type: integer
@@ -6665,35 +6665,35 @@ definitions:
     type: object
     properties:
       resource:
-        $ref: "#/definitions/controllerv1betaResource"
+        $ref: '#/definitions/controllerv1betaResource'
         title: Updated resource state
     title: UpdateResourceResponse represents a response to update a resource's state
   coremgmtv1betaLivenessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   coremgmtv1betaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   coreusagev1betaLivenessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   coreusagev1betaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   googlelongrunningOperation:
@@ -6706,7 +6706,7 @@ definitions:
           originally returns it. If you use the default HTTP mapping, the
           `name` should be a resource name ending with `operations/{unique_id}`.
       metadata:
-        $ref: "#/definitions/protobufAny"
+        $ref: '#/definitions/protobufAny'
         description: |-
           Service-specific metadata associated with the operation.  It typically
           contains progress information and common metadata such as create time.
@@ -6719,10 +6719,10 @@ definitions:
           If `true`, the operation is completed, and either `error` or `response` is
           available.
       error:
-        $ref: "#/definitions/googlerpcStatus"
+        $ref: '#/definitions/googlerpcStatus'
         description: The error result of the operation in case of failure or cancellation.
       response:
-        $ref: "#/definitions/protobufAny"
+        $ref: '#/definitions/protobufAny'
         description: |-
           The normal response of the operation in case of success.  If the original
           method returns no data on success, such as `Delete`, the response is
@@ -6755,7 +6755,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/protobufAny"
+          $ref: '#/definitions/protobufAny'
         description: |-
           A list of messages that carry the error details.  There is a common set of
           message types for APIs to use.
@@ -6874,28 +6874,28 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   modelcontrollerv1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   modelmodelv1alphaLivenessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   modelmodelv1alphaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   modelv1alphaView:
@@ -6930,7 +6930,7 @@ definitions:
   protobufAny:
     type: object
     properties:
-      "@type":
+      '@type':
         type: string
         description: |-
           A URL/resource name that uniquely identifies the type of the serialized
@@ -7087,7 +7087,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: "#/definitions/v1alphaModelState"
+        $ref: '#/definitions/v1alphaModelState'
         title: Retrieved model state
     title: |-
       CheckModelAdminResponse represents a response to fetch a model's
@@ -7139,10 +7139,14 @@ definitions:
     properties:
       type:
         type: string
+        title: Type of Content
       content:
         type: string
+        title: Content of Text Message
       prompt_image:
-        $ref: "#/definitions/v1alphaPromptImage"
+        $ref: '#/definitions/v1alphaPromptImage'
+        title: Content of Image
+    title: Content used for chat history in text generation model
   v1alphaConversationObject:
     type: object
     properties:
@@ -7157,7 +7161,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: Create model operation message
         readOnly: true
     title: CreateUserModelBinaryFileUploadResponse represents a response for a model
@@ -7165,7 +7169,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: Create model operation message
         readOnly: true
     title: CreateUserModelResponse represents a response for a model
@@ -7176,7 +7180,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: Deploy operation message
     title: DeployModelAdminResponse represents a response for a deployed model
   v1alphaDeployUserModelResponse:
@@ -7230,7 +7234,7 @@ definitions:
         title: Detection object score
         readOnly: true
       bounding_box:
-        $ref: "#/definitions/v1alphaBoundingBox"
+        $ref: '#/definitions/v1alphaBoundingBox'
         title: Detection bounding box
         readOnly: true
     title: DetectionObject represents a predicted object
@@ -7241,7 +7245,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaDetectionObject"
+          $ref: '#/definitions/v1alphaDetectionObject'
         title: A list of detection objects
         readOnly: true
     title: DetectionOutput represents the output of detection task
@@ -7261,28 +7265,28 @@ definitions:
     type: object
     properties:
       model_definition:
-        $ref: "#/definitions/v1alphaModelDefinition"
+        $ref: '#/definitions/v1alphaModelDefinition'
         title: A model definition instance
     title: GetModelDefinitionResponse represents a response for a model definition
   v1alphaGetModelOperationResponse:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: The retrieved model operation
     title: GetModelOperationResponse represents a response for a model operation
   v1alphaGetUserModelCardResponse:
     type: object
     properties:
       readme:
-        $ref: "#/definitions/v1alphaModelCard"
+        $ref: '#/definitions/v1alphaModelCard'
         title: Retrieved model card
     title: GetUserModelCardResponse represents a response to fetch a model's README card
   v1alphaGetUserModelResponse:
     type: object
     properties:
       model:
-        $ref: "#/definitions/v1alphaModel"
+        $ref: '#/definitions/v1alphaModel'
         title: The retrieved model
     title: GetUserModelResponse represents a response for a model
   v1alphaImageToImageInput:
@@ -7317,7 +7321,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaExtraParamObject"
+          $ref: '#/definitions/v1alphaExtraParamObject'
         title: The extra parameters
     title: ImageToImageInput represents the input of image to image task
     required:
@@ -7378,7 +7382,7 @@ definitions:
         title: Instance score
         readOnly: true
       bounding_box:
-        $ref: "#/definitions/v1alphaBoundingBox"
+        $ref: '#/definitions/v1alphaBoundingBox'
         title: Instance bounding box
         readOnly: true
     title: InstanceSegmentationObject corresponding to a instance segmentation object
@@ -7389,7 +7393,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaInstanceSegmentationObject"
+          $ref: '#/definitions/v1alphaInstanceSegmentationObject'
         title: A list of instance segmentation objects
         readOnly: true
     title: |-
@@ -7450,7 +7454,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaKeypoint"
+          $ref: '#/definitions/v1alphaKeypoint'
         title: Keypoints
         readOnly: true
       score:
@@ -7459,7 +7463,7 @@ definitions:
         title: Keypoint score
         readOnly: true
       bounding_box:
-        $ref: "#/definitions/v1alphaBoundingBox"
+        $ref: '#/definitions/v1alphaBoundingBox'
         title: Bounding box object
         readOnly: true
     title: KeypointObject corresponding to a person object
@@ -7470,7 +7474,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaKeypointObject"
+          $ref: '#/definitions/v1alphaKeypointObject'
         title: A list of keypoint objects
         readOnly: true
     title: KeypointOutput represents the output of keypoint detection task
@@ -7481,7 +7485,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaModelDefinition"
+          $ref: '#/definitions/v1alphaModelDefinition'
         title: a list of ModelDefinition instances
       next_page_token:
         type: string
@@ -7500,7 +7504,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaModel"
+          $ref: '#/definitions/v1alphaModel'
         title: a list of Models
       next_page_token:
         type: string
@@ -7517,7 +7521,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaModel"
+          $ref: '#/definitions/v1alphaModel'
         title: a list of Models
       next_page_token:
         type: string
@@ -7534,7 +7538,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaModel"
+          $ref: '#/definitions/v1alphaModel'
         title: a list of Models
       next_page_token:
         type: string
@@ -7548,14 +7552,14 @@ definitions:
     type: object
     properties:
       model:
-        $ref: "#/definitions/v1alphaModel"
+        $ref: '#/definitions/v1alphaModel'
         title: A model resource
     title: LookUpModelResponse represents a response for a model
   v1alphaLookUpModelResponse:
     type: object
     properties:
       model:
-        $ref: "#/definitions/v1alphaModel"
+        $ref: '#/definitions/v1alphaModel'
         title: A model resource
     title: LookUpModelResponse represents a response for a model
   v1alphaModel:
@@ -7590,15 +7594,15 @@ definitions:
           Model configuration represents the configuration JSON that has been
           validated using the `model_spec` JSON schema of a ModelDefinition
       task:
-        $ref: "#/definitions/v1alphaTask"
+        $ref: '#/definitions/v1alphaTask'
         title: Model task
         readOnly: true
       state:
-        $ref: "#/definitions/v1alphaModelState"
+        $ref: '#/definitions/v1alphaModelState'
         title: Model state
         readOnly: true
       visibility:
-        $ref: "#/definitions/v1alphaModelVisibility"
+        $ref: '#/definitions/v1alphaModelVisibility'
         title: Model visibility including public or private
         readOnly: true
       create_time:
@@ -7687,7 +7691,7 @@ definitions:
         title: ModelDefinition icon
         readOnly: true
       release_stage:
-        $ref: "#/definitions/v1alphaReleaseStage"
+        $ref: '#/definitions/v1alphaReleaseStage'
         title: ModelDefinition release stage
         readOnly: true
       model_spec:
@@ -7777,7 +7781,7 @@ definitions:
         title: OCR text score
         readOnly: true
       bounding_box:
-        $ref: "#/definitions/v1alphaBoundingBox"
+        $ref: '#/definitions/v1alphaBoundingBox'
         title: OCR bounding box
         readOnly: true
     title: OcrObject represents a predicted ocr object
@@ -7788,7 +7792,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaOcrObject"
+          $ref: '#/definitions/v1alphaOcrObject'
         title: A list of OCR objects
         readOnly: true
     title: OcrOutput represents the output of ocr task
@@ -7797,14 +7801,16 @@ definitions:
     properties:
       prompt_image_url:
         type: string
+        title: Image URL
       prompt_image_base64:
         type: string
-    title: "reference to: https://github.com/instill-ai/connector/blob/main/pkg/openai/text_generation.go#L17"
+        title: Base64 encoded Image
+    title: Prompt Image for text generation model
   v1alphaPublishUserModelResponse:
     type: object
     properties:
       model:
-        $ref: "#/definitions/v1alphaModel"
+        $ref: '#/definitions/v1alphaModel'
         title: Published model
     title: PublishUserModelResponse represents a response for the published model
   v1alphaReleaseStage:
@@ -7827,7 +7833,7 @@ definitions:
     type: object
     properties:
       model:
-        $ref: "#/definitions/v1alphaModel"
+        $ref: '#/definitions/v1alphaModel'
         title: Renamed model
     title: RenameUserModelResponse represents a response for a model
   v1alphaSemanticSegmentationInput:
@@ -7866,7 +7872,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaSemanticSegmentationStuff"
+          $ref: '#/definitions/v1alphaSemanticSegmentationStuff'
         title: A list of semantic segmentation stuffs
         readOnly: true
     title: |-
@@ -7922,131 +7928,131 @@ definitions:
     type: object
     properties:
       classification:
-        $ref: "#/definitions/v1alphaClassificationInput"
+        $ref: '#/definitions/v1alphaClassificationInput'
         title: The classification input
       detection:
-        $ref: "#/definitions/v1alphaDetectionInput"
+        $ref: '#/definitions/v1alphaDetectionInput'
         title: The detection input
       keypoint:
-        $ref: "#/definitions/v1alphaKeypointInput"
+        $ref: '#/definitions/v1alphaKeypointInput'
         title: The keypoint input
       ocr:
-        $ref: "#/definitions/v1alphaOcrInput"
+        $ref: '#/definitions/v1alphaOcrInput'
         title: The ocr input
       instance_segmentation:
-        $ref: "#/definitions/v1alphaInstanceSegmentationInput"
+        $ref: '#/definitions/v1alphaInstanceSegmentationInput'
         title: The instance segmentation input
       semantic_segmentation:
-        $ref: "#/definitions/v1alphaSemanticSegmentationInput"
+        $ref: '#/definitions/v1alphaSemanticSegmentationInput'
         title: The semantic segmentation input
       text_to_image:
-        $ref: "#/definitions/v1alphaTextToImageInput"
+        $ref: '#/definitions/v1alphaTextToImageInput'
         title: The text to image input
       image_to_image:
-        $ref: "#/definitions/v1alphaImageToImageInput"
+        $ref: '#/definitions/v1alphaImageToImageInput'
         title: The image to image input
       text_generation:
-        $ref: "#/definitions/v1alphaTextGenerationInput"
+        $ref: '#/definitions/v1alphaTextGenerationInput'
         title: The text generation input
       text_generation_chat:
-        $ref: "#/definitions/v1alphaTextGenerationChatInput"
+        $ref: '#/definitions/v1alphaTextGenerationChatInput'
         title: The text generation chat input
       visual_question_answering:
-        $ref: "#/definitions/v1alphaVisualQuestionAnsweringInput"
+        $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
         title: The visual question answering input
       unspecified:
-        $ref: "#/definitions/v1alphaUnspecifiedInput"
+        $ref: '#/definitions/v1alphaUnspecifiedInput'
         title: The unspecified task input
     title: Input represents the input to trigger a model
   v1alphaTaskInputStream:
     type: object
     properties:
       classification:
-        $ref: "#/definitions/v1alphaClassificationInputStream"
+        $ref: '#/definitions/v1alphaClassificationInputStream'
         title: The classification input
       detection:
-        $ref: "#/definitions/v1alphaDetectionInputStream"
+        $ref: '#/definitions/v1alphaDetectionInputStream'
         title: The detection input
       keypoint:
-        $ref: "#/definitions/v1alphaKeypointInputStream"
+        $ref: '#/definitions/v1alphaKeypointInputStream'
         title: The keypoint input
       ocr:
-        $ref: "#/definitions/v1alphaOcrInputStream"
+        $ref: '#/definitions/v1alphaOcrInputStream'
         title: The ocr input
       instance_segmentation:
-        $ref: "#/definitions/v1alphaInstanceSegmentationInputStream"
+        $ref: '#/definitions/v1alphaInstanceSegmentationInputStream'
         title: The instance segmentation input
       semantic_segmentation:
-        $ref: "#/definitions/v1alphaSemanticSegmentationInputStream"
+        $ref: '#/definitions/v1alphaSemanticSegmentationInputStream'
         title: The semantic segmentation input
       text_to_image:
-        $ref: "#/definitions/v1alphaTextToImageInput"
+        $ref: '#/definitions/v1alphaTextToImageInput'
         title: The text to image input
       image_to_image:
-        $ref: "#/definitions/v1alphaImageToImageInput"
+        $ref: '#/definitions/v1alphaImageToImageInput'
         title: The image to image input
       text_generation:
-        $ref: "#/definitions/v1alphaTextGenerationInput"
+        $ref: '#/definitions/v1alphaTextGenerationInput'
         title: The text generation input
       text_generation_chat:
-        $ref: "#/definitions/v1alphaTextGenerationChatInput"
+        $ref: '#/definitions/v1alphaTextGenerationChatInput'
         title: The text generation chat input
       visual_question_answering:
-        $ref: "#/definitions/v1alphaVisualQuestionAnsweringInput"
+        $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
         title: The visual question answering input
       unspecified:
-        $ref: "#/definitions/v1alphaUnspecifiedInput"
+        $ref: '#/definitions/v1alphaUnspecifiedInput'
         title: The unspecified task input
     title: TaskInputStream represents the input to trigger a model with stream method
   v1alphaTaskOutput:
     type: object
     properties:
       classification:
-        $ref: "#/definitions/v1alphaClassificationOutput"
+        $ref: '#/definitions/v1alphaClassificationOutput'
         title: The classification output
         readOnly: true
       detection:
-        $ref: "#/definitions/v1alphaDetectionOutput"
+        $ref: '#/definitions/v1alphaDetectionOutput'
         title: The detection output
         readOnly: true
       keypoint:
-        $ref: "#/definitions/v1alphaKeypointOutput"
+        $ref: '#/definitions/v1alphaKeypointOutput'
         title: The keypoint output
         readOnly: true
       ocr:
-        $ref: "#/definitions/v1alphaOcrOutput"
+        $ref: '#/definitions/v1alphaOcrOutput'
         title: The ocr output
         readOnly: true
       instance_segmentation:
-        $ref: "#/definitions/v1alphaInstanceSegmentationOutput"
+        $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
         title: The instance segmentation output
         readOnly: true
       semantic_segmentation:
-        $ref: "#/definitions/v1alphaSemanticSegmentationOutput"
+        $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
         title: The semantic segmentation output
         readOnly: true
       text_to_image:
-        $ref: "#/definitions/v1alphaTextToImageOutput"
+        $ref: '#/definitions/v1alphaTextToImageOutput'
         title: The text to image output
         readOnly: true
       image_to_image:
-        $ref: "#/definitions/v1alphaImageToImageOutput"
+        $ref: '#/definitions/v1alphaImageToImageOutput'
         title: The image to image output
         readOnly: true
       text_generation:
-        $ref: "#/definitions/v1alphaTextGenerationOutput"
+        $ref: '#/definitions/v1alphaTextGenerationOutput'
         title: The text generation output
         readOnly: true
       text_generation_chat:
-        $ref: "#/definitions/v1alphaTextGenerationChatOutput"
+        $ref: '#/definitions/v1alphaTextGenerationChatOutput'
         title: The text generation output
         readOnly: true
       visual_question_answering:
-        $ref: "#/definitions/v1alphaVisualQuestionAnsweringOutput"
+        $ref: '#/definitions/v1alphaVisualQuestionAnsweringOutput'
         title: The text generation output
         readOnly: true
       unspecified:
-        $ref: "#/definitions/v1alphaUnspecifiedOutput"
+        $ref: '#/definitions/v1alphaUnspecifiedOutput'
         title: The unspecified task output
         readOnly: true
     title: TaskOutput represents the output of a CV Task result from a model
@@ -8054,13 +8060,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: "#/definitions/v1alphaTask"
+        $ref: '#/definitions/v1alphaTask'
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaTaskOutput"
+          $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
       TestUserModelBinaryFileUploadResponse represents a response for the
@@ -8072,13 +8078,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: "#/definitions/v1alphaTask"
+        $ref: '#/definitions/v1alphaTask'
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaTaskOutput"
+          $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
       TestUserModelResponse represents a response for the output for
@@ -8093,7 +8099,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaConversationObject"
+          $ref: '#/definitions/v1alphaConversationObject'
         title: The prompt text
       max_new_tokens:
         type: integer
@@ -8115,7 +8121,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaExtraParamObject"
+          $ref: '#/definitions/v1alphaExtraParamObject'
         title: The extra parameters
     title: TextGenerationChatInput represents the input of text generation chat task
     required:
@@ -8138,15 +8144,17 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaPromptImage"
-        title: Optional fields
+          $ref: '#/definitions/v1alphaPromptImage'
+        title: The prompt images
       chat_history:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaContent"
+          $ref: '#/definitions/v1alphaContent'
+        title: The chat history
       system_message:
         type: string
+        title: The system message
       max_new_tokens:
         type: integer
         format: int32
@@ -8209,7 +8217,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaExtraParamObject"
+          $ref: '#/definitions/v1alphaExtraParamObject'
         title: The extra parameters
     title: TextToImageInput represents the input of text to image task
     required:
@@ -8228,13 +8236,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: "#/definitions/v1alphaTask"
+        $ref: '#/definitions/v1alphaTask'
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaTaskOutput"
+          $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
       TriggerUserModelBinaryFileUploadResponse represents a response for the
@@ -8246,13 +8254,13 @@ definitions:
     type: object
     properties:
       task:
-        $ref: "#/definitions/v1alphaTask"
+        $ref: '#/definitions/v1alphaTask'
         title: The task type
       task_outputs:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaTaskOutput"
+          $ref: '#/definitions/v1alphaTaskOutput'
         title: The task output from a model
     title: |-
       TriggerUserModelResponse represents a response for the output for
@@ -8261,7 +8269,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: Undeploy operation message
     title: UndeployModelAdminResponse represents a response for a undeployed model
   v1alphaUndeployUserModelResponse:
@@ -8277,7 +8285,7 @@ definitions:
     type: object
     properties:
       model:
-        $ref: "#/definitions/v1alphaModel"
+        $ref: '#/definitions/v1alphaModel'
         title: Unpublished model
     title: UnpublishUserModelResponse represents a response for the unpublished model
   v1alphaUnspecifiedInput:
@@ -8303,7 +8311,7 @@ definitions:
     type: object
     properties:
       model:
-        $ref: "#/definitions/v1alphaModel"
+        $ref: '#/definitions/v1alphaModel'
         title: The updated model
     title: UpdateUserModelResponse represents a response for a model
   v1alphaVisualQuestionAnsweringInput:
@@ -8338,7 +8346,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1alphaExtraParamObject"
+          $ref: '#/definitions/v1alphaExtraParamObject'
         title: The extra parameters
     title: VisualQuestionAnsweringInput represents the input of visaul question answering task
     required:
@@ -8355,7 +8363,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: "#/definitions/v1alphaModelState"
+        $ref: '#/definitions/v1alphaModelState'
         title: Retrieved model state
       progress:
         type: integer
@@ -8401,7 +8409,7 @@ definitions:
           that issued the token.
         readOnly: true
       state:
-        $ref: "#/definitions/v1betaApiTokenState"
+        $ref: '#/definitions/v1betaApiTokenState'
         title: API token state
         readOnly: true
       token_type:
@@ -8471,7 +8479,7 @@ definitions:
     type: object
     properties:
       access_token:
-        $ref: "#/definitions/AuthTokenIssuerResponseUnsignedAccessToken"
+        $ref: '#/definitions/AuthTokenIssuerResponseUnsignedAccessToken'
         title: access_token
     title: Response for user logout
   v1betaAuthValidateAccessTokenResponse:
@@ -8481,7 +8489,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: "#/definitions/v1betaConnectorState"
+        $ref: '#/definitions/v1betaConnectorState'
         title: Retrieved connector state
     title: |-
       CheckConnectorResponse represents a response to fetch a
@@ -8501,7 +8509,7 @@ definitions:
     type: object
     properties:
       type:
-        $ref: "#/definitions/CheckNamespaceResponseNamespace"
+        $ref: '#/definitions/CheckNamespaceResponseNamespace'
         title: Namespace type
     title: |-
       CheckNamespaceResponse represents a response about whether
@@ -8516,25 +8524,25 @@ definitions:
         type: string
         title: A pipeline component resource name
       resource:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: A pipeline component resource detail
         readOnly: true
       configuration:
         type: object
         title: Configuration for the pipeline component
       type:
-        $ref: "#/definitions/v1betaComponentType"
+        $ref: '#/definitions/v1betaComponentType'
         title: Resource Type
         readOnly: true
       definition_name:
         type: string
         title: A pipeline component definition name
       operator_definition:
-        $ref: "#/definitions/v1betaOperatorDefinition"
+        $ref: '#/definitions/v1betaOperatorDefinition'
         title: operator definition detail
         readOnly: true
       connector_definition:
-        $ref: "#/definitions/v1betaConnectorDefinition"
+        $ref: '#/definitions/v1betaConnectorDefinition'
         title: connector definition detail
         readOnly: true
     title: Represents a pipeline component
@@ -8561,7 +8569,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: A connector
     title: |-
       ConnectOrganizationConnectorResponse represents a connected
@@ -8570,7 +8578,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: A connector
     title: |-
       ConnectUserConnectorResponse represents a connected
@@ -8599,7 +8607,7 @@ definitions:
         type: string
         title: ConnectorDefinition resource
       type:
-        $ref: "#/definitions/v1betaConnectorType"
+        $ref: '#/definitions/v1betaConnectorType'
         title: Connector Type
         readOnly: true
       description:
@@ -8609,7 +8617,7 @@ definitions:
         type: object
         title: Connector configuration in JSON format
       state:
-        $ref: "#/definitions/v1betaConnectorState"
+        $ref: '#/definitions/v1betaConnectorState'
         title: Connector state
         readOnly: true
       tombstone:
@@ -8627,11 +8635,11 @@ definitions:
         title: Connector update time
         readOnly: true
       visibility:
-        $ref: "#/definitions/v1betaConnectorVisibility"
+        $ref: '#/definitions/v1betaConnectorVisibility'
         title: Connector visibility including public or private
         readOnly: true
       connector_definition:
-        $ref: "#/definitions/v1betaConnectorDefinition"
+        $ref: '#/definitions/v1betaConnectorDefinition'
         title: Embed the content of the connector_definition
         readOnly: true
       delete_time:
@@ -8684,11 +8692,11 @@ definitions:
         title: ConnectorDefinition icon
         readOnly: true
       spec:
-        $ref: "#/definitions/v1betaConnectorSpec"
+        $ref: '#/definitions/v1betaConnectorSpec'
         title: ConnectorDefinition spec
         readOnly: true
       type:
-        $ref: "#/definitions/v1betaConnectorType"
+        $ref: '#/definitions/v1betaConnectorType'
         title: Connector Type
         readOnly: true
       tombstone:
@@ -8745,7 +8753,7 @@ definitions:
         type: string
         title: UID for the executed connector
       status:
-        $ref: "#/definitions/mgmtv1betaStatus"
+        $ref: '#/definitions/mgmtv1betaStatus'
         title: Status of connector execution
         readOnly: true
       time_buckets:
@@ -8806,7 +8814,7 @@ definitions:
         title: Total compute time duration for this execution
         readOnly: true
       status:
-        $ref: "#/definitions/mgmtv1betaStatus"
+        $ref: '#/definitions/mgmtv1betaStatus'
         title: Final status for the connector execution
         readOnly: true
     title: ConnectorExecuteRecord represents a record for connector execution
@@ -8892,7 +8900,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaConnectorUsageDataUserUsageData"
+          $ref: '#/definitions/v1betaConnectorUsageDataUserUsageData'
         title: Usage data of all users in the connector service
     title: Connector service usage data
   v1betaConnectorUsageDataUserUsageData:
@@ -8905,10 +8913,10 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/UserUsageDataConnectorExecuteData"
+          $ref: '#/definitions/UserUsageDataConnectorExecuteData'
         title: Execution data for each user
       owner_type:
-        $ref: "#/definitions/v1betaOwnerType"
+        $ref: '#/definitions/v1betaOwnerType'
         title: Owner type
     title: Per user usage data in the connector service
     required:
@@ -8945,7 +8953,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: connector
     title: |-
       CreateOrganizationConnectorResponse represents a response for a
@@ -8954,42 +8962,42 @@ definitions:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: The created pipeline_release resource
     title: CreateOrganizationPipelineReleaseResponse represents a response for a pipeline_release resource
   v1betaCreateOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: The created pipeline resource
     title: CreateOrganizationPipelineResponse represents a response for a pipeline resource
   v1betaCreateOrganizationResponse:
     type: object
     properties:
       organization:
-        $ref: "#/definitions/v1betaOrganization"
+        $ref: '#/definitions/v1betaOrganization'
         title: A organization resource
     title: CreateOrganizationResponse represents a response for a organization response
   v1betaCreateSessionResponse:
     type: object
     properties:
       session:
-        $ref: "#/definitions/v1betaSession"
+        $ref: '#/definitions/v1betaSession'
         title: A session resource
     title: CreateSessionResponse represents a response for a session response
   v1betaCreateTokenResponse:
     type: object
     properties:
       token:
-        $ref: "#/definitions/v1betaApiToken"
+        $ref: '#/definitions/v1betaApiToken'
         title: The created API token resource
     title: CreateTokenResponse represents a response for a API token resource
   v1betaCreateUserConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: connector
     title: |-
       CreateUserConnectorResponse represents a response for a
@@ -8998,14 +9006,14 @@ definitions:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: The created pipeline_release resource
     title: CreateUserPipelineReleaseResponse represents a response for a pipeline_release resource
   v1betaCreateUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: The created pipeline resource
     title: CreateUserPipelineResponse represents a response for a pipeline resource
   v1betaDeleteOrganizationConnectorResponse:
@@ -9042,7 +9050,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: A connector
     title: |-
       DisconnectOrganizationConnectorResponse represents a disconnected
@@ -9051,7 +9059,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: A connector
     title: |-
       DisconnectUserConnectorResponse represents a disconnected
@@ -9085,7 +9093,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaGetCumulativeModelOnlineRecordsResponse"
+          $ref: '#/definitions/v1betaGetCumulativeModelOnlineRecordsResponse'
         title: A list of cumulative model online record lists
     title: |-
       GetBulkCumulativeModelOnlineRecordsResponse represents a response to
@@ -9099,7 +9107,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaGetCumulativePipelineTriggerRecordsResponse"
+          $ref: '#/definitions/v1betaGetCumulativePipelineTriggerRecordsResponse'
         title: A list of cumulative pipeline trigger record lists
     title: |-
       GetBulkCumulativePipelineTriggerRecordsResponse represents a response to
@@ -9113,7 +9121,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaGetModelOnlinePriceResponse"
+          $ref: '#/definitions/v1betaGetModelOnlinePriceResponse'
         title: A list of model online price lists
     title: |-
       GetBulkModelOnlinePriceResponse represents a response to
@@ -9127,7 +9135,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaGetModelOnlineRecordsResponse"
+          $ref: '#/definitions/v1betaGetModelOnlineRecordsResponse'
         title: A list of model online record lists
     title: |-
       GetBulkModelOnlineRecordsResponse represents a response to
@@ -9141,7 +9149,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaGetModelOnlineSummaryResponse"
+          $ref: '#/definitions/v1betaGetModelOnlineSummaryResponse'
         title: A list of model online usage summaries
     title: |-
       GetBulkModelOnlineSummaryResponse represents a response to
@@ -9155,7 +9163,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaGetPipelineTriggerPriceResponse"
+          $ref: '#/definitions/v1betaGetPipelineTriggerPriceResponse'
         title: A list of pipeline trigger price lists
     title: |-
       GetBulkPipelineTriggerPriceResponse represents a response to
@@ -9169,7 +9177,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaGetPipelineTriggerRecordsResponse"
+          $ref: '#/definitions/v1betaGetPipelineTriggerRecordsResponse'
         title: A list of pipeline trigger record lists
     title: |-
       GetBulkPipelineTriggerRecordsResponse represents a response to
@@ -9183,7 +9191,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaGetPipelineTriggerSummaryResponse"
+          $ref: '#/definitions/v1betaGetPipelineTriggerSummaryResponse'
         title: A list of pipeline trigger usage summaries
     title: |-
       GetBulkPipelineTriggerSummariesResponse represents a response to
@@ -9194,7 +9202,7 @@ definitions:
     type: object
     properties:
       connector_definition:
-        $ref: "#/definitions/v1betaConnectorDefinition"
+        $ref: '#/definitions/v1betaConnectorDefinition'
         title: A ConnectorDefinition resource
     title: |-
       GetConnectorDefinitionResponse represents a
@@ -9203,13 +9211,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       model:
-        $ref: "#/definitions/v1betaModelData"
+        $ref: '#/definitions/v1betaModelData'
         title: Model information
       time_interval:
-        $ref: "#/definitions/v1betaTimeInterval"
+        $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
       GetCumulativeModelOnlineRecordsRequest represents a query for cumulative
@@ -9225,7 +9233,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaModelUsageRecord"
+          $ref: '#/definitions/v1betaModelUsageRecord'
         title: A list of model online records in cumulative format
     title: |-
       GetCumulativeModelOnlineRecordsResponse represents a response to
@@ -9236,13 +9244,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       pipeline:
-        $ref: "#/definitions/v1betaPipelineData"
+        $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
       time_interval:
-        $ref: "#/definitions/v1betaTimeInterval"
+        $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
       GetCumulativePipelineTriggerRecordsRequest represents a query for cumulative
@@ -9257,7 +9265,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineUsageRecord"
+          $ref: '#/definitions/v1betaPipelineUsageRecord'
         title: Pipeline trigger records where values are in cumulative formats
     title: |-
       GetCumulativePipelineTriggerRecordsResponse represents a response to
@@ -9268,13 +9276,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       model:
-        $ref: "#/definitions/v1betaModelData"
+        $ref: '#/definitions/v1betaModelData'
         title: Pipeline information
       time_interval:
-        $ref: "#/definitions/v1betaTimeInterval"
+        $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
       GetPipelineTriggerPriceRequest represents a query for price data of the
@@ -9290,7 +9298,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPriceData"
+          $ref: '#/definitions/v1betaPriceData'
         title: |-
           A list of model online prices given the billing periods covered by the time
           interval
@@ -9303,13 +9311,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       model:
-        $ref: "#/definitions/v1betaModelData"
+        $ref: '#/definitions/v1betaModelData'
         title: Model information
       time_interval:
-        $ref: "#/definitions/v1betaTimeInterval"
+        $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: GetModelOnlineRecordsRequest represent a query for model online records
     required:
@@ -9323,7 +9331,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaModelUsageRecord"
+          $ref: '#/definitions/v1betaModelUsageRecord'
         title: A list of model trigger records
     title: |-
       GetModelOnlineRecordsResponse represents a response to
@@ -9334,13 +9342,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       model:
-        $ref: "#/definitions/v1betaModelData"
+        $ref: '#/definitions/v1betaModelData'
         title: Pipeline information
       time_interval:
-        $ref: "#/definitions/v1betaTimeInterval"
+        $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: GetModelOnlineSummaryRequest represents a query for model online summary
     required:
@@ -9351,7 +9359,7 @@ definitions:
     type: object
     properties:
       summary:
-        $ref: "#/definitions/v1betaUsageSummary"
+        $ref: '#/definitions/v1betaUsageSummary'
         title: The total model online usage in the time interval
     title: |-
       GetModelOnlineSummaryResponse represents a response to
@@ -9365,7 +9373,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaModelData"
+          $ref: '#/definitions/v1betaModelData'
         title: A list of model informations
     title: GetPipelinesResponse represents a respond to GetModelsRequest
     required:
@@ -9374,7 +9382,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: The retrieved longrunning operation
         readOnly: true
     title: |-
@@ -9384,7 +9392,7 @@ definitions:
     type: object
     properties:
       operator_definition:
-        $ref: "#/definitions/v1betaOperatorDefinition"
+        $ref: '#/definitions/v1betaOperatorDefinition'
         title: A Operator resource
     title: |-
       GetOperatorDefinitionResponse represents a
@@ -9393,14 +9401,14 @@ definitions:
     type: object
     properties:
       organization:
-        $ref: "#/definitions/v1betaOrganization"
+        $ref: '#/definitions/v1betaOrganization'
         title: A organization resource
     title: GetOrganizationAdminResponse represents a response for a organization resource
   v1betaGetOrganizationConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: connector
     title: |-
       GetOrganizationConnectorResponse represents a response for a
@@ -9409,55 +9417,55 @@ definitions:
     type: object
     properties:
       membership:
-        $ref: "#/definitions/v1betaOrganizationMembership"
+        $ref: '#/definitions/v1betaOrganizationMembership'
         title: A membership resource
     title: GetOrganizationMembershipResponse represents a response for a membership resource
   v1betaGetOrganizationPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: A pipeline_release resource
     title: GetOrganizationPipelineReleaseResponse represents a response for a pipeline_release resource
   v1betaGetOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: A pipeline resource
     title: GetOrganizationPipelineResponse represents a response for a pipeline resource
   v1betaGetOrganizationResponse:
     type: object
     properties:
       organization:
-        $ref: "#/definitions/v1betaOrganization"
+        $ref: '#/definitions/v1betaOrganization'
         title: A organization resource
     title: GetOrganizationResponse represents a response for a organization resource
   v1betaGetOrganizationSubscriptionAdminResponse:
     type: object
     properties:
       subscription:
-        $ref: "#/definitions/v1betaSubscription"
+        $ref: '#/definitions/v1betaSubscription'
         title: Subscription
     title: GetOrganizationSubscriptionAdminResponse
   v1betaGetOrganizationSubscriptionResponse:
     type: object
     properties:
       subscription:
-        $ref: "#/definitions/v1betaSubscription"
+        $ref: '#/definitions/v1betaSubscription'
         title: Subscription
     title: GetOrganizationSubscriptionResponse
   v1betaGetPipelineTriggerPriceRequest:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       pipeline:
-        $ref: "#/definitions/v1betaPipelineData"
+        $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
       time_interval:
-        $ref: "#/definitions/v1betaTimeInterval"
+        $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
       GetPipelineTriggerPriceRequest represents a query for pipeline trigger prices
@@ -9473,7 +9481,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPriceData"
+          $ref: '#/definitions/v1betaPriceData'
         title: |-
           A list of pipeline trigger prices given the billing periods covered by the
           time interval
@@ -9486,13 +9494,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       pipeline:
-        $ref: "#/definitions/v1betaPipelineData"
+        $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
       time_interval:
-        $ref: "#/definitions/v1betaTimeInterval"
+        $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
       GetPipelineTriggerRecordsRequest represents a query for pipeline trigger
@@ -9507,7 +9515,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineUsageRecord"
+          $ref: '#/definitions/v1betaPipelineUsageRecord'
         title: A list of pipeline trigger records
     title: |-
       GetPipelineTriggerRecordsResponse represents a response to
@@ -9518,13 +9526,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       pipeline:
-        $ref: "#/definitions/v1betaPipelineData"
+        $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
       time_interval:
-        $ref: "#/definitions/v1betaTimeInterval"
+        $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
       GetPipelineTriggerSummaryRequest represents a query for pipeline trigger
@@ -9536,7 +9544,7 @@ definitions:
     type: object
     properties:
       summaries:
-        $ref: "#/definitions/v1betaUsageSummary"
+        $ref: '#/definitions/v1betaUsageSummary'
         title: The total pipeline trigger usage in the time interval
     title: |-
       GetPipelineTriggerSummaryResponse represents a response to
@@ -9550,7 +9558,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineData"
+          $ref: '#/definitions/v1betaPipelineData'
         title: A list of pipeline informations
     title: GetPipelinesResponse represents a respond to GetPipelineRequest
     required:
@@ -9559,21 +9567,21 @@ definitions:
     type: object
     properties:
       token:
-        $ref: "#/definitions/v1betaApiToken"
+        $ref: '#/definitions/v1betaApiToken'
         title: An API token resource
     title: GetTokenResponse represents a response for an API token resource
   v1betaGetUserAdminResponse:
     type: object
     properties:
       user:
-        $ref: "#/definitions/mgmtv1betaUser"
+        $ref: '#/definitions/mgmtv1betaUser'
         title: A user resource
     title: GetUserAdminResponse represents a response for a user resource
   v1betaGetUserConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: connector
     title: |-
       GetUserConnectorResponse represents a response for a
@@ -9582,42 +9590,42 @@ definitions:
     type: object
     properties:
       membership:
-        $ref: "#/definitions/v1betaUserMembership"
+        $ref: '#/definitions/v1betaUserMembership'
         title: A membership resource
     title: GetUserMembershipResponse represents a response for a membership resource
   v1betaGetUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: A pipeline_release resource
     title: GetUserPipelineReleaseResponse represents a response for a pipeline_release resource
   v1betaGetUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: A pipeline resource
     title: GetUserPipelineResponse represents a response for a pipeline resource
   v1betaGetUserResponse:
     type: object
     properties:
       user:
-        $ref: "#/definitions/mgmtv1betaUser"
+        $ref: '#/definitions/mgmtv1betaUser'
         title: A user resource
     title: GetUserResponse represents a response for a user resource
   v1betaGetUserSubscriptionAdminResponse:
     type: object
     properties:
       subscription:
-        $ref: "#/definitions/v1betaSubscription"
+        $ref: '#/definitions/v1betaSubscription'
         title: Subscription
     title: GetUserSubscriptionAdminResponse
   v1betaGetUserSubscriptionResponse:
     type: object
     properties:
       subscription:
-        $ref: "#/definitions/v1betaSubscription"
+        $ref: '#/definitions/v1betaSubscription'
         title: Subscription
     title: GetUserSubscriptionResponse
   v1betaHealthCheckRequest:
@@ -9631,7 +9639,7 @@ definitions:
     type: object
     properties:
       status:
-        $ref: "#/definitions/HealthCheckResponseServingStatus"
+        $ref: '#/definitions/HealthCheckResponseServingStatus'
         title: Status is the instance of the enum type ServingStatus
     title: HealthCheckResponse represents a response for a service heath status
   v1betaListConnectorDefinitionsResponse:
@@ -9641,7 +9649,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaConnectorDefinition"
+          $ref: '#/definitions/v1betaConnectorDefinition'
         title: A list of ConnectorDefinition resources
       next_page_token:
         type: string
@@ -9660,7 +9668,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaConnectorExecuteChartRecord"
+          $ref: '#/definitions/v1betaConnectorExecuteChartRecord'
         title: A list of connector execute records
     title: |-
       ListConnectorExecuteChartRecordsResponse represents a response for a list
@@ -9672,7 +9680,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaConnectorExecuteRecord"
+          $ref: '#/definitions/v1betaConnectorExecuteRecord'
         title: A list of connector execute records
       next_page_token:
         type: string
@@ -9691,7 +9699,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaConnectorExecuteTableRecord"
+          $ref: '#/definitions/v1betaConnectorExecuteTableRecord'
         title: A list of connector execute records
       next_page_token:
         type: string
@@ -9710,7 +9718,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaConnector"
+          $ref: '#/definitions/v1betaConnector'
         title: A list of connectors
       next_page_token:
         type: string
@@ -9729,7 +9737,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaConnector"
+          $ref: '#/definitions/v1betaConnector'
         title: A list of connectors
       next_page_token:
         type: string
@@ -9748,7 +9756,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaOperatorDefinition"
+          $ref: '#/definitions/v1betaOperatorDefinition'
         title: A list of Operator resources
       next_page_token:
         type: string
@@ -9767,7 +9775,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaConnector"
+          $ref: '#/definitions/v1betaConnector'
         title: A list of connectors
       next_page_token:
         type: string
@@ -9786,7 +9794,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaOrganizationMembership"
+          $ref: '#/definitions/v1betaOrganizationMembership'
         title: A list of memberships
     title: ListOrganizationMembershipsResponse represents a response for a list of memberships
   v1betaListOrganizationPipelineReleasesResponse:
@@ -9796,7 +9804,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineRelease"
+          $ref: '#/definitions/v1betaPipelineRelease'
         title: A list of pipeline_release resources
       next_page_token:
         type: string
@@ -9813,7 +9821,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipeline"
+          $ref: '#/definitions/v1betaPipeline'
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -9830,7 +9838,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaOrganization"
+          $ref: '#/definitions/v1betaOrganization'
         title: A list of organizations
       next_page_token:
         type: string
@@ -9847,7 +9855,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaOrganization"
+          $ref: '#/definitions/v1betaOrganization'
         title: A list of organizations
       next_page_token:
         type: string
@@ -9864,7 +9872,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineRelease"
+          $ref: '#/definitions/v1betaPipelineRelease'
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -9884,7 +9892,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineTriggerChartRecord"
+          $ref: '#/definitions/v1betaPipelineTriggerChartRecord'
         title: A list of pipeline trigger records
     title: |-
       ListPipelineTriggerChartRecordsResponse represents a response for a list
@@ -9896,7 +9904,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineTriggerRecord"
+          $ref: '#/definitions/v1betaPipelineTriggerRecord'
         title: A list of pipeline trigger records
       next_page_token:
         type: string
@@ -9915,7 +9923,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineTriggerTableRecord"
+          $ref: '#/definitions/v1betaPipelineTriggerTableRecord'
         title: A list of pipeline trigger table records
       next_page_token:
         type: string
@@ -9934,7 +9942,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipeline"
+          $ref: '#/definitions/v1betaPipeline'
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -9954,7 +9962,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipeline"
+          $ref: '#/definitions/v1betaPipeline'
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -9971,7 +9979,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaApiToken"
+          $ref: '#/definitions/v1betaApiToken'
         title: A list of API tokens resources
       next_page_token:
         type: string
@@ -9988,7 +9996,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaConnector"
+          $ref: '#/definitions/v1betaConnector'
         title: A list of connectors
       next_page_token:
         type: string
@@ -10007,7 +10015,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaUserMembership"
+          $ref: '#/definitions/v1betaUserMembership'
         title: A list of memberships
     title: ListUserMembershipsResponse represents a response for a list of memberships
   v1betaListUserPipelineReleasesResponse:
@@ -10017,7 +10025,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineRelease"
+          $ref: '#/definitions/v1betaPipelineRelease'
         title: A list of pipeline_release resources
       next_page_token:
         type: string
@@ -10034,7 +10042,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipeline"
+          $ref: '#/definitions/v1betaPipeline'
         title: A list of pipeline resources
       next_page_token:
         type: string
@@ -10051,7 +10059,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/mgmtv1betaUser"
+          $ref: '#/definitions/mgmtv1betaUser'
         title: A list of users
       next_page_token:
         type: string
@@ -10068,7 +10076,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/mgmtv1betaUser"
+          $ref: '#/definitions/mgmtv1betaUser'
         title: A list of users
       next_page_token:
         type: string
@@ -10082,7 +10090,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: connector
     title: |-
       LookUpConnectorAdminResponse represents a response for a
@@ -10091,7 +10099,7 @@ definitions:
     type: object
     properties:
       connector_definition:
-        $ref: "#/definitions/v1betaConnectorDefinition"
+        $ref: '#/definitions/v1betaConnectorDefinition'
         title: Connector resource
     title: |-
       LookUpConnectorDefinitionAdminResponse represents a response for a
@@ -10100,7 +10108,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: connector
     title: |-
       LookUpConnectorResponse represents a response for a
@@ -10109,7 +10117,7 @@ definitions:
     type: object
     properties:
       operator_definition:
-        $ref: "#/definitions/v1betaOperatorDefinition"
+        $ref: '#/definitions/v1betaOperatorDefinition'
         title: operator resource
     title: |-
       LookUpOperatorAdminResponse represents a response for a
@@ -10118,28 +10126,28 @@ definitions:
     type: object
     properties:
       organization:
-        $ref: "#/definitions/v1betaOrganization"
+        $ref: '#/definitions/v1betaOrganization'
         title: A organization resource
     title: LookUpOrganizationAdminResponse represents a response for a organization resource by admin
   v1betaLookUpPipelineAdminResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: A pipeline resource
     title: LookUpPipelineAdminResponse represents a response for a pipeline resource
   v1betaLookUpPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: A pipeline resource
     title: LookUpPipelineResponse represents a response for a pipeline resource
   v1betaLookUpUserAdminResponse:
     type: object
     properties:
       user:
-        $ref: "#/definitions/mgmtv1betaUser"
+        $ref: '#/definitions/mgmtv1betaUser'
         title: A user resource
     title: LookUpUserAdminResponse represents a response for a user resource by admin
   v1betaMembershipState:
@@ -10161,7 +10169,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/mgmtv1betaUser"
+          $ref: '#/definitions/mgmtv1betaUser'
         title: Repeated user usage data
     title: Management service usage data
   v1betaMode:
@@ -10204,7 +10212,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaModelUsageDataUserUsageData"
+          $ref: '#/definitions/v1betaModelUsageDataUserUsageData'
         title: Usage data of all users in the model service
     title: Model service usage data
   v1betaModelUsageDataUserUsageData:
@@ -10217,10 +10225,10 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/UserUsageDataModelTriggerData"
+          $ref: '#/definitions/UserUsageDataModelTriggerData'
         title: Trigger data for each user
       owner_type:
-        $ref: "#/definitions/v1betaOwnerType"
+        $ref: '#/definitions/v1betaOwnerType'
         title: Owner type
     title: Per user usage data in the model service
     required:
@@ -10287,7 +10295,7 @@ definitions:
         title: Operator icon
         readOnly: true
       spec:
-        $ref: "#/definitions/v1betaOperatorSpec"
+        $ref: '#/definitions/v1betaOperatorSpec'
         title: Operator spec
         readOnly: true
       tombstone:
@@ -10363,7 +10371,7 @@ definitions:
       create_time:
         type: string
         format: date-time
-        title: "Owner type: fixed to `OWNER_TYPE_USER`"
+        title: 'Owner type: fixed to `OWNER_TYPE_USER`'
         readOnly: true
       update_time:
         type: string
@@ -10384,7 +10392,7 @@ definitions:
         type: object
         title: Profile Data
       owner:
-        $ref: "#/definitions/mgmtv1betaUser"
+        $ref: '#/definitions/mgmtv1betaUser'
         title: Owner
         readOnly: true
     title: Organization represents the content of a organization
@@ -10401,15 +10409,15 @@ definitions:
         type: string
         title: Role
       state:
-        $ref: "#/definitions/v1betaMembershipState"
+        $ref: '#/definitions/v1betaMembershipState'
         title: State
         readOnly: true
       user:
-        $ref: "#/definitions/mgmtv1betaUser"
+        $ref: '#/definitions/mgmtv1betaUser'
         title: User
         readOnly: true
       organization:
-        $ref: "#/definitions/v1betaOrganization"
+        $ref: '#/definitions/v1betaOrganization'
         title: Organization
         readOnly: true
     title: Membership represents the content of a membership
@@ -10431,7 +10439,7 @@ definitions:
     type: object
     properties:
       user:
-        $ref: "#/definitions/mgmtv1betaUser"
+        $ref: '#/definitions/mgmtv1betaUser'
         title: A user resource
     title: |-
       PatchAuthenticatedUserResponse represents a response for
@@ -10468,7 +10476,7 @@ definitions:
         type: string
         title: Pipeline description
       recipe:
-        $ref: "#/definitions/v1betaRecipe"
+        $ref: '#/definitions/v1betaRecipe'
         title: Pipeline recipe
       create_time:
         type: string
@@ -10490,11 +10498,11 @@ definitions:
         title: Pipeline delete time
         readOnly: true
       sharing:
-        $ref: "#/definitions/v1betaSharing"
+        $ref: '#/definitions/v1betaSharing'
         title: Pipeline sharing
       metadata:
         type: object
-        title: "Metadata: store Console-related data such as pipeline builder layout"
+        title: 'Metadata: store Console-related data such as pipeline builder layout'
       owner_name:
         type: string
         title: Owner Name
@@ -10507,14 +10515,14 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineRelease"
+          $ref: '#/definitions/v1betaPipelineRelease'
         title: Releases
         readOnly: true
       readme:
         type: string
         title: readme
       permission:
-        $ref: "#/definitions/v1betaPermission"
+        $ref: '#/definitions/v1betaPermission'
         title: Permission
         readOnly: true
     title: Pipeline represents the content of a pipeline
@@ -10555,7 +10563,7 @@ definitions:
         type: string
         title: PipelineRelease description
       recipe:
-        $ref: "#/definitions/v1betaRecipe"
+        $ref: '#/definitions/v1betaRecipe'
         title: Pipeline recipe snapshot
         readOnly: true
       create_time:
@@ -10583,7 +10591,7 @@ definitions:
         readOnly: true
       metadata:
         type: object
-        title: "Metadata: store Console-related data such as pipeline builder layout"
+        title: 'Metadata: store Console-related data such as pipeline builder layout'
       readme:
         type: string
         title: readme
@@ -10598,10 +10606,10 @@ definitions:
         type: string
         title: UID for the triggered pipeline
       trigger_mode:
-        $ref: "#/definitions/v1betaMode"
+        $ref: '#/definitions/v1betaMode'
         title: Trigger mode
       status:
-        $ref: "#/definitions/mgmtv1betaStatus"
+        $ref: '#/definitions/mgmtv1betaStatus'
         title: Status of pipeline trigger
         readOnly: true
       time_buckets:
@@ -10653,7 +10661,7 @@ definitions:
         type: string
         title: UID for the triggered pipeline
       trigger_mode:
-        $ref: "#/definitions/v1betaMode"
+        $ref: '#/definitions/v1betaMode'
         title: Trigger mode
       compute_time_duration:
         type: number
@@ -10661,7 +10669,7 @@ definitions:
         title: Total compute time duration for this pipeline trigger
         readOnly: true
       status:
-        $ref: "#/definitions/mgmtv1betaStatus"
+        $ref: '#/definitions/mgmtv1betaStatus'
         title: Final status for pipeline trigger
         readOnly: true
       pipeline_release_id:
@@ -10710,7 +10718,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaPipelineUsageDataUserUsageData"
+          $ref: '#/definitions/v1betaPipelineUsageDataUserUsageData'
         title: Usage data of all users in the pipeline service
     title: Pipeline service usage data
   v1betaPipelineUsageDataUserUsageData:
@@ -10723,10 +10731,10 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/UserUsageDataPipelineTriggerData"
+          $ref: '#/definitions/UserUsageDataPipelineTriggerData'
         title: Trigger data for each user
       owner_type:
-        $ref: "#/definitions/v1betaOwnerType"
+        $ref: '#/definitions/v1betaOwnerType'
         title: Owner type
     title: Per user usage data in the pipeline service
     required:
@@ -10785,7 +10793,7 @@ definitions:
     type: object
     properties:
       time:
-        $ref: "#/definitions/v1betaTimeInterval"
+        $ref: '#/definitions/v1betaTimeInterval'
         title: Time when the price record is generated
       currency:
         type: string
@@ -10809,14 +10817,14 @@ definitions:
         type: array
         items:
           type: object
-          $ref: "#/definitions/v1betaComponent"
+          $ref: '#/definitions/v1betaComponent'
         title: List of pipeline components
     title: Pipeline represents a pipeline recipe
   v1betaRenameOrganizationConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: A connector
     title: |-
       RenameOrganizationConnectorResponse represents a renamed Connector
@@ -10825,21 +10833,21 @@ definitions:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: A pipeline resource
     title: RenameOrganizationPipelineReleaseResponse represents a renamed pipeline release resource
   v1betaRenameOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: A pipeline resource
     title: RenameOrganizationPipelineResponse represents a renamed pipeline resource
   v1betaRenameUserConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: A connector
     title: |-
       RenameUserConnectorResponse represents a renamed Connector
@@ -10848,27 +10856,27 @@ definitions:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: A pipeline resource
     title: RenameUserPipelineReleaseResponse represents a renamed pipeline release resource
   v1betaRenameUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: A pipeline resource
     title: RenameUserPipelineResponse represents a renamed pipeline resource
   v1betaReportModelOnlineRequest:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       model:
-        $ref: "#/definitions/v1betaModelData"
+        $ref: '#/definitions/v1betaModelData'
         title: Model information
       cum_usage_record:
-        $ref: "#/definitions/v1betaModelUsageRecord"
+        $ref: '#/definitions/v1betaModelUsageRecord'
         title: Model online record
     title: |-
       ReportModelOnlineRequest represents a request for reporting a model-online
@@ -10881,7 +10889,7 @@ definitions:
     type: object
     properties:
       "null":
-        $ref: "#/definitions/v1betaNullMessage"
+        $ref: '#/definitions/v1betaNullMessage'
         title: Null message for empty response
     title: |-
       ReportModelOnlineResponse represents a respond to a model-online-record
@@ -10890,7 +10898,7 @@ definitions:
     type: object
     properties:
       "null":
-        $ref: "#/definitions/v1betaNullMessage"
+        $ref: '#/definitions/v1betaNullMessage'
         title: Null message for empty response
     title: |-
       ReportModelOnlinesResponse represents a respond to a model-online-records
@@ -10899,13 +10907,13 @@ definitions:
     type: object
     properties:
       user:
-        $ref: "#/definitions/v1betaUserData"
+        $ref: '#/definitions/v1betaUserData'
         title: User information
       pipeline:
-        $ref: "#/definitions/v1betaPipelineData"
+        $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
       usage_record:
-        $ref: "#/definitions/v1betaPipelineUsageRecord"
+        $ref: '#/definitions/v1betaPipelineUsageRecord'
         title: Pipeline trigger record
     title: |-
       ReportPipelineTriggerRequest represents a request for reporting a
@@ -10918,7 +10926,7 @@ definitions:
     type: object
     properties:
       "null":
-        $ref: "#/definitions/v1betaNullMessage"
+        $ref: '#/definitions/v1betaNullMessage'
         title: Null message for empty response
     title: |-
       ReportPipelineTriggerResponse represents a respond to a
@@ -10927,7 +10935,7 @@ definitions:
     type: object
     properties:
       "null":
-        $ref: "#/definitions/v1betaNullMessage"
+        $ref: '#/definitions/v1betaNullMessage'
         title: Null message for empty response
     title: |-
       ReportPipelineTriggersResponse represents a respond to a
@@ -10936,14 +10944,14 @@ definitions:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: A pipeline resource
     title: RestoreOrganizationPipelineReleaseResponse
   v1betaRestoreUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: A pipeline resource
     title: RestoreUserPipelineReleaseResponse
   v1betaRole:
@@ -10973,11 +10981,11 @@ definitions:
         title: Resource UUID
         readOnly: true
       service:
-        $ref: "#/definitions/SessionService"
+        $ref: '#/definitions/SessionService'
         title: name of the service to collect data from
       edition:
         type: string
-        title: "Session edition, allowed values include: 'local-ce' and 'local-ce:dev'"
+        title: 'Session edition, allowed values include: ''local-ce'' and ''local-ce:dev'''
       version:
         type: string
         title: Version of the service
@@ -11040,19 +11048,19 @@ definitions:
         type: string
         title: Proof-of-work See https://en.wikipedia.org/wiki/Proof_of_work
       session:
-        $ref: "#/definitions/v1betaSession"
+        $ref: '#/definitions/v1betaSession'
         title: Session
       mgmt_usage_data:
-        $ref: "#/definitions/v1betaMgmtUsageData"
+        $ref: '#/definitions/v1betaMgmtUsageData'
         title: Management service usage data
       connector_usage_data:
-        $ref: "#/definitions/v1betaConnectorUsageData"
+        $ref: '#/definitions/v1betaConnectorUsageData'
         title: Connector service usage data
       model_usage_data:
-        $ref: "#/definitions/v1betaModelUsageData"
+        $ref: '#/definitions/v1betaModelUsageData'
         title: Model service usage data
       pipeline_usage_data:
-        $ref: "#/definitions/v1betaPipelineUsageData"
+        $ref: '#/definitions/v1betaPipelineUsageData'
         title: Pipeline service usage data
     title: |-
       SessionReport represents a report to be sent to the server that includes the
@@ -11068,10 +11076,10 @@ definitions:
       users:
         type: object
         additionalProperties:
-          $ref: "#/definitions/v1betaSharingUser"
+          $ref: '#/definitions/v1betaSharingUser'
         title: users
       share_code:
-        $ref: "#/definitions/SharingShareCode"
+        $ref: '#/definitions/SharingShareCode'
         title: shared code
     title: Sharing
   v1betaSharingUser:
@@ -11081,7 +11089,7 @@ definitions:
         type: boolean
         title: enabled
       role:
-        $ref: "#/definitions/v1betaRole"
+        $ref: '#/definitions/v1betaRole'
         title: role
     title: User
   v1betaSubscription:
@@ -11091,14 +11099,14 @@ definitions:
         type: string
         title: plan
       quota:
-        $ref: "#/definitions/SubscriptionQuota"
+        $ref: '#/definitions/SubscriptionQuota'
         title: plan
     title: Subscription
   v1betaTestOrganizationConnectorResponse:
     type: object
     properties:
       state:
-        $ref: "#/definitions/v1betaConnectorState"
+        $ref: '#/definitions/v1betaConnectorState'
         title: Retrieved connector state
     title: |-
       TestOrganizationConnectorResponse represents a response containing a
@@ -11107,7 +11115,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: "#/definitions/v1betaConnectorState"
+        $ref: '#/definitions/v1betaConnectorState'
         title: Retrieved connector state
     title: |-
       TestUserConnectorResponse represents a response containing a
@@ -11133,7 +11141,7 @@ definitions:
       statuses:
         type: array
         items:
-          $ref: "#/definitions/v1betaTraceStatus"
+          $ref: '#/definitions/v1betaTraceStatus'
         title: status
       inputs:
         type: array
@@ -11171,7 +11179,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
@@ -11181,7 +11189,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
@@ -11191,7 +11199,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
@@ -11201,7 +11209,7 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: "#/definitions/googlelongrunningOperation"
+        $ref: '#/definitions/googlelongrunningOperation'
         title: Trigger async pipeline operation message
         readOnly: true
     title: |-
@@ -11213,8 +11221,8 @@ definitions:
       traces:
         type: object
         additionalProperties:
-          $ref: "#/definitions/v1betaTrace"
-        title: "The traces of the pipeline inference, {component_id: Trace}"
+          $ref: '#/definitions/v1betaTrace'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: The metadata
   v1betaTriggerOrganizationPipelineReleaseResponse:
     type: object
@@ -11225,8 +11233,8 @@ definitions:
           type: object
         title: The multiple model inference outputs
       metadata:
-        $ref: "#/definitions/v1betaTriggerMetadata"
-        title: "The traces of the pipeline inference, {component_id: Trace}"
+        $ref: '#/definitions/v1betaTriggerMetadata'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: |-
       TriggerOrganizationPipelineReleaseResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
@@ -11239,8 +11247,8 @@ definitions:
           type: object
         title: The multiple model inference outputs
       metadata:
-        $ref: "#/definitions/v1betaTriggerMetadata"
-        title: "The traces of the pipeline inference, {component_id: Trace}"
+        $ref: '#/definitions/v1betaTriggerMetadata'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: |-
       TriggerOrganizationPipelineResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
@@ -11253,8 +11261,8 @@ definitions:
           type: object
         title: The multiple model inference outputs
       metadata:
-        $ref: "#/definitions/v1betaTriggerMetadata"
-        title: "The traces of the pipeline inference, {component_id: Trace}"
+        $ref: '#/definitions/v1betaTriggerMetadata'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: |-
       TriggerUserPipelineReleaseResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
@@ -11267,8 +11275,8 @@ definitions:
           type: object
         title: The multiple model inference outputs
       metadata:
-        $ref: "#/definitions/v1betaTriggerMetadata"
-        title: "The traces of the pipeline inference, {component_id: Trace}"
+        $ref: '#/definitions/v1betaTriggerMetadata'
+        title: 'The traces of the pipeline inference, {component_id: Trace}'
     title: |-
       TriggerUserPipelineResponse represents a response for the output
       of a pipeline, i.e., the multiple model inference outputs
@@ -11276,7 +11284,7 @@ definitions:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: connector
     title: |-
       UpdateOrganizationConnectorResponse represents a response for a
@@ -11285,35 +11293,35 @@ definitions:
     type: object
     properties:
       membership:
-        $ref: "#/definitions/v1betaOrganizationMembership"
+        $ref: '#/definitions/v1betaOrganizationMembership'
         title: An updated membership resource
     title: UpdateOrganizationMembershipResponse represents a response for a membership resource
   v1betaUpdateOrganizationPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: An updated pipeline resource
     title: UpdateOrganizationPipelineReleaseResponse represents a response for a pipeline resource
   v1betaUpdateOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: An updated pipeline resource
     title: UpdateOrganizationPipelineResponse represents a response for a pipeline resource
   v1betaUpdateOrganizationResponse:
     type: object
     properties:
       organization:
-        $ref: "#/definitions/v1betaOrganization"
+        $ref: '#/definitions/v1betaOrganization'
         title: A organization resource
     title: UpdateOrganizationResponse represents a response for a organization resource
   v1betaUpdateUserConnectorResponse:
     type: object
     properties:
       connector:
-        $ref: "#/definitions/v1betaConnector"
+        $ref: '#/definitions/v1betaConnector'
         title: connector
     title: |-
       UpdateUserConnectorResponse represents a response for a
@@ -11322,21 +11330,21 @@ definitions:
     type: object
     properties:
       membership:
-        $ref: "#/definitions/v1betaUserMembership"
+        $ref: '#/definitions/v1betaUserMembership'
         title: An updated membership resource
     title: UpdateUserMembershipResponse represents a response for a membership resource
   v1betaUpdateUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: "#/definitions/v1betaPipelineRelease"
+        $ref: '#/definitions/v1betaPipelineRelease'
         title: An updated pipeline resource
     title: UpdateUserPipelineReleaseResponse represents a response for a pipeline resource
   v1betaUpdateUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: An updated pipeline resource
     title: UpdateUserPipelineResponse represents a response for a pipeline resource
   v1betaUsageSummary:
@@ -11378,14 +11386,14 @@ definitions:
         title: Role
         readOnly: true
       state:
-        $ref: "#/definitions/v1betaMembershipState"
+        $ref: '#/definitions/v1betaMembershipState'
         title: State
       user:
-        $ref: "#/definitions/mgmtv1betaUser"
+        $ref: '#/definitions/mgmtv1betaUser'
         title: User
         readOnly: true
       organization:
-        $ref: "#/definitions/v1betaOrganization"
+        $ref: '#/definitions/v1betaOrganization'
         title: Organization
         readOnly: true
     title: Membership represents the content of a membership
@@ -11395,7 +11403,7 @@ definitions:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: A pipeline resource
     title: ValidateOrganizationPipelineResponse represents an response of validated pipeline
   v1betaValidateTokenResponse:
@@ -11410,14 +11418,14 @@ definitions:
     type: object
     properties:
       pipeline:
-        $ref: "#/definitions/v1betaPipeline"
+        $ref: '#/definitions/v1betaPipeline'
         title: A pipeline resource
     title: ValidateUserPipelineResponse represents an response of validated pipeline
   v1betaWatchOrganizationConnectorResponse:
     type: object
     properties:
       state:
-        $ref: "#/definitions/v1betaConnectorState"
+        $ref: '#/definitions/v1betaConnectorState'
         title: Retrieved connector state
     title: |-
       WatchOrganizationConnectorResponse represents a response to fetch a
@@ -11426,7 +11434,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: "#/definitions/pipelinev1betaState"
+        $ref: '#/definitions/pipelinev1betaState'
         title: Retrieved pipeline state
     title: |-
       WatchOrganizationPipelineReleaseResponse represents a response to fetch a pipeline's
@@ -11435,7 +11443,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: "#/definitions/v1betaConnectorState"
+        $ref: '#/definitions/v1betaConnectorState'
         title: Retrieved connector state
     title: |-
       WatchUserConnectorResponse represents a response to fetch a
@@ -11444,7 +11452,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: "#/definitions/pipelinev1betaState"
+        $ref: '#/definitions/pipelinev1betaState'
         title: Retrieved pipeline state
     title: |-
       WatchUserPipelineReleaseResponse represents a response to fetch a pipeline's
@@ -11453,27 +11461,27 @@ definitions:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdpcontrollerv1betaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
   vdppipelinev1betaLivenessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   vdppipelinev1betaReadinessResponse:
     type: object
     properties:
       health_check_response:
-        $ref: "#/definitions/v1betaHealthCheckResponse"
+        $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status


### PR DESCRIPTION
Because ... 

- This update is necessitated by the need to align our current text-generation-task schema more closely with OpenAI's task structure.

This commit .. 

1. **Enhancement of TASK_TEXT_GENERATION**: Following our discussion in [INS-2982](https://linear.app/instill-ai/issue/INS-2982/harmonizing-the-text-generation-tasks-protocol-buffer-with-the-openai), we have introduced three new fields to the `TASK_TEXT_GENERATION` protocol buffer:
   - An optional `admin_message` string.
   - An optional `chat_history` field, now mirroring the type used in `conversation`.
   - An optional `image_url` string, which is a base64 encoded string including batch dimension.

2. **Improved `extra_param` Support**: To offer enhanced functionality for the `extra_param`, we have implemented the suggestions in [INS-2954](https://linear.app/instill-ai/issue/INS-2954/improve-param-value-filed-type).
