### PR TITLE
docs(openapi): Validate OpenAPI against readme.io validator

### DIFF
--- a/.github/workflows/buf-gen-openapi.yaml
+++ b/.github/workflows/buf-gen-openapi.yaml
@@ -25,11 +25,9 @@ jobs:
         run: |
           buf generate
       - name: Lint generated OpenAPI definitions
-        uses: mhiew/redoc-lint-github-action@v3
+        uses: mbowman100/swagger-validator-action@master
         with:
-          # Named path parameters (e.g. `/admin/{pipeline.permalink}/lookUp`)
-          # cause linter errors despite being unambiguously resolved.
-          args: openapiv2/openapiv2.swagger.yaml --skip-rule=no-ambiguous-paths --skip-rule=no-identical-paths
+          files: openapiv2/openapiv2.swagger.yaml
       - name: Commit and push
         run: |
           if [[ `git status --porcelain` ]]; then

--- a/common/openapi/v1beta/options.proto
+++ b/common/openapi/v1beta/options.proto
@@ -20,7 +20,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       url: "https://github.com/instill-ai/protobufs/blob/main/LICENSE";
     };
   };
-  host: "https://api.instill.tech";
+  host: "api.instill.tech";
   external_docs: {
     url: "https://www.instill.tech/docs";
     description: "More about Instill AI";

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -304,7 +304,7 @@ message GetUserResponse {
 // authenticated user.
 message PatchAuthenticatedUserRequest {
   // The user fields that will replace the existing ones.
-  User user = 1 [(google.api.field_behavior) = REQUIRED];
+  User user = 1;
   // The update mask specifies the subset of fields that should be modified.
   //
   // For more information about this field, see
@@ -407,7 +407,7 @@ message ApiToken {
 // CreateTokenRequest represents a request to create an API token.
 message CreateTokenRequest {
   // The properties of the token to be created.
-  ApiToken token = 1 [(google.api.field_behavior) = REQUIRED];
+  ApiToken token = 1;
 }
 
 // CreateTokenResponse contains the created token.
@@ -612,7 +612,7 @@ message ListOrganizationsResponse {
 // CreateOrganizationRequest represents a request to create an organization.
 message CreateOrganizationRequest {
   // The properties of the organization to be created.
-  Organization organization = 1 [(google.api.field_behavior) = REQUIRED];
+  Organization organization = 1;
 }
 
 // CreateOrganizationResponse contains the created organization.

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -21,7 +21,7 @@ tags:
     externalDocs:
       description: More about VDP
       url: https://github.com/instill-ai/vdp
-host: https://api.instill.tech
+host: api.instill.tech
 schemes:
   - http
   - https
@@ -775,8 +775,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaConnector'
-            required:
-              - connector
       tags:
         - PipelinePublicService
   /v1beta/{organization.name}/memberships:
@@ -913,8 +911,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaPipeline'
-            required:
-              - pipeline
       tags:
         - PipelinePublicService
   /v1beta/{organization.name}/releases:
@@ -1022,8 +1018,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaPipelineRelease'
-            required:
-              - release
       tags:
         - PipelinePublicService
   /v1beta/{organization.name}/subscription:
@@ -2646,8 +2640,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaConnector'
-            required:
-              - connector
       tags:
         - PipelinePublicService
   /v1beta/{user.name}/memberships:
@@ -2788,8 +2780,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaPipeline'
-            required:
-              - pipeline
       tags:
         - PipelinePublicService
   /v1beta/{user.name}/releases:
@@ -2900,8 +2890,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaPipelineRelease'
-            required:
-              - release
       tags:
         - PipelinePublicService
   /v1beta/{user.name}/subscription:
@@ -4546,8 +4534,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaOrganization'
-            required:
-              - organization
       tags:
         - MgmtPublicService
   /v1beta/pipelines:
@@ -4671,8 +4657,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaApiToken'
-            required:
-              - token
       tags:
         - MgmtPublicService
   /v1beta/users:
@@ -4759,8 +4743,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/mgmtv1betaUser'
-            required:
-              - user
       tags:
         - MgmtPublicService
   /v1beta/validate_token:

--- a/vdp/pipeline/v1beta/connector.proto
+++ b/vdp/pipeline/v1beta/connector.proto
@@ -163,7 +163,7 @@ message LookUpConnectorResponse {
 // connector.
 message CreateUserConnectorRequest {
   // The properties of the connector to be created.
-  Connector connector = 1 [(google.api.field_behavior) = REQUIRED];
+  Connector connector = 1;
   // The parent resource, i.e., the user that creates the connector.
   // - Format: `users/{user.id}`.
   string parent = 2 [
@@ -413,7 +413,7 @@ message WatchUserConnectorResponse {
 // to create a connector.
 message CreateOrganizationConnectorRequest {
   // The properties of the connector to be created.
-  Connector connector = 1 [(google.api.field_behavior) = REQUIRED];
+  Connector connector = 1;
   // The parent resource, i.e., the organization that creates the connector.
   // - Format: `organizations/{organization.id}`.
   string parent = 2 [

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -288,7 +288,7 @@ message LookUpPipelineResponse {
 // pipeline.
 message CreateUserPipelineRequest {
   // The properties of the pipeline to be created.
-  Pipeline pipeline = 1 [(google.api.field_behavior) = REQUIRED];
+  Pipeline pipeline = 1;
   // The parent resource, i.e., the user that creates the pipeline.
   // - Format: `users/{user.id}`.
   string parent = 2 [
@@ -504,7 +504,7 @@ message TriggerAsyncUserPipelineResponse {
 // in a user-owned pipeline.
 message CreateUserPipelineReleaseRequest {
   // The release information.
-  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
+  PipelineRelease release = 1;
   // Name of the pipeline for which the release will be created.
   // Format: `users/{user.id}/pipelines/{pipeline.id}`
   string parent = 2 [
@@ -741,7 +741,7 @@ message TriggerAsyncUserPipelineReleaseResponse {
 // to create a pipeline.
 message CreateOrganizationPipelineRequest {
   // The properties of the pipeline to be created.
-  Pipeline pipeline = 1 [(google.api.field_behavior) = REQUIRED];
+  Pipeline pipeline = 1;
   // The parent resource, i.e., the organization that creates the pipeline.
   // - Format: `organizations/{organization.id}`.
   string parent = 2 [
@@ -957,7 +957,7 @@ message TriggerAsyncOrganizationPipelineResponse {
 // version in an organization-owned pipeline.
 message CreateOrganizationPipelineReleaseRequest {
   // The release information.
-  PipelineRelease release = 1 [(google.api.field_behavior) = REQUIRED];
+  PipelineRelease release = 1;
   // Name of the pipeline for which the release will be created.
   // Format: `organizations/{organization.id}/pipelines/{pipeline.id}`
   string parent = 2 [


### PR DESCRIPTION
Because

- We want to publish our docs in readme.io
- The upload step fails on validation (against `swagger-cli`)

This commit

- Updates the proto definitions to produce a valid OpenAPI output
- Updates the GHA linter

## Notes

Validation errors:
```
> swagger-cli validate openapiv2/openapiv2.swagger.yaml
Swagger schema validation failed.
#/host must match pattern "^[^{}/ :\\]+(?::\d+)?$"
Property 'connector' listed as required but does not exist in '/paths/v1beta/{organization.name}/connectors/post/parameters/connector'
Property 'connector' listed as required but does not exist in '/paths/v1beta/{organization.name}/connectors/post/parameters/connector'
Property 'pipeline' listed as required but does not exist in '/paths/v1beta/{organization.name}/pipelines/post/parameters/pipeline'
Property 'release' listed as required but does not exist in '/paths/v1beta/{organization.name}/releases/post/parameters/release'
```

- `host` format is corrected quite easily.
- About the `REQUIRED` field behaviour deletions, these are ony problematic when we map the HTTP request body to a field in the proto request message. This already [produces the `required: true` output](https://github.com/instill-ai/protobufs/pull/247/files#diff-f04d4351e93e5851ea23dfdede1c557068641a468fd40127559653b8371036d1L913) in OpenAPI and the option produced [another `required` statement](https://github.com/instill-ai/protobufs/pull/247/files#diff-f04d4351e93e5851ea23dfdede1c557068641a468fd40127559653b8371036d1L916) that didn't make sense (the object doesn't have itself as a field).