### PR TITLE
chore(pipeline): add `Visibility` enum in pipeline

### DIFF
--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -5329,7 +5329,8 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com.
+          type.googleapis.com. As of May 2023, there are no widely used type server
+          implementations and no plans to implement one.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -5364,7 +5365,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-      Example 3: Pack and unpack a message in Python.
+       Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -5374,7 +5375,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-      Example 4: Pack and unpack a message in Go
+       Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -5394,7 +5395,7 @@ definitions:
       name "y.z".
 
       JSON
-
+      ====
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -5426,7 +5427,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-       The JSON representation for `NullValue` is JSON `null`.
+      The JSON representation for `NullValue` is JSON `null`.
 
        - NULL_VALUE: Null value.
   v1alphaBoundingBox:

--- a/openapiv2/openapiv2.swagger.yaml
+++ b/openapiv2/openapiv2.swagger.yaml
@@ -2153,6 +2153,10 @@ paths:
                 $ref: '#/definitions/v1betaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
+              visibility:
+                $ref: '#/definitions/v1betaPipelineVisibility'
+                description: Pipeline visibility.
+                readOnly: true
             title: The pipeline fields that will replace the existing ones.
       tags:
         - PipelinePublicService
@@ -2258,6 +2262,10 @@ paths:
               permission:
                 $ref: '#/definitions/v1betaPermission'
                 description: Permission defines how a pipeline can be used.
+                readOnly: true
+              visibility:
+                $ref: '#/definitions/v1betaPipelineVisibility'
+                description: Pipeline visibility.
                 readOnly: true
             title: The pipeline fields that will replace the existing ones.
       tags:
@@ -4598,6 +4606,19 @@ paths:
           in: query
           required: false
           type: boolean
+        - name: visibility
+          description: |-
+            Limit results to pipelines with the specified visibility.
+
+             - VISIBILITY_UNSPECIFIED: Unspecified, equivalent to PRIVATE.
+             - VISIBILITY_PRIVATE: Only the user can see the pipeline.
+             - VISIBILITY_PUBLIC: Other users can see the pipeline.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VISIBILITY_PRIVATE
+            - VISIBILITY_PUBLIC
       tags:
         - PipelinePublicService
   /v1beta/tokens:
@@ -5308,8 +5329,7 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com. As of May 2023, there are no widely used type server
-          implementations and no plans to implement one.
+          type.googleapis.com.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -5344,7 +5364,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-       Example 3: Pack and unpack a message in Python.
+      Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -5354,7 +5374,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-       Example 4: Pack and unpack a message in Go
+      Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -5374,7 +5394,7 @@ definitions:
       name "y.z".
 
       JSON
-      ====
+
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -5406,7 +5426,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-      The JSON representation for `NullValue` is JSON `null`.
+       The JSON representation for `NullValue` is JSON `null`.
 
        - NULL_VALUE: Null value.
   v1alphaBoundingBox:
@@ -8863,6 +8883,10 @@ definitions:
         $ref: '#/definitions/v1betaPermission'
         description: Permission defines how a pipeline can be used.
         readOnly: true
+      visibility:
+        $ref: '#/definitions/v1betaPipelineVisibility'
+        description: Pipeline visibility.
+        readOnly: true
     description: |-
       A Pipeline is an end-to-end workflow that automates a sequence of components
       to process data.
@@ -9138,6 +9162,17 @@ definitions:
        - VIEW_BASIC: Default view, only includes basic information.
        - VIEW_FULL: Full representation.
        - VIEW_RECIPE: Contains the recipe of the resource.
+  v1betaPipelineVisibility:
+    type: string
+    enum:
+      - VISIBILITY_PRIVATE
+      - VISIBILITY_PUBLIC
+    description: |-
+      Visibility defines who can access the pipeline.
+
+       - VISIBILITY_UNSPECIFIED: Unspecified, equivalent to PRIVATE.
+       - VISIBILITY_PRIVATE: Only the user can see the pipeline.
+       - VISIBILITY_PUBLIC: Other users can see the pipeline.
   v1betaPriceData:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -132,6 +132,16 @@ message Pipeline {
     VIEW_RECIPE = 3;
   }
 
+  // Visibility defines who can access the pipeline.
+  enum Visibility {
+    // Unspecified, equivalent to PRIVATE.
+    VISIBILITY_UNSPECIFIED = 0;
+    // Only the user can see the pipeline.
+    VISIBILITY_PRIVATE = 1;
+    // Other users can see the pipeline.
+    VISIBILITY_PUBLIC = 2;
+  }
+
   // The name of the pipeline, defined by its owner and ID.
   // - Format: `users/{user.id}/pipelines/{pipeline.id}`.
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -168,6 +178,8 @@ message Pipeline {
   string readme = 20 [(google.api.field_behavior) = OPTIONAL];
   // Permission defines how a pipeline can be used.
   Permission permission = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Pipeline visibility.
+  Visibility visibility = 22 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // TriggerMetadata contains the traces of the pipeline inference.
@@ -257,6 +269,8 @@ message ListPipelinesRequest {
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // Include soft-deleted pipelines in the result.
   optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Limit results to pipelines with the specified visibility.
+  optional Pipeline.Visibility visibility = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelinesResponse contains a list of pipelines.


### PR DESCRIPTION
Because

- Currently, we have the `ListPipelines` API that returns all the pipelines to which the user has permissions. However, in the Instill Hub, we only want to list the public pipelines that all users have permission to access. Instead of introducing a new API, we have decided to use a query parameter to limit the results.

This commit

- add `Visibility` enum in pipeline message
- add `Visibility` param in the request of `ListPipelines`
