### PR TITLE
docs(openapi): fix path param rendering in readme.io

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -161,7 +161,7 @@ message GetUserAdminRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/User",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -224,7 +224,7 @@ message GetOrganizationAdminRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Organization",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -287,7 +287,7 @@ message GetUserRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/User",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -444,7 +444,7 @@ message GetTokenRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "token.name"}
+      field_configuration: {path_param_name: "token_name"}
     }
   ];
 }
@@ -463,7 +463,7 @@ message DeleteTokenRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "token.name"}
+      field_configuration: {path_param_name: "token_name"}
     }
   ];
 }
@@ -557,7 +557,13 @@ message Organization {
 
   // The name of the organization, defined by its ID.
   // - Format: `organization/{organization.id}`.
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string name = 1 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "organization_name"}
+    }
+  ];
+
   // Organization UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Resource ID (used in `name` as the last segment). This conforms to
@@ -630,7 +636,7 @@ message GetOrganizationRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Organization",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -668,7 +674,7 @@ message DeleteOrganizationRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "api.instill.tech/Organization",
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
 }
@@ -682,7 +688,13 @@ message OrganizationMembership {
   // The resource name of the membership, which allows its access by
   // organization and user ID.
   // - Format: `organizations/{organization.id}/memberships/{user.id}`.
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string name = 1 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "organization_membership_name"}
+    }
+  ];
+
   // Role of the user in the organization.
   string role = 3 [(google.api.field_behavior) = REQUIRED];
   // State of the membership.
@@ -699,7 +711,13 @@ message UserMembership {
   // The resource name of the membership, which allows its access by user and
   // organization ID.
   // - Format: `users/{user.id}/memberships/{organization.id}`.
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string name = 1 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_membership_name"}
+    }
+  ];
+
   // Role of the user in the organization.
   string role = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // State of the membership.
@@ -719,7 +737,7 @@ message ListUserMembershipsRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
 }
@@ -739,7 +757,7 @@ message GetUserMembershipRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/UserMembership"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_membership.name"}
+      field_configuration: {path_param_name: "user_membership_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -779,7 +797,7 @@ message DeleteUserMembershipRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/UserMembership"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_membership.name"}
+      field_configuration: {path_param_name: "user_membership_name"}
     }
   ];
 }
@@ -797,7 +815,7 @@ message ListOrganizationMembershipsRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
 }
@@ -819,7 +837,7 @@ message GetOrganizationMembershipRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/OrganizationMembership"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_membership.name"}
+      field_configuration: {path_param_name: "organization_membership_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -860,7 +878,7 @@ message DeleteOrganizationMembershipRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/OrganizationMembership"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_membership.name"}
+      field_configuration: {path_param_name: "organization_membership_name"}
     }
   ];
 }
@@ -883,7 +901,7 @@ message GetUserSubscriptionRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/User"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
 }
@@ -904,7 +922,7 @@ message GetOrganizationSubscriptionRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
 }

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -23,7 +23,76 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1beta/{membership.name_1}:
+  /v1beta/{organization_membership_name}:
+    get:
+      summary: Get a an organization membership
+      description: Returns the details of a user membership within an organization.
+      operationId: MgmtPublicService_GetOrganizationMembership
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetOrganizationMembershipResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_membership_name
+          description: |-
+            The resource name of the membership, which allows its access by
+            organization and user ID.
+            - Format: `organizations/{organization.id}/memberships/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/memberships/[^/]+
+        - name: view
+          description: |-
+            View allows clients to specify the desired resource view in the response.
+
+             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+      tags:
+        - MgmtPublicService
+    delete:
+      summary: Delete an organization membership
+      description: Deletes a user membership within an organization.
+      operationId: MgmtPublicService_DeleteOrganizationMembership
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDeleteOrganizationMembershipResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_membership_name
+          description: |-
+            The resource name of the membership, which allows its access by
+            organization and user ID.
+            - Format: `organizations/{organization.id}/memberships/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/memberships/[^/]+
+      tags:
+        - MgmtPublicService
     put:
       summary: Uppdate an organization membership
       description: Updates a user membership within an organization.
@@ -41,7 +110,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: membership.name_1
+        - name: organization_membership_name
           description: |-
             The resource name of the membership, which allows its access by
             organization and user ID.
@@ -86,70 +155,7 @@ paths:
           type: string
       tags:
         - MgmtPublicService
-  /v1beta/{membership.name}:
-    put:
-      summary: Update a user membership
-      description: Accesses and updates a user membership by parent and membership IDs.
-      operationId: MgmtPublicService_UpdateUserMembership
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaUpdateUserMembershipResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: membership.name
-          description: |-
-            The resource name of the membership, which allows its access by user and
-            organization ID.
-            - Format: `users/{user.id}/memberships/{organization.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/memberships/[^/]+
-        - name: membership
-          description: The membership fields to update.
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              role:
-                type: string
-                description: Role of the user in the organization.
-                readOnly: true
-              state:
-                $ref: '#/definitions/v1betaMembershipState'
-                description: State of the membership.
-              user:
-                $ref: '#/definitions/v1betaUser'
-                description: User information.
-                readOnly: true
-              organization:
-                $ref: '#/definitions/v1betaOrganization'
-                description: Organization information.
-                readOnly: true
-            title: The membership fields to update.
-            required:
-              - state
-        - name: update_mask
-          description: |-
-            The update mask specifies the subset of fields that should be modified.
-
-            For more information about this field, see
-            https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
-          in: query
-          required: true
-          type: string
-      tags:
-        - MgmtPublicService
-  /v1beta/{organization.name}:
+  /v1beta/{organization_name}:
     get:
       summary: Get an organization
       description: Returns the organization details by its ID.
@@ -167,7 +173,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The resource name of the organization, which allows its access by ID.
             - Format: `organizations/{organization.id}`.
@@ -207,7 +213,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The resource name of the organization, which allows its access by ID.
             - Format: `organizations/{organization.id}`.
@@ -238,7 +244,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The name of the organization, defined by its ID.
             - Format: `organization/{organization.id}`.
@@ -298,7 +304,7 @@ paths:
               - id
       tags:
         - MgmtPublicService
-  /v1beta/{organization.name}/memberships:
+  /v1beta/{organization_name}/memberships:
     get:
       summary: List organization memberships
       description: Returns a paginated list of the user memberships in an organization.
@@ -316,7 +322,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The parent resource, i.e., the organization to which the memberships
             belong.
@@ -327,7 +333,7 @@ paths:
           pattern: organizations/[^/]+
       tags:
         - MgmtPublicService
-  /v1beta/{organization.name}/subscription:
+  /v1beta/{organization_name}/subscription:
     get:
       summary: Get an organization subscription
       description: Returns the subscription details of an organization.
@@ -345,7 +351,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The parent resource, i.e., the organization to which the subscription
             refers.
@@ -356,77 +362,7 @@ paths:
           pattern: organizations/[^/]+
       tags:
         - MgmtPublicService
-  /v1beta/{organization_membership.name}:
-    get:
-      summary: Get a an organization membership
-      description: Returns the details of a user membership within an organization.
-      operationId: MgmtPublicService_GetOrganizationMembership
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetOrganizationMembershipResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_membership.name
-          description: |-
-            The resource name of the membership, which allows its access by
-            organization and user ID.
-            - Format: `organizations/{organization.id}/memberships/{user.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/memberships/[^/]+
-        - name: view
-          description: |-
-            View allows clients to specify the desired resource view in the response.
-
-             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
-             - VIEW_BASIC: Default view, only includes basic information.
-             - VIEW_FULL: Full representation.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-      tags:
-        - MgmtPublicService
-    delete:
-      summary: Delete an organization membership
-      description: Deletes a user membership within an organization.
-      operationId: MgmtPublicService_DeleteOrganizationMembership
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaDeleteOrganizationMembershipResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_membership.name
-          description: |-
-            The resource name of the membership, which allows its access by
-            organization and user ID.
-            - Format: `organizations/{organization.id}/memberships/{user.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/memberships/[^/]+
-      tags:
-        - MgmtPublicService
-  /v1beta/{token.name}:
+  /v1beta/{token_name}:
     get:
       summary: Get an API token
       description: Returns the details of an API token.
@@ -444,7 +380,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: token.name
+        - name: token_name
           description: |-
             The resource name of the token, which allows its access by ID.
             - Format: `tokens/{token.id}`.
@@ -471,7 +407,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: token.name
+        - name: token_name
           description: |-
             The resource name of the token, which allows its access by ID.
             - Format: `tokens/{token.id}`.
@@ -481,104 +417,7 @@ paths:
           pattern: tokens/[^/]+
       tags:
         - MgmtPublicService
-  /v1beta/{user.name}:
-    get:
-      summary: Get a user
-      description: Returns the details of a user by their ID.
-      operationId: MgmtPublicService_GetUser
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetUserResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user.name
-          description: |-
-            The resource name of the user, which allows its access by ID.
-            - Format: `users/{user.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+
-        - name: view
-          description: |-
-            View allows clients to specify the desired resource view in the response.
-
-             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
-             - VIEW_BASIC: Default view, only includes basic information.
-             - VIEW_FULL: Full representation.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-      tags:
-        - MgmtPublicService
-  /v1beta/{user.name}/memberships:
-    get:
-      summary: List user memberships
-      description: Returns the memberships of a user.
-      operationId: MgmtPublicService_ListUserMemberships
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaListUserMembershipsResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user.name
-          description: |-
-            The parent resource, i.e., the user to which the memberships belong.
-            Format: `users/{user.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+
-      tags:
-        - MgmtPublicService
-  /v1beta/{user.name}/subscription:
-    get:
-      summary: Get a user subscription
-      description: Returns the subscription details of a user.
-      operationId: MgmtPublicService_GetUserSubscription
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetUserSubscriptionResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user.name
-          description: |-
-            The parent resource, i.e., the user to which the subscription refers.
-            Format: `users/{user.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+
-      tags:
-        - MgmtPublicService
-  /v1beta/{user_membership.name}:
+  /v1beta/{user_membership_name}:
     get:
       summary: Get a user membership
       description: |-
@@ -598,7 +437,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_membership.name
+        - name: user_membership_name
           description: |-
             The resource name of the membership, which allows its access by user and
             organization ID.
@@ -639,7 +478,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_membership.name
+        - name: user_membership_name
           description: |-
             The resource name of the membership, which allows its access by user and
             organization ID.
@@ -648,6 +487,165 @@ paths:
           required: true
           type: string
           pattern: users/[^/]+/memberships/[^/]+
+      tags:
+        - MgmtPublicService
+    put:
+      summary: Update a user membership
+      description: Accesses and updates a user membership by parent and membership IDs.
+      operationId: MgmtPublicService_UpdateUserMembership
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaUpdateUserMembershipResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_membership_name
+          description: |-
+            The resource name of the membership, which allows its access by user and
+            organization ID.
+            - Format: `users/{user.id}/memberships/{organization.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/memberships/[^/]+
+        - name: membership
+          description: The membership fields to update.
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              role:
+                type: string
+                description: Role of the user in the organization.
+                readOnly: true
+              state:
+                $ref: '#/definitions/v1betaMembershipState'
+                description: State of the membership.
+              user:
+                $ref: '#/definitions/v1betaUser'
+                description: User information.
+                readOnly: true
+              organization:
+                $ref: '#/definitions/v1betaOrganization'
+                description: Organization information.
+                readOnly: true
+            title: The membership fields to update.
+            required:
+              - state
+        - name: update_mask
+          description: |-
+            The update mask specifies the subset of fields that should be modified.
+
+            For more information about this field, see
+            https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+          in: query
+          required: true
+          type: string
+      tags:
+        - MgmtPublicService
+  /v1beta/{user_name}:
+    get:
+      summary: Get a user
+      description: Returns the details of a user by their ID.
+      operationId: MgmtPublicService_GetUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetUserResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_name
+          description: |-
+            The resource name of the user, which allows its access by ID.
+            - Format: `users/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+        - name: view
+          description: |-
+            View allows clients to specify the desired resource view in the response.
+
+             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+      tags:
+        - MgmtPublicService
+  /v1beta/{user_name}/memberships:
+    get:
+      summary: List user memberships
+      description: Returns the memberships of a user.
+      operationId: MgmtPublicService_ListUserMemberships
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaListUserMembershipsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_name
+          description: |-
+            The parent resource, i.e., the user to which the memberships belong.
+            Format: `users/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+      tags:
+        - MgmtPublicService
+  /v1beta/{user_name}/subscription:
+    get:
+      summary: Get a user subscription
+      description: Returns the subscription details of a user.
+      operationId: MgmtPublicService_GetUserSubscription
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetUserSubscriptionResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_name
+          description: |-
+            The parent resource, i.e., the user to which the subscription refers.
+            Format: `users/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
       tags:
         - MgmtPublicService
   /v1beta/check-namespace:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -23,7 +23,48 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1beta/{connector.name_1}:
+  /v1beta/{connector_definition_name}:
+    get:
+      summary: Get connector definition
+      description: Returns the details of a connector definition.
+      operationId: PipelinePublicService_GetConnectorDefinition
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetConnectorDefinitionResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: connector_definition_name
+          description: |-
+            The resource name of the connector definition, which allows its access by ID.
+            - Format: `connector-definitions/{id}`.
+          in: path
+          required: true
+          type: string
+          pattern: connector-definitions/[^/]+
+        - name: view
+          description: |-
+            View allows clients to specify the desired resource view in the response.
+
+             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+      tags:
+        - PipelinePublicService
+  /v1beta/{connector_name_1}:
     patch:
       summary: Update a connector owned by an organization.
       description: |-
@@ -45,7 +86,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: connector.name_1
+        - name: connector_name_1
           description: |-
             The name of the connector, defined by its ID.
             - Format: `connectors/{id}`.
@@ -130,7 +171,7 @@ paths:
               - configuration
       tags:
         - PipelinePublicService
-  /v1beta/{connector.name}:
+  /v1beta/{connector_name}:
     patch:
       summary: Update a connector owned by a user.
       description: |-
@@ -153,7 +194,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: connector.name
+        - name: connector_name
           description: |-
             The name of the connector, defined by its ID.
             - Format: `connectors/{id}`.
@@ -238,47 +279,6 @@ paths:
               - configuration
       tags:
         - PipelinePublicService
-  /v1beta/{connector_definition.name}:
-    get:
-      summary: Get connector definition
-      description: Returns the details of a connector definition.
-      operationId: PipelinePublicService_GetConnectorDefinition
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetConnectorDefinitionResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: connector_definition.name
-          description: |-
-            The resource name of the connector definition, which allows its access by ID.
-            - Format: `connector-definitions/{id}`.
-          in: path
-          required: true
-          type: string
-          pattern: connector-definitions/[^/]+
-        - name: view
-          description: |-
-            View allows clients to specify the desired resource view in the response.
-
-             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
-             - VIEW_BASIC: Default view, only includes basic information.
-             - VIEW_FULL: Full representation.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-      tags:
-        - PipelinePublicService
   /v1beta/{name}:
     get:
       summary: Get the details of a long-running operation
@@ -309,7 +309,7 @@ paths:
           pattern: operations/[^/]+
       tags:
         - PipelinePublicService
-  /v1beta/{operator_definition.name}:
+  /v1beta/{operator_definition_name}:
     get:
       summary: Get operator definition
       description: Returns the details of an operator definition.
@@ -327,7 +327,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: operator_definition.name
+        - name: operator_definition_name
           description: |-
             The resource name of the operator definition, which allows its access by ID.
             - Format: `operator-definitions/{id}`.
@@ -350,7 +350,7 @@ paths:
             - VIEW_FULL
       tags:
         - PipelinePublicService
-  /v1beta/{operator_definition.permalink}/lookUp:
+  /v1beta/{operator_definition_permalink}/lookUp:
     get:
       summary: Get a connector by UID
       description: Returns the details of a connector by UID.
@@ -368,7 +368,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: operator_definition.permalink
+        - name: operator_definition_permalink
           description: |-
             The permalink of the connector, which allows its access by UID.
             - Format: `connectors/{uid}`.
@@ -393,7 +393,314 @@ paths:
             - VIEW_CONFIGURATION
       tags:
         - PipelinePublicService
-  /v1beta/{organization.name}/connectors:
+  /v1beta/{organization_connector_name}:
+    get:
+      summary: Get a connector owned by an organization.
+      description: Returns the details of an organization-owned connector.
+      operationId: PipelinePublicService_GetOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetOrganizationConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent
+            organization and ID.
+            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: view
+          description: |-
+            View allows clients to specify the desired resource view in the response.
+
+             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+             - VIEW_CONFIGURATION: Contains the connector configuration.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_CONFIGURATION
+      tags:
+        - PipelinePublicService
+    delete:
+      summary: Delete a connector owned by an organization
+      description: Deletes a connector.
+      operationId: PipelinePublicService_DeleteOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDeleteOrganizationConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent
+            organization and ID.
+            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1beta/{organization_connector_name}/connect:
+    post:
+      summary: Connect a connector owned by an organization
+      description: |-
+        Transitions the state of a connector from `DISCONNECTED` to `CONNECTED`. If
+        the state of the connector is different when the request is made, an error
+        is returned.
+      operationId: PipelinePublicService_ConnectOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaConnectOrganizationConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent
+            organization and ID.
+            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            description: |-
+              ConnectOrganizationConnectorRequest represents a request to connect a
+              connector owned by an organization.
+      tags:
+        - PipelinePublicService
+  /v1beta/{organization_connector_name}/disconnect:
+    post:
+      summary: Disconnect a connector owned by an organization
+      description: |-
+        Transitions the state of a connector from `CONNECTED` to `DISCONNECTED`. If
+        the state of the connector is different when the request is made, an error
+        is returned.
+      operationId: PipelinePublicService_DisconnectOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDisconnectOrganizationConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent
+            organization and ID.
+            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            description: |-
+              DisconnectOrganizationConnectorRequest represents a request to disconnect a
+              connector owned by an organization.
+      tags:
+        - PipelinePublicService
+  /v1beta/{organization_connector_name}/execute:
+    post:
+      summary: Execute a connector owned by an organization
+      description: Executes a task in an organization-owned connector.
+      operationId: PipelinePublicService_ExecuteOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaExecuteOrganizationConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent
+            organization and ID.
+            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                description: Connector input parameters.
+              task:
+                type: string
+                description: Task to be passed to the connector (e.g. `TASK_TEXT_GENERATION`).
+            description: |-
+              ExecuteOrganizationConnectorRequest represents a request to execute a
+              connector owned by an organization.
+      tags:
+        - PipelinePublicService
+  /v1beta/{organization_connector_name}/rename:
+    post:
+      summary: Rename a connector owned by an organization
+      description: |-
+        Updates the ID of a connector. Since this is an output-only field, a custom
+        method is required to modify it.
+
+        The connector name will be updated accordingly, as it is  composed by the
+        parent organization and ID of the connector (e.g.
+        `organizations/indiana-jones/connector/whip`).
+      operationId: PipelinePublicService_RenameOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaRenameOrganizationConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent
+            organization and ID.
+            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_connector_id:
+                type: string
+                description: |-
+                  The new resource ID. This will transform the resource name into
+                  `organizations/{organization.id}/connectors/{new_connector_id}`.
+            description: |-
+              RenameOrganizationConnectorRequest represents a request to rename the name
+              of a connector owned by an organization.
+            required:
+              - new_connector_id
+      tags:
+        - PipelinePublicService
+  /v1beta/{organization_connector_name}/testConnection:
+    post:
+      summary: Test a connector owned by an organization
+      description: Tests the connection on an organization-owned connector.
+      operationId: PipelinePublicService_TestOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaTestOrganizationConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent
+            organization and ID.
+            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1beta/{organization_connector_name}/watch:
+    get:
+      summary: Get the state of a connector owned by an organization
+      description: Gets the state of an organization-owned connector.
+      operationId: PipelinePublicService_WatchOrganizationConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaWatchOrganizationConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent
+            connector and ID.
+            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/connectors/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1beta/{organization_name}/connectors:
     get:
       summary: List organization connectors
       description: |-
@@ -413,7 +720,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The parent resource, i.e., the organization that created the connectors.
             - Format: `organizations/{organization.id}`.
@@ -479,7 +786,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The parent resource, i.e., the organization that creates the connector.
             - Format: `organizations/{organization.id}`.
@@ -495,7 +802,7 @@ paths:
             $ref: '#/definitions/v1betaConnector'
       tags:
         - PipelinePublicService
-  /v1beta/{organization.name}/pipelines:
+  /v1beta/{organization_name}/pipelines:
     get:
       summary: List organization pipelines
       description: |-
@@ -515,7 +822,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The parent resource, i.e., the organization that created the pipelines.
             - Format: `organizations/{organization.id}`.
@@ -586,7 +893,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The parent resource, i.e., the organization that creates the pipeline.
             - Format: `organizations/{organization.id}`.
@@ -602,7 +909,7 @@ paths:
             $ref: '#/definitions/v1betaPipeline'
       tags:
         - PipelinePublicService
-  /v1beta/{organization.name}/releases:
+  /v1beta/{organization_name}/releases:
     get:
       summary: List the releases in a pipeline owned by an organization
       description: |-
@@ -622,7 +929,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             The parent resource where this pipeline release will be created.
             Format: `organizations/{organization.id}/pipelines/{pipeline.id}`
@@ -693,7 +1000,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization.name
+        - name: organization_name
           description: |-
             Name of the pipeline for which the release will be created.
             Format: `organizations/{organization.id}/pipelines/{pipeline.id}`
@@ -709,314 +1016,7 @@ paths:
             $ref: '#/definitions/v1betaPipelineRelease'
       tags:
         - PipelinePublicService
-  /v1beta/{organization_connector.name}:
-    get:
-      summary: Get a connector owned by an organization.
-      description: Returns the details of an organization-owned connector.
-      operationId: PipelinePublicService_GetOrganizationConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetOrganizationConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent
-            organization and ID.
-            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/connectors/[^/]+
-        - name: view
-          description: |-
-            View allows clients to specify the desired resource view in the response.
-
-             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
-             - VIEW_BASIC: Default view, only includes basic information.
-             - VIEW_FULL: Full representation.
-             - VIEW_CONFIGURATION: Contains the connector configuration.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-            - VIEW_CONFIGURATION
-      tags:
-        - PipelinePublicService
-    delete:
-      summary: Delete a connector owned by an organization
-      description: Deletes a connector.
-      operationId: PipelinePublicService_DeleteOrganizationConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaDeleteOrganizationConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent
-            organization and ID.
-            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/connectors/[^/]+
-      tags:
-        - PipelinePublicService
-  /v1beta/{organization_connector.name}/connect:
-    post:
-      summary: Connect a connector owned by an organization
-      description: |-
-        Transitions the state of a connector from `DISCONNECTED` to `CONNECTED`. If
-        the state of the connector is different when the request is made, an error
-        is returned.
-      operationId: PipelinePublicService_ConnectOrganizationConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaConnectOrganizationConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent
-            organization and ID.
-            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/connectors/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            description: |-
-              ConnectOrganizationConnectorRequest represents a request to connect a
-              connector owned by an organization.
-      tags:
-        - PipelinePublicService
-  /v1beta/{organization_connector.name}/disconnect:
-    post:
-      summary: Disconnect a connector owned by an organization
-      description: |-
-        Transitions the state of a connector from `CONNECTED` to `DISCONNECTED`. If
-        the state of the connector is different when the request is made, an error
-        is returned.
-      operationId: PipelinePublicService_DisconnectOrganizationConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaDisconnectOrganizationConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent
-            organization and ID.
-            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/connectors/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            description: |-
-              DisconnectOrganizationConnectorRequest represents a request to disconnect a
-              connector owned by an organization.
-      tags:
-        - PipelinePublicService
-  /v1beta/{organization_connector.name}/execute:
-    post:
-      summary: Execute a connector owned by an organization
-      description: Executes a task in an organization-owned connector.
-      operationId: PipelinePublicService_ExecuteOrganizationConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaExecuteOrganizationConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent
-            organization and ID.
-            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/connectors/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              inputs:
-                type: array
-                items:
-                  type: object
-                description: Connector input parameters.
-              task:
-                type: string
-                description: Task to be passed to the connector (e.g. `TASK_TEXT_GENERATION`).
-            description: |-
-              ExecuteOrganizationConnectorRequest represents a request to execute a
-              connector owned by an organization.
-      tags:
-        - PipelinePublicService
-  /v1beta/{organization_connector.name}/rename:
-    post:
-      summary: Rename a connector owned by an organization
-      description: |-
-        Updates the ID of a connector. Since this is an output-only field, a custom
-        method is required to modify it.
-
-        The connector name will be updated accordingly, as it is  composed by the
-        parent organization and ID of the connector (e.g.
-        `organizations/indiana-jones/connector/whip`).
-      operationId: PipelinePublicService_RenameOrganizationConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaRenameOrganizationConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent
-            organization and ID.
-            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/connectors/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              new_connector_id:
-                type: string
-                description: |-
-                  The new resource ID. This will transform the resource name into
-                  `organizations/{organization.id}/connectors/{new_connector_id}`.
-            description: |-
-              RenameOrganizationConnectorRequest represents a request to rename the name
-              of a connector owned by an organization.
-            required:
-              - new_connector_id
-      tags:
-        - PipelinePublicService
-  /v1beta/{organization_connector.name}/testConnection:
-    post:
-      summary: Test a connector owned by an organization
-      description: Tests the connection on an organization-owned connector.
-      operationId: PipelinePublicService_TestOrganizationConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaTestOrganizationConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent
-            organization and ID.
-            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/connectors/[^/]+
-      tags:
-        - PipelinePublicService
-  /v1beta/{organization_connector.name}/watch:
-    get:
-      summary: Get the state of a connector owned by an organization
-      description: Gets the state of an organization-owned connector.
-      operationId: PipelinePublicService_WatchOrganizationConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaWatchOrganizationConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent
-            connector and ID.
-            - Format: `organizations/{organization.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/connectors/[^/]+
-      tags:
-        - PipelinePublicService
-  /v1beta/{organization_pipeline.name}:
+  /v1beta/{organization_pipeline_name}:
     get:
       summary: Get a pipeline owned by an organization
       description: |-
@@ -1036,7 +1036,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline.name
+        - name: organization_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent
             organization and ID.
@@ -1081,7 +1081,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline.name
+        - name: organization_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent
             organization and ID.
@@ -1092,7 +1092,7 @@ paths:
           pattern: organizations/[^/]+/pipelines/[^/]+
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline.name}/rename:
+  /v1beta/{organization_pipeline_name}/rename:
     post:
       summary: Rename a pipeline owned by an organization
       description: |-
@@ -1116,7 +1116,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline.name
+        - name: organization_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent
             organization and ID.
@@ -1143,7 +1143,7 @@ paths:
               - new_pipeline_id
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline.name}/trigger:
+  /v1beta/{organization_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by an organization
       description: |-
@@ -1170,7 +1170,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline.name
+        - name: organization_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent
             organization and ID.
@@ -1197,7 +1197,7 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline.name}/triggerAsync:
+  /v1beta/{organization_pipeline_name}/triggerAsync:
     post:
       summary: Trigger a pipeline owned by an organization asynchronously
       description: |-
@@ -1225,7 +1225,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline.name
+        - name: organization_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent
             organization and ID.
@@ -1252,7 +1252,7 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline.name}/validate:
+  /v1beta/{organization_pipeline_name}/validate:
     post:
       summary: Validate a pipeline a pipeline owned by an organization
       description: |-
@@ -1275,7 +1275,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline.name
+        - name: organization_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent
             organization and ID.
@@ -1294,7 +1294,7 @@ paths:
               pipeline owned by an organization.
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline_release.name}:
+  /v1beta/{organization_pipeline_release_name}:
     get:
       summary: Get a release in a pipeline owned by an organization
       description: |-
@@ -1314,7 +1314,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline_release.name
+        - name: organization_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -1360,7 +1360,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline_release.name
+        - name: organization_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -1372,7 +1372,7 @@ paths:
           pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline_release.name}/rename:
+  /v1beta/{organization_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by an organization
       description: |-
@@ -1397,7 +1397,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline_release.name
+        - name: organization_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -1425,7 +1425,7 @@ paths:
               - new_pipeline_release_id
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline_release.name}/restore:
+  /v1beta/{organization_pipeline_release_name}/restore:
     post:
       summary: Set the version of a pipeline owned by an organization to a pinned release
       description: |-
@@ -1447,7 +1447,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline_release.name
+        - name: organization_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -1459,7 +1459,7 @@ paths:
           pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline_release.name}/trigger:
+  /v1beta/{organization_pipeline_release_name}/trigger:
     post:
       summary: Trigger a version of a pipeline owned by an organization
       description: |-
@@ -1484,7 +1484,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline_release.name
+        - name: organization_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -1512,7 +1512,7 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline_release.name}/triggerAsync:
+  /v1beta/{organization_pipeline_release_name}/triggerAsync:
     post:
       summary: Trigger a version of a pipeline owned by an organization asynchronously
       description: |-
@@ -1537,7 +1537,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline_release.name
+        - name: organization_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -1565,7 +1565,7 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline_release.name}/watch:
+  /v1beta/{organization_pipeline_release_name}/watch:
     get:
       summary: Get the state of a release in a pipeline owned by an organization
       description: |-
@@ -1585,7 +1585,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_pipeline_release.name
+        - name: organization_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -1642,7 +1642,7 @@ paths:
             - VIEW_RECIPE
       tags:
         - PipelinePublicService
-  /v1beta/{pipeline.name_1}:
+  /v1beta/{pipeline_name_1}:
     patch:
       summary: Update a pipeline owned by an organization
       description: |-
@@ -1664,10 +1664,10 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: pipeline.name_1
+        - name: pipeline_name_1
           description: |-
-            The name of the pipeline, defined by its owner and ID.
-            - Format: `users/{user.id}/pipelines/{pipeline.id}`.
+            The name of the pipeline, defined by its parent and ID.
+            - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
           in: path
           required: true
           type: string
@@ -1750,7 +1750,7 @@ paths:
             title: The pipeline fields that will replace the existing ones.
       tags:
         - PipelinePublicService
-  /v1beta/{pipeline.name}:
+  /v1beta/{pipeline_name}:
     patch:
       summary: Update a pipeline owned by a user
       description: |-
@@ -1774,10 +1774,10 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: pipeline.name
+        - name: pipeline_name
           description: |-
-            The name of the pipeline, defined by its owner and ID.
-            - Format: `users/{user.id}/pipelines/{pipeline.id}`.
+            The name of the pipeline, defined by its parent and ID.
+            - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
           in: path
           required: true
           type: string
@@ -1860,7 +1860,7 @@ paths:
             title: The pipeline fields that will replace the existing ones.
       tags:
         - PipelinePublicService
-  /v1beta/{release.name_1}:
+  /v1beta/{pipeline_release_name_1}:
     patch:
       summary: Update a release in a pipeline owned by an organization
       description: |-
@@ -1880,14 +1880,14 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: release.name_1
+        - name: pipeline_release_name_1
           description: |-
-            The name of the release, defined by its owner and ID.
-            - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{release.id}
+            The name of the release, defined by its parent and ID.
+            - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}
           in: path
           required: true
           type: string
-          pattern: organizationsr/[^/]+/pipelines/[^/]+/releases/[^/]+
+          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
         - name: release
           description: |-
             The pipeline release fields that will replace the existing ones.
@@ -1949,7 +1949,7 @@ paths:
               A pipeline release resource to update
       tags:
         - PipelinePublicService
-  /v1beta/{release.name}:
+  /v1beta/{pipeline_release_name}:
     patch:
       summary: Update a release in a pipeline owned by a user
       description: |-
@@ -1972,14 +1972,14 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: release.name
+        - name: pipeline_release_name
           description: |-
-            The name of the release, defined by its owner and ID.
-            - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{release.id}
+            The name of the release, defined by its parent and ID.
+            - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}
           in: path
           required: true
           type: string
-          pattern: usersr/[^/]+/pipelines/[^/]+/releases/[^/]+
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
         - name: release
           description: |-
             The pipeline release fields that will replace the existing ones.
@@ -2041,7 +2041,319 @@ paths:
               A pipeline release resource to update
       tags:
         - PipelinePublicService
-  /v1beta/{user.name}/connectors:
+  /v1beta/{user_connector_name}:
+    get:
+      summary: Get a connector owned by a user.
+      description: Returns the details of a user-owned connector.
+      operationId: PipelinePublicService_GetUserConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetUserConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/connectors/[^/]+
+        - name: view
+          description: |-
+            View allows clients to specify the desired resource view in the response.
+
+             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+             - VIEW_CONFIGURATION: Contains the connector configuration.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_CONFIGURATION
+      tags:
+        - PipelinePublicService
+    delete:
+      summary: Delete a connector owned by a user
+      description: |-
+        Deletes a connector. The authenticated user must be the parent of the
+        connector in order to delete it.
+      operationId: PipelinePublicService_DeleteUserConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDeleteUserConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/connectors/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1beta/{user_connector_name}/connect:
+    post:
+      summary: Connect a connector owned by a user
+      description: |-
+        Transitions the state of a connector from `DISCONNECTED` to `CONNECTED`. If
+        the state of the connector is different when the request is made, an error
+        is returned.
+      operationId: PipelinePublicService_ConnectUserConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaConnectUserConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            description: |-
+              ConnectUserConnectorRequest represents a request to connect a connector
+              owned by a user.
+      tags:
+        - PipelinePublicService
+  /v1beta/{user_connector_name}/disconnect:
+    post:
+      summary: Disconnect a connector owned by a user
+      description: |-
+        Transitions the state of a connector from `CONNECTED` to `DISCONNECTED`. If
+        the state of the connector is different when the request is made, an error
+        is returned.
+      operationId: PipelinePublicService_DisconnectUserConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDisconnectUserConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            description: |-
+              DisconnectUserConnectorRequest represents a request to disconnect a
+              connector owned by a user.
+      tags:
+        - PipelinePublicService
+  /v1beta/{user_connector_name}/execute:
+    post:
+      summary: Execute a connector owned by a user
+      description: Executes a task in a user-owned connector.
+      operationId: PipelinePublicService_ExecuteUserConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaExecuteUserConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              inputs:
+                type: array
+                items:
+                  type: object
+                description: Connector input parameters.
+              task:
+                type: string
+                description: Task to be passed to the connector (e.g. `TASK_TEXT_GENERATION`).
+            description: |-
+              ExecuteUserConnectorRequest represents a request to execute a connector
+              owned by a user.
+      tags:
+        - PipelinePublicService
+  /v1beta/{user_connector_name}/rename:
+    post:
+      summary: Rename a connector owned by a user
+      description: |-
+        Updates the ID of a connector. Since this is an output-only field, a custom
+        method is required to modify it.
+
+        The connector name will be updated accordingly, as it is  composed by the
+        parent user and ID of the connector (e.g.
+        `users/indiana-jones/connector/whip`).
+
+        The authenticated user must be the parent of the connector in order to
+        perform this action.
+      operationId: PipelinePublicService_RenameUserConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaRenameUserConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/connectors/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              new_connector_id:
+                type: string
+                description: |-
+                  The new resource ID. This will transform the resource name into
+                  `users/{user.id}/connectors/{new_connector_id}`.
+            description: |-
+              RenameUserConnectorRequest represents a request to rename the name of a
+              connector owned by a user.
+            required:
+              - new_connector_id
+      tags:
+        - PipelinePublicService
+  /v1beta/{user_connector_name}/testConnection:
+    post:
+      summary: Test a connector owned by a user
+      description: Tests the connection on a user-owned connector.
+      operationId: PipelinePublicService_TestUserConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaTestUserConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/connectors/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1beta/{user_connector_name}/watch:
+    get:
+      summary: Get the state of a connector owned by a user
+      description: Gets the state of a user-owned connector.
+      operationId: PipelinePublicService_WatchUserConnector
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaWatchUserConnectorResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_connector_name
+          description: |-
+            The resource name of the connector, which allows its access by parent
+            connector and ID.
+            - Format: `users/{user.id}/connectors/{connector.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/connectors/[^/]+
+      tags:
+        - PipelinePublicService
+  /v1beta/{user_name}/connectors:
     get:
       summary: List user connectors
       description: Returns a paginated list of connectors that belong to the specified user.
@@ -2059,7 +2371,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user.name
+        - name: user_name
           description: |-
             The parent resource, i.e., the user that created the connectors.
             - Format: `users/{user.id}`.
@@ -2128,7 +2440,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user.name
+        - name: user_name
           description: |-
             The parent resource, i.e., the user that creates the connector.
             - Format: `users/{user.id}`.
@@ -2144,7 +2456,7 @@ paths:
             $ref: '#/definitions/v1betaConnector'
       tags:
         - PipelinePublicService
-  /v1beta/{user.name}/pipelines:
+  /v1beta/{user_name}/pipelines:
     get:
       summary: List user pipelines
       description: |-
@@ -2166,7 +2478,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user.name
+        - name: user_name
           description: |-
             The parent resource, i.e., the user that created the pipelines.
             - Format: `users/{user.id}`.
@@ -2240,7 +2552,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user.name
+        - name: user_name
           description: |-
             The parent resource, i.e., the user that creates the pipeline.
             - Format: `users/{user.id}`.
@@ -2256,7 +2568,7 @@ paths:
             $ref: '#/definitions/v1betaPipeline'
       tags:
         - PipelinePublicService
-  /v1beta/{user.name}/releases:
+  /v1beta/{user_name}/releases:
     get:
       summary: List the releases in a pipeline owned by a user
       description: |-
@@ -2276,7 +2588,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user.name
+        - name: user_name
           description: |-
             The parent resource where this pipeline release will be created.
             Format: `users/{user.id}/pipelines/{pipeline.id}`.
@@ -2350,7 +2662,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user.name
+        - name: user_name
           description: |-
             Name of the pipeline for which the release will be created.
             Format: `users/{user.id}/pipelines/{pipeline.id}`
@@ -2366,319 +2678,7 @@ paths:
             $ref: '#/definitions/v1betaPipelineRelease'
       tags:
         - PipelinePublicService
-  /v1beta/{user_connector.name}:
-    get:
-      summary: Get a connector owned by a user.
-      description: Returns the details of a user-owned connector.
-      operationId: PipelinePublicService_GetUserConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetUserConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent user
-            and ID.
-            - Format: `users/{user.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/connectors/[^/]+
-        - name: view
-          description: |-
-            View allows clients to specify the desired resource view in the response.
-
-             - VIEW_UNSPECIFIED: Unspecified, equivalent to BASIC.
-             - VIEW_BASIC: Default view, only includes basic information.
-             - VIEW_FULL: Full representation.
-             - VIEW_CONFIGURATION: Contains the connector configuration.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-            - VIEW_CONFIGURATION
-      tags:
-        - PipelinePublicService
-    delete:
-      summary: Delete a connector owned by a user
-      description: |-
-        Deletes a connector. The authenticated user must be the parent of the
-        connector in order to delete it.
-      operationId: PipelinePublicService_DeleteUserConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaDeleteUserConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent user
-            and ID.
-            - Format: `users/{user.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/connectors/[^/]+
-      tags:
-        - PipelinePublicService
-  /v1beta/{user_connector.name}/connect:
-    post:
-      summary: Connect a connector owned by a user
-      description: |-
-        Transitions the state of a connector from `DISCONNECTED` to `CONNECTED`. If
-        the state of the connector is different when the request is made, an error
-        is returned.
-      operationId: PipelinePublicService_ConnectUserConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaConnectUserConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent user
-            and ID.
-            - Format: `users/{user.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/connectors/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            description: |-
-              ConnectUserConnectorRequest represents a request to connect a connector
-              owned by a user.
-      tags:
-        - PipelinePublicService
-  /v1beta/{user_connector.name}/disconnect:
-    post:
-      summary: Disconnect a connector owned by a user
-      description: |-
-        Transitions the state of a connector from `CONNECTED` to `DISCONNECTED`. If
-        the state of the connector is different when the request is made, an error
-        is returned.
-      operationId: PipelinePublicService_DisconnectUserConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaDisconnectUserConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent user
-            and ID.
-            - Format: `users/{user.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/connectors/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            description: |-
-              DisconnectUserConnectorRequest represents a request to disconnect a
-              connector owned by a user.
-      tags:
-        - PipelinePublicService
-  /v1beta/{user_connector.name}/execute:
-    post:
-      summary: Execute a connector owned by a user
-      description: Executes a task in a user-owned connector.
-      operationId: PipelinePublicService_ExecuteUserConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaExecuteUserConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent user
-            and ID.
-            - Format: `users/{user.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/connectors/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              inputs:
-                type: array
-                items:
-                  type: object
-                description: Connector input parameters.
-              task:
-                type: string
-                description: Task to be passed to the connector (e.g. `TASK_TEXT_GENERATION`).
-            description: |-
-              ExecuteUserConnectorRequest represents a request to execute a connector
-              owned by a user.
-      tags:
-        - PipelinePublicService
-  /v1beta/{user_connector.name}/rename:
-    post:
-      summary: Rename a connector owned by a user
-      description: |-
-        Updates the ID of a connector. Since this is an output-only field, a custom
-        method is required to modify it.
-
-        The connector name will be updated accordingly, as it is  composed by the
-        parent user and ID of the connector (e.g.
-        `users/indiana-jones/connector/whip`).
-
-        The authenticated user must be the parent of the connector in order to
-        perform this action.
-      operationId: PipelinePublicService_RenameUserConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaRenameUserConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent user
-            and ID.
-            - Format: `users/{user.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/connectors/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              new_connector_id:
-                type: string
-                description: |-
-                  The new resource ID. This will transform the resource name into
-                  `users/{user.id}/connectors/{new_connector_id}`.
-            description: |-
-              RenameUserConnectorRequest represents a request to rename the name of a
-              connector owned by a user.
-            required:
-              - new_connector_id
-      tags:
-        - PipelinePublicService
-  /v1beta/{user_connector.name}/testConnection:
-    post:
-      summary: Test a connector owned by a user
-      description: Tests the connection on a user-owned connector.
-      operationId: PipelinePublicService_TestUserConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaTestUserConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent user
-            and ID.
-            - Format: `users/{user.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/connectors/[^/]+
-      tags:
-        - PipelinePublicService
-  /v1beta/{user_connector.name}/watch:
-    get:
-      summary: Get the state of a connector owned by a user
-      description: Gets the state of a user-owned connector.
-      operationId: PipelinePublicService_WatchUserConnector
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaWatchUserConnectorResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_connector.name
-          description: |-
-            The resource name of the connector, which allows its access by parent
-            connector and ID.
-            - Format: `users/{user.id}/connectors/{connector.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/connectors/[^/]+
-      tags:
-        - PipelinePublicService
-  /v1beta/{user_pipeline.name}:
+  /v1beta/{user_pipeline_name}:
     get:
       summary: Get a pipeline owned by a user
       description: |-
@@ -2698,7 +2698,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline.name
+        - name: user_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent user
             and ID.
@@ -2744,7 +2744,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline.name
+        - name: user_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent user
             and ID.
@@ -2755,7 +2755,7 @@ paths:
           pattern: users/[^/]+/pipelines/[^/]+
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline.name}/rename:
+  /v1beta/{user_pipeline_name}/rename:
     post:
       summary: Rename a pipeline owned by a user
       description: |-
@@ -2782,7 +2782,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline.name
+        - name: user_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent user
             and ID.
@@ -2809,7 +2809,7 @@ paths:
               - new_pipeline_id
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline.name}/trigger:
+  /v1beta/{user_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by a user
       description: |-
@@ -2836,7 +2836,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline.name
+        - name: user_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent user
             and ID.
@@ -2863,7 +2863,7 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline.name}/triggerAsync:
+  /v1beta/{user_pipeline_name}/triggerAsync:
     post:
       summary: Trigger a pipeline owned by a user asynchronously
       description: |-
@@ -2891,7 +2891,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline.name
+        - name: user_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent user
             and ID.
@@ -2918,7 +2918,7 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline.name}/validate:
+  /v1beta/{user_pipeline_name}/validate:
     post:
       summary: Validate a pipeline a pipeline owned by a user
       description: |-
@@ -2940,7 +2940,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline.name
+        - name: user_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent user
             and ID.
@@ -2959,7 +2959,7 @@ paths:
               owned by a user.
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline_release.name}:
+  /v1beta/{user_pipeline_release_name}:
     get:
       summary: Get a release in a pipeline owned by a user
       description: |-
@@ -2979,7 +2979,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline_release.name
+        - name: user_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -3027,7 +3027,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline_release.name
+        - name: user_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -3038,7 +3038,7 @@ paths:
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline_release.name}/rename:
+  /v1beta/{user_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by a user
       description: |-
@@ -3066,7 +3066,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline_release.name
+        - name: user_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -3093,7 +3093,7 @@ paths:
               - new_pipeline_release_id
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline_release.name}/restore:
+  /v1beta/{user_pipeline_release_name}/restore:
     post:
       summary: Set the version of a pipeline owned by a user to a pinned release
       description: |-
@@ -3118,7 +3118,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline_release.name
+        - name: user_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -3129,7 +3129,7 @@ paths:
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline_release.name}/trigger:
+  /v1beta/{user_pipeline_release_name}/trigger:
     post:
       summary: Trigger a version of a pipeline owned by a user
       description: |-
@@ -3154,7 +3154,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline_release.name
+        - name: user_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -3181,7 +3181,7 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline_release.name}/triggerAsync:
+  /v1beta/{user_pipeline_release_name}/triggerAsync:
     post:
       summary: Trigger a version of a pipeline owned by a user asynchronously
       description: |-
@@ -3206,7 +3206,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline_release.name
+        - name: user_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -3233,7 +3233,7 @@ paths:
               - inputs
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline_release.name}/watch:
+  /v1beta/{user_pipeline_release_name}/watch:
     get:
       summary: Get the state of a release in a pipeline owned by a user
       description: |-
@@ -3253,7 +3253,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline_release.name
+        - name: user_pipeline_release_name
           description: |-
             The resource name of the pipeline release, which allows its access by
             parent pipeline and ID.
@@ -4659,8 +4659,8 @@ definitions:
       name:
         type: string
         description: |-
-          The name of the pipeline, defined by its owner and ID.
-          - Format: `users/{user.id}/pipelines/{pipeline.id}`.
+          The name of the pipeline, defined by its parent and ID.
+          - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
         readOnly: true
       uid:
         type: string
@@ -4743,8 +4743,8 @@ definitions:
       name:
         type: string
         title: |-
-          The name of the release, defined by its owner and ID.
-          - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{release.id}
+          The name of the release, defined by its parent and ID.
+          - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}
         readOnly: true
       uid:
         type: string

--- a/vdp/pipeline/v1beta/connector.proto
+++ b/vdp/pipeline/v1beta/connector.proto
@@ -63,7 +63,13 @@ message Connector {
 
   // The name of the connector, defined by its ID.
   // - Format: `connectors/{id}`.
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string name = 1 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "connector_name"}
+    }
+
+  ];
   // Connector UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Connector resource ID (used in `name` as the last segment). This conforms
@@ -146,7 +152,7 @@ message LookUpConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "operator_definition.permalink"}
+      field_configuration: {path_param_name: "operator_definition_permalink"}
     }
   ];
   // View allows clients to specify the desired connector view in the response.
@@ -170,7 +176,7 @@ message CreateUserConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
 }
@@ -200,7 +206,7 @@ message ListUserConnectorsRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
   // Include soft-deleted connectors in the result.
@@ -227,7 +233,7 @@ message GetUserConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_connector.name"}
+      field_configuration: {path_param_name: "user_connector_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -268,7 +274,7 @@ message DeleteUserConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_connector.name"}
+      field_configuration: {path_param_name: "user_connector_name"}
     }
   ];
 }
@@ -286,7 +292,7 @@ message ConnectUserConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_connector.name"}
+      field_configuration: {path_param_name: "user_connector_name"}
     }
   ];
 }
@@ -307,7 +313,7 @@ message DisconnectUserConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_connector.name"}
+      field_configuration: {path_param_name: "user_connector_name"}
     }
   ];
 }
@@ -328,7 +334,7 @@ message RenameUserConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_connector.name"}
+      field_configuration: {path_param_name: "user_connector_name"}
     }
   ];
   // The new resource ID. This will transform the resource name into
@@ -352,7 +358,7 @@ message ExecuteUserConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_connector.name"}
+      field_configuration: {path_param_name: "user_connector_name"}
     }
   ];
   // Connector input parameters.
@@ -377,7 +383,7 @@ message TestUserConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_connector.name"}
+      field_configuration: {path_param_name: "user_connector_name"}
     }
   ];
 }
@@ -398,7 +404,7 @@ message WatchUserConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_connector.name"}
+      field_configuration: {path_param_name: "user_connector_name"}
     }
   ];
 }
@@ -420,7 +426,7 @@ message CreateOrganizationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
 }
@@ -450,7 +456,7 @@ message ListOrganizationConnectorsRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
   // Include soft-deleted connectors in the result.
@@ -477,7 +483,7 @@ message GetOrganizationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_connector.name"}
+      field_configuration: {path_param_name: "organization_connector_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -518,7 +524,7 @@ message DeleteOrganizationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_connector.name"}
+      field_configuration: {path_param_name: "organization_connector_name"}
     }
   ];
 }
@@ -536,7 +542,7 @@ message ConnectOrganizationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_connector.name"}
+      field_configuration: {path_param_name: "organization_connector_name"}
     }
   ];
 }
@@ -557,7 +563,7 @@ message DisconnectOrganizationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_connector.name"}
+      field_configuration: {path_param_name: "organization_connector_name"}
     }
   ];
 }
@@ -578,7 +584,7 @@ message RenameOrganizationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_connector.name"}
+      field_configuration: {path_param_name: "organization_connector_name"}
     }
   ];
   // The new resource ID. This will transform the resource name into
@@ -602,7 +608,7 @@ message ExecuteOrganizationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_connector.name"}
+      field_configuration: {path_param_name: "organization_connector_name"}
     }
   ];
   // Connector input parameters.
@@ -627,7 +633,7 @@ message TestOrganizationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_connector.name"}
+      field_configuration: {path_param_name: "organization_connector_name"}
     }
   ];
 }
@@ -648,7 +654,7 @@ message WatchOrganizationConnectorRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Connector"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_connector.name"}
+      field_configuration: {path_param_name: "organization_connector_name"}
     }
   ];
 }

--- a/vdp/pipeline/v1beta/connector_definition.proto
+++ b/vdp/pipeline/v1beta/connector_definition.proto
@@ -143,7 +143,7 @@ message GetConnectorDefinitionRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/ConnectorDefinition"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "connector_definition.name"}
+      field_configuration: {path_param_name: "connector_definition_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -165,7 +165,7 @@ message LookUpConnectorDefinitionAdminRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/ConnectorDefinition"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "connector_definition.permalink"}
+      field_configuration: {path_param_name: "connector_definition_permalink"}
     }
   ];
   // View allows clients to specify the desired connector definition view in

--- a/vdp/pipeline/v1beta/operator_definition.proto
+++ b/vdp/pipeline/v1beta/operator_definition.proto
@@ -114,7 +114,7 @@ message GetOperatorDefinitionRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/OperatorDefinition"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "operator_definition.name"}
+      field_configuration: {path_param_name: "operator_definition_name"}
     }
   ];
   // View allows clients to specify the desired resource view in the response.
@@ -136,7 +136,7 @@ message LookUpOperatorDefinitionAdminRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/OperatorDefinition"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "operator_definition.permalink"}
+      field_configuration: {path_param_name: "operator_definition_permalink"}
     }
   ];
   // View allows clients to specify the desired operator definition view in the

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -142,9 +142,15 @@ message Pipeline {
     VISIBILITY_PUBLIC = 2;
   }
 
-  // The name of the pipeline, defined by its owner and ID.
-  // - Format: `users/{user.id}/pipelines/{pipeline.id}`.
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The name of the pipeline, defined by its parent and ID.
+  // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
+  string name = 1 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline_name"}
+    }
+  ];
+
   // Pipeline UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline resource ID (used in `name` as the last segment). This conforms
@@ -222,9 +228,14 @@ message PipelineRelease {
     pattern: "users/{user.id}/pipelines/{pipeline.id}/releases/{release.id}"
   };
 
-  // The name of the release, defined by its owner and ID.
-  // - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{release.id}
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The name of the release, defined by its parent and ID.
+  // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}
+  string name = 1 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "pipeline_release_name"}
+    }
+  ];
   // Release UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Release resource ID (used in `name` as the last segment). It must be a
@@ -309,7 +320,7 @@ message CreateUserPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
 }
@@ -343,7 +354,7 @@ message ListUserPipelinesRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
   // Include soft-deleted pipelines in the result.
@@ -370,7 +381,7 @@ message GetUserPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline.name"}
+      field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
   // View allows clients to specify the desired pipeline view in the response.
@@ -411,7 +422,7 @@ message DeleteUserPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline.name"}
+      field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
 }
@@ -429,7 +440,7 @@ message ValidateUserPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline.name"}
+      field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
 }
@@ -450,7 +461,7 @@ message RenameUserPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline.name"}
+      field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
   // The new resource ID. This will transform the resource name into
@@ -474,7 +485,7 @@ message TriggerUserPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline.name"}
+      field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
   // Pipeline input parameters.
@@ -500,7 +511,7 @@ message TriggerAsyncUserPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline.name"}
+      field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
   // Pipeline input parameters.
@@ -525,7 +536,7 @@ message CreateUserPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
 }
@@ -557,7 +568,7 @@ message ListUserPipelineReleasesRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user.name"}
+      field_configuration: {path_param_name: "user_name"}
     }
   ];
   // Include soft-deleted pipelines in the result.
@@ -584,7 +595,7 @@ message GetUserPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_release.name"}
+      field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
   // View allows clients to specify the desired pipeline view in the response.
@@ -626,7 +637,7 @@ message DeleteUserPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_release.name"}
+      field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
 }
@@ -644,7 +655,7 @@ message RestoreUserPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_release.name"}
+      field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
 }
@@ -665,7 +676,7 @@ message RenameUserPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_release.name"}
+      field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
   // The new resource ID. This will transform the resource name into
@@ -689,7 +700,7 @@ message WatchUserPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_release.name"}
+      field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
 }
@@ -711,7 +722,7 @@ message TriggerUserPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_release.name"}
+      field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
   // Pipeline input parameters.
@@ -737,7 +748,7 @@ message TriggerAsyncUserPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_release.name"}
+      field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
   // Pipeline input parameters.
@@ -762,7 +773,7 @@ message CreateOrganizationPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
 }
@@ -796,7 +807,7 @@ message ListOrganizationPipelinesRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
   // Include soft-deleted pipelines in the result.
@@ -823,7 +834,7 @@ message GetOrganizationPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline.name"}
+      field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
   // View allows clients to specify the desired pipeline view in the response.
@@ -864,7 +875,7 @@ message DeleteOrganizationPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline.name"}
+      field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
 }
@@ -882,7 +893,7 @@ message ValidateOrganizationPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline.name"}
+      field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
 }
@@ -903,7 +914,7 @@ message RenameOrganizationPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline.name"}
+      field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
   // The new resource ID. This will transform the resource name into
@@ -927,7 +938,7 @@ message TriggerOrganizationPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline.name"}
+      field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
   // Pipeline input parameters.
@@ -953,7 +964,7 @@ message TriggerAsyncOrganizationPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline.name"}
+      field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
   // Pipeline input parameters.
@@ -978,7 +989,7 @@ message CreateOrganizationPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
 }
@@ -1010,7 +1021,7 @@ message ListOrganizationPipelineReleasesRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {child_type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization.name"}
+      field_configuration: {path_param_name: "organization_name"}
     }
   ];
   // Include soft-deleted pipelines in the result.
@@ -1038,7 +1049,7 @@ message GetOrganizationPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline_release.name"}
+      field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
   // View allows clients to specify the desired pipeline view in the response.
@@ -1082,7 +1093,7 @@ message DeleteOrganizationPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline_release.name"}
+      field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
 }
@@ -1101,7 +1112,7 @@ message RestoreOrganizationPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline_release.name"}
+      field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
 }
@@ -1124,7 +1135,7 @@ message RenameOrganizationPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline_release.name"}
+      field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
   // The new resource ID. This will transform the resource name into
@@ -1149,7 +1160,7 @@ message WatchOrganizationPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline_release.name"}
+      field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
 }
@@ -1172,7 +1183,7 @@ message TriggerOrganizationPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline_release.name"}
+      field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
   // Pipeline input parameters.
@@ -1199,7 +1210,7 @@ message TriggerAsyncOrganizationPipelineReleaseRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline_release.name"}
+      field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
   // Pipeline input parameters.
@@ -1303,7 +1314,7 @@ message LookUpPipelineAdminRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline.permalink"}
+      field_configuration: {path_param_name: "pipeline_permalink"}
     }
   ];
   // View allows clients to specify the desired pipeline view in the response.

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -233,7 +233,7 @@ service PipelinePublicService {
   // perform this action.
   rpc UpdateUserPipelineRelease(UpdateUserPipelineReleaseRequest) returns (UpdateUserPipelineReleaseResponse) {
     option (google.api.http) = {
-      patch: "/v1beta/{release.name=usersr/*/pipelines/*/releases/*}"
+      patch: "/v1beta/{release.name=users/*/pipelines/*/releases/*}"
       body: "release"
     };
     option (google.api.method_signature) = "release,update_mask";
@@ -486,7 +486,7 @@ service PipelinePublicService {
   // by its resource name, formed by its parent organization and ID.
   rpc UpdateOrganizationPipelineRelease(UpdateOrganizationPipelineReleaseRequest) returns (UpdateOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {
-      patch: "/v1beta/{release.name=organizationsr/*/pipelines/*/releases/*}"
+      patch: "/v1beta/{release.name=organizations/*/pipelines/*/releases/*}"
       body: "release"
     };
     option (google.api.method_signature) = "release,update_mask";


### PR DESCRIPTION
Because

- Path parameters aren't read correctly, e.g.
`/vdp/v1beta/{operator_definition.name}` -> `/vdp/v1beta/%7Boperator_definition.name%7D`

This commit

- Updates the path param names to remove dots, which break the rendering in
  readme.io

## Notes

When trying to make use of the `curl` console the website escapes the
characters. This doesn't prevent the user from making the API call but results in an ugly cURL command. Other callers like Node don't escape the slashes.
![CleanShot 2024-01-11 at 13 29 25](https://github.com/instill-ai/protobufs/assets/3977183/85e8adfa-f49c-4b4b-a608-830b7f9dc5c3)


