### PR TITLE
chore(model): move workflowid into resource

### DIFF
--- a/model/controller/v1alpha/controller.proto
+++ b/model/controller/v1alpha/controller.proto
@@ -53,6 +53,8 @@ message Resource {
   }
   // Resource longrunning progress
   optional int32 progress = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Resource longrunning workflow id
+  optional string workflow_id = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetResourceRequest represents a request to query a resource's state
@@ -78,8 +80,6 @@ message GetResourceResponse {
 message UpdateResourceRequest {
   // Resource state
   Resource resource = 1 [(google.api.field_behavior) = REQUIRED];
-  // Resource long-running workflow id
-  optional string workflow_id = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // UpdateResourceResponse represents a response to update a resource's state

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2574,6 +2574,9 @@ definitions:
         type: integer
         format: int32
         title: Resource longrunning progress
+      workflow_id:
+        type: string
+        title: Resource longrunning workflow id
     title: Resource represents the current information of a resource
     required:
       - resource_permalink


### PR DESCRIPTION
Because

- model-backend needs to be able to retrieve workflowid with `GetResource`

This commit

- move workflowid field into resource message
