### PR TITLE
feat(vdp): add visibility param for list pipelines endpoints

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -215,6 +215,18 @@ paths:
           in: query
           required: false
           type: boolean
+        - name: visibility
+          description: |-
+            Limit results to pipelines with the specified visibility.
+
+             - VISIBILITY_PRIVATE: Only the user can see the pipeline.
+             - VISIBILITY_PUBLIC: Other users can see the pipeline.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VISIBILITY_PRIVATE
+            - VISIBILITY_PUBLIC
       tags:
         - PipelinePublicService
     post:
@@ -1150,6 +1162,18 @@ paths:
           in: query
           required: false
           type: boolean
+        - name: visibility
+          description: |-
+            Limit results to pipelines with the specified visibility.
+
+             - VISIBILITY_PRIVATE: Only the user can see the pipeline.
+             - VISIBILITY_PUBLIC: Other users can see the pipeline.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VISIBILITY_PRIVATE
+            - VISIBILITY_PUBLIC
       tags:
         - PipelinePublicService
     post:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -360,6 +360,8 @@ message ListUserPipelinesRequest {
   ];
   // Include soft-deleted pipelines in the result.
   optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Limit results to pipelines with the specified visibility.
+  optional Pipeline.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUserPipelinesResponse contains a list of pipelines.
@@ -813,6 +815,8 @@ message ListOrganizationPipelinesRequest {
   ];
   // Include soft-deleted pipelines in the result.
   optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Limit results to pipelines with the specified visibility.
+  optional Pipeline.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListOrganizationPipelinesResponse contains a list of pipelines.


### PR DESCRIPTION
Because

- We want to let user query user and organization pipelines with `visibility`

This commit

- add visibility param for `ListUserPipelines` and `ListOrganizationPipelines` endpoints
