### PR TITLE
feat(vdp): add `CloneUserPipeline` and `CloneOrganizationPipeline` endpoints

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -532,6 +532,40 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceRenameUserPipelineBody'
       tags:
         - PipelinePublicService
+  /v1beta/{user_pipeline_name}/clone:
+    post:
+      summary: Clone a pipeline owned by a user
+      description: Clone a pipeline owned by a user, the target pipeline can be under a user or organization namespace.
+      operationId: PipelinePublicService_CloneUserPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCloneUserPipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_pipeline_name
+          description: |-
+            The resource name of the pipeline, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/pipelines/{pipeline.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceCloneUserPipelineBody'
+      tags:
+        - PipelinePublicService
   /v1beta/{user_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by a user
@@ -1469,6 +1503,40 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceRenameOrganizationPipelineBody'
+      tags:
+        - PipelinePublicService
+  /v1beta/{user_pipeline_name_1}/clone:
+    post:
+      summary: Clone a pipeline owned by an organization
+      description: Clone a pipeline owned by an organization, the target pipeline can be under a user or organization namespace.
+      operationId: PipelinePublicService_CloneOrganizationPipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCloneOrganizationPipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_pipeline_name_1
+          description: |-
+            The resource name of the pipeline, which allows its access by parent user
+            and ID.
+            - Format: `organizations/{org.id}/pipelines/{pipeline.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineBody'
       tags:
         - PipelinePublicService
   /v1beta/{organization_pipeline_name}/trigger:
@@ -3331,6 +3399,28 @@ definitions:
       - SERVING_STATUS_SERVING: Serving status: SERVING
        - SERVING_STATUS_NOT_SERVING: Serving status: NOT SERVING
     title: ServingStatus enumerates the status of a queried service
+  PipelinePublicServiceCloneOrganizationPipelineBody:
+    type: object
+    properties:
+      target:
+        type: string
+        title: |-
+          The target pipeline
+          - Format: `users/{user.id}/pipelines/{pipeline.id}` or `organizations/{org.id}/pipelines/{pipeline.id}`
+    description: CloneOrganizationPipelineRequest represents a request to clone a pipeline owned by a organization.
+    required:
+      - target
+  PipelinePublicServiceCloneUserPipelineBody:
+    type: object
+    properties:
+      target:
+        type: string
+        title: |-
+          The target pipeline
+          - Format: `users/{user.id}/pipelines/{pipeline.id}` or `organizations/{org.id}/pipelines/{pipeline.id}`
+    description: CloneUserPipelineRequest represents a request to clone a pipeline owned by a user.
+    required:
+      - target
   PipelinePublicServiceConnectOrganizationConnectorBody:
     type: object
     description: |-
@@ -3819,6 +3909,20 @@ definitions:
         $ref: '#/definitions/v1betaConnectorState'
         description: Connector state.
     description: CheckConnectorResponse contains the connector's current state.
+  v1betaCloneOrganizationPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1betaPipeline'
+        description: The cloned pipeline resource.
+    description: CloneOrganizationPipelineResponse contains a cloned pipeline.
+  v1betaCloneUserPipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        $ref: '#/definitions/v1betaPipeline'
+        description: The cloned pipeline resource.
+    description: CloneUserPipelineResponse contains a cloned pipeline.
   v1betaComponent:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -478,6 +478,29 @@ message RenameUserPipelineResponse {
   Pipeline pipeline = 1;
 }
 
+// CloneUserPipelineRequest represents a request to clone a pipeline owned by a user.
+message CloneUserPipelineRequest {
+  // The resource name of the pipeline, which allows its access by parent user
+  // and ID.
+  // - Format: `users/{user.id}/pipelines/{pipeline.id}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_pipeline_name"}
+    }
+  ];
+  // The target pipeline
+  // - Format: `users/{user.id}/pipelines/{pipeline.id}` or `organizations/{org.id}/pipelines/{pipeline.id}`
+  string target = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CloneUserPipelineResponse contains a cloned pipeline.
+message CloneUserPipelineResponse {
+  // The cloned pipeline resource.
+  Pipeline pipeline = 1;
+}
+
 // TriggerUserPipelineRequest represents a request to trigger a user-owned
 // pipeline synchronously.
 message TriggerUserPipelineRequest {
@@ -930,6 +953,29 @@ message RenameOrganizationPipelineRequest {
 // RenameOrganizationPipelineResponse contains a renamed pipeline.
 message RenameOrganizationPipelineResponse {
   // The renamed pipeline resource.
+  Pipeline pipeline = 1;
+}
+
+// CloneOrganizationPipelineRequest represents a request to clone a pipeline owned by a organization.
+message CloneOrganizationPipelineRequest {
+  // The resource name of the pipeline, which allows its access by parent user
+  // and ID.
+  // - Format: `organizations/{org.id}/pipelines/{pipeline.id}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_pipeline_name"}
+    }
+  ];
+  // The target pipeline
+  // - Format: `users/{user.id}/pipelines/{pipeline.id}` or `organizations/{org.id}/pipelines/{pipeline.id}`
+  string target = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CloneOrganizationPipelineResponse contains a cloned pipeline.
+message CloneOrganizationPipelineResponse {
+  // The cloned pipeline resource.
   Pipeline pipeline = 1;
 }
 

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -149,6 +149,17 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name,new_pipeline_id";
   }
 
+  // Clone a pipeline owned by a user
+  //
+  // Clone a pipeline owned by a user, the target pipeline can be under a user or organization namespace.
+  rpc CloneUserPipeline(CloneUserPipelineRequest) returns (CloneUserPipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{name=users/*/pipelines/*}/clone"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,target";
+  }
+
   // Trigger a pipeline owned by a user
   //
   // Triggers the execution of a pipeline synchronously, i.e., the result is
@@ -406,6 +417,17 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,new_pipeline_id";
+  }
+
+  // Clone a pipeline owned by an organization
+  //
+  // Clone a pipeline owned by an organization, the target pipeline can be under a user or organization namespace.
+  rpc CloneOrganizationPipeline(CloneOrganizationPipelineRequest) returns (CloneOrganizationPipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{name=organizations/*/pipelines/*}/clone"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,target";
   }
 
   // Trigger a pipeline owned by an organization


### PR DESCRIPTION
Because

- We want to provide an API to let user clone the pipeline recipe.

This commit

- Add `CloneUserPipeline` and `CloneOrganizationPipeline` endpoints
