### PR TITLE
feat(vdp): add CheckName endpoint

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -3389,7 +3389,49 @@ paths:
           pattern: organizations/[^/]+/connectors/[^/]+
       tags:
         - PipelinePublicService
+  /v1beta/check-name:
+    post:
+      summary: Check the availibity of a resource name
+      description: |-
+        Check the availibity of a resource name. The name should be in the formats:
+         - users/<user_id>/pipelines/<pipeline_id>
+         - users/<user_id>/connectors/<connector_id>
+         - organizations/<org_id>/pipelines/<pipeline_id>
+         - organizations/<org_id>/connectors/<connector_id>
+      operationId: PipelinePublicService_CheckName
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCheckNameResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: body
+          description: |-
+            CheckNameRequest represents a request to verify if a name is
+            available.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1betaCheckNameRequest'
+      tags:
+        - PipelinePublicService
 definitions:
+  CheckNameResponseName:
+    type: string
+    enum:
+      - NAME_AVAILABLE
+      - NAME_UNAVAILABLE
+    description: |-
+      - NAME_AVAILABLE: Available.
+       - NAME_UNAVAILABLE: Unavailable.
+    title: Availability of Name
   HealthCheckResponseServingStatus:
     type: string
     enum:
@@ -3909,6 +3951,31 @@ definitions:
         $ref: '#/definitions/v1betaConnectorState'
         description: Connector state.
     description: CheckConnectorResponse contains the connector's current state.
+  v1betaCheckNameRequest:
+    type: object
+    properties:
+      name:
+        type: string
+        title: |-
+          The name of the resource to be checked, should be in the formats:
+           - users/<user_id>/pipelines/<pipeline_id>
+           - users/<user_id>/connectors/<connector_id>
+           - organizations/<org_id>/pipelines/<pipeline_id>
+           - organizations/<org_id>/connectors/<connector_id>
+    description: |-
+      CheckNameRequest represents a request to verify if a name is
+      available.
+    required:
+      - name
+  v1betaCheckNameResponse:
+    type: object
+    properties:
+      availability:
+        $ref: '#/definitions/CheckNameResponseName'
+        title: Availability
+    description: |-
+      CheckNameResponse contains the availability of a name
+      of resource that's using it.
   v1betaCloneOrganizationPipelineResponse:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/common.proto
+++ b/vdp/pipeline/v1beta/common.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package vdp.pipeline.v1beta;
 
+import "google/api/field_behavior.proto";
+
 // Role describes the permissions a user has over a resource.
 enum Role {
   // Unspecified, equivalent to VIEWER.
@@ -59,4 +61,32 @@ message Permission {
   bool can_edit = 1;
   // Defines whether the resource can be executed.
   bool can_trigger = 2;
+}
+
+// CheckNameRequest represents a request to verify if a name is
+// available.
+message CheckNameRequest {
+  // The name of the resource to be checked, should be in the formats:
+  //  - users/<user_id>/pipelines/<pipeline_id>
+  //  - users/<user_id>/connectors/<connector_id>
+  //  - organizations/<org_id>/pipelines/<pipeline_id>
+  //  - organizations/<org_id>/connectors/<connector_id>
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CheckNameResponse contains the availability of a name
+// of resource that's using it.
+message CheckNameResponse {
+  // Availability of Name
+  enum Name {
+    // Unspecified.
+    NAME_UNSPECIFIED = 0;
+    // Available.
+    NAME_AVAILABLE = 1;
+    // Unavailable.
+    NAME_UNAVAILABLE = 2;
+  }
+
+  // Availability
+  Name availability = 1;
 }

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -9,6 +9,7 @@ import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
 // VDP definitions
+import "vdp/pipeline/v1beta/common.proto";
 import "vdp/pipeline/v1beta/connector.proto";
 import "vdp/pipeline/v1beta/connector_definition.proto";
 import "vdp/pipeline/v1beta/operator_definition.proto";
@@ -890,6 +891,21 @@ service PipelinePublicService {
   // Tests the connection on an organization-owned connector.
   rpc TestOrganizationConnector(TestOrganizationConnectorRequest) returns (TestOrganizationConnectorResponse) {
     option (google.api.http) = {post: "/v1beta/{name=organizations/*/connectors/*}/testConnection"};
+    option (google.api.method_signature) = "name";
+  }
+
+  // Check the availibity of a resource name
+  //
+  // Check the availibity of a resource name. The name should be in the formats:
+  //  - users/<user_id>/pipelines/<pipeline_id>
+  //  - users/<user_id>/connectors/<connector_id>
+  //  - organizations/<org_id>/pipelines/<pipeline_id>
+  //  - organizations/<org_id>/connectors/<connector_id>
+  rpc CheckName(CheckNameRequest) returns (CheckNameResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/check-name"
+      body: "*"
+    };
     option (google.api.method_signature) = "name";
   }
 }


### PR DESCRIPTION
Because

- We want to provide an endpoint to let Console check the availability of pipeline or connector name.

This commit

- Add `CheckName` endpoint
