### PR TITLE
feat(mgmt): refactor APIs for `Get` and `Patch` authenticated user

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -71,13 +71,20 @@ enum MembershipState {
   MEMBERSHIP_STATE_PENDING = 2;
 }
 
-// User describes an individual that interacts with Instill AI.
-message User {
-  option (google.api.resource) = {
-    type: "api.instill.tech/User"
-    pattern: "users/{user.id}"
-    pattern: "users/{user.uid}"
-  };
+// OnboardingStatus describes the status of the user onboarding process.
+enum OnboardingStatus {
+  // Unspecified.
+  ONBOARDING_STATUS_UNSPECIFIED = 0;
+  // In progress, i.e., the user has initiated the onboarding process
+  // but has not yet completed it.
+  ONBOARDING_STATUS_IN_PROGRESS = 1;
+  // Completed.
+  ONBOARDING_STATUS_COMPLETED = 2;
+}
+
+// AuthenticatedUser describes the authenticated user that interacts with Instill AI.
+message AuthenticatedUser {
+  option (google.api.resource) = {type: "api.instill.tech/AuthenticatedUser"};
 
   // The name of the user, defined by its ID.
   // - Format: `users/{user.id}`.
@@ -105,7 +112,7 @@ message User {
   // Last name.
   optional string last_name = 10 [(google.api.field_behavior) = OPTIONAL];
   // Company or institution name.
-  optional string org_name = 11 [(google.api.field_behavior) = OPTIONAL];
+  optional string company_name = 11 [(google.api.field_behavior) = OPTIONAL];
   // Role.
   //
   // It must be one of the following allowed roles:
@@ -119,12 +126,49 @@ message User {
   optional string role = 12 [(google.api.field_behavior) = OPTIONAL];
   // This defines whether the user is subscribed to Instill AI's newsletter.
   bool newsletter_subscription = 13 [(google.api.field_behavior) = REQUIRED];
-  // Console cookie token.
-  optional string cookie_token = 14 [(google.api.field_behavior) = OPTIONAL];
   // Profile Avatar in base64.
   optional string profile_avatar = 15 [(google.api.field_behavior) = OPTIONAL];
   // Profile Data.
   optional google.protobuf.Struct profile_data = 16 [(google.api.field_behavior) = OPTIONAL];
+  // Onboarding Status.
+  OnboardingStatus onboarding_status = 17 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// User describes an individual that interacts with Instill AI.
+message User {
+  option (google.api.resource) = {
+    type: "api.instill.tech/User"
+    pattern: "users/{user.id}"
+    pattern: "users/{user.uid}"
+  };
+
+  // The name of the user, defined by its ID.
+  // - Format: `users/{user.id}`.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // User UUID. This field is optionally set by users on creation (it will be
+  // server-generated if unspecified).
+  optional string uid = 2 [(google.api.field_behavior) = IMMUTABLE];
+  // Resource ID (used in `name` as the last segment). This conforms to
+  // RFC-1034, which restricts to letters, numbers, and hyphen, with the first
+  // character a letter, the last a letter or a number, and a 63 character
+  // maximum.
+  //
+  // Note that the ID can be updated.
+  string id = 3 [(google.api.field_behavior) = REQUIRED];
+  // Creation time.
+  google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Update time.
+  google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Stripe customer ID. This field is used in Instill Cloud.
+  string customer_id = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // First name.
+  optional string first_name = 7 [(google.api.field_behavior) = OPTIONAL];
+  // Last name.
+  optional string last_name = 8 [(google.api.field_behavior) = OPTIONAL];
+  // Profile Avatar in base64.
+  optional string profile_avatar = 9 [(google.api.field_behavior) = OPTIONAL];
+  // Profile Data.
+  optional google.protobuf.Struct profile_data = 10 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUsersAdminRequest represents a request to list all users by admin
@@ -300,11 +344,21 @@ message GetUserResponse {
   User user = 1;
 }
 
+// GetAuthenticatedUserRequest represents a request to get the
+// authenticated user.
+message GetAuthenticatedUserRequest {}
+
+// GetAuthenticatedUserResponse contains the requested authenticated user.
+message GetAuthenticatedUserResponse {
+  // The authenticated user resource.
+  AuthenticatedUser user = 1;
+}
+
 // PatchAuthenticatedUserRequest represents a request to update the
 // authenticated user.
 message PatchAuthenticatedUserRequest {
   // The user fields that will replace the existing ones.
-  User user = 1;
+  AuthenticatedUser user = 1;
   // The update mask specifies the subset of fields that should be modified.
   //
   // For more information about this field, see
@@ -316,7 +370,7 @@ message PatchAuthenticatedUserRequest {
 // the authenticated user resource
 message PatchAuthenticatedUserResponse {
   // The updated user resource.
-  User user = 1;
+  AuthenticatedUser user = 1;
 }
 
 // CheckNamespaceRequest represents a request to verify if a namespace is

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -82,7 +82,9 @@ enum OnboardingStatus {
   ONBOARDING_STATUS_COMPLETED = 2;
 }
 
-// AuthenticatedUser describes the authenticated user that interacts with Instill AI.
+// AuthenticatedUser contains the information of an authenticated user, i.e.,
+// the public user information plus some fields that should only be accessed by
+// the user themselves.
 message AuthenticatedUser {
   option (google.api.resource) = {type: "api.instill.tech/AuthenticatedUser"};
 
@@ -134,7 +136,8 @@ message AuthenticatedUser {
   OnboardingStatus onboarding_status = 17 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// User describes an individual that interacts with Instill AI.
+// User describes an individual that interacts with Instill AI. It doesn't
+// contain any private information about the user.
 message User {
   option (google.api.resource) = {
     type: "api.instill.tech/User"

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -64,6 +64,28 @@ service MgmtPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
+  // Get the authenticated user
+  //
+  // Accesses the authenticated user.
+  rpc GetAuthenticatedUser(GetAuthenticatedUserRequest) returns (GetAuthenticatedUserResponse) {
+    option (google.api.http) = {get: "/v1beta/user"};
+    option (google.api.method_signature) = "user,update_mask";
+  }
+
+  // Update the authenticated user
+  //
+  // Accesses and updates the authenticated user.
+  //
+  // In REST requests, only the supplied user fields will be taken into account
+  // when updating the resource.
+  rpc PatchAuthenticatedUser(PatchAuthenticatedUserRequest) returns (PatchAuthenticatedUserResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta/user"
+      body: "user"
+    };
+    option (google.api.method_signature) = "user,update_mask";
+  }
+
   // List users
   //
   // Returns a paginated list of users.
@@ -78,21 +100,6 @@ service MgmtPublicService {
     option (google.api.http) = {get: "/v1beta/{name=users/*}"};
     option (google.api.method_signature) = "name";
     option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // Update a user
-  //
-  // Accesses and updates a user by ID. The authenticated user must match the
-  // target in order to modify it.
-  //
-  // In REST requests, only the supplied user fields will be taken into account
-  // when updating the resource.
-  rpc PatchAuthenticatedUser(PatchAuthenticatedUserRequest) returns (PatchAuthenticatedUserResponse) {
-    option (google.api.http) = {
-      patch: "/v1beta/users/me"
-      body: "user"
-    };
-    option (google.api.method_signature) = "user,update_mask";
   }
 
   // List user memberships

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -66,7 +66,7 @@ service MgmtPublicService {
 
   // Get the authenticated user
   //
-  // Accesses the authenticated user.
+  // Returns the details of the authenticated user.
   rpc GetAuthenticatedUser(GetAuthenticatedUserRequest) returns (GetAuthenticatedUserResponse) {
     option (google.api.http) = {get: "/v1beta/user"};
     option (google.api.method_signature) = "user,update_mask";
@@ -74,7 +74,7 @@ service MgmtPublicService {
 
   // Update the authenticated user
   //
-  // Accesses and updates the authenticated user.
+  // Updates the information of the authenticated user.
   //
   // In REST requests, only the supplied user fields will be taken into account
   // when updating the resource.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -55,7 +55,7 @@ paths:
   /v1beta/user:
     get:
       summary: Get the authenticated user
-      description: Accesses the authenticated user.
+      description: Returns the details of the authenticated user.
       operationId: MgmtPublicService_GetAuthenticatedUser
       responses:
         "200":
@@ -74,7 +74,7 @@ paths:
     patch:
       summary: Update the authenticated user
       description: |-
-        Accesses and updates the authenticated user.
+        Updates the information of the authenticated user.
 
         In REST requests, only the supplied user fields will be taken into account
         when updating the resource.
@@ -480,7 +480,10 @@ definitions:
       onboarding_status:
         $ref: '#/definitions/v1betaOnboardingStatus'
         description: Onboarding Status.
-    description: AuthenticatedUser describes the authenticated user that interacts with Instill AI.
+    description: |-
+      AuthenticatedUser contains the information of an authenticated user, i.e.,
+      the public user information plus some fields that should only be accessed by
+      the user themselves.
     required:
       - id
       - email
@@ -1582,7 +1585,9 @@ definitions:
       profile_data:
         type: object
         description: Profile Data.
-    description: User describes an individual that interacts with Instill AI.
+    description: |-
+      User describes an individual that interacts with Instill AI. It doesn't
+      contain any private information about the user.
     required:
       - id
   v1betaUserData:

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -52,6 +52,54 @@ paths:
           pattern: organizations/[^/]+/memberships/[^/]+
       tags:
         - MgmtPublicService
+  /v1beta/user:
+    get:
+      summary: Get the authenticated user
+      description: Accesses the authenticated user.
+      operationId: MgmtPublicService_GetAuthenticatedUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetAuthenticatedUserResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - MgmtPublicService
+    patch:
+      summary: Update the authenticated user
+      description: |-
+        Accesses and updates the authenticated user.
+
+        In REST requests, only the supplied user fields will be taken into account
+        when updating the resource.
+      operationId: MgmtPublicService_PatchAuthenticatedUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaPatchAuthenticatedUserResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user
+          description: The user fields that will replace the existing ones.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1betaAuthenticatedUser'
+      tags:
+        - MgmtPublicService
   /v1beta/users:
     get:
       summary: List users
@@ -104,37 +152,6 @@ paths:
           in: query
           required: false
           type: string
-      tags:
-        - MgmtPublicService
-  /v1beta/users/me:
-    patch:
-      summary: Update a user
-      description: |-
-        Accesses and updates a user by ID. The authenticated user must match the
-        target in order to modify it.
-
-        In REST requests, only the supplied user fields will be taken into account
-        when updating the resource.
-      operationId: MgmtPublicService_PatchAuthenticatedUser
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaPatchAuthenticatedUserResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user
-          description: The user fields that will replace the existing ones.
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/v1betaUser'
       tags:
         - MgmtPublicService
   /v1beta/{user_membership_name}:
@@ -389,6 +406,85 @@ definitions:
        - TASK_IMAGE_TO_IMAGE: Image to Image - generate an image from another image.
        - TASK_TEXT_EMBEDDINGS: Text Embeddings - generate an embedding (a representation as coordinates) from a text input.
        - TASK_SPEECH_RECOGNITION: Speech Recognition - transcribe the words in an audio input.
+  v1betaAuthenticatedUser:
+    type: object
+    properties:
+      name:
+        type: string
+        description: |-
+          The name of the user, defined by its ID.
+          - Format: `users/{user.id}`.
+        readOnly: true
+      uid:
+        type: string
+        description: |-
+          User UUID. This field is optionally set by users on creation (it will be
+          server-generated if unspecified).
+      id:
+        type: string
+        description: |-
+          Resource ID (used in `name` as the last segment). This conforms to
+          RFC-1034, which restricts to letters, numbers, and hyphen, with the first
+          character a letter, the last a letter or a number, and a 63 character
+          maximum.
+
+          Note that the ID can be updated.
+      create_time:
+        type: string
+        format: date-time
+        description: Creation time.
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        description: Update time.
+        readOnly: true
+      email:
+        type: string
+        description: Email.
+      customer_id:
+        type: string
+        description: Stripe customer ID. This field is used in Instill Cloud.
+        readOnly: true
+      first_name:
+        type: string
+        description: First name.
+      last_name:
+        type: string
+        description: Last name.
+      company_name:
+        type: string
+        description: Company or institution name.
+      role:
+        type: string
+        description: |-
+          Role.
+
+          It must be one of the following allowed roles:
+          - `manager`
+          - `ai-researcher`
+          - `ai-engineer`
+          - `data-engineer`
+          - `data-scientist`
+          - `analytics-engineer`
+          - `hobbyist`
+      newsletter_subscription:
+        type: boolean
+        description: This defines whether the user is subscribed to Instill AI's newsletter.
+      profile_avatar:
+        type: string
+        description: Profile Avatar in base64.
+      profile_data:
+        type: object
+        description: Profile Data.
+      onboarding_status:
+        $ref: '#/definitions/v1betaOnboardingStatus'
+        description: Onboarding Status.
+    description: AuthenticatedUser describes the authenticated user that interacts with Instill AI.
+    required:
+      - id
+      - email
+      - newsletter_subscription
   v1betaConnectorUsageData:
     type: object
     properties:
@@ -432,6 +528,13 @@ definitions:
   v1betaDeleteUserMembershipResponse:
     type: object
     description: DeleteUserMembershipResponse is an empty response.
+  v1betaGetAuthenticatedUserResponse:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/v1betaAuthenticatedUser'
+        description: The authenticated user resource.
+    description: GetAuthenticatedUserResponse contains the requested authenticated user.
   v1betaGetBulkCumulativeModelOnlineRecordsResponse:
     type: object
     properties:
@@ -1033,6 +1136,17 @@ definitions:
   v1betaNullMessage:
     type: object
     title: Nul Message for gRPC REQ/RES
+  v1betaOnboardingStatus:
+    type: string
+    enum:
+      - ONBOARDING_STATUS_IN_PROGRESS
+      - ONBOARDING_STATUS_COMPLETED
+    description: |-
+      OnboardingStatus describes the status of the user onboarding process.
+
+       - ONBOARDING_STATUS_IN_PROGRESS: In progress, i.e., the user has initiated the onboarding process
+      but has not yet completed it.
+       - ONBOARDING_STATUS_COMPLETED: Completed.
   v1betaOrganization:
     type: object
     properties:
@@ -1100,7 +1214,7 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUser'
+        $ref: '#/definitions/v1betaAuthenticatedUser'
         description: The updated user resource.
     title: |-
       PatchAuthenticatedUserResponse contains the updated user.
@@ -1452,9 +1566,6 @@ definitions:
         format: date-time
         description: Update time.
         readOnly: true
-      email:
-        type: string
-        description: Email.
       customer_id:
         type: string
         description: Stripe customer ID. This field is used in Instill Cloud.
@@ -1465,28 +1576,6 @@ definitions:
       last_name:
         type: string
         description: Last name.
-      org_name:
-        type: string
-        description: Company or institution name.
-      role:
-        type: string
-        description: |-
-          Role.
-
-          It must be one of the following allowed roles:
-          - `manager`
-          - `ai-researcher`
-          - `ai-engineer`
-          - `data-engineer`
-          - `data-scientist`
-          - `analytics-engineer`
-          - `hobbyist`
-      newsletter_subscription:
-        type: boolean
-        description: This defines whether the user is subscribed to Instill AI's newsletter.
-      cookie_token:
-        type: string
-        description: Console cookie token.
       profile_avatar:
         type: string
         description: Profile Avatar in base64.
@@ -1496,8 +1585,6 @@ definitions:
     description: User describes an individual that interacts with Instill AI.
     required:
       - id
-      - email
-      - newsletter_subscription
   v1betaUserData:
     type: object
     properties:


### PR DESCRIPTION
Because

- Some user information is sensitive and should not be accessed by other users.
- We didn't return the onboarding process status, making it difficult for the Console to handle the user onboarding workflow.

This commit

- Adds a new `GetAuthenticatedUser` endpoint for getting authenticated users' own data.
- Introduces the `OnboardingStatus` enum to indicate the status of the onboarding process.
- Removes sensitive data from the responses of `GetUser` and `ListUsers`.
- Changes `org_name` in `User` to `company_name` to prevent confusion.