### PR TITLE
feat(mgmt): refactor user/org profile and subscription endpoints

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -8,7 +8,6 @@ import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 // Protobuf standard
 import "google/protobuf/field_mask.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -82,6 +81,38 @@ enum OnboardingStatus {
   ONBOARDING_STATUS_COMPLETED = 2;
 }
 
+// UserProfile describes the public data of a user.
+message UserProfile {
+  // Display name.
+  optional string display_name = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Biography.
+  optional string bio = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Avatar in base64 format.
+  optional string avatar = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Public email.
+  optional string public_email = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Company name.
+  optional string company_name = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Social profile links list the links to the user's social profiles.
+  // The key represents the provider, and the value is the corresponding URL.
+  map<string, string> social_profile_links = 6 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// OrganizationProfile describes the public data of an organization.
+message OrganizationProfile {
+  // Display name.
+  optional string display_name = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Biography.
+  optional string bio = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Avatar in base64 format.
+  optional string avatar = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Public email.
+  optional string public_email = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Social profile links list the links to the organization's social profiles.
+  // The key represents the provider, and the value is the corresponding URL.
+  map<string, string> social_profile_links = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
 // AuthenticatedUser contains the information of an authenticated user, i.e.,
 // the public user information plus some fields that should only be accessed by
 // the user themselves.
@@ -107,14 +138,6 @@ message AuthenticatedUser {
   google.protobuf.Timestamp update_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Email.
   string email = 7 [(google.api.field_behavior) = REQUIRED];
-  // Stripe customer ID. This field is used in Instill Cloud.
-  string customer_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // First name.
-  optional string first_name = 9 [(google.api.field_behavior) = OPTIONAL];
-  // Last name.
-  optional string last_name = 10 [(google.api.field_behavior) = OPTIONAL];
-  // Company or institution name.
-  optional string company_name = 11 [(google.api.field_behavior) = OPTIONAL];
   // Role.
   //
   // It must be one of the following allowed roles:
@@ -128,12 +151,12 @@ message AuthenticatedUser {
   optional string role = 12 [(google.api.field_behavior) = OPTIONAL];
   // This defines whether the user is subscribed to Instill AI's newsletter.
   bool newsletter_subscription = 13 [(google.api.field_behavior) = REQUIRED];
-  // Profile Avatar in base64.
-  optional string profile_avatar = 15 [(google.api.field_behavior) = OPTIONAL];
-  // Profile Data.
-  optional google.protobuf.Struct profile_data = 16 [(google.api.field_behavior) = OPTIONAL];
+  // Console cookie token.
+  optional string cookie_token = 14 [(google.api.field_behavior) = OPTIONAL];
   // Onboarding Status.
   OnboardingStatus onboarding_status = 17 [(google.api.field_behavior) = OPTIONAL];
+  // Profile.
+  UserProfile profile = 18;
 }
 
 // User describes an individual that interacts with Instill AI. It doesn't
@@ -162,16 +185,8 @@ message User {
   google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Update time.
   google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Stripe customer ID. This field is used in Instill Cloud.
-  string customer_id = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // First name.
-  optional string first_name = 7 [(google.api.field_behavior) = OPTIONAL];
-  // Last name.
-  optional string last_name = 8 [(google.api.field_behavior) = OPTIONAL];
-  // Profile Avatar in base64.
-  optional string profile_avatar = 9 [(google.api.field_behavior) = OPTIONAL];
-  // Profile Data.
-  optional google.protobuf.Struct profile_data = 10 [(google.api.field_behavior) = OPTIONAL];
+  // Profile.
+  UserProfile profile = 11;
 }
 
 // ListUsersAdminRequest represents a request to list all users by admin
@@ -634,16 +649,10 @@ message Organization {
   google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Update time.
   google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Company or institution name.
-  optional string org_name = 6 [(google.api.field_behavior) = OPTIONAL];
-  // Stripe customer ID. This field is used in Instill Cloud.
-  string customer_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Profile Avatar in base64.
-  optional string profile_avatar = 9 [(google.api.field_behavior) = OPTIONAL];
-  // Profile Data.
-  optional google.protobuf.Struct profile_data = 10 [(google.api.field_behavior) = OPTIONAL];
   // The user that owns the organization.
   User owner = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Profile.
+  OrganizationProfile profile = 12;
 }
 
 // ListOrganizationsRequest represents a request to list all organizations
@@ -943,30 +952,72 @@ message DeleteOrganizationMembershipRequest {
 // DeleteOrganizationMembershipResponse is an empty response.
 message DeleteOrganizationMembershipResponse {}
 
-// Subscription details describe the plan (i.e. the features) a user has access to.
-message Subscription {
-  // Plan identifier, e.g. `freemium`.
-  string plan = 1;
+// StripeSubscriptionDetail describes the details of a subscription in Stripe.
+message StripeSubscriptionDetail {
+  // Customer ID associated with the subscription.
+  string customer_id = 1;
+  // Product name associated with the subscription in Stripe.
+  string product_name = 2;
+  // Unique identifier for the subscription.
+  string id = 3;
+  // Identifier for the specific item within the subscription.
+  string item_id = 4;
+  // Price of the subscription.
+  float price = 5;
+  // Optional timestamp indicating when the subscription was canceled, if applicable.
+  optional int32 canceled_at = 6;
 }
 
-// GetUserSubscriptionRequest represents a query to fetch the subscription
-// details of a user.
-message GetUserSubscriptionRequest {
-  // The parent resource, i.e., the user to which the subscription refers.
-  // Format: `users/{user.id}`.
-  string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/User"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_name"}
-    }
-  ];
+// UserSubscription details describe the plan (i.e., features) a user has access to.
+message UserSubscription {
+  // Enumerates the plan types for the user subscription.
+  enum Plan {
+    // Unspecified plan.
+    PLAN_UNSPECIFIED = 0;
+    // Freemium plan.
+    PLAN_FREEMIUM = 1;
+    // Pro plan.
+    PLAN_PRO = 2;
+  }
+
+  // Plan identifier.
+  Plan plan = 1;
+  // Details of the associated Stripe subscription.
+  StripeSubscriptionDetail detail = 2;
 }
 
-// GetUserSubscriptionResponse contains the requested subscription.
-message GetUserSubscriptionResponse {
+// OrganizationSubscription details describe the plan (i.e., features) an organization has access to.
+message OrganizationSubscription {
+  // Enumerates the plan types for the organization subscription.
+  enum Plan {
+    // Unspecified plan.
+    PLAN_UNSPECIFIED = 0;
+    // Freemium plan.
+    PLAN_FREEMIUM = 1;
+    // Team plan.
+    PLAN_TEAM = 2;
+    // Enterprise plan.
+    PLAN_ENTERPRISE = 3;
+  }
+
+  // Plan identifier.
+  Plan plan = 1;
+  // Details of the associated Stripe subscription.
+  StripeSubscriptionDetail detail = 2;
+  // Maximum number of seats allowed.
+  int32 max_seats = 3;
+  // Number of used seats within the organization subscription.
+  int32 used_seats = 4;
+}
+
+// GetAuthenticatedUserSubscriptionRequest represents a query to fetch the subscription
+// details of the authenticated user.
+message GetAuthenticatedUserSubscriptionRequest {}
+
+// GetAuthenticatedUserSubscriptionResponse contains the requested subscription.
+message GetAuthenticatedUserSubscriptionResponse {
   // The subscription resource.
-  Subscription subscription = 1;
+  UserSubscription subscription = 1;
 }
 
 // GetOrganizationSubscriptionRequest represents a query to fetch the
@@ -987,7 +1038,7 @@ message GetOrganizationSubscriptionRequest {
 // GetOrganizationSubscriptionResponse contains the requested subscription.
 message GetOrganizationSubscriptionResponse {
   // The subscription resource.
-  Subscription subscription = 1;
+  OrganizationSubscription subscription = 1;
 }
 
 // GetUserSubscriptionAdminRequest
@@ -1002,7 +1053,7 @@ message GetUserSubscriptionAdminRequest {
 // GetUserSubscriptionAdminResponse
 message GetUserSubscriptionAdminResponse {
   // Subscription
-  Subscription subscription = 1;
+  UserSubscription subscription = 1;
 }
 
 // GetOrganizationSubscriptionAdminRequest
@@ -1017,5 +1068,5 @@ message GetOrganizationSubscriptionAdminRequest {
 // GetOrganizationSubscriptionAdminResponse
 message GetOrganizationSubscriptionAdminResponse {
   // Subscription
-  Subscription subscription = 1;
+  OrganizationSubscription subscription = 1;
 }

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -138,6 +138,8 @@ message AuthenticatedUser {
   google.protobuf.Timestamp update_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Email.
   string email = 7 [(google.api.field_behavior) = REQUIRED];
+  // Stripe customer ID. This field is used in Instill Cloud.
+  string customer_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Role.
   //
   // It must be one of the following allowed roles:

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -224,12 +224,11 @@ service MgmtPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // Get a user subscription
+  // Get the subscription of the authenticated user
   //
-  // Returns the subscription details of a user.
-  rpc GetUserSubscription(GetUserSubscriptionRequest) returns (GetUserSubscriptionResponse) {
-    option (google.api.http) = {get: "/v1beta/{parent=users/*}/subscription"};
-    option (google.api.method_signature) = "parent";
+  // Returns the subscription details of the authenticated user.
+  rpc GetAuthenticatedUserSubscription(GetAuthenticatedUserSubscriptionRequest) returns (GetAuthenticatedUserSubscriptionResponse) {
+    option (google.api.http) = {get: "/v1beta/user/subscription"};
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -367,13 +367,6 @@ definitions:
       '@type':
         type: string
     additionalProperties: {}
-  protobufNullValue:
-    type: string
-    description: |-
-      `NullValue` is a singleton enumeration to represent the null value for the
-      `Value` type union.
-
-      The JSON representation for `NullValue` is JSON `null`.
   v1alphaTask:
     type: string
     enum:
@@ -442,19 +435,6 @@ definitions:
       email:
         type: string
         description: Email.
-      customer_id:
-        type: string
-        description: Stripe customer ID. This field is used in Instill Cloud.
-        readOnly: true
-      first_name:
-        type: string
-        description: First name.
-      last_name:
-        type: string
-        description: Last name.
-      company_name:
-        type: string
-        description: Company or institution name.
       role:
         type: string
         description: |-
@@ -471,15 +451,15 @@ definitions:
       newsletter_subscription:
         type: boolean
         description: This defines whether the user is subscribed to Instill AI's newsletter.
-      profile_avatar:
+      cookie_token:
         type: string
-        description: Profile Avatar in base64.
-      profile_data:
-        type: object
-        description: Profile Data.
+        description: Console cookie token.
       onboarding_status:
         $ref: '#/definitions/v1betaOnboardingStatus'
         description: Onboarding Status.
+      profile:
+        $ref: '#/definitions/v1betaUserProfile'
+        description: Profile.
     description: |-
       AuthenticatedUser contains the information of an authenticated user, i.e.,
       the public user information plus some fields that should only be accessed by
@@ -832,7 +812,7 @@ definitions:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaSubscription'
+        $ref: '#/definitions/v1betaOrganizationSubscription'
         title: Subscription
     title: GetOrganizationSubscriptionAdminResponse
   v1betaGetPipelineTriggerPriceRequest:
@@ -954,7 +934,7 @@ definitions:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaSubscription'
+        $ref: '#/definitions/v1betaUserSubscription'
         title: Subscription
     title: GetUserSubscriptionAdminResponse
   v1betaHealthCheckRequest:
@@ -1182,28 +1162,71 @@ definitions:
         format: date-time
         description: Update time.
         readOnly: true
-      org_name:
-        type: string
-        description: Company or institution name.
-      customer_id:
-        type: string
-        description: Stripe customer ID. This field is used in Instill Cloud.
-        readOnly: true
-      profile_avatar:
-        type: string
-        description: Profile Avatar in base64.
-      profile_data:
-        type: object
-        description: Profile Data.
       owner:
         $ref: '#/definitions/v1betaUser'
         description: The user that owns the organization.
         readOnly: true
+      profile:
+        $ref: '#/definitions/v1betaOrganizationProfile'
+        description: Profile.
     description: |-
       Organizations group several users. As entities, they can own resources such
       as pipelines or releases.
     required:
       - id
+  v1betaOrganizationProfile:
+    type: object
+    properties:
+      display_name:
+        type: string
+        description: Display name.
+      bio:
+        type: string
+        description: Biography.
+      avatar:
+        type: string
+        description: Avatar in base64 format.
+      public_email:
+        type: string
+        description: Public email.
+      social_profile_links:
+        type: object
+        additionalProperties:
+          type: string
+        description: |-
+          Social profile links list the links to the organization's social profiles.
+          The key represents the provider, and the value is the corresponding URL.
+    description: OrganizationProfile describes the public data of an organization.
+  v1betaOrganizationSubscription:
+    type: object
+    properties:
+      plan:
+        $ref: '#/definitions/v1betaOrganizationSubscriptionPlan'
+        description: Plan identifier.
+      detail:
+        $ref: '#/definitions/v1betaStripeSubscriptionDetail'
+        description: Details of the associated Stripe subscription.
+      max_seats:
+        type: integer
+        format: int32
+        description: Maximum number of seats allowed.
+      used_seats:
+        type: integer
+        format: int32
+        description: Number of used seats within the organization subscription.
+    description: OrganizationSubscription details describe the plan (i.e., features) an organization has access to.
+  v1betaOrganizationSubscriptionPlan:
+    type: string
+    enum:
+      - PLAN_FREEMIUM
+      - PLAN_TEAM
+      - PLAN_ENTERPRISE
+    description: |-
+      Enumerates the plan types for the organization subscription.
+
+       - PLAN_FREEMIUM: Freemium plan.
+       - PLAN_TEAM: Team plan.
+       - PLAN_ENTERPRISE: Enterprise plan.
   v1betaOwnerType:
     type: string
     enum:
@@ -1499,13 +1522,30 @@ definitions:
       - token
       - pow
       - session
-  v1betaSubscription:
+  v1betaStripeSubscriptionDetail:
     type: object
     properties:
-      plan:
+      customer_id:
         type: string
-        description: Plan identifier, e.g. `freemium`.
-    description: Subscription details describe the plan (i.e. the features) a user has access to.
+        description: Customer ID associated with the subscription.
+      product_name:
+        type: string
+        description: Product name associated with the subscription in Stripe.
+      id:
+        type: string
+        description: Unique identifier for the subscription.
+      item_id:
+        type: string
+        description: Identifier for the specific item within the subscription.
+      price:
+        type: number
+        format: float
+        description: Price of the subscription.
+      canceled_at:
+        type: integer
+        format: int32
+        description: Optional timestamp indicating when the subscription was canceled, if applicable.
+    description: StripeSubscriptionDetail describes the details of a subscription in Stripe.
   v1betaTimeInterval:
     type: object
     properties:
@@ -1569,22 +1609,9 @@ definitions:
         format: date-time
         description: Update time.
         readOnly: true
-      customer_id:
-        type: string
-        description: Stripe customer ID. This field is used in Instill Cloud.
-        readOnly: true
-      first_name:
-        type: string
-        description: First name.
-      last_name:
-        type: string
-        description: Last name.
-      profile_avatar:
-        type: string
-        description: Profile Avatar in base64.
-      profile_data:
-        type: object
-        description: Profile Data.
+      profile:
+        $ref: '#/definitions/v1betaUserProfile'
+        description: Profile.
     description: |-
       User describes an individual that interacts with Instill AI. It doesn't
       contain any private information about the user.
@@ -1602,6 +1629,52 @@ definitions:
     title: User records definition
     required:
       - uid
+  v1betaUserProfile:
+    type: object
+    properties:
+      display_name:
+        type: string
+        description: Display name.
+      bio:
+        type: string
+        description: Biography.
+      avatar:
+        type: string
+        description: Avatar in base64 format.
+      public_email:
+        type: string
+        description: Public email.
+      company_name:
+        type: string
+        description: Company name.
+      social_profile_links:
+        type: object
+        additionalProperties:
+          type: string
+        description: |-
+          Social profile links list the links to the user's social profiles.
+          The key represents the provider, and the value is the corresponding URL.
+    description: UserProfile describes the public data of a user.
+  v1betaUserSubscription:
+    type: object
+    properties:
+      plan:
+        $ref: '#/definitions/v1betaUserSubscriptionPlan'
+        description: Plan identifier.
+      detail:
+        $ref: '#/definitions/v1betaStripeSubscriptionDetail'
+        description: Details of the associated Stripe subscription.
+    description: UserSubscription details describe the plan (i.e., features) a user has access to.
+  v1betaUserSubscriptionPlan:
+    type: string
+    enum:
+      - PLAN_FREEMIUM
+      - PLAN_PRO
+    description: |-
+      Enumerates the plan types for the user subscription.
+
+       - PLAN_FREEMIUM: Freemium plan.
+       - PLAN_PRO: Pro plan.
   v1betaView:
     type: string
     enum:

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -435,6 +435,10 @@ definitions:
       email:
         type: string
         description: Email.
+      customer_id:
+        type: string
+        description: Stripe customer ID. This field is used in Instill Cloud.
+        readOnly: true
       role:
         type: string
         description: |-


### PR DESCRIPTION
Because

- Initially, the `profile_data` is a free-form structure and is not well-documented, making it challenging to create comprehensive documentation.
- We aim to integrate Stripe subscription information into the subscription endpoints.

This commit

- Introduces `UserProfile` and `OrganizationProfile` messages to describe the profile data.
- Incorporates Stripe subscription information in the subscription responses.
- Adds `cookie_token` back since Console still need it for tracking user.