### PR TITLE
chore(mgmt): remove unnecessary `customer_id`

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -956,18 +956,16 @@ message DeleteOrganizationMembershipResponse {}
 
 // StripeSubscriptionDetail describes the details of a subscription in Stripe.
 message StripeSubscriptionDetail {
-  // Customer ID associated with the subscription.
-  string customer_id = 1;
   // Product name associated with the subscription in Stripe.
-  string product_name = 2;
+  string product_name = 1;
   // Unique identifier for the subscription.
-  string id = 3;
+  string id = 2;
   // Identifier for the specific item within the subscription.
-  string item_id = 4;
+  string item_id = 3;
   // Price of the subscription.
-  float price = 5;
+  float price = 4;
   // Optional timestamp indicating when the subscription was canceled, if applicable.
-  optional int32 canceled_at = 6;
+  optional int32 canceled_at = 5;
 }
 
 // UserSubscription details describe the plan (i.e., features) a user has access to.


### PR DESCRIPTION
Because

- `customer_id` is not needed in the subscription message.

This commit

- Removes unnecessary `customer_id`
