### PR TITLE
feat(mgmt): add Stripe `status` and `trial_end`

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -956,6 +956,28 @@ message DeleteOrganizationMembershipResponse {}
 
 // StripeSubscriptionDetail describes the details of a subscription in Stripe.
 message StripeSubscriptionDetail {
+  // Enumerates the status types for the user's subscription.
+  enum Status {
+    // Unspecified status.
+    STATUS_UNSPECIFIED = 0;
+    // Incomplete.
+    STATUS_INCOMPLETE = 1;
+    // Incomplete Expired.
+    STATUS_INCOMPLETE_EXPIRED = 2;
+    // Trialing.
+    STATUS_TRIALING = 3;
+    // Active.
+    STATUS_ACTIVE = 4;
+    // Past due.
+    STATUS_PAST_DUE = 5;
+    // Canceled.
+    STATUS_CANCELED = 6;
+    // Unpaid.
+    STATUS_UNPAID = 7;
+    // Paused.
+    STATUS_PAUSED = 8;
+  }
+
   // Product name associated with the subscription in Stripe.
   string product_name = 1;
   // Unique identifier for the subscription.
@@ -966,6 +988,10 @@ message StripeSubscriptionDetail {
   float price = 4;
   // Optional timestamp indicating when the subscription was canceled, if applicable.
   optional int32 canceled_at = 5;
+  // Optional timestamp indicating when the trial ended, if applicable.
+  optional int32 trial_end = 6;
+  // Status of the subscription.
+  Status status = 7;
 }
 
 // UserSubscription details describe the plan (i.e., features) a user has access to.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1574,7 +1574,36 @@ definitions:
         type: integer
         format: int32
         description: Optional timestamp indicating when the subscription was canceled, if applicable.
+      trial_end:
+        type: integer
+        format: int32
+        description: Optional timestamp indicating when the trial ended, if applicable.
+      status:
+        $ref: '#/definitions/v1betaStripeSubscriptionDetailStatus'
+        description: Status of the subscription.
     description: StripeSubscriptionDetail describes the details of a subscription in Stripe.
+  v1betaStripeSubscriptionDetailStatus:
+    type: string
+    enum:
+      - STATUS_INCOMPLETE
+      - STATUS_INCOMPLETE_EXPIRED
+      - STATUS_TRIALING
+      - STATUS_ACTIVE
+      - STATUS_PAST_DUE
+      - STATUS_CANCELED
+      - STATUS_UNPAID
+      - STATUS_PAUSED
+    description: |-
+      Enumerates the status types for the user's subscription.
+
+       - STATUS_INCOMPLETE: Incomplete.
+       - STATUS_INCOMPLETE_EXPIRED: Incomplete Expired.
+       - STATUS_TRIALING: Trialing.
+       - STATUS_ACTIVE: Active.
+       - STATUS_PAST_DUE: Past due.
+       - STATUS_CANCELED: Canceled.
+       - STATUS_UNPAID: Unpaid.
+       - STATUS_PAUSED: Paused.
   v1betaTimeInterval:
     type: object
     properties:


### PR DESCRIPTION
Because

- We need the `status` and `trial_end` data from Stripe.

This commit

- adds Stripe's `status` enum and `trial_end` field.

Note
- [Reference for the enum](https://stripe.com/docs/api/subscriptions/object#subscription_object-status)