### PR TITLE
feat(artifact): add services

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package artifact.artifact.v1alpha;
+
+import "common/healthcheck/v1beta/healthcheck.proto";
+// Google API
+import "google/api/field_behavior.proto";
+
+// LivenessRequest represents a request to check a service liveness status
+message LivenessRequest {
+  // HealthCheckRequest message
+  optional common.healthcheck.v1beta.HealthCheckRequest health_check_request = 1 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// LivenessResponse represents a response for a service liveness status
+message LivenessResponse {
+  // HealthCheckResponse message
+  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
+}
+
+// ReadinessRequest represents a request to check a service readiness status
+message ReadinessRequest {
+  // HealthCheckRequest message
+  optional common.healthcheck.v1beta.HealthCheckRequest health_check_request = 1 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ReadinessResponse represents a response for a service readiness status
+message ReadinessResponse {
+  // HealthCheckResponse message
+  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
+}

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package artifact.artifact.v1alpha;
+
+// Artifact definitions
+import "artifact/artifact/v1alpha/artifact.proto";
+// Google API
+import "google/api/annotations.proto";
+import "google/api/visibility.proto";
+// OpenAPI definition
+import "protoc-gen-openapiv2/options/annotations.proto";
+
+// Artifact
+//
+// ArtifactPublicService exposes the public endpoints that allow clients to
+// manage artifacts.
+service ArtifactPublicService {
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {description: "Public Artifact endpoints"};
+
+  // Check if the artifact server is alive
+  //
+  // See https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
+  rpc Liveness(LivenessRequest) returns (LivenessResponse) {
+    option (google.api.http) = {
+      get: "/v1alpha/__liveness"
+      additional_bindings: [
+        {get: "/v1alpha/health/artifact"}]
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Check if the artifact server is ready
+  //
+  // See https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+  rpc Readiness(ReadinessRequest) returns (ReadinessResponse) {
+    option (google.api.http) = {
+      get: "/v1alpha/__readiness"
+      additional_bindings: [
+        {get: "/v1alpha/ready/artifact"}]
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+}

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -1,0 +1,32 @@
+swagger: "2.0"
+info:
+  title: common/healthcheck/v1beta/healthcheck.proto
+  version: version not set
+tags:
+  - name: ArtifactPublicService
+    description: Public Artifact endpoints
+consumes:
+  - application/json
+produces:
+  - application/json
+paths: {}
+definitions:
+  protobufAny:
+    type: object
+    properties:
+      '@type':
+        type: string
+    additionalProperties: {}
+  rpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      details:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/protobufAny'


### PR DESCRIPTION
Because

- to initiate `artifact` services

This commit

- add basic `liveness` and `readiness`
