### PR TITLE
feat(openapi): keep public and private API docs in sync with main branch

### DIFF
--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -1,0 +1,73 @@
+name: Sync docs in ReadMe 🦉
+
+on:
+  push:
+    branches:
+      # This workflow will run every time changes in the OpenAPI docs are
+      # pushed to the `main` branch.
+      - main
+    paths:
+      - 'openapiv2/core/**'
+      - 'openapiv2/model/**'
+      - 'openapiv2/vdp/**'
+
+jobs:
+  sync-openapi-private:
+    name: Keep private (staging) docs in sync with `main`
+    runs-on: ubuntu-latest
+    outputs:
+      should_update_public: ${{ steps.check-new-release.outputs.is_new_release }}
+    steps:
+      - name: Check out repo 📚
+        uses: actions/checkout@v3
+        with:
+          # Needed in checkNewRelease to compare with the previous commit.
+          fetch-depth: 0
+
+      - name: Sync Core 🔮
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/core/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65ca17433dcd850078ffca3f
+
+      - name: Sync Model ⚗️
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/model/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65ca17433dcd850078ffca41
+
+      - name: Sync VDP 💧
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/vdp/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65ca17433dcd850078ffca40
+
+      - name: Check new release 🔍
+        id: check-new-release
+        run: |
+          if [[ `git diff ${{ github.event.before }} ${{ github.event.after }} openapiv2/vdp openapiv2/core openapiv2/model | grep "^+\s\+version"` ]]; then
+            echo 'is_new_release=true' >> $GITHUB_OUTPUT
+          else
+            echo 'is_new_release=false' >> $GITHUB_OUTPUT
+          fi
+
+  sync-openapi-public:
+    name: Sync public docs on new release
+    needs: [sync-openapi-private]
+    runs-on: ubuntu-latest
+    if: needs.sync-openapi-private.outputs.should_update_public == 'true'
+    steps:
+      - name: Check out repo 📚
+        uses: actions/checkout@v3
+
+      - name: Sync Core 🔮
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/core/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=659fcafc3ca8be005651d43f
+
+      - name: Sync Model ⚗️
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/model/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65a6a52ab94959005b83f6fc
+
+      - name: Sync VDP 💧
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/vdp/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65a15372e7857a001655767c

--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -16,6 +16,7 @@ jobs:
     name: Keep private (staging) docs in sync with `main`
     runs-on: ubuntu-latest
     outputs:
+      old_release: ${{ steps.check-new-release.outputs.old_release }}
       new_release: ${{ steps.check-new-release.outputs.new_release }}
     steps:
       - name: Check out repo 📚
@@ -42,10 +43,20 @@ jobs:
       - name: Check new release 🔍
         id: check-new-release
         run: |
-          # If the version in the OpenAPI configuration has changed, set the
-          # new release version (without the "v" prefix) to a variable.
-          if [[ `git diff ${{ github.event.before }} ${{ github.event.after }} common/openapi/v1beta/api_info.conf | grep "^+\s\+version"` ]]; then
-            echo "new_release=$(grep version common/openapi/v1beta/api_info.conf | sed 's/.*\"v\(.*\)\".*/\1/')" >> $GITHUB_OUTPUT
+          # If the version in the OpenAPI configuration has changed, extract
+          # the old and new release versions (without the "v" prefix) to
+          # variables.
+          version_file=common/openapi/v1beta/api_info.conf
+          capture_old='^-\s\+\<version:'
+          capture_new='^+\s\+\<version:'
+          remove_v_prefix='s/.*"v\(.*\)".*/\1/'
+
+          old_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_old | sed $remove_v_prefix)
+          new_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_new | sed $remove_v_prefix)
+
+          if [[ $new_version ]]; then
+            echo "new_release=$new_version" >> $GITHUB_OUTPUT
+            echo "old_release=$old_version" >> $GITHUB_OUTPUT
           fi
 
   sync-openapi-public:
@@ -63,3 +74,9 @@ jobs:
           Release: ${{ needs.sync-openapi-private.outputs.new_release }}
         with:
           rdme: versions:create ${{ env.Release }} --fork 0-beta-staging --codename=${{ env.Release}} --main true --beta true --isPublic true --key=${{ secrets.README_API_KEY }}
+      - name: Delete old version 🧹
+        uses: readmeio/rdme@v8
+        env:
+          OldRelease: ${{ needs.sync-openapi-private.outputs.old_release }}
+        with:
+          rdme: versions:delete ${{ env.OldRelease }} --key=${{ secrets.README_API_KEY }}

--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -49,10 +49,10 @@ jobs:
           version_file=common/openapi/v1beta/api_info.conf
           capture_old='^-\s\+\<version:'
           capture_new='^+\s\+\<version:'
-          remove_v_prefix='s/.*"v\(.*\)".*/\1/'
+          extract_version='s/.*"v\(.*\)".*/\1/'
 
-          old_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_old | sed $remove_v_prefix)
-          new_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_new | sed $remove_v_prefix)
+          old_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_old | sed $extract_version)
+          new_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_new | sed $extract_version)
 
           if [[ $new_version ]]; then
             echo "new_release=$new_version" >> $GITHUB_OUTPUT
@@ -74,6 +74,7 @@ jobs:
           Release: ${{ needs.sync-openapi-private.outputs.new_release }}
         with:
           rdme: versions:create ${{ env.Release }} --fork 0-beta-staging --codename=${{ env.Release}} --main true --beta true --isPublic true --key=${{ secrets.README_API_KEY }}
+
       - name: Delete old version 🧹
         uses: readmeio/rdme@v8
         env:

--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -16,12 +16,12 @@ jobs:
     name: Keep private (staging) docs in sync with `main`
     runs-on: ubuntu-latest
     outputs:
-      should_update_public: ${{ steps.check-new-release.outputs.is_new_release }}
+      new_release: ${{ steps.check-new-release.outputs.new_release }}
     steps:
       - name: Check out repo 📚
         uses: actions/checkout@v3
         with:
-          # Needed in checkNewRelease to compare with the previous commit.
+          # Needed in check-new-release to compare with the previous commit.
           fetch-depth: 0
 
       - name: Sync Core 🔮
@@ -42,32 +42,24 @@ jobs:
       - name: Check new release 🔍
         id: check-new-release
         run: |
-          if [[ `git diff ${{ github.event.before }} ${{ github.event.after }} openapiv2/vdp openapiv2/core openapiv2/model | grep "^+\s\+version"` ]]; then
-            echo 'is_new_release=true' >> $GITHUB_OUTPUT
-          else
-            echo 'is_new_release=false' >> $GITHUB_OUTPUT
+          # If the version in the OpenAPI configuration has changed, set the
+          # new release version (without the "v" prefix) to a variable.
+          if [[ `git diff ${{ github.event.before }} ${{ github.event.after }} common/openapi/v1beta/api_info.conf | grep "^+\s\+version"` ]]; then
+            echo "new_release=$(grep version common/openapi/v1beta/api_info.conf | sed 's/.*\"v\(.*\)\".*/\1/')" >> $GITHUB_OUTPUT
           fi
 
   sync-openapi-public:
     name: Sync public docs on new release
     needs: [sync-openapi-private]
     runs-on: ubuntu-latest
-    if: needs.sync-openapi-private.outputs.should_update_public == 'true'
+    if: needs.sync-openapi-private.outputs.new_release != ''
     steps:
       - name: Check out repo 📚
         uses: actions/checkout@v3
 
-      - name: Sync Core 🔮
+      - name: Create new version 🚀
         uses: readmeio/rdme@v8
+        env:
+          Release: ${{ needs.sync-openapi-private.outputs.new_release }}
         with:
-          rdme: openapi openapiv2/core/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=659fcafc3ca8be005651d43f
-
-      - name: Sync Model ⚗️
-        uses: readmeio/rdme@v8
-        with:
-          rdme: openapi openapiv2/model/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65a6a52ab94959005b83f6fc
-
-      - name: Sync VDP 💧
-        uses: readmeio/rdme@v8
-        with:
-          rdme: openapi openapiv2/vdp/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65a15372e7857a001655767c
+          rdme: versions:create ${{ env.Release }} --fork 0-beta-staging --codename=${{ env.Release}} --main true --beta true --isPublic true --key=${{ secrets.README_API_KEY }}

--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -28,17 +28,17 @@ jobs:
       - name: Sync Core 🔮
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/core/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65ca17433dcd850078ffca3f
+          rdme: openapi openapiv2/core/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65bcfc78e72e300017c0b162
 
       - name: Sync Model ⚗️
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/model/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65ca17433dcd850078ffca41
+          rdme: openapi openapiv2/model/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65bcfc78e72e300017c0b163
 
       - name: Sync VDP 💧
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/vdp/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65ca17433dcd850078ffca40
+          rdme: openapi openapiv2/vdp/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65bcfc78e72e300017c0b164
 
       - name: Check new release 🔍
         id: check-new-release


### PR DESCRIPTION
Because

- OpenAPI changes require manual uploads in ReadMe.com
- We have no staging docs

This commit

- Syncs the `main` branch with the public and private version of the API
    - Changes in main branch update the staging docs
    - Version changes in main branch update the public docs


## Notes

I created [a playground environment](https://github.com/jvallesm/instill-protobufs) to test the GitHub actions:

- See the [README](https://github.com/jvallesm/instill-protobufs) for a more detailed explanation.
- Workflow run [without version changes](https://github.com/jvallesm/instill-protobufs/actions/runs/7899195585/job/21558124375).
- Workflow run [with version changes](https://github.com/jvallesm/instill-protobufs/actions/runs/7899206790).

✅  This PR will need:
- [x] Changes in ReadMe.com to have a staging version + adapt existing version to the naming introduced in this one.
- [x] An update in the workflow to match the staging API reference IDs to those in the Instill AI organization.
- [x] A `README_API_KEY` repository variable.

