### PR TITLE
feat(usage): use `AuthenticatedUser` message in usage collection

### DIFF
--- a/core/usage/v1beta/usage.proto
+++ b/core/usage/v1beta/usage.proto
@@ -93,7 +93,7 @@ message Session {
 // Management service usage data
 message MgmtUsageData {
   // Repeated user usage data
-  repeated core.mgmt.v1beta.User user_usages = 1;
+  repeated core.mgmt.v1beta.AuthenticatedUser user_usages = 1;
   // Repeated org usage data
   repeated core.mgmt.v1beta.Organization org_usages = 2;
 }

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1052,7 +1052,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaUser'
+          $ref: '#/definitions/v1betaAuthenticatedUser'
         title: Repeated user usage data
       org_usages:
         type: array


### PR DESCRIPTION
Because

- We removed some onboarding data from `User` message and put them in the `AuthenticatedUser` message. Thus, we should use `AuthenticatedUser` to collect the usage data.

This commit

- Uses `AuthenticatedUser` message in usage collection.
