### PR TITLE
feat(core): add `Owner` message for embedding user and organization information

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -166,9 +166,9 @@ message Owner {
   // The owner, which can be either a User or an Organization.
   oneof owner {
     // User.
-    core.mgmt.v1beta.User user = 23 [(google.api.field_behavior) = OUTPUT_ONLY];
+    core.mgmt.v1beta.User user = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
     // Organization.
-    core.mgmt.v1beta.Organization organization = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
+    core.mgmt.v1beta.Organization organization = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
 }
 

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -161,6 +161,17 @@ message AuthenticatedUser {
   UserProfile profile = 18;
 }
 
+// Owner is a wrapper for User and Organization, used to embed owner information in other resources.
+message Owner {
+  // The owner, which can be either a User or an Organization.
+  oneof owner {
+    // User.
+    core.mgmt.v1beta.User user = 23 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Organization.
+    core.mgmt.v1beta.Organization organization = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+}
+
 // User describes an individual that interacts with Instill AI. It doesn't
 // contain any private information about the user.
 message User {

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -5,6 +5,8 @@ package model.model.v1alpha;
 // Model definitions
 import "common/healthcheck/v1beta/healthcheck.proto";
 import "common/task/v1alpha/task.proto";
+// Core definitions
+import "core/mgmt/v1beta/mgmt.proto";
 // Google API
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
@@ -129,8 +131,13 @@ message Model {
   google.protobuf.Timestamp delete_time = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Resource name of the owner.
   string owner_name = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Owner details, such as the profile data.
-  google.protobuf.Struct owner = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Deleted Fields.
+  reserved 16;
+  // Model owner.
+  optional core.mgmt.v1beta.Owner owner = 17 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 }
 
 // ModelCard represents a README.md file that accompanies the model to describe

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -39,7 +39,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -85,7 +85,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_definition_name
           description: |-
@@ -125,7 +125,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: page_size
           description: |-
@@ -176,7 +176,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: permalink
           description: |-
@@ -219,7 +219,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_name
           description: |-
@@ -282,7 +282,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_name
           description: |-
@@ -316,7 +316,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_name
           description: |-
@@ -358,7 +358,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_name
           description: |-
@@ -392,7 +392,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_name
           description: |-
@@ -437,7 +437,7 @@ paths:
                 description: Model task.
                 readOnly: true
               state:
-                $ref: '#/definitions/ModelState'
+                $ref: '#/definitions/v1alphaModelState'
                 description: Model state.
                 readOnly: true
               visibility:
@@ -464,8 +464,8 @@ paths:
                 description: Resource name of the owner.
                 readOnly: true
               owner:
-                type: object
-                description: Owner details, such as the profile data.
+                $ref: '#/definitions/v1betaOwner'
+                description: Model owner.
                 readOnly: true
             title: The model to update
       tags:
@@ -488,7 +488,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_name
           description: |-
@@ -524,7 +524,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_name
           description: |-
@@ -560,7 +560,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_name
           description: |-
@@ -602,7 +602,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_name
           description: |-
@@ -644,7 +644,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_name
           description: |-
@@ -680,7 +680,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_card_name
           description: |-
@@ -712,7 +712,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_name
           description: |-
@@ -743,7 +743,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user_model_name
           description: |-
@@ -780,7 +780,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_name
           description: |-
@@ -843,7 +843,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_name
           description: |-
@@ -877,7 +877,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_name
           description: |-
@@ -919,7 +919,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_name
           description: |-
@@ -953,7 +953,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: model_name_1
           description: |-
@@ -998,7 +998,7 @@ paths:
                 description: Model task.
                 readOnly: true
               state:
-                $ref: '#/definitions/ModelState'
+                $ref: '#/definitions/v1alphaModelState'
                 description: Model state.
                 readOnly: true
               visibility:
@@ -1025,8 +1025,8 @@ paths:
                 description: Resource name of the owner.
                 readOnly: true
               owner:
-                type: object
-                description: Owner details, such as the profile data.
+                $ref: '#/definitions/v1betaOwner'
+                description: Model owner.
                 readOnly: true
             title: The model to update
       tags:
@@ -1049,7 +1049,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_name
           description: |-
@@ -1085,7 +1085,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_name
           description: |-
@@ -1121,7 +1121,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_name
           description: |-
@@ -1163,7 +1163,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_name
           description: |-
@@ -1205,7 +1205,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_name
           description: |-
@@ -1241,7 +1241,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_card_name
           description: |-
@@ -1273,7 +1273,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_name
           description: |-
@@ -1304,7 +1304,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: organization_model_name
           description: |-
@@ -1340,7 +1340,7 @@ paths:
         default:
           description: An unexpected error response.
           schema:
-            $ref: '#/definitions/rpcStatus'
+            $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
           description: |-
@@ -1452,23 +1452,6 @@ definitions:
   ModelPublicServiceUnpublishUserModelBody:
     type: object
     description: UnpublishUserModelRequest represents a request to unpublish a model.
-  ModelState:
-    type: string
-    enum:
-      - STATE_OFFLINE
-      - STATE_ONLINE
-      - STATE_ERROR
-    description: |-
-      State describes the state of a model. See [Deploy
-      Models](https://www.instill.tech/docs/latest/model/deploy) for more
-      information.
-
-       - STATE_OFFLINE: Offline is the default state when a model is initially created. A model
-      can be switched from ONLINE to this state by using the `undeploy`
-      method.
-       - STATE_ONLINE: Online is the state of a model when it has been deployed (i.e. when the
-      `deploy` method has been used on an OFFLINE model).
-       - STATE_ERROR: Error is the state when the model is undeployable on Instill Model.
   googlelongrunningOperation:
     type: object
     properties:
@@ -1492,7 +1475,7 @@ definitions:
           If `true`, the operation is completed, and either `error` or `response` is
           available.
       error:
-        $ref: '#/definitions/rpcStatus'
+        $ref: '#/definitions/googlerpcStatus'
         description: The error result of the operation in case of failure or cancellation.
       response:
         $ref: '#/definitions/protobufAny'
@@ -1508,6 +1491,38 @@ definitions:
     description: |-
       This resource represents a long-running operation that is the result of a
       network API call.
+  googlerpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+        description: |-
+          The status code, which should be an enum value of
+          [google.rpc.Code][google.rpc.Code].
+      message:
+        type: string
+        description: |-
+          A developer-facing error message, which should be in English. Any
+          user-facing error message should be localized and sent in the
+          [google.rpc.Status.details][google.rpc.Status.details] field, or localized
+          by the client.
+      details:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/protobufAny'
+        description: |-
+          A list of messages that carry the error details.  There is a common set of
+          message types for APIs to use.
+    description: |-
+      The `Status` type defines a logical error model that is suitable for
+      different programming environments, including REST APIs and RPC APIs. It is
+      used by [gRPC](https://github.com/grpc). Each `Status` message contains
+      three pieces of data: error code, error message, and error details.
+
+      You can find out more about this error model and how to work with it in the
+      [API Design Guide](https://cloud.google.com/apis/design/errors).
   modelcontrollerv1alphaLivenessResponse:
     type: object
     properties:
@@ -1522,6 +1537,16 @@ definitions:
         $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
+  modelv1alphaView:
+    type: string
+    enum:
+      - VIEW_BASIC
+      - VIEW_FULL
+    description: |-
+      View defines how a model definition is presented.
+
+       - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
+       - VIEW_FULL: Full representation.
   protobufAny:
     type: object
     properties:
@@ -1650,38 +1675,6 @@ definitions:
       `Value` type union.
 
       The JSON representation for `NullValue` is JSON `null`.
-  rpcStatus:
-    type: object
-    properties:
-      code:
-        type: integer
-        format: int32
-        description: |-
-          The status code, which should be an enum value of
-          [google.rpc.Code][google.rpc.Code].
-      message:
-        type: string
-        description: |-
-          A developer-facing error message, which should be in English. Any
-          user-facing error message should be localized and sent in the
-          [google.rpc.Status.details][google.rpc.Status.details] field, or localized
-          by the client.
-      details:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/protobufAny'
-        description: |-
-          A list of messages that carry the error details.  There is a common set of
-          message types for APIs to use.
-    description: |-
-      The `Status` type defines a logical error model that is suitable for
-      different programming environments, including REST APIs and RPC APIs. It is
-      used by [gRPC](https://github.com/grpc). Each `Status` message contains
-      three pieces of data: error code, error message, and error details.
-
-      You can find out more about this error model and how to work with it in the
-      [API Design Guide](https://cloud.google.com/apis/design/errors).
   v1alphaBoundingBox:
     type: object
     properties:
@@ -1712,7 +1705,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/ModelState'
+        $ref: '#/definitions/v1alphaModelState'
         title: Retrieved model state
     title: |-
       CheckModelAdminResponse represents a response to fetch a model's
@@ -2311,7 +2304,7 @@ definitions:
         description: Model task.
         readOnly: true
       state:
-        $ref: '#/definitions/ModelState'
+        $ref: '#/definitions/v1alphaModelState'
         description: Model state.
         readOnly: true
       visibility:
@@ -2338,8 +2331,8 @@ definitions:
         description: Resource name of the owner.
         readOnly: true
       owner:
-        type: object
-        description: Owner details, such as the profile data.
+        $ref: '#/definitions/v1betaOwner'
+        description: Model owner.
         readOnly: true
     title: |-
       Model represents an AI model, i.e. a program that performs tasks as decision
@@ -2435,6 +2428,23 @@ definitions:
         description: Update time.
         readOnly: true
     description: ModelDefinition defines how to configure and import a model.
+  v1alphaModelState:
+    type: string
+    enum:
+      - STATE_OFFLINE
+      - STATE_ONLINE
+      - STATE_ERROR
+    description: |-
+      State describes the state of a model. See [Deploy
+      Models](https://www.instill.tech/docs/latest/model/deploy) for more
+      information.
+
+       - STATE_OFFLINE: Offline is the default state when a model is initially created. A model
+      can be switched from ONLINE to this state by using the `undeploy`
+      method.
+       - STATE_ONLINE: Online is the state of a model when it has been deployed (i.e. when the
+      `deploy` method has been used on an OFFLINE model).
+       - STATE_ERROR: Error is the state when the model is undeployable on Instill Model.
   v1alphaModelVisibility:
     type: string
     enum:
@@ -2565,7 +2575,7 @@ definitions:
           Permalink of a resource. For example:
           "resources/{resource_uuid}/types/{type}"
       model_state:
-        $ref: '#/definitions/ModelState'
+        $ref: '#/definitions/v1alphaModelState'
         title: Model state
       backend_state:
         $ref: '#/definitions/HealthCheckResponseServingStatus'
@@ -3085,16 +3095,6 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         description: The updated model resource.
     description: UpdateUserModelResponse contains the updated model.
-  v1alphaView:
-    type: string
-    enum:
-      - VIEW_BASIC
-      - VIEW_FULL
-    description: |-
-      View defines how a model definition is presented.
-
-       - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
-       - VIEW_FULL: Full representation.
   v1alphaVisualQuestionAnsweringInput:
     type: object
     properties:
@@ -3156,7 +3156,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/ModelState'
+        $ref: '#/definitions/v1alphaModelState'
         description: State.
       progress:
         type: integer
@@ -3169,7 +3169,7 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/ModelState'
+        $ref: '#/definitions/v1alphaModelState'
         description: State.
       progress:
         type: integer
@@ -3192,6 +3192,152 @@ definitions:
         $ref: '#/definitions/HealthCheckResponseServingStatus'
         title: Status is the instance of the enum type ServingStatus
     title: HealthCheckResponse represents a response for a service heath status
+  v1betaOrganization:
+    type: object
+    properties:
+      name:
+        type: string
+        description: |-
+          The name of the organization, defined by its ID.
+          - Format: `organization/{organization.id}`.
+        readOnly: true
+      uid:
+        type: string
+        description: Organization UUID.
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          Resource ID (used in `name` as the last segment). This conforms to
+          RFC-1034, which restricts to letters, numbers, and hyphen, with the first
+          character a letter, the last a letter or a number, and a 63 character
+          maximum.
+
+          Note that the ID can be updated.
+      create_time:
+        type: string
+        format: date-time
+        description: Creation time.
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        description: Update time.
+        readOnly: true
+      owner:
+        $ref: '#/definitions/v1betaUser'
+        description: The user that owns the organization.
+        readOnly: true
+      profile:
+        $ref: '#/definitions/v1betaOrganizationProfile'
+        description: Profile.
+    description: |-
+      Organizations group several users. As entities, they can own resources such
+      as pipelines or releases.
+    required:
+      - id
+  v1betaOrganizationProfile:
+    type: object
+    properties:
+      display_name:
+        type: string
+        description: Display name.
+      bio:
+        type: string
+        description: Biography.
+      avatar:
+        type: string
+        description: Avatar in base64 format.
+      public_email:
+        type: string
+        description: Public email.
+      social_profile_links:
+        type: object
+        additionalProperties:
+          type: string
+        description: |-
+          Social profile links list the links to the organization's social profiles.
+          The key represents the provider, and the value is the corresponding URL.
+    description: OrganizationProfile describes the public data of an organization.
+  v1betaOwner:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/v1betaUser'
+        description: User.
+        readOnly: true
+      organization:
+        $ref: '#/definitions/v1betaOrganization'
+        description: Organization.
+        readOnly: true
+    description: Owner is a wrapper for User and Organization, used to embed owner information in other resources.
+  v1betaUser:
+    type: object
+    properties:
+      name:
+        type: string
+        description: |-
+          The name of the user, defined by its ID.
+          - Format: `users/{user.id}`.
+        readOnly: true
+      uid:
+        type: string
+        description: |-
+          User UUID. This field is optionally set by users on creation (it will be
+          server-generated if unspecified).
+      id:
+        type: string
+        description: |-
+          Resource ID (used in `name` as the last segment). This conforms to
+          RFC-1034, which restricts to letters, numbers, and hyphen, with the first
+          character a letter, the last a letter or a number, and a 63 character
+          maximum.
+
+          Note that the ID can be updated.
+      create_time:
+        type: string
+        format: date-time
+        description: Creation time.
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        description: Update time.
+        readOnly: true
+      profile:
+        $ref: '#/definitions/v1betaUserProfile'
+        description: Profile.
+    description: |-
+      User describes an individual that interacts with Instill AI. It doesn't
+      contain any private information about the user.
+    required:
+      - id
+  v1betaUserProfile:
+    type: object
+    properties:
+      display_name:
+        type: string
+        description: Display name.
+      bio:
+        type: string
+        description: Biography.
+      avatar:
+        type: string
+        description: Avatar in base64 format.
+      public_email:
+        type: string
+        description: Public email.
+      company_name:
+        type: string
+        description: Company name.
+      social_profile_links:
+        type: object
+        additionalProperties:
+          type: string
+        description: |-
+          Social profile links list the links to the user's social profiles.
+          The key represents the provider, and the value is the corresponding URL.
+    description: UserProfile describes the public data of a user.
 securityDefinitions:
   Bearer:
     type: apiKey

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -426,10 +426,6 @@ paths:
                 type: string
                 description: Owner Name.
                 readOnly: true
-              owner:
-                type: object
-                description: Owner details.
-                readOnly: true
               releases:
                 type: array
                 items:
@@ -447,6 +443,10 @@ paths:
               visibility:
                 $ref: '#/definitions/v1betaPipelineVisibility'
                 description: Pipeline visibility.
+                readOnly: true
+              owner:
+                $ref: '#/definitions/v1betaOwner'
+                description: Pipeline owner.
                 readOnly: true
             title: The pipeline fields that will replace the existing ones.
       tags:
@@ -1403,10 +1403,6 @@ paths:
                 type: string
                 description: Owner Name.
                 readOnly: true
-              owner:
-                type: object
-                description: Owner details.
-                readOnly: true
               releases:
                 type: array
                 items:
@@ -1424,6 +1420,10 @@ paths:
               visibility:
                 $ref: '#/definitions/v1betaPipelineVisibility'
                 description: Pipeline visibility.
+                readOnly: true
+              owner:
+                $ref: '#/definitions/v1betaOwner'
+                description: Pipeline owner.
                 readOnly: true
             title: The pipeline fields that will replace the existing ones.
       tags:
@@ -2695,8 +2695,8 @@ paths:
                 description: Owner name.
                 readOnly: true
               owner:
-                type: object
-                description: Owner details.
+                $ref: '#/definitions/v1betaOwner'
+                description: Connector owner.
                 readOnly: true
             title: The connector fields that will replace the existing ones.
             required:
@@ -3183,8 +3183,8 @@ paths:
                 description: Owner name.
                 readOnly: true
               owner:
-                type: object
-                description: Owner details.
+                $ref: '#/definitions/v1betaOwner'
+                description: Connector owner.
                 readOnly: true
             title: The connector fields that will replace the existing ones.
             required:
@@ -3728,16 +3728,6 @@ definitions:
         $ref: '#/definitions/v1betaRole'
         description: Defines the role users will have over the resource.
     description: ShareCode describes a sharing configuration through a link.
-  SharingUser:
-    type: object
-    properties:
-      enabled:
-        type: boolean
-        description: Defines whether the sharing option with this user is enabled.
-      role:
-        $ref: '#/definitions/v1betaRole'
-        description: Defines the role the user will have over the resource.
-    description: Describes the sharing configuration with a given user.
   googlelongrunningOperation:
     type: object
     properties:
@@ -3809,6 +3799,47 @@ definitions:
 
       You can find out more about this error model and how to work with it in the
       [API Design Guide](https://cloud.google.com/apis/design/errors).
+  mgmtv1betaUser:
+    type: object
+    properties:
+      name:
+        type: string
+        description: |-
+          The name of the user, defined by its ID.
+          - Format: `users/{user.id}`.
+        readOnly: true
+      uid:
+        type: string
+        description: |-
+          User UUID. This field is optionally set by users on creation (it will be
+          server-generated if unspecified).
+      id:
+        type: string
+        description: |-
+          Resource ID (used in `name` as the last segment). This conforms to
+          RFC-1034, which restricts to letters, numbers, and hyphen, with the first
+          character a letter, the last a letter or a number, and a 63 character
+          maximum.
+
+          Note that the ID can be updated.
+      create_time:
+        type: string
+        format: date-time
+        description: Creation time.
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        description: Update time.
+        readOnly: true
+      profile:
+        $ref: '#/definitions/v1betaUserProfile'
+        description: Profile.
+    description: |-
+      User describes an individual that interacts with Instill AI. It doesn't
+      contain any private information about the user.
+    required:
+      - id
   pipelinev1betaState:
     type: string
     enum:
@@ -4154,8 +4185,8 @@ definitions:
         description: Owner name.
         readOnly: true
       owner:
-        type: object
-        description: Owner details.
+        $ref: '#/definitions/v1betaOwner'
+        description: Connector owner.
         readOnly: true
     description: |-
       A Connector is a type of pipeline component that queries, processes or sends
@@ -4886,6 +4917,85 @@ definitions:
     required:
       - component_specification
       - openapi_specifications
+  v1betaOrganization:
+    type: object
+    properties:
+      name:
+        type: string
+        description: |-
+          The name of the organization, defined by its ID.
+          - Format: `organization/{organization.id}`.
+        readOnly: true
+      uid:
+        type: string
+        description: Organization UUID.
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          Resource ID (used in `name` as the last segment). This conforms to
+          RFC-1034, which restricts to letters, numbers, and hyphen, with the first
+          character a letter, the last a letter or a number, and a 63 character
+          maximum.
+
+          Note that the ID can be updated.
+      create_time:
+        type: string
+        format: date-time
+        description: Creation time.
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        description: Update time.
+        readOnly: true
+      owner:
+        $ref: '#/definitions/mgmtv1betaUser'
+        description: The user that owns the organization.
+        readOnly: true
+      profile:
+        $ref: '#/definitions/v1betaOrganizationProfile'
+        description: Profile.
+    description: |-
+      Organizations group several users. As entities, they can own resources such
+      as pipelines or releases.
+    required:
+      - id
+  v1betaOrganizationProfile:
+    type: object
+    properties:
+      display_name:
+        type: string
+        description: Display name.
+      bio:
+        type: string
+        description: Biography.
+      avatar:
+        type: string
+        description: Avatar in base64 format.
+      public_email:
+        type: string
+        description: Public email.
+      social_profile_links:
+        type: object
+        additionalProperties:
+          type: string
+        description: |-
+          Social profile links list the links to the organization's social profiles.
+          The key represents the provider, and the value is the corresponding URL.
+    description: OrganizationProfile describes the public data of an organization.
+  v1betaOwner:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/mgmtv1betaUser'
+        description: User.
+        readOnly: true
+      organization:
+        $ref: '#/definitions/v1betaOrganization'
+        description: Organization.
+        readOnly: true
+    description: Owner is a wrapper for User and Organization, used to embed owner information in other resources.
   v1betaPermission:
     type: object
     properties:
@@ -4951,10 +5061,6 @@ definitions:
         type: string
         description: Owner Name.
         readOnly: true
-      owner:
-        type: object
-        description: Owner details.
-        readOnly: true
       releases:
         type: array
         items:
@@ -4972,6 +5078,10 @@ definitions:
       visibility:
         $ref: '#/definitions/v1betaPipelineVisibility'
         description: Pipeline visibility.
+        readOnly: true
+      owner:
+        $ref: '#/definitions/v1betaOwner'
+        description: Pipeline owner.
         readOnly: true
     description: |-
       A Pipeline is an end-to-end workflow that automates a sequence of components
@@ -5148,7 +5258,7 @@ definitions:
       users:
         type: object
         additionalProperties:
-          $ref: '#/definitions/SharingUser'
+          $ref: '#/definitions/v1betaSharingUser'
         description: |-
           Defines sharing rules for a set of user resource names.
 
@@ -5165,6 +5275,16 @@ definitions:
       Sharing contains the information to share a resource with other users.
 
       For more information, see [Share Pipelines](https://www.instill.tech/docs/latest/vdp/share).
+  v1betaSharingUser:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        description: Defines whether the sharing option with this user is enabled.
+      role:
+        $ref: '#/definitions/v1betaRole'
+        description: Defines the role the user will have over the resource.
+    description: Describes the sharing configuration with a given user.
   v1betaTestOrganizationConnectorResponse:
     type: object
     properties:
@@ -5368,6 +5488,32 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The updated pipeline resource.
     description: UpdateUserPipelineResponse contains the updated pipeline.
+  v1betaUserProfile:
+    type: object
+    properties:
+      display_name:
+        type: string
+        description: Display name.
+      bio:
+        type: string
+        description: Biography.
+      avatar:
+        type: string
+        description: Avatar in base64 format.
+      public_email:
+        type: string
+        description: Public email.
+      company_name:
+        type: string
+        description: Company name.
+      social_profile_links:
+        type: object
+        additionalProperties:
+          type: string
+        description: |-
+          Social profile links list the links to the user's social profiles.
+          The key represents the provider, and the value is the corresponding URL.
+    description: UserProfile describes the public data of a user.
   v1betaValidateOrganizationPipelineResponse:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/connector.proto
+++ b/vdp/pipeline/v1beta/connector.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package vdp.pipeline.v1beta;
 
+// Core definitions
+import "core/mgmt/v1beta/mgmt.proto";
 import "google/api/field_behavior.proto";
 // Google API
 import "google/api/resource.proto";
@@ -11,6 +13,7 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
+// VDP definitions
 import "vdp/pipeline/v1beta/connector_definition.proto";
 
 // A Connector is a type of pipeline component that queries, processes or sends
@@ -104,8 +107,13 @@ message Connector {
   google.protobuf.Timestamp delete_time = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Owner name.
   string owner_name = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Owner details.
-  google.protobuf.Struct owner = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Deleted Fields.
+  reserved 19;
+  // Connector owner.
+  optional core.mgmt.v1beta.Owner owner = 20 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 }
 
 ///////////////////////////////////////////////////////////////////////

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package vdp.pipeline.v1beta;
 
 import "common/healthcheck/v1beta/healthcheck.proto";
+// Core definitions
+import "core/mgmt/v1beta/mgmt.proto";
 // Google API
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
@@ -177,8 +179,8 @@ message Pipeline {
   google.protobuf.Struct metadata = 16;
   // Owner Name.
   string owner_name = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Owner details.
-  google.protobuf.Struct owner = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Deleted Fields.
+  reserved 18;
   // Releases holds the history of pipeline versions.
   repeated PipelineRelease releases = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
   // README holds the pipeline documentation.
@@ -187,6 +189,11 @@ message Pipeline {
   Permission permission = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline visibility.
   Visibility visibility = 22 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Pipeline owner.
+  optional core.mgmt.v1beta.Owner owner = 23 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 }
 
 // TriggerMetadata contains the traces of the pipeline inference.


### PR DESCRIPTION
Because:

- Originally, we used `owner_name` and `owner` (`structpb`) to embed owner information for Console. However, `owner` is a `structpb`, and it is not well-formatted. Since we already have dedicated messages for `User` and `Organization`, we should utilize these messages.

This commit:

- Adds a new `Owner` message to wrap the `User` and `Organization` messages.
- Removes  `owner` in resource response.
- Marks `owner_name` in resource response as deprecated. Once the frontend removes it, we'll remove it as well.