### PR TITLE
feat(mgmt): add description field in subscription response

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1003,6 +1003,8 @@ message StripeSubscriptionDetail {
   optional int32 trial_end = 6;
   // Status of the subscription.
   Status status = 7;
+  // Description of the subscription.
+  string description = 8;
 }
 
 // UserSubscription details describe the plan (i.e., features) a user has access to.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1581,6 +1581,9 @@ definitions:
       status:
         $ref: '#/definitions/v1betaStripeSubscriptionDetailStatus'
         description: Status of the subscription.
+      description:
+        type: string
+        description: Description of the subscription.
     description: StripeSubscriptionDetail describes the details of a subscription in Stripe.
   v1betaStripeSubscriptionDetailStatus:
     type: string

--- a/vdp/pipeline/v1beta/common.proto
+++ b/vdp/pipeline/v1beta/common.proto
@@ -117,5 +117,4 @@ enum ComponentType {
   COMPONENT_TYPE_OPERATOR = 4;
   // Connect with an external application.
   COMPONENT_TYPE_CONNECTOR_APPLICATION = 5;
-
 }

--- a/vdp/pipeline/v1beta/component_definition.proto
+++ b/vdp/pipeline/v1beta/component_definition.proto
@@ -80,9 +80,9 @@ enum ConnectorType {
 // in the official documentation.
 message ConnectorDefinition {
   option (google.api.resource) = {
-type: "api.instill.tech/ConnectorDefinition"
-        pattern: "connector-definitions/{id}"
-        pattern: "connector-definitions/{uid}"
+    type: "api.instill.tech/ConnectorDefinition"
+    pattern: "connector-definitions/{id}"
+    pattern: "connector-definitions/{uid}"
   };
 
   // The name of the connector definition, defined by its ID.
@@ -148,9 +148,9 @@ message OperatorSpec {
 // in the official documentation.
 message OperatorDefinition {
   option (google.api.resource) = {
-type: "api.instill.tech/OperatorDefinition"
-        pattern: "operator-definitions/{id}"
-        pattern: "operator-definitions/{uid}"
+    type: "api.instill.tech/OperatorDefinition"
+    pattern: "operator-definitions/{id}"
+    pattern: "operator-definitions/{uid}"
   };
 
   // The name of the operator definition.
@@ -264,7 +264,7 @@ message GetConnectorDefinitionRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/ConnectorDefinition"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-field_configuration: {path_param_name: "connector_definition_name"}
+      field_configuration: {path_param_name: "connector_definition_name"}
     }
   ];
   // field 2 is reserved for the "view" property of ConnectorDefinition.View
@@ -320,7 +320,7 @@ message GetOperatorDefinitionRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/OperatorDefinition"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-field_configuration: {path_param_name: "operator_definition_name"}
+      field_configuration: {path_param_name: "operator_definition_name"}
     }
   ];
   // field 2 is reserved for the "view" property of OperatorDefinition.View


### PR DESCRIPTION
Because

- We want to display additional description about the subscription.

This commit

- Adds description field in subscription response.
