### PR TITLE
fix(openapi): add readme.com extension for showing "Bearer" in auth

### DIFF
--- a/common/openapi/v1beta/api_config.conf
+++ b/common/openapi/v1beta/api_config.conf
@@ -16,6 +16,10 @@
         in: IN_HEADER;
         name: "Authorization";
         description: "Enter the token with the `Bearer ` prefix, e.g. `Bearer abcde12345`";
+        extensions: {
+          key: "x-default";
+          value {string_value: "Bearer instill_sk_***"}
+        }
       }
     }
   }

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1754,6 +1754,7 @@ securityDefinitions:
     description: Enter the token with the `Bearer ` prefix, e.g. `Bearer abcde12345`
     name: Authorization
     in: header
+    x-default: Bearer instill_sk_***
 security:
   - Bearer: []
 externalDocs:

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -3344,6 +3344,7 @@ securityDefinitions:
     description: Enter the token with the `Bearer ` prefix, e.g. `Bearer abcde12345`
     name: Authorization
     in: header
+    x-default: Bearer instill_sk_***
 security:
   - Bearer: []
 externalDocs:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -5631,6 +5631,7 @@ securityDefinitions:
     description: Enter the token with the `Bearer ` prefix, e.g. `Bearer abcde12345`
     name: Authorization
     in: header
+    x-default: Bearer instill_sk_***
 security:
   - Bearer: []
 externalDocs:


### PR DESCRIPTION
Because

- As `grpc-gateway` only supports OpenAPI 2.x, we were relying on the
field description to specify `Bearer` is part of the API key.

![CleanShot 2024-02-29 at 11 43 06](https://github.com/instill-ai/protobufs/assets/3977183/175d9219-836d-4d0f-8ab3-9c15306a9628)

This commit

- Adds a [readme.com extension](https://docs.readme.com/main/docs/openapi-extensions#authentication-defaults) to display an auth example

![CleanShot 2024-02-29 at 11 50 39](https://github.com/instill-ai/protobufs/assets/3977183/b00c35f9-5cfc-4175-b954-2726a0dbde07)
