### PR TITLE
feat(vdp): add description field to component definitions

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4373,6 +4373,10 @@ definitions:
           $ref: '#/definitions/v1betaComponentTask'
         description: List of tasks that can be executed by the connector.
         readOnly: true
+      description:
+        type: string
+        description: Short description of the connector.
+        readOnly: true
     description: |-
       A Connector is a type of pipeline component that queries, processes or sends
       the ingested unstructured data to a service or app. Users need to configure
@@ -4961,6 +4965,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaComponentTask'
         description: List of tasks that can be executed by the operator.
+        readOnly: true
+      description:
+        type: string
+        description: Short description of the operator.
         readOnly: true
     description: |-
       An Operator is a type of pipeline component that performs data injection and

--- a/vdp/pipeline/v1beta/component_definition.proto
+++ b/vdp/pipeline/v1beta/component_definition.proto
@@ -130,6 +130,8 @@ message ConnectorDefinition {
   string version = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
   // List of tasks that can be executed by the connector.
   repeated ComponentTask tasks = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Short description of the connector.
+  string description = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // OperatorSpec represents a specification data model.
@@ -191,6 +193,8 @@ message OperatorDefinition {
   string version = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
   // List of tasks that can be executed by the operator.
   repeated ComponentTask tasks = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Short description of the operator.
+  string description = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because

- Component page needs to receive the `description` field in the component `definitions.json`

This commit

- Exposes the description in the `Connector` and `Operator` proto entities.

## Before

```sh
$ curl --request GET \
  --url "localhost:8080/vdp/v1beta/component-definitions?page=1" \
  --header 'accept: application/json' | jq '.component_definitions[7]'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7683    0  7683    0     0   357k      0 --:--:-- --:--:-- --:--:--  375k
{
  "type": "COMPONENT_TYPE_OPERATOR",
  "operator_definition": {
    "name": "operator-definitions/json",
    "uid": "28f53d15-6150-46e6-99aa-f76b70a926c0",
    "id": "json",
    "title": "JSON",
    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/json",
    "icon": "assets/json.svg",
    "spec": null,
    "tombstone": false,
    "public": true,
    "custom": false,
    "source_url": "https://github.com/instill-ai/operator/blob/main/pkg/json/v0",
    "version": "0.1.0-alpha",
    "tasks": [
      {
        "name": "TASK_MARSHAL",
        "title": "Marshal",
        "description": "Convert JSON to a string"
      },
      {
        "name": "TASK_UNMARSHAL",
        "title": "Unmarshal",
        "description": "Convert a string to JSON"
      },
      {
        "name": "TASK_JQ",
        "title": "jq",
        "description": "Process JSON through a `jq` command"
      }
    ]
  }
}
```

## After

```sh
$ curl --request GET \
  --url "localhost:8080/vdp/v1beta/component-definitions?page=1" \
  --header 'accept: application/json' | jq '.component_definitions[7]'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7683    0  7683    0     0   357k      0 --:--:-- --:--:-- --:--:--  375k
{
  "type": "COMPONENT_TYPE_OPERATOR",
  "operator_definition": {
    "name": "operator-definitions/json",
    "description": "Enables users to manipulate and convert JSON objects",
    "uid": "28f53d15-6150-46e6-99aa-f76b70a926c0",
    "id": "json",
    "title": "JSON",
    "documentation_url": "https://www.instill.tech/docs/latest/vdp/operators/json",
    "icon": "assets/json.svg",
    "spec": null,
    "tombstone": false,
    "public": true,
    "custom": false,
    "source_url": "https://github.com/instill-ai/operator/blob/main/pkg/json/v0",
    "version": "0.1.0-alpha",
    "tasks": [
      {
        "name": "TASK_MARSHAL",
        "title": "Marshal",
        "description": "Convert JSON to a string"
      },
      {
        "name": "TASK_UNMARSHAL",
        "title": "Unmarshal",
        "description": "Convert a string to JSON"
      },
      {
        "name": "TASK_JQ",
        "title": "jq",
        "description": "Process JSON through a `jq` command"
      }
    ]
  }
}
```