### PR TITLE
feat(vdp): revamp pipeline recipe and introduce iterator component

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4284,12 +4284,12 @@ definitions:
         $ref: '#/definitions/v1betaConnectorDefinition'
         description: Connector definition.
         readOnly: true
-      resource_name:
+      connector_name:
         type: string
-        description: Resource name. Leave empty if not created.
-      resource:
+        description: Connector name. Leave empty if not created.
+      connector:
         $ref: '#/definitions/v1betaConnector'
-        description: Describes the connector resource details (e.g., configuration to connect with the vendor service).
+        description: Describes the connector details (e.g., configuration to connect with the vendor service).
         readOnly: true
       task:
         type: string
@@ -5514,6 +5514,10 @@ definitions:
         type: integer
         format: int32
         description: Instill UI order.
+      instill_ui_multiline:
+        type: integer
+        format: int32
+        description: Instill UI Multiline.
     description: Represents a field within the start component.
   v1betaTestOrganizationConnectorResponse:
     type: object

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4091,43 +4091,32 @@ definitions:
       id:
         type: string
         description: Component ID, provided by the user on creation.
-      resource_name:
-        type: string
-        description: Resource name.
-      resource:
-        $ref: '#/definitions/v1betaConnector'
-        description: |-
-          If the component is a connector, describes the connector details (e.g. the
-          configuration to connect with an AI model).
-        readOnly: true
-      configuration:
+      metadata:
         type: object
-        description: Describes the component configuration.
-      type:
-        $ref: '#/definitions/v1betaComponentType'
-        description: Defines the type of task the component will perform.
-        readOnly: true
-      definition_name:
-        type: string
-        description: |-
-          The name of the component definition. It references the connector or
-          operator definition on top of which a connector is built.
-      operator_definition:
-        $ref: '#/definitions/v1betaOperatorDefinition'
-        title: operator definition detail
-        readOnly: true
-      connector_definition:
-        $ref: '#/definitions/v1betaConnectorDefinition'
-        title: connector definition detail
-        readOnly: true
+        description: Metadata of the component.
+      start_component:
+        $ref: '#/definitions/v1betaStartComponent'
+        title: StartComponent
+      end_component:
+        $ref: '#/definitions/v1betaEndComponent'
+        title: EndComponent
+      connector_component:
+        $ref: '#/definitions/v1betaConnectorComponent'
+        title: ConnectorComponent
+      operator_component:
+        $ref: '#/definitions/v1betaOperatorComponent'
+        title: OperatorComponent
+      iterator_component:
+        $ref: '#/definitions/v1betaIteratorComponent'
+        title: IteratorComponent
     description: |-
-      Component is the fundamental building block in pipelines.
+      Component
+      Fundamental building block in pipelines.
 
       For more information, see [Pipeline
       Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
     required:
       - id
-      - definition_name
   v1betaComponentDefinition:
     type: object
     properties:
@@ -4285,6 +4274,35 @@ definitions:
       in the official documentation.
     required:
       - configuration
+  v1betaConnectorComponent:
+    type: object
+    properties:
+      definition_name:
+        type: string
+        description: Definition name.
+      definition:
+        $ref: '#/definitions/v1betaConnectorDefinition'
+        description: Connector definition.
+        readOnly: true
+      resource_name:
+        type: string
+        description: Resource name. Leave empty if not created.
+      resource:
+        $ref: '#/definitions/v1betaConnector'
+        description: Describes the connector resource details (e.g., configuration to connect with the vendor service).
+        readOnly: true
+      task:
+        type: string
+        description: Task.
+      input:
+        type: object
+        description: Input configuration of the component. JSON schema described in the connector definition.
+      condition:
+        type: string
+        description: Condition statement determining whether the component is executed or not.
+    description: |-
+      ConnectorComponent
+      Configures a connector component. Requires the creation of a connector resource first.
   v1betaConnectorDefinition:
     type: object
     properties:
@@ -4525,6 +4543,37 @@ definitions:
         $ref: '#/definitions/v1betaConnector'
         title: A connector
     description: DisconnectUserConnectorResponse contains the connector details.
+  v1betaEndComponent:
+    type: object
+    properties:
+      fields:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1betaEndComponentField'
+        description: |-
+          Fields configuration.
+          Key: Key of the output data.
+          Field: Field settings of the value.
+    description: |-
+      EndComponent
+      Configures the ending point for pipeline triggering.
+  v1betaEndComponentField:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Title of the field.
+      description:
+        type: string
+        description: Description of the field.
+      value:
+        type: string
+        description: Value of the field.
+      instill_ui_order:
+        type: integer
+        format: int32
+        description: Instill UI order.
+    description: Represents a field within the end component.
   v1betaExecuteOrganizationConnectorResponse:
     type: object
     properties:
@@ -4607,6 +4656,41 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The pipeline resource.
     description: GetUserPipelineResponse contains the requested pipeline.
+  v1betaIteratorComponent:
+    type: object
+    properties:
+      input:
+        type: string
+        description: 'Input: The iterator will iterate over the elements of the input (must be an array).'
+      output_elements:
+        type: object
+        additionalProperties:
+          type: string
+        title: |-
+          Output elements: Configure the output arrays of the iterator.
+          The key is the output element variable name, and the value is the data reference of the template.
+          Example:
+          output_elements: {
+            "key1": "${element.output.a}",
+            "key2": "${element.output.b}",
+          }
+          This will create the results:
+          output: {
+            "key1": [ ${element1.output.a},  ${element2.output.a} ... ],
+            "key2": [ ${element1.output.b},  ${element2.output.b} ... ],
+          }
+      components:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaNestedComponent'
+        description: 'Components: These components will be executed for each input element.'
+      condition:
+        type: string
+        description: Condition statement determining whether the component is executed or not.
+    description: |-
+      IteratorComponent
+      Configures an iterator component for iteration.
   v1betaListComponentDefinitionsResponse:
     type: object
     properties:
@@ -4892,6 +4976,48 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The requested pipeline.
     description: LookUpPipelineResponse contains the requested pipeline.
+  v1betaNestedComponent:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Component ID, provided by the user on creation.
+      metadata:
+        type: object
+        description: Metadata of the component.
+      connector_component:
+        $ref: '#/definitions/v1betaConnectorComponent'
+        title: ConnectorConfiguration
+      operator_component:
+        $ref: '#/definitions/v1betaOperatorComponent'
+        title: OperatorConfiguration
+    description: |-
+      NestedComponent
+      Fundamental building block in iterator component.
+    required:
+      - id
+  v1betaOperatorComponent:
+    type: object
+    properties:
+      definition_name:
+        type: string
+        description: Definition name.
+      definition:
+        $ref: '#/definitions/v1betaOperatorDefinition'
+        description: Operator definition.
+        readOnly: true
+      task:
+        type: string
+        description: Task.
+      input:
+        type: object
+        description: Input configuration of the component. JSON schema described in the operator definition.
+      condition:
+        type: string
+        description: Condition statement determining whether the component is executed or not.
+    description: |-
+      OperatorComponent
+      Configures an operator component.
   v1betaOperatorDefinition:
     type: object
     properties:
@@ -5358,6 +5484,37 @@ definitions:
         $ref: '#/definitions/v1betaRole'
         description: Defines the role the user will have over the resource.
     description: Describes the sharing configuration with a given user.
+  v1betaStartComponent:
+    type: object
+    properties:
+      fields:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1betaStartComponentField'
+        description: |-
+          Fields configuration.
+          Key: Key of the input data.
+          Field: Field settings of the value.
+    description: |-
+      StartComponent
+      Configures the starting point for pipeline triggering.
+  v1betaStartComponentField:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Title of the field.
+      description:
+        type: string
+        description: Description of the field.
+      instill_format:
+        type: string
+        description: Instill format.
+      instill_ui_order:
+        type: integer
+        format: int32
+        description: Instill UI order.
+    description: Represents a field within the start component.
   v1betaTestOrganizationConnectorResponse:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4265,9 +4265,10 @@ definitions:
         description: Connector owner.
         readOnly: true
     description: |-
-      A Connector is a type of pipeline component that queries, processes or sends
-      the ingested unstructured data to a service or app. Users need to configure
-      their connectors (e.g. by providing an API token to a remote service).
+      A connector allows users to query, process or send data to a service or app.
+      Users can create and configure connectors that may later be referenced in
+      their pipelines via a connector component in order to process their ingested
+      unstructured data.
 
       For more information, see
       [Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -5519,8 +5519,7 @@ definitions:
         format: int32
         description: Instill UI order.
       instill_ui_multiline:
-        type: integer
-        format: int32
+        type: boolean
         description: Instill UI Multiline.
     description: Represents a field within the start component.
   v1betaTestOrganizationConnectorResponse:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4691,7 +4691,10 @@ definitions:
         description: Condition statement determining whether the component is executed or not.
     description: |-
       IteratorComponent
-      Configures an iterator component for iteration.
+      Configures an iterator component. An iterator takes an array and executes an
+      operation (defined by a set of nested components) on each of its elements.
+      It can be regarded as triggering a sub-pipeline using the elements of an
+      array as input.
   v1betaListComponentDefinitionsResponse:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/connector.proto
+++ b/vdp/pipeline/v1beta/connector.proto
@@ -16,9 +16,10 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 // VDP definitions
 import "vdp/pipeline/v1beta/component_definition.proto";
 
-// A Connector is a type of pipeline component that queries, processes or sends
-// the ingested unstructured data to a service or app. Users need to configure
-// their connectors (e.g. by providing an API token to a remote service).
+// A connector allows users to query, process or send data to a service or app.
+// Users can create and configure connectors that may later be referenced in
+// their pipelines via a connector component in order to process their ingested
+// unstructured data.
 //
 // For more information, see
 // [Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -44,34 +44,147 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
-// Component is the fundamental building block in pipelines.
+// StartComponent
+// Configures the starting point for pipeline triggering.
+message StartComponent {
+  // Represents a field within the start component.
+  message Field {
+    // Title of the field.
+    string title = 1 [(google.api.field_behavior) = OPTIONAL];
+    // Description of the field.
+    string description = 2 [(google.api.field_behavior) = OPTIONAL];
+    // Instill format.
+    string instill_format = 3 [(google.api.field_behavior) = OPTIONAL];
+    // Instill UI order.
+    int32 instill_ui_order = 4 [(google.api.field_behavior) = OPTIONAL];
+  }
+  // Fields configuration.
+  // Key: Key of the input data.
+  // Field: Field settings of the value.
+  map<string, Field> fields = 1 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// EndComponent
+// Configures the ending point for pipeline triggering.
+message EndComponent {
+  // Represents a field within the end component.
+  message Field {
+    // Title of the field.
+    string title = 1 [(google.api.field_behavior) = OPTIONAL];
+    // Description of the field.
+    string description = 2 [(google.api.field_behavior) = OPTIONAL];
+    // Value of the field.
+    string value = 3 [(google.api.field_behavior) = OPTIONAL];
+    // Instill UI order.
+    int32 instill_ui_order = 4 [(google.api.field_behavior) = OPTIONAL];
+  }
+  // Fields configuration.
+  // Key: Key of the output data.
+  // Field: Field settings of the value.
+  map<string, Field> fields = 1 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ConnectorComponent
+// Configures a connector component. Requires the creation of a connector resource first.
+message ConnectorComponent {
+  // Definition name.
+  string definition_name = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Connector definition.
+  ConnectorDefinition definition = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Resource name. Leave empty if not created.
+  string resource_name = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Describes the connector resource details (e.g., configuration to connect with the vendor service).
+  Connector resource = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Task.
+  string task = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Input configuration of the component. JSON schema described in the connector definition.
+  google.protobuf.Struct input = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Condition statement determining whether the component is executed or not.
+  string condition = 7 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// OperatorComponent
+// Configures an operator component.
+message OperatorComponent {
+  // Definition name.
+  string definition_name = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Operator definition.
+  OperatorDefinition definition = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Task.
+  string task = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Input configuration of the component. JSON schema described in the operator definition.
+  google.protobuf.Struct input = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Condition statement determining whether the component is executed or not.
+  string condition = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// IteratorComponent
+// Configures an iterator component for iteration.
+message IteratorComponent {
+  // Input: The iterator will iterate over the elements of the input (must be an array).
+  string input = 1 [(google.api.field_behavior) = OPTIONAL];
+
+  // Output elements: Configure the output arrays of the iterator.
+  // The key is the output element variable name, and the value is the data reference of the template.
+  // Example:
+  // output_elements: {
+  //   "key1": "${element.output.a}",
+  //   "key2": "${element.output.b}",
+  // }
+  // This will create the results:
+  // output: {
+  //   "key1": [ ${element1.output.a},  ${element2.output.a} ... ],
+  //   "key2": [ ${element1.output.b},  ${element2.output.b} ... ],
+  // }
+  map<string, string> output_elements = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Components: These components will be executed for each input element.
+  repeated NestedComponent components = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Condition statement determining whether the component is executed or not.
+  string condition = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Component
+// Fundamental building block in pipelines.
 //
 // For more information, see [Pipeline
 // Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
 message Component {
   // Component ID, provided by the user on creation.
   string id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Resource name.
-  string resource_name = 2 [(google.api.resource_reference).type = "*"];
-  // If the component is a connector, describes the connector details (e.g. the
-  // configuration to connect with an AI model).
-  Connector resource = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Describes the component configuration.
-  google.protobuf.Struct configuration = 4;
-  // Defines the type of task the component will perform.
-  ComponentType type = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // The name of the component definition. It references the connector or
-  // operator definition on top of which a connector is built.
-  string definition_name = 7 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "*"
-  ];
-  // The component definition details.
-  oneof definition {
-    // operator definition detail
-    OperatorDefinition operator_definition = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // connector definition detail
-    ConnectorDefinition connector_definition = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Deleted fields
+  reserved 2 to 9;
+  // Metadata of the component.
+  google.protobuf.Struct metadata = 10 [(google.api.field_behavior) = OPTIONAL];
+  // The component configuration.
+  oneof component {
+    // StartComponent
+    StartComponent start_component = 11;
+    // EndComponent
+    EndComponent end_component = 12;
+    // ConnectorComponent
+    ConnectorComponent connector_component = 13;
+    // OperatorComponent
+    OperatorComponent operator_component = 14;
+    // IteratorComponent
+    IteratorComponent iterator_component = 15;
+  }
+}
+
+// NestedComponent
+// Fundamental building block in iterator component.
+message NestedComponent {
+  // Component ID, provided by the user on creation.
+  string id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Metadata of the component.
+  google.protobuf.Struct metadata = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The component configuration.
+  oneof component {
+    // ConnectorConfiguration
+    ConnectorComponent connector_component = 3;
+    // OperatorConfiguration
+    OperatorComponent operator_component = 4;
   }
 }
 

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -58,7 +58,7 @@ message StartComponent {
     // Instill UI order.
     int32 instill_ui_order = 4 [(google.api.field_behavior) = OPTIONAL];
     // Instill UI Multiline.
-    int32 instill_ui_multiline = 5 [(google.api.field_behavior) = OPTIONAL];
+    bool instill_ui_multiline = 5 [(google.api.field_behavior) = OPTIONAL];
   }
   // Fields configuration.
   // Key: Key of the input data.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -57,6 +57,8 @@ message StartComponent {
     string instill_format = 3 [(google.api.field_behavior) = OPTIONAL];
     // Instill UI order.
     int32 instill_ui_order = 4 [(google.api.field_behavior) = OPTIONAL];
+    // Instill UI Multiline.
+    int32 instill_ui_multiline = 5 [(google.api.field_behavior) = OPTIONAL];
   }
   // Fields configuration.
   // Key: Key of the input data.
@@ -91,10 +93,10 @@ message ConnectorComponent {
   string definition_name = 1 [(google.api.field_behavior) = OPTIONAL];
   // Connector definition.
   ConnectorDefinition definition = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Resource name. Leave empty if not created.
-  string resource_name = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Describes the connector resource details (e.g., configuration to connect with the vendor service).
-  Connector resource = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Connector name. Leave empty if not created.
+  string connector_name = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Describes the connector details (e.g., configuration to connect with the vendor service).
+  Connector connector = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Task.
   string task = 5 [(google.api.field_behavior) = OPTIONAL];
   // Input configuration of the component. JSON schema described in the connector definition.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -121,7 +121,10 @@ message OperatorComponent {
 }
 
 // IteratorComponent
-// Configures an iterator component for iteration.
+// Configures an iterator component. An iterator takes an array and executes an
+// operation (defined by a set of nested components) on each of its elements.
+// It can be regarded as triggering a sub-pipeline using the elements of an
+// array as input.
 message IteratorComponent {
   // Input: The iterator will iterate over the elements of the input (must be an array).
   string input = 1 [(google.api.field_behavior) = OPTIONAL];


### PR DESCRIPTION
Because:

- The original recipe message utilized `structpb` to encapsulate every configuration, creating an implicit structure that posed a challenge for users or developers to comprehend the data structure. Given the distinct structures associated with various components, it is essential to explicitly expose them to the user.
- A special iterator component for array data iteration is desired.

This commit:

- Revamped the recipe messages by introducing new messages: `StartComponent`, `EndComponent`, `OperatorComponent`, `ConnectorComponent`, and `IteratorComponent`.

Note:

- This is a breaking change in the interface, requiring an update to the implementation on the client-side.