### PR TITLE
feat(artifact): add tag create / list endpoints

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -6,8 +6,6 @@ import "common/healthcheck/v1beta/healthcheck.proto";
 // Google API
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
-// OpenAPI definition
-import "protoc-gen-openapiv2/options/annotations.proto";
 // Protocol Buffers Well-Known Types
 import "google/protobuf/timestamp.proto";
 
@@ -35,8 +33,47 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
-// ImageTag contains information about the version of a container image.
-message ImageTag {
+/*
+
+This API is under development and, therefore, some of its entitites and
+entpoints are not implemented yet. This section aims to give context about the
+current interface and how it fits in the Artifact vision.
+
+# Artifact
+
+The Artifact domain is responsible of storing data that will later be used for
+processing unstructured data. Artifact will support the following types of
+data:
+
+- Repositories
+- Objects
+- Vectors
+
+## Repositories
+
+An implementation of the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec?tab=readme-ov-file)
+is used to manage versioned content. The main use for repositories is storing
+container images that can be used to deploy AI models or VDP pipelines.
+
+The ID of a repository has 2 segments, the owner (an Instill user or
+organization) and the content ID (the AI model or pipeline ID), e.g.
+`curious-wombat/llava-34b`.
+
+## Objects
+
+Raw data is stored in binary blobs. Object storage allows users to upload data
+(e.g. images, audio) that can be used by pipelines or to store the results or a
+pipeline trigger.
+
+## Vectors
+
+Vector embeddings have their own storage, which allows fast retrieval and similarity search.
+
+*/
+
+// RepositoryTag contains information about the version of some content in a
+// repository.
+message RepositoryTag {
   // The name of the tag, defined by its parent repository and ID.
   // - Format: `repositories/{repository.id}/tags/{tag.id}`.
   string name = 1 [(google.api.field_behavior) = IMMUTABLE];
@@ -49,29 +86,26 @@ message ImageTag {
 }
 
 // ListRepositoryTagsRequest represents a request to list the tags of a
-// container image repository.
+// repository.
 message ListRepositoryTagsRequest {
   // The maximum number of tags to return. The default and cap values are 10
   // and 100, respectively.
   optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page number.
   optional int32 page = 2 [(google.api.field_behavior) = OPTIONAL];
-  // The repository holding the different container image versions.
+  // The repository holding the different versions of a given content.
   // - Format: `repositories/{repository.id}`.
-  // - Example: `repository/flaming-wombat/llava-34b`.
+  // - Example: `repository/flaming-wombat/llama-2-7b`.
   string parent = 3 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Repository"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "repository"}
-    }
+    (google.api.resource_reference) = {type: "api.instill.tech/Repository"}
   ];
 }
 
 // ListRepositoryTagsResponse contains a list of container image tags.
 message ListRepositoryTagsResponse {
-  // A list of container image tags.
-  repeated ImageTag image_tags = 1;
+  // A list of repository tags.
+  repeated RepositoryTag tags = 1;
   // Total number of tags.
   int32 total_size = 2;
   // The requested page size.

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -113,3 +113,23 @@ message ListRepositoryTagsResponse {
   // The requested page offset.
   int32 page = 4;
 }
+
+// CreateRepositoryTagRequest represents a request to add a tag to a given
+// repository.
+message CreateRepositoryTagRequest {
+  // The tag information.
+  RepositoryTag tag = 1;
+  // The repository holding the different versions of a given content.
+  // - Format: `repositories/{repository.id}`.
+  // - Example: `repository/flaming-wombat/llama-2-7b`.
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Repository"}
+  ];
+}
+
+// CreateRepositoryTagResponse contains the created tag.
+message CreateRepositoryTagResponse {
+  // The created tag.
+  RepositoryTag tag = 1;
+}

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -5,6 +5,11 @@ package artifact.artifact.v1alpha;
 import "common/healthcheck/v1beta/healthcheck.proto";
 // Google API
 import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+// OpenAPI definition
+import "protoc-gen-openapiv2/options/annotations.proto";
+// Protocol Buffers Well-Known Types
+import "google/protobuf/timestamp.proto";
 
 // LivenessRequest represents a request to check a service liveness status
 message LivenessRequest {
@@ -28,4 +33,49 @@ message ReadinessRequest {
 message ReadinessResponse {
   // HealthCheckResponse message
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
+}
+
+// ImageTag contains information about the version of a container image.
+message ImageTag {
+  // The name of the tag, defined by its parent repository and ID.
+  // - Format: `repositories/{repository.id}/tags/{tag.id}`.
+  string name = 1 [(google.api.field_behavior) = IMMUTABLE];
+  // The tag identifier.
+  string id = 2 [(google.api.field_behavior) = IMMUTABLE];
+  // Unique identifier, computed from the manifest the tag refers to.
+  string digest = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Tag update time, i.e. timestamp of the last push.
+  google.protobuf.Timestamp update_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListRepositoryTagsRequest represents a request to list the tags of a
+// container image repository.
+message ListRepositoryTagsRequest {
+  // The maximum number of tags to return. The default and cap values are 10
+  // and 100, respectively.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page number.
+  optional int32 page = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The repository holding the different container image versions.
+  // - Format: `repositories/{repository.id}`.
+  // - Example: `repository/flaming-wombat/llava-34b`.
+  string parent = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Repository"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "repository"}
+    }
+  ];
+}
+
+// ListRepositoryTagsResponse contains a list of container image tags.
+message ListRepositoryTagsResponse {
+  // A list of container image tags.
+  repeated ImageTag image_tags = 1;
+  // Total number of tags.
+  int32 total_size = 2;
+  // The requested page size.
+  int32 page_size = 3;
+  // The requested page offset.
+  int32 page = 4;
 }

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package artifact.artifact.v1alpha;
+
+import "google/api/visibility.proto";
+import "artifact/artifact/v1alpha/artifact.proto";
+
+// ArtifactPrivateService exposes the private endpoints that allow clients to
+// manage artifacts.
+service ArtifactPrivateService {
+  // List the tags in a repository.
+  //
+  // Returns a portion of the versions that the specified repository holds.
+  rpc ListRepositoryTags(ListRepositoryTagsRequest) returns (ListRepositoryTagsResponse);
+
+  option (google.api.api_visibility).restriction = "INTERNAL";
+}

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -13,5 +13,15 @@ service ArtifactPrivateService {
   // Returns a portion of the versions that the specified repository holds.
   rpc ListRepositoryTags(ListRepositoryTagsRequest) returns (ListRepositoryTagsResponse);
 
+  // Create a new repository tag.
+  //
+  // Adds a tag to a given repository. Note that this operation is only
+  // intended to register the information of an *already created* tag. This
+  // method should be called as part of the content push operation, right after
+  // the [PUT Manifest](https://distribution.github.io/distribution/#put-manifest) has
+  // succeeded. The distribution registry won't hold data such as the push time
+  // or the tag digest, so `artifact-backend` will hold this information locally.
+  rpc CreateRepositoryTag(CreateRepositoryTagRequest) returns (CreateRepositoryTagResponse);
+
   option (google.api.api_visibility).restriction = "INTERNAL";
 }

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -60,7 +60,7 @@ service ArtifactPublicService {
   // Returns a portion of the tags for the specified container image
   // repository.
   rpc ListRepositoryTags(ListRepositoryTagsRequest) returns (ListRepositoryTagsResponse) {
-    option (google.api.http) = {get: "/v1alpha/{parent=repositories/*}/tags"};
+    option (google.api.http) = {get: "/v1alpha/{parent=repositories/**}/tags"};
     option (google.api.method_signature) = "parent";
   }
 }

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -60,7 +60,7 @@ service ArtifactPublicService {
   // Returns a portion of the tags for the specified container image
   // repository.
   rpc ListRepositoryTags(ListRepositoryTagsRequest) returns (ListRepositoryTagsResponse) {
-    option (google.api.http) = {get: "/v1beta/{parent=repositories/*}/tags"};
+    option (google.api.http) = {get: "/v1alpha/{parent=repositories/*}/tags"};
     option (google.api.method_signature) = "parent";
   }
 }

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -6,6 +6,7 @@ package artifact.artifact.v1alpha;
 import "artifact/artifact/v1alpha/artifact.proto";
 // Google API
 import "google/api/annotations.proto";
+import "google/api/client.proto";
 import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -39,5 +40,27 @@ service ArtifactPublicService {
         {get: "/v1alpha/ready/artifact"}]
     };
     option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // ----------
+  // Repository
+  // ----------
+  //
+  // The following section documents the public endpoints for content
+  // distribution (namely, container image) repositories. An image repository
+  // contains different (tagged) images that represent versions of a, for
+  // example, model or pipeline.
+  //
+  // TODO: this should be better documented in a Repository entity but for the
+  // current feature specs it is not needed. As this API grows, less or no
+  // context will be needed in this section.
+
+  // List the versions of an image.
+  //
+  // Returns a portion of the tags for the specified container image
+  // repository.
+  rpc ListRepositoryTags(ListRepositoryTagsRequest) returns (ListRepositoryTagsResponse) {
+    option (google.api.http) = {get: "/v1beta/{parent=repositories/*}/tags"};
+    option (google.api.method_signature) = "parent";
   }
 }

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -6,13 +6,10 @@ package artifact.artifact.v1alpha;
 import "artifact/artifact/v1alpha/artifact.proto";
 // Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
 import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
 
-// Artifact
-//
 // ArtifactPublicService exposes the public endpoints that allow clients to
 // manage artifacts.
 service ArtifactPublicService {
@@ -40,27 +37,5 @@ service ArtifactPublicService {
         {get: "/v1alpha/ready/artifact"}]
     };
     option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // ----------
-  // Repository
-  // ----------
-  //
-  // The following section documents the public endpoints for content
-  // distribution (namely, container image) repositories. An image repository
-  // contains different (tagged) images that represent versions of a, for
-  // example, model or pipeline.
-  //
-  // TODO: this should be better documented in a Repository entity but for the
-  // current feature specs it is not needed. As this API grows, less or no
-  // context will be needed in this section.
-
-  // List the versions of an image.
-  //
-  // Returns a portion of the tags for the specified container image
-  // repository.
-  rpc ListRepositoryTags(ListRepositoryTagsRequest) returns (ListRepositoryTagsResponse) {
-    option (google.api.http) = {get: "/v1alpha/{parent=repositories/**}/tags"};
-    option (google.api.method_signature) = "parent";
   }
 }

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -9,7 +9,49 @@ consumes:
   - application/json
 produces:
   - application/json
-paths: {}
+paths:
+  /v1beta/{repository}/tags:
+    get:
+      summary: List the versions of an image.
+      description: |-
+        Returns a portion of the tags for the specified container image
+        repository.
+      operationId: ArtifactPublicService_ListRepositoryTags
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListRepositoryTagsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: repository
+          description: |-
+            The repository holding the different container image versions.
+            - Format: `repositories/{repository.id}`.
+            - Example: `repository/flaming-wombat/llava-34b`.
+          in: path
+          required: true
+          type: string
+          pattern: repositories/[^/]+
+        - name: page_size
+          description: |-
+            The maximum number of tags to return. The default and cap values are 10
+            and 100, respectively.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: page
+          description: Page number.
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - ArtifactPublicService
 definitions:
   protobufAny:
     type: object
@@ -30,3 +72,46 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/protobufAny'
+  v1alphaImageTag:
+    type: object
+    properties:
+      name:
+        type: string
+        description: |-
+          The name of the tag, defined by its parent repository and ID.
+          - Format: `repositories/{repository.id}/tags/{tag.id}`.
+      id:
+        type: string
+        description: The tag identifier.
+      digest:
+        type: string
+        description: Unique identifier, computed from the manifest the tag refers to.
+        readOnly: true
+      update_time:
+        type: string
+        format: date-time
+        description: Tag update time, i.e. timestamp of the last push.
+        readOnly: true
+    description: ImageTag contains information about the version of a container image.
+  v1alphaListRepositoryTagsResponse:
+    type: object
+    properties:
+      image_tags:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaImageTag'
+        description: A list of container image tags.
+      total_size:
+        type: integer
+        format: int32
+        description: Total number of tags.
+      page_size:
+        type: integer
+        format: int32
+        description: The requested page size.
+      page:
+        type: integer
+        format: int32
+        description: The requested page offset.
+    description: ListRepositoryTagsResponse contains a list of container image tags.

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -9,49 +9,7 @@ consumes:
   - application/json
 produces:
   - application/json
-paths:
-  /v1alpha/{repository}/tags:
-    get:
-      summary: List the versions of an image.
-      description: |-
-        Returns a portion of the tags for the specified container image
-        repository.
-      operationId: ArtifactPublicService_ListRepositoryTags
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaListRepositoryTagsResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: repository
-          description: |-
-            The repository holding the different container image versions.
-            - Format: `repositories/{repository.id}`.
-            - Example: `repository/flaming-wombat/llava-34b`.
-          in: path
-          required: true
-          type: string
-          pattern: repositories/.+
-        - name: page_size
-          description: |-
-            The maximum number of tags to return. The default and cap values are 10
-            and 100, respectively.
-          in: query
-          required: false
-          type: integer
-          format: int32
-        - name: page
-          description: Page number.
-          in: query
-          required: false
-          type: integer
-          format: int32
-      tags:
-        - ArtifactPublicService
+paths: {}
 definitions:
   protobufAny:
     type: object
@@ -72,7 +30,36 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/protobufAny'
-  v1alphaImageTag:
+  v1alphaCreateRepositoryTagResponse:
+    type: object
+    properties:
+      tag:
+        $ref: '#/definitions/v1alphaRepositoryTag'
+        description: The created tag.
+    description: CreateRepositoryTagResponse contains the created tag.
+  v1alphaListRepositoryTagsResponse:
+    type: object
+    properties:
+      tags:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaRepositoryTag'
+        description: A list of repository tags.
+      total_size:
+        type: integer
+        format: int32
+        description: Total number of tags.
+      page_size:
+        type: integer
+        format: int32
+        description: The requested page size.
+      page:
+        type: integer
+        format: int32
+        description: The requested page offset.
+    description: ListRepositoryTagsResponse contains a list of container image tags.
+  v1alphaRepositoryTag:
     type: object
     properties:
       name:
@@ -92,26 +79,6 @@ definitions:
         format: date-time
         description: Tag update time, i.e. timestamp of the last push.
         readOnly: true
-    description: ImageTag contains information about the version of a container image.
-  v1alphaListRepositoryTagsResponse:
-    type: object
-    properties:
-      image_tags:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaImageTag'
-        description: A list of container image tags.
-      total_size:
-        type: integer
-        format: int32
-        description: Total number of tags.
-      page_size:
-        type: integer
-        format: int32
-        description: The requested page size.
-      page:
-        type: integer
-        format: int32
-        description: The requested page offset.
-    description: ListRepositoryTagsResponse contains a list of container image tags.
+    description: |-
+      RepositoryTag contains information about the version of some content in a
+      repository.

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -10,7 +10,7 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1beta/{repository}/tags:
+  /v1alpha/{repository}/tags:
     get:
       summary: List the versions of an image.
       description: |-

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -35,7 +35,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: repositories/[^/]+
+          pattern: repositories/.+
         - name: page_size
           description: |-
             The maximum number of tags to return. The default and cap values are 10

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -868,7 +868,7 @@ paths:
         - name: pipeline_release_name
           description: |-
             The name of the release, defined by its parent and ID.
-            - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}
+            - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}`.
           in: path
           required: true
           type: string
@@ -1836,7 +1836,7 @@ paths:
         - name: pipeline_release_name_1
           description: |-
             The name of the release, defined by its parent and ID.
-            - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}
+            - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}`.
           in: path
           required: true
           type: string
@@ -5369,9 +5369,9 @@ definitions:
     properties:
       name:
         type: string
-        title: |-
+        description: |-
           The name of the release, defined by its parent and ID.
-          - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}
+          - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}`.
         readOnly: true
       uid:
         type: string

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -345,7 +345,7 @@ message PipelineRelease {
   };
 
   // The name of the release, defined by its parent and ID.
-  // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}
+  // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}`.
   string name = 1 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {


### PR DESCRIPTION
Because

- We want to list the versions of a model.
- Registry has a [tags](https://distribution.github.io/distribution/#listing-image-tags) endpoint but it doesn't expose any timestamp.

![CleanShot 2024-03-19 at 20 24 14](https://github.com/instill-ai/protobufs/assets/3977183/38f408d1-0096-4f39-b3fe-92991104fa66)

This commit

- Adds and documents a private API for the repository tags in artifact.
  - Only `api-gateway` (when it detects the end of the image push operation) should communicate the creation of a tag.
  - The tags won't be exposed directly to the client. `model-backend` will request this information to expose the model versions in the same family as the rest of the model endpoints.

## 🗒️ Notes

As an initial addition to the Artifact domain, I made some naming choices. Please review and provide feedback about them.

## ⏭️ Next steps

- `artifact-backend` will implement a first version of this endpoint that will fetch the tag list from the `registry` instance. This endpoint only returns the tag list so the digest and update time will be empty.
- In order to record the update time, `api-gateway` will call the creation endpoint when we intercept a `PUT manifest` request. We'll store the digest and update time in the `artifact` database and we'll aggregate that info to the `registry` tag list (the registry should remain the source of truth).