### PR TITLE
chore(model): add message in watch endpoint

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -35,39 +35,39 @@ message ReadinessResponse {
 
 /*
 
-This API is under development and, therefore, some of its entitites and
-entpoints are not implemented yet. This section aims to give context about the
-current interface and how it fits in the Artifact vision.
+   This API is under development and, therefore, some of its entitites and
+   entpoints are not implemented yet. This section aims to give context about the
+   current interface and how it fits in the Artifact vision.
 
-# Artifact
+   # Artifact
 
-The Artifact domain is responsible of storing data that will later be used for
-processing unstructured data. Artifact will support the following types of
-data:
+   The Artifact domain is responsible of storing data that will later be used for
+   processing unstructured data. Artifact will support the following types of
+   data:
 
-- Repositories
-- Objects
-- Vectors
+   - Repositories
+   - Objects
+   - Vectors
 
-## Repositories
+   ## Repositories
 
-An implementation of the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec?tab=readme-ov-file)
-is used to manage versioned content. The main use for repositories is storing
-container images that can be used to deploy AI models or VDP pipelines.
+   An implementation of the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec?tab=readme-ov-file)
+   is used to manage versioned content. The main use for repositories is storing
+   container images that can be used to deploy AI models or VDP pipelines.
 
-The ID of a repository has 2 segments, the owner (an Instill user or
-organization) and the content ID (the AI model or pipeline ID), e.g.
-`curious-wombat/llava-34b`.
+   The ID of a repository has 2 segments, the owner (an Instill user or
+   organization) and the content ID (the AI model or pipeline ID), e.g.
+   `curious-wombat/llava-34b`.
 
-## Objects
+   ## Objects
 
-Raw data is stored in binary blobs. Object storage allows users to upload data
-(e.g. images, audio) that can be used by pipelines or to store the results or a
-pipeline trigger.
+   Raw data is stored in binary blobs. Object storage allows users to upload data
+   (e.g. images, audio) that can be used by pipelines or to store the results or a
+   pipeline trigger.
 
-## Vectors
+   ## Vectors
 
-Vector embeddings have their own storage, which allows fast retrieval and similarity search.
+   Vector embeddings have their own storage, which allows fast retrieval and similarity search.
 
 */
 

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package artifact.artifact.v1alpha;
 
-import "google/api/visibility.proto";
 import "artifact/artifact/v1alpha/artifact.proto";
+import "google/api/visibility.proto";
 
 // ArtifactPrivateService exposes the private endpoints that allow clients to
 // manage artifacts.

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -438,6 +438,8 @@ message WatchUserModelResponse {
   State state = 1;
   // Deprecated field `progress`
   reserved 2;
+  // Detail description of the state
+  string message = 3;
 }
 
 ////////////////////////////////////
@@ -817,6 +819,8 @@ message WatchOrganizationModelResponse {
   State state = 1;
   // Deprecated field `progress`
   reserved 2;
+  // Detail description of the state
+  string message = 3;
 }
 
 // TriggerOrganizationModelRequest represents a request to trigger a model inference.

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2915,6 +2915,9 @@ definitions:
       state:
         $ref: '#/definitions/modelv1alphaState'
         description: State.
+      message:
+        type: string
+        title: Detail description of the state
     description: WatchOrganizationModelResponse contains the state of a model.
   v1alphaWatchUserModelResponse:
     type: object
@@ -2922,6 +2925,9 @@ definitions:
       state:
         $ref: '#/definitions/modelv1alphaState'
         description: State.
+      message:
+        type: string
+        title: Detail description of the state
     description: WatchUserModelResponse contains the state of a model.
   v1betaOrganization:
     type: object


### PR DESCRIPTION
Because

- We'd like to provide more information to model state

This commit

- add message field in watch response
