### PR TITLE
feat(artifact): document optional tag fields

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -79,10 +79,19 @@ message RepositoryTag {
   string name = 1 [(google.api.field_behavior) = IMMUTABLE];
   // The tag identifier.
   string id = 2 [(google.api.field_behavior) = IMMUTABLE];
+
+  // The Artifact backend will register the tag digest and timestamp when a
+  // new version is pushed. However, the registry remains the source of truth
+  // for tags, so if this information isn't found in the Artifact database,
+  // these fields will be empty.
+
   // Unique identifier, computed from the manifest the tag refers to.
-  string digest = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string digest = 3 [(google.api.field_behavior) = OPTIONAL];
   // Tag update time, i.e. timestamp of the last push.
-  google.protobuf.Timestamp update_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Timestamp update_time = 4 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 // ListRepositoryTagsRequest represents a request to list the tags of a

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -73,7 +73,6 @@ definitions:
       digest:
         type: string
         description: Unique identifier, computed from the manifest the tag refers to.
-        readOnly: true
       update_time:
         type: string
         format: date-time


### PR DESCRIPTION
Because

- optional fields in `RepositoryTag` should be documented. The backend will return a successful `List` response even when these aren't present.
- `digest` ins't output-only. It will be set in the `Create` endpoint.

This commit

- updates the protobuf definition with the right field behaviours.