### PR TITLE
fix(artifact): remove unnecessary parent param in tag creation

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -104,7 +104,7 @@ message ListRepositoryTagsRequest {
   optional int32 page = 2 [(google.api.field_behavior) = OPTIONAL];
   // The repository holding the different versions of a given content.
   // - Format: `repositories/{repository.id}`.
-  // - Example: `repository/flaming-wombat/llama-2-7b`.
+  // - Example: `repositories/flaming-wombat/llama-2-7b`.
   string parent = 3 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Repository"}

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -128,13 +128,6 @@ message ListRepositoryTagsResponse {
 message CreateRepositoryTagRequest {
   // The tag information.
   RepositoryTag tag = 1;
-  // The repository holding the different versions of a given content.
-  // - Format: `repositories/{repository.id}`.
-  // - Example: `repository/flaming-wombat/llama-2-7b`.
-  string parent = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Repository"}
-  ];
 }
 
 // CreateRepositoryTagResponse contains the created tag.


### PR DESCRIPTION
Because

- `parent` param is redundant with `tag.name`.

This commit

- Removes param.
