### PR TITLE
feat(vdp): remove embedded owner data in pipeline/connector response

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -440,10 +440,6 @@ paths:
                 $ref: '#/definitions/v1betaPipelineVisibility'
                 description: Pipeline visibility.
                 readOnly: true
-              owner:
-                $ref: '#/definitions/v1betaOwner'
-                description: Pipeline owner.
-                readOnly: true
               data_specification:
                 $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
@@ -1416,10 +1412,6 @@ paths:
               visibility:
                 $ref: '#/definitions/v1betaPipelineVisibility'
                 description: Pipeline visibility.
-                readOnly: true
-              owner:
-                $ref: '#/definitions/v1betaOwner'
-                description: Pipeline owner.
                 readOnly: true
               data_specification:
                 $ref: '#/definitions/v1betaDataSpecification'
@@ -2754,10 +2746,6 @@ paths:
                 type: string
                 description: Owner name.
                 readOnly: true
-              owner:
-                $ref: '#/definitions/v1betaOwner'
-                description: Connector owner.
-                readOnly: true
             title: The connector fields that will replace the existing ones.
             required:
               - configuration
@@ -3241,10 +3229,6 @@ paths:
               owner_name:
                 type: string
                 description: Owner name.
-                readOnly: true
-              owner:
-                $ref: '#/definitions/v1betaOwner'
-                description: Connector owner.
                 readOnly: true
             title: The connector fields that will replace the existing ones.
             required:
@@ -3829,6 +3813,16 @@ definitions:
         $ref: '#/definitions/v1betaRole'
         description: Defines the role users will have over the resource.
     description: ShareCode describes a sharing configuration through a link.
+  SharingUser:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        description: Defines whether the sharing option with this user is enabled.
+      role:
+        $ref: '#/definitions/v1betaRole'
+        description: Defines the role the user will have over the resource.
+    description: Describes the sharing configuration with a given user.
   googlelongrunningOperation:
     type: object
     properties:
@@ -3900,47 +3894,6 @@ definitions:
 
       You can find out more about this error model and how to work with it in the
       [API Design Guide](https://cloud.google.com/apis/design/errors).
-  mgmtv1betaUser:
-    type: object
-    properties:
-      name:
-        type: string
-        description: |-
-          The name of the user, defined by its ID.
-          - Format: `users/{user.id}`.
-        readOnly: true
-      uid:
-        type: string
-        description: |-
-          User UUID. This field is optionally set by users on creation (it will be
-          server-generated if unspecified).
-      id:
-        type: string
-        description: |-
-          Resource ID (used in `name` as the last segment). This conforms to
-          RFC-1034, which restricts to letters, numbers, and hyphen, with the first
-          character a letter, the last a letter or a number, and a 63 character
-          maximum.
-
-          Note that the ID can be updated.
-      create_time:
-        type: string
-        format: date-time
-        description: Creation time.
-        readOnly: true
-      update_time:
-        type: string
-        format: date-time
-        description: Update time.
-        readOnly: true
-      profile:
-        $ref: '#/definitions/v1betaUserProfile'
-        description: Profile.
-    description: |-
-      User describes an individual that interacts with Instill AI. It doesn't
-      contain any private information about the user.
-    required:
-      - id
   pipelinev1betaState:
     type: string
     enum:
@@ -4300,10 +4253,6 @@ definitions:
       owner_name:
         type: string
         description: Owner name.
-        readOnly: true
-      owner:
-        $ref: '#/definitions/v1betaOwner'
-        description: Connector owner.
         readOnly: true
     description: |-
       A connector allows users to query, process or send data to a service or app.
@@ -5191,85 +5140,6 @@ definitions:
     required:
       - component_specification
       - data_specifications
-  v1betaOrganization:
-    type: object
-    properties:
-      name:
-        type: string
-        description: |-
-          The name of the organization, defined by its ID.
-          - Format: `organization/{organization.id}`.
-        readOnly: true
-      uid:
-        type: string
-        description: Organization UUID.
-        readOnly: true
-      id:
-        type: string
-        description: |-
-          Resource ID (used in `name` as the last segment). This conforms to
-          RFC-1034, which restricts to letters, numbers, and hyphen, with the first
-          character a letter, the last a letter or a number, and a 63 character
-          maximum.
-
-          Note that the ID can be updated.
-      create_time:
-        type: string
-        format: date-time
-        description: Creation time.
-        readOnly: true
-      update_time:
-        type: string
-        format: date-time
-        description: Update time.
-        readOnly: true
-      owner:
-        $ref: '#/definitions/mgmtv1betaUser'
-        description: The user that owns the organization.
-        readOnly: true
-      profile:
-        $ref: '#/definitions/v1betaOrganizationProfile'
-        description: Profile.
-    description: |-
-      Organizations group several users. As entities, they can own resources such
-      as pipelines or releases.
-    required:
-      - id
-  v1betaOrganizationProfile:
-    type: object
-    properties:
-      display_name:
-        type: string
-        description: Display name.
-      bio:
-        type: string
-        description: Biography.
-      avatar:
-        type: string
-        description: Avatar in base64 format.
-      public_email:
-        type: string
-        description: Public email.
-      social_profile_links:
-        type: object
-        additionalProperties:
-          type: string
-        description: |-
-          Social profile links list the links to the organization's social profiles.
-          The key represents the provider, and the value is the corresponding URL.
-    description: OrganizationProfile describes the public data of an organization.
-  v1betaOwner:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/mgmtv1betaUser'
-        description: User.
-        readOnly: true
-      organization:
-        $ref: '#/definitions/v1betaOrganization'
-        description: Organization.
-        readOnly: true
-    description: Owner is a wrapper for User and Organization, used to embed owner information in other resources.
   v1betaPermission:
     type: object
     properties:
@@ -5348,10 +5218,6 @@ definitions:
       visibility:
         $ref: '#/definitions/v1betaPipelineVisibility'
         description: Pipeline visibility.
-        readOnly: true
-      owner:
-        $ref: '#/definitions/v1betaOwner'
-        description: Pipeline owner.
         readOnly: true
       data_specification:
         $ref: '#/definitions/v1betaDataSpecification'
@@ -5532,7 +5398,7 @@ definitions:
       users:
         type: object
         additionalProperties:
-          $ref: '#/definitions/v1betaSharingUser'
+          $ref: '#/definitions/SharingUser'
         description: |-
           Defines sharing rules for a set of user resource names.
 
@@ -5549,16 +5415,6 @@ definitions:
       Sharing contains the information to share a resource with other users.
 
       For more information, see [Share Pipelines](https://www.instill.tech/docs/latest/vdp/share).
-  v1betaSharingUser:
-    type: object
-    properties:
-      enabled:
-        type: boolean
-        description: Defines whether the sharing option with this user is enabled.
-      role:
-        $ref: '#/definitions/v1betaRole'
-        description: Defines the role the user will have over the resource.
-    description: Describes the sharing configuration with a given user.
   v1betaStartComponent:
     type: object
     properties:
@@ -5796,32 +5652,6 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The updated pipeline resource.
     description: UpdateUserPipelineResponse contains the updated pipeline.
-  v1betaUserProfile:
-    type: object
-    properties:
-      display_name:
-        type: string
-        description: Display name.
-      bio:
-        type: string
-        description: Biography.
-      avatar:
-        type: string
-        description: Avatar in base64 format.
-      public_email:
-        type: string
-        description: Public email.
-      company_name:
-        type: string
-        description: Company name.
-      social_profile_links:
-        type: object
-        additionalProperties:
-          type: string
-        description: |-
-          Social profile links list the links to the user's social profiles.
-          The key represents the provider, and the value is the corresponding URL.
-    description: UserProfile describes the public data of a user.
   v1betaValidateOrganizationPipelineResponse:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/connector.proto
+++ b/vdp/pipeline/v1beta/connector.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package vdp.pipeline.v1beta;
 
 // Core definitions
-import "core/mgmt/v1beta/mgmt.proto";
 import "google/api/field_behavior.proto";
 // Google API
 import "google/api/resource.proto";
@@ -109,12 +108,7 @@ message Connector {
   // Owner name.
   string owner_name = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Deleted Fields.
-  reserved 19;
-  // Connector owner.
-  optional core.mgmt.v1beta.Owner owner = 20 [
-    (google.api.field_behavior) = OPTIONAL,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+  reserved 19, 20;
 }
 
 ///////////////////////////////////////////////////////////////////////

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 package vdp.pipeline.v1beta;
 
 import "common/healthcheck/v1beta/healthcheck.proto";
-// Core definitions
-import "core/mgmt/v1beta/mgmt.proto";
 // Google API
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
@@ -295,11 +293,8 @@ message Pipeline {
   Permission permission = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline visibility.
   Visibility visibility = 22 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Pipeline owner.
-  optional core.mgmt.v1beta.Owner owner = 23 [
-    (google.api.field_behavior) = OPTIONAL,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+  // Deleted fields
+  reserved 23;
   // Data specifications.
   DataSpecification data_specification = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
 }


### PR DESCRIPTION
Because

- Embedding owner data in pipeline/connector responses is not efficient for the Console. The Console should fetch the owner data asynchronously.

This commit

- Removes embedded owner data in pipeline/connector responses.