### PR TITLE
feat(vdp): revamp start component and end component

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -2974,12 +2974,9 @@ definitions:
       metadata:
         type: object
         description: Metadata of the component.
-      start_component:
-        $ref: '#/definitions/v1betaStartComponent'
-        title: StartComponent
-      end_component:
-        $ref: '#/definitions/v1betaEndComponent'
-        title: EndComponent
+      response_component:
+        $ref: '#/definitions/v1betaResponseComponent'
+        title: ResponseComponent
       connector_component:
         $ref: '#/definitions/v1betaConnectorComponent'
         title: ConnectorComponent
@@ -3268,37 +3265,6 @@ definitions:
   v1betaDeleteUserPipelineResponse:
     type: object
     description: DeleteUserPipelineResponse is an empty response.
-  v1betaEndComponent:
-    type: object
-    properties:
-      fields:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/v1betaEndComponentField'
-        description: |-
-          Fields configuration.
-          Key: Key of the output data.
-          Field: Field settings of the value.
-    description: |-
-      EndComponent
-      Configures the ending point for pipeline triggering.
-  v1betaEndComponentField:
-    type: object
-    properties:
-      title:
-        type: string
-        description: Title of the field.
-      description:
-        type: string
-        description: Description of the field.
-      value:
-        type: string
-        description: Value of the field.
-      instill_ui_order:
-        type: integer
-        format: int32
-        description: Instill UI order.
-    description: Represents a field within the end component.
   v1betaGetConnectorDefinitionResponse:
     type: object
     properties:
@@ -4002,6 +3968,9 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaComponent'
         description: List of pipeline components.
+      trigger_by_request:
+        $ref: '#/definitions/v1betaTriggerByRequest'
+        description: Triggered by reqeust.
     description: Recipe describes the components of a Pipeline and how they are connected.
   v1betaRenameOrganizationPipelineReleaseResponse:
     type: object
@@ -4031,6 +4000,37 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The renamed pipeline resource.
     description: RenameUserPipelineResponse contains a renamed pipeline.
+  v1betaResponseComponent:
+    type: object
+    properties:
+      fields:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1betaResponseComponentField'
+        description: |-
+          Fields configuration.
+          Key: Key of the output data.
+          Field: Field settings of the value.
+    description: |-
+      ResponseComponent
+      Configures the payload format of response when triggered by a request.
+  v1betaResponseComponentField:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Title of the field.
+      description:
+        type: string
+        description: Description of the field.
+      value:
+        type: string
+        description: Value of the field.
+      instill_ui_order:
+        type: integer
+        format: int32
+        description: Instill UI order.
+    description: Represents a field within the end component.
   v1betaRestoreOrganizationPipelineReleaseResponse:
     type: object
     properties:
@@ -4090,40 +4090,6 @@ definitions:
         $ref: '#/definitions/v1betaRole'
         description: Defines the role the user will have over the resource.
     description: Describes the sharing configuration with a given user.
-  v1betaStartComponent:
-    type: object
-    properties:
-      fields:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/v1betaStartComponentField'
-        description: |-
-          Fields configuration.
-          Key: Key of the input data.
-          Field: Field settings of the value.
-    description: |-
-      StartComponent
-      Configures the starting point for pipeline triggering.
-  v1betaStartComponentField:
-    type: object
-    properties:
-      title:
-        type: string
-        description: Title of the field.
-      description:
-        type: string
-        description: Description of the field.
-      instill_format:
-        type: string
-        description: Instill format.
-      instill_ui_order:
-        type: integer
-        format: int32
-        description: Instill UI order.
-      instill_ui_multiline:
-        type: boolean
-        description: Instill UI Multiline.
-    description: Represents a field within the start component.
   v1betaTrace:
     type: object
     properties:
@@ -4202,6 +4168,40 @@ definitions:
     description: |-
       TriggerAsyncUserPipelineResponse contains the information to access the
       status of an asynchronous pipeline execution.
+  v1betaTriggerByRequest:
+    type: object
+    properties:
+      fields:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1betaTriggerByRequestField'
+        description: |-
+          Fields configuration.
+          Key: Key of the input data.
+          Field: Field settings of the value.
+    description: |-
+      TriggerByRequest
+      Configures the payload format of request when triggered by a request.
+  v1betaTriggerByRequestField:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Title of the field.
+      description:
+        type: string
+        description: Description of the field.
+      instill_format:
+        type: string
+        description: Instill format.
+      instill_ui_order:
+        type: integer
+        format: int32
+        description: Instill UI order.
+      instill_ui_multiline:
+        type: boolean
+        description: Instill UI Multiline.
+    description: Represents a field within the start component.
   v1betaTriggerMetadata:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -43,9 +43,9 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
-// StartComponent
-// Configures the starting point for pipeline triggering.
-message StartComponent {
+// TriggerByRequest
+// Configures the payload format of request when triggered by a request.
+message TriggerByRequest {
   // Represents a field within the start component.
   message Field {
     // Title of the field.
@@ -65,9 +65,9 @@ message StartComponent {
   map<string, Field> fields = 1 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// EndComponent
-// Configures the ending point for pipeline triggering.
-message EndComponent {
+// ResponseComponent
+// Configures the payload format of response when triggered by a request.
+message ResponseComponent {
   // Represents a field within the end component.
   message Field {
     // Title of the field.
@@ -162,12 +162,12 @@ message Component {
   reserved 2 to 9;
   // Metadata of the component.
   google.protobuf.Struct metadata = 10 [(google.api.field_behavior) = OPTIONAL];
+  // Deleted fields
+  reserved 11;
   // The component configuration.
   oneof component {
-    // StartComponent
-    StartComponent start_component = 11;
-    // EndComponent
-    EndComponent end_component = 12;
+    // ResponseComponent
+    ResponseComponent response_component = 12;
     // ConnectorComponent
     ConnectorComponent connector_component = 13;
     // OperatorComponent
@@ -199,6 +199,11 @@ message Recipe {
   string version = 1;
   // List of pipeline components.
   repeated Component components = 2;
+  // The component trigger method.
+  oneof trigger {
+    // Triggered by reqeust.
+    TriggerByRequest trigger_by_request = 3;
+  }
 }
 
 // State describes the state of a pipeline.


### PR DESCRIPTION
Because

- We are designing a new trigger field to allow users to set up different trigger methods. As a result, we are going to retire the original start component and incorporate it into the trigger method.

This commit

- Removes "start component".
- Adds "trigger" field with "trigger_by_request" method.
- Renames "end component" to "response component".
