### PR TITLE
feat(vdp): add connection field in ConnectorComponent

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -3072,6 +3072,9 @@ definitions:
       condition:
         type: string
         description: Condition statement determining whether the component is executed or not.
+      connection:
+        type: object
+        description: Connection configuration of the component. JSON schema described in the connector definition.
     description: |-
       ConnectorComponent
       Configures a connector component. Requires the creation of a connector resource first.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -100,6 +100,8 @@ message ConnectorComponent {
   google.protobuf.Struct input = 6 [(google.api.field_behavior) = OPTIONAL];
   // Condition statement determining whether the component is executed or not.
   string condition = 7 [(google.api.field_behavior) = OPTIONAL];
+  // Connection configuration of the component. JSON schema described in the connector definition.
+  google.protobuf.Struct connection = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // OperatorComponent


### PR DESCRIPTION
Because

- We've retired `Connector`, but we still need a place to store connection configuration.

This commit

- Adds `connection` field in `ConnectorComponent`.
