### PR TITLE
feat(vdp): remove watch endpoints for pipeline releases

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -970,37 +970,6 @@ paths:
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
-  /v1beta/{user_pipeline_release_name}/watch:
-    get:
-      summary: Get the state of a release in a pipeline owned by a user
-      description: |-
-        Gets the state of a pipeline release, where the pipeline is identified by
-        its resource name, formed by the parent user and ID of the pipeline.
-      operationId: PipelinePublicService_WatchUserPipelineRelease
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaWatchUserPipelineReleaseResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_pipeline_release_name
-          description: |-
-            The resource name of the pipeline release, which allows its access by
-            parent pipeline and ID.
-            - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{release.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
-      tags:
-        - PipelinePublicService
   /v1beta/{user_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by a user
@@ -1936,38 +1905,6 @@ paths:
           pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - PipelinePublicService
-  /v1beta/{organization_pipeline_release_name}/watch:
-    get:
-      summary: Get the state of a release in a pipeline owned by an organization
-      description: |-
-        Gets the state of a pipeline release, where the pipeline is identified by
-        its resource name, formed by the parent organization and ID of the pipeline.
-      operationId: PipelinePublicService_WatchOrganizationPipelineRelease
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaWatchOrganizationPipelineReleaseResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_pipeline_release_name
-          description: |-
-            The resource name of the pipeline release, which allows its access by
-            parent pipeline and ID.
-            - Format:
-            `organizations/{organization.id}/pipelines/{pipeline.id}/releases/{release.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
-      tags:
-        - PipelinePublicService
   /v1beta/{organization_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by an organization
@@ -2787,18 +2724,6 @@ definitions:
       contain any private information about the user.
     required:
       - id
-  pipelinev1betaState:
-    type: string
-    enum:
-      - STATE_INACTIVE
-      - STATE_ACTIVE
-      - STATE_ERROR
-    description: |-
-      State describes the state of a pipeline.
-
-       - STATE_INACTIVE: Inactive.
-       - STATE_ACTIVE: Active.
-       - STATE_ERROR: The pipeline has an error.
   protobufAny:
     type: object
     properties:
@@ -4342,24 +4267,6 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The validated pipeline resource.
     description: ValidateUserPipelineResponse contains a validated pipeline.
-  v1betaWatchOrganizationPipelineReleaseResponse:
-    type: object
-    properties:
-      state:
-        $ref: '#/definitions/pipelinev1betaState'
-        description: The pipeline release state.
-    description: |-
-      WatchOrganizationPipelineReleaseResponse contains the pipeline release
-      current state.
-  v1betaWatchUserPipelineReleaseResponse:
-    type: object
-    properties:
-      state:
-        $ref: '#/definitions/pipelinev1betaState'
-        description: The pipeline release state.
-    description: |-
-      WatchUserPipelineReleaseResponse contains the pipeline release current
-      state.
 securityDefinitions:
   Bearer:
     type: apiKey

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -840,28 +840,6 @@ message RenameUserPipelineReleaseResponse {
   PipelineRelease release = 1;
 }
 
-// WatchUserPipelineReleaseRequest represents a request to query the state of a
-// user-owned pipeline release.
-message WatchUserPipelineReleaseRequest {
-  // The resource name of the pipeline release, which allows its access by
-  // parent pipeline and ID.
-  // - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{release.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_release_name"}
-    }
-  ];
-}
-
-// WatchUserPipelineReleaseResponse contains the pipeline release current
-// state.
-message WatchUserPipelineReleaseResponse {
-  // The pipeline release state.
-  State state = 1;
-}
-
 // TriggerUserPipelineReleaseRequest represents a request to trigger a pinned
 // release of a user-owned pipeline.
 message TriggerUserPipelineReleaseRequest {
@@ -1325,29 +1303,6 @@ message RenameOrganizationPipelineReleaseRequest {
 message RenameOrganizationPipelineReleaseResponse {
   // The renamed pipeline release.
   PipelineRelease release = 1;
-}
-
-// WatchOrganizationPipelineReleaseRequest represents a request to query the
-// state of an organization-owned pipeline release.
-message WatchOrganizationPipelineReleaseRequest {
-  // The resource name of the pipeline release, which allows its access by
-  // parent pipeline and ID.
-  // - Format:
-  // `organizations/{organization.id}/pipelines/{pipeline.id}/releases/{release.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/PipelineRelease"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_pipeline_release_name"}
-    }
-  ];
-}
-
-// WatchOrganizationPipelineReleaseResponse contains the pipeline release
-// current state.
-message WatchOrganizationPipelineReleaseResponse {
-  // The pipeline release state.
-  State state = 1;
 }
 
 // TriggerOrganizationPipelineReleaseRequest represents a request to trigger a

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -273,15 +273,6 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name";
   }
 
-  // Get the state of a release in a pipeline owned by a user
-  //
-  // Gets the state of a pipeline release, where the pipeline is identified by
-  // its resource name, formed by the parent user and ID of the pipeline.
-  rpc WatchUserPipelineRelease(WatchUserPipelineReleaseRequest) returns (WatchUserPipelineReleaseResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*/releases/*}/watch"};
-    option (google.api.method_signature) = "name";
-  }
-
   // Rename a release in a pipeline owned by a user
   //
   // Updates the ID of a pipeline release, where the pipeline is identified by
@@ -529,15 +520,6 @@ service PipelinePublicService {
   // organization and ID.
   rpc RestoreOrganizationPipelineRelease(RestoreOrganizationPipelineReleaseRequest) returns (RestoreOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/restore"};
-    option (google.api.method_signature) = "name";
-  }
-
-  // Get the state of a release in a pipeline owned by an organization
-  //
-  // Gets the state of a pipeline release, where the pipeline is identified by
-  // its resource name, formed by the parent organization and ID of the pipeline.
-  rpc WatchOrganizationPipelineRelease(WatchOrganizationPipelineReleaseRequest) returns (WatchOrganizationPipelineReleaseResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/watch"};
     option (google.api.method_signature) = "name";
   }
 


### PR DESCRIPTION
Because

- The `watch` endpoints for pipeline releases are not needed.

This commit

- Removes `watch` endpoints for pipeline releases.
