### PR TITLE
feat(vdp): remove ResponseComponent and merge it into TriggerByRequest

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -3002,6 +3002,43 @@ definitions:
         $ref: '#/definitions/v1betaRole'
         description: Defines the role users will have over the resource.
     description: ShareCode describes a sharing configuration through a link.
+  TriggerByRequestRequestField:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Title of the field.
+      description:
+        type: string
+        description: Description of the field.
+      instill_format:
+        type: string
+        description: Instill format.
+      instill_ui_order:
+        type: integer
+        format: int32
+        description: Instill UI order.
+      instill_ui_multiline:
+        type: boolean
+        description: Instill UI Multiline.
+    description: Represents a field within the reqeuest.
+  TriggerByRequestResponseField:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Title of the field.
+      description:
+        type: string
+        description: Description of the field.
+      value:
+        type: string
+        description: Value of the field.
+      instill_ui_order:
+        type: integer
+        format: int32
+        description: Instill UI order.
+    description: Represents a field within the response.
   googlelongrunningOperation:
     type: object
     properties:
@@ -3289,9 +3326,6 @@ definitions:
       metadata:
         type: object
         description: Metadata of the component.
-      response_component:
-        $ref: '#/definitions/v1betaResponseComponent'
-        title: ResponseComponent
       connector_component:
         $ref: '#/definitions/v1betaConnectorComponent'
         title: ConnectorComponent
@@ -4391,37 +4425,6 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The renamed pipeline resource.
     description: RenameUserPipelineResponse contains a renamed pipeline.
-  v1betaResponseComponent:
-    type: object
-    properties:
-      fields:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/v1betaResponseComponentField'
-        description: |-
-          Fields configuration.
-          Key: Key of the output data.
-          Field: Field settings of the value.
-    description: |-
-      ResponseComponent
-      Configures the payload format of response when triggered by a request.
-  v1betaResponseComponentField:
-    type: object
-    properties:
-      title:
-        type: string
-        description: Title of the field.
-      description:
-        type: string
-        description: Description of the field.
-      value:
-        type: string
-        description: Value of the field.
-      instill_ui_order:
-        type: integer
-        format: int32
-        description: Instill UI order.
-    description: Represents a field within the end component.
   v1betaRestoreOrganizationPipelineReleaseResponse:
     type: object
     properties:
@@ -4606,37 +4609,25 @@ definitions:
   v1betaTriggerByRequest:
     type: object
     properties:
-      fields:
+      request_fields:
         type: object
         additionalProperties:
-          $ref: '#/definitions/v1betaTriggerByRequestField'
+          $ref: '#/definitions/TriggerByRequestRequestField'
         description: |-
-          Fields configuration.
+          Fields configuration of request.
+          Key: Key of the input data.
+          Field: Field settings of the value.
+      response_fields:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/TriggerByRequestResponseField'
+        description: |-
+          Fields configuration of response.
           Key: Key of the input data.
           Field: Field settings of the value.
     description: |-
       TriggerByRequest
       Configures the payload format of request when triggered by a request.
-  v1betaTriggerByRequestField:
-    type: object
-    properties:
-      title:
-        type: string
-        description: Title of the field.
-      description:
-        type: string
-        description: Description of the field.
-      instill_format:
-        type: string
-        description: Instill format.
-      instill_ui_order:
-        type: integer
-        format: int32
-        description: Instill UI order.
-      instill_ui_multiline:
-        type: boolean
-        description: Instill UI Multiline.
-    description: Represents a field within the start component.
   v1betaTriggerMetadata:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -46,8 +46,8 @@ message ReadinessResponse {
 // TriggerByRequest
 // Configures the payload format of request when triggered by a request.
 message TriggerByRequest {
-  // Represents a field within the start component.
-  message Field {
+  // Represents a field within the reqeuest.
+  message RequestField {
     // Title of the field.
     string title = 1 [(google.api.field_behavior) = OPTIONAL];
     // Description of the field.
@@ -59,17 +59,8 @@ message TriggerByRequest {
     // Instill UI Multiline.
     bool instill_ui_multiline = 5 [(google.api.field_behavior) = OPTIONAL];
   }
-  // Fields configuration.
-  // Key: Key of the input data.
-  // Field: Field settings of the value.
-  map<string, Field> fields = 1 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// ResponseComponent
-// Configures the payload format of response when triggered by a request.
-message ResponseComponent {
-  // Represents a field within the end component.
-  message Field {
+  // Represents a field within the response.
+  message ResponseField {
     // Title of the field.
     string title = 1 [(google.api.field_behavior) = OPTIONAL];
     // Description of the field.
@@ -79,10 +70,16 @@ message ResponseComponent {
     // Instill UI order.
     int32 instill_ui_order = 4 [(google.api.field_behavior) = OPTIONAL];
   }
-  // Fields configuration.
-  // Key: Key of the output data.
+
+  // Fields configuration of request.
+  // Key: Key of the input data.
   // Field: Field settings of the value.
-  map<string, Field> fields = 1 [(google.api.field_behavior) = OPTIONAL];
+  map<string, RequestField> request_fields = 1 [(google.api.field_behavior) = OPTIONAL];
+
+  // Fields configuration of response.
+  // Key: Key of the input data.
+  // Field: Field settings of the value.
+  map<string, ResponseField> response_fields = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ConnectorComponent
@@ -165,11 +162,9 @@ message Component {
   // Metadata of the component.
   google.protobuf.Struct metadata = 10 [(google.api.field_behavior) = OPTIONAL];
   // Deleted fields
-  reserved 11;
+  reserved 11, 12;
   // The component configuration.
   oneof component {
-    // ResponseComponent
-    ResponseComponent response_component = 12;
     // ConnectorComponent
     ConnectorComponent connector_component = 13;
     // OperatorComponent


### PR DESCRIPTION
Because

- The `ResponseComponent` is highly coupled with `TriggerByRequest`. We should put them together

This commit

- Merges `ResponseComponent` into `TriggerByRequest` message.
