### PR TITLE
feat(vdp): add `secrets` field in trigger endpoints

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -2876,6 +2876,11 @@ definitions:
         items:
           type: object
         description: Pipeline input parameters.
+      secrets:
+        type: object
+        additionalProperties:
+          type: string
+        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
     description: |-
       TriggerOrganizationPipelineRequest represents a request to trigger an
       organization-owned pipeline synchronously.
@@ -2889,6 +2894,11 @@ definitions:
         items:
           type: object
         description: Pipeline input parameters.
+      secrets:
+        type: object
+        additionalProperties:
+          type: string
+        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
     description: |-
       TriggerOrganizationPipelineReleaseRequest represents a request to trigger a
       pinned release of an organization-owned pipeline asynchronously.
@@ -2902,6 +2912,11 @@ definitions:
         items:
           type: object
         description: Pipeline input parameters.
+      secrets:
+        type: object
+        additionalProperties:
+          type: string
+        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
     description: |-
       TriggerUserPipelineRequest represents a request to trigger a user-owned
       pipeline synchronously.
@@ -2915,6 +2930,11 @@ definitions:
         items:
           type: object
         description: Pipeline input parameters.
+      secrets:
+        type: object
+        additionalProperties:
+          type: string
+        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
     description: |-
       TriggerUserPipelineReleaseRequest represents a request to trigger a pinned
       release of a user-owned pipeline asynchronously.
@@ -2928,6 +2948,11 @@ definitions:
         items:
           type: object
         description: Pipeline input parameters.
+      secrets:
+        type: object
+        additionalProperties:
+          type: string
+        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
     description: |-
       TriggerOrganizationPipelineRequest represents a request to trigger an
       organization-owned pipeline synchronously.
@@ -2941,6 +2966,11 @@ definitions:
         items:
           type: object
         description: Pipeline input parameters.
+      secrets:
+        type: object
+        additionalProperties:
+          type: string
+        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
     description: |-
       TriggerOrganizationPipelineReleaseRequest represents a request to trigger a
       pinned release of an organization-owned pipeline.
@@ -2954,6 +2984,11 @@ definitions:
         items:
           type: object
         description: Pipeline input parameters.
+      secrets:
+        type: object
+        additionalProperties:
+          type: string
+        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
     description: |-
       TriggerUserPipelineRequest represents a request to trigger a user-owned
       pipeline synchronously.
@@ -2967,6 +3002,11 @@ definitions:
         items:
           type: object
         description: Pipeline input parameters.
+      secrets:
+        type: object
+        additionalProperties:
+          type: string
+        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
     description: |-
       TriggerUserPipelineReleaseRequest represents a request to trigger a pinned
       release of a user-owned pipeline.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -643,6 +643,8 @@ message TriggerUserPipelineRequest {
   ];
   // Pipeline input parameters.
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerUserPipelineResponse contains the pipeline execution results, i.e.,
@@ -669,6 +671,8 @@ message TriggerAsyncUserPipelineRequest {
   ];
   // Pipeline input parameters.
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerAsyncUserPipelineResponse contains the information to access the
@@ -858,6 +862,8 @@ message TriggerUserPipelineReleaseRequest {
   ];
   // Pipeline input parameters.
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerUserPipelineReleaseResponse contains the pipeline execution results,
@@ -884,6 +890,8 @@ message TriggerAsyncUserPipelineReleaseRequest {
   ];
   // Pipeline input parameters.
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerAsyncUserPipelineReleaseResponse contains the information to access
@@ -1102,6 +1110,8 @@ message TriggerOrganizationPipelineRequest {
   ];
   // Pipeline input parameters.
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerOrganizationPipelineResponse contains the pipeline execution results,
@@ -1128,6 +1138,8 @@ message TriggerAsyncOrganizationPipelineRequest {
   ];
   // Pipeline input parameters.
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerAsyncOrganizationPipelineResponse contains the information to access
@@ -1324,6 +1336,8 @@ message TriggerOrganizationPipelineReleaseRequest {
   ];
   // Pipeline input parameters.
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerOrganizationPipelineReleaseResponse contains the pipeline execution
@@ -1351,6 +1365,8 @@ message TriggerAsyncOrganizationPipelineReleaseRequest {
   ];
   // Pipeline input parameters.
   repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerAsyncOrganizationPipelineReleaseResponse contains the information to


### PR DESCRIPTION
Because

- We will provide functionality that allows users to put secrets in the request to override the owner's secrets.

This commit

- Adds a `secrets` field in trigger endpoints.