### PR TITLE
feat(mgmt): add concept to credit entries

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -593,6 +593,8 @@ message SubtractCreditRequest {
   string owner = 1 [(google.api.field_behavior) = REQUIRED];
   // The credit amount to subtract.
   float amount = 2;
+  // The description of the entry, for traceability.
+  string concept = 3;
 }
 
 // SubtractCreditResponse contains the remaining credit of an account after the

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -71,7 +71,7 @@ service MgmtPrivateService {
   // requested amount, it will be subtracted anyways, leaving the account
   // credit at zero. A ResourceExhausted error will be returned in this case.
   //
-  // On Instill Core, this endpoint will return a 404 Not Found status.
+  // On Instill Core, this endpoint will return an Unimplemented status.
   rpc SubtractCredit(SubtractCreditRequest) returns (SubtractCreditResponse) {
     option (google.api.method_signature) = "owner,amount";
   }


### PR DESCRIPTION
Because

- Though we'll have more metadata in the metrics, it's beneficial to register credit additions / subtractions with a concept, so the DB rows are more meaningful.

This commit

- Adds a `concept` param in the credit subtraction endpoint.
