### PR TITLE
feat(vdp): adjust user secrets endpoint

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -2344,7 +2344,7 @@ paths:
             $ref: '#/definitions/v1betaCheckNameRequest'
       tags:
         - PipelinePublicService
-  /v1beta/user/secrets:
+  /v1beta/{user_name}/secrets:
     get:
       summary: List user secrets
       description: |-
@@ -2364,6 +2364,14 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
+        - name: user_name
+          description: |-
+            The parent resource, i.e., the user that creates the secret.
+            - Format: `users/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
         - name: page_size
           description: |-
             The maximum number of secrets to return. If this parameter is unspecified,
@@ -2397,6 +2405,14 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
+        - name: user_name
+          description: |-
+            The parent resource, i.e., the user that creates the secret.
+            - Format: `users/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
         - name: secret
           description: The properties of the secret to be created.
           in: body
@@ -2428,11 +2444,11 @@ paths:
         - name: user_secret_name
           description: |-
             The resource name of the secret, which allows its access by ID.
-            - Format: `user/secrets/{secret.id}`.
+            - Format: `users/{user.id}/secrets/{secret.id}`.
           in: path
           required: true
           type: string
-          pattern: user/secrets/[^/]+
+          pattern: users/[^/]+/secrets/[^/]+
       tags:
         - PipelinePublicService
     delete:
@@ -2457,11 +2473,11 @@ paths:
         - name: user_secret_name
           description: |-
             The resource name of the secret, which allows its access by ID.
-            - Format: `user/secrets/{secret.id}`.
+            - Format: `users/{user.id}/secrets/{secret.id}`.
           in: path
           required: true
           type: string
-          pattern: user/secrets/[^/]+
+          pattern: users/[^/]+/secrets/[^/]+
       tags:
         - PipelinePublicService
   /v1beta/{secret.name}:
@@ -2493,7 +2509,7 @@ paths:
           in: path
           required: true
           type: string
-          pattern: user/secrets/[^/]+
+          pattern: users/[^/]+/secrets/[^/]+
         - name: secret
           description: The secret fields to update.
           in: body

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -640,10 +640,10 @@ service PipelinePublicService {
   // Creates a new secret under the parenthood of an user.
   rpc CreateUserSecret(CreateUserSecretRequest) returns (CreateUserSecretResponse) {
     option (google.api.http) = {
-      post: "/v1beta/user/secrets"
+      post: "/v1beta/{parent=users/*}/secrets"
       body: "secret"
     };
-    option (google.api.method_signature) = "secret";
+    option (google.api.method_signature) = "parent,secret";
   }
 
   // List user secrets
@@ -651,7 +651,8 @@ service PipelinePublicService {
   // Returns a paginated list of secrets that belong to the specified
   // user.
   rpc ListUserSecrets(ListUserSecretsRequest) returns (ListUserSecretsResponse) {
-    option (google.api.http) = {get: "/v1beta/user/secrets"};
+    option (google.api.http) = {get: "/v1beta/{parent=users/*}/secrets"};
+    option (google.api.method_signature) = "parent";
   }
 
   // Get a secret owned by an user
@@ -659,7 +660,7 @@ service PipelinePublicService {
   // Returns the details of an user-owned secret by its resource name,
   // which is defined by the parent user and the ID of the secret.
   rpc GetUserSecret(GetUserSecretRequest) returns (GetUserSecretResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=user/secrets/*}"};
+    option (google.api.http) = {get: "/v1beta/{name=users/*/secrets/*}"};
     option (google.api.method_signature) = "name";
   }
 
@@ -671,7 +672,7 @@ service PipelinePublicService {
   // account when updating the resource.
   rpc UpdateUserSecret(UpdateUserSecretRequest) returns (UpdateUserSecretResponse) {
     option (google.api.http) = {
-      patch: "/v1beta/{secret.name=user/secrets/*}"
+      patch: "/v1beta/{secret.name=users/*/secrets/*}"
       body: "secret"
     };
     option (google.api.method_signature) = "secret,update_mask";
@@ -682,7 +683,7 @@ service PipelinePublicService {
   // Deletes a secret, accesing it by its resource name, which is defined by
   // the parent user and the ID of the secret.
   rpc DeleteUserSecret(DeleteUserSecretRequest) returns (DeleteUserSecretResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=user/secrets/*}"};
+    option (google.api.http) = {delete: "/v1beta/{name=users/*/secrets/*}"};
     option (google.api.method_signature) = "name";
   }
 

--- a/vdp/pipeline/v1beta/secret.proto
+++ b/vdp/pipeline/v1beta/secret.proto
@@ -15,7 +15,7 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 message Secret {
   option (google.api.resource) = {
     type: "api.instill.tech/Secret"
-    pattern: "user/secrets/{secret.id}"
+    pattern: "users/{user.id}/secrets/{secret.id}"
     pattern: "organizations/{organization.id}/secrets/{secret.id}"
   };
 
@@ -43,6 +43,15 @@ message Secret {
 message CreateUserSecretRequest {
   // The properties of the secret to be created.
   Secret secret = 1;
+  // The parent resource, i.e., the user that creates the secret.
+  // - Format: `users/{user.id}`.
+  string parent = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Secret"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_name"}
+    }
+  ];
 }
 
 // CreateUserSecretResponse contains the created secret.
@@ -59,6 +68,15 @@ message ListUserSecretsRequest {
   optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page secret.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The parent resource, i.e., the user that creates the secret.
+  // - Format: `users/{user.id}`.
+  string parent = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {child_type: "api.instill.tech/Secret"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_name"}
+    }
+  ];
 }
 
 // ListUserSecretsResponse contains a list of secrets.
@@ -74,7 +92,7 @@ message ListUserSecretsResponse {
 // GetUserSecretRequest represents a request to fetch the details of a secret
 message GetUserSecretRequest {
   // The resource name of the secret, which allows its access by ID.
-  // - Format: `user/secrets/{secret.id}`.
+  // - Format: `users/{user.id}/secrets/{secret.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Secret"},
@@ -110,7 +128,7 @@ message UpdateUserSecretResponse {
 // DeleteUserSecretRequest represents a request to delete a secret resource.
 message DeleteUserSecretRequest {
   // The resource name of the secret, which allows its access by ID.
-  // - Format: `user/secrets/{secret.id}`.
+  // - Format: `users/{user.id}/secrets/{secret.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Secret"},


### PR DESCRIPTION
Because

- Originally, we used the `user/secrets` path for managing user secrets. However, this path style is not consistent with the pipeline endpoints. We should change it to `users/<userid>/secrets` for consistency.

This commit
- Adjusts the user secrets endpoint.