### PR TITLE
feat(mgmt): add Permission field in organization response

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -59,6 +59,12 @@ enum OwnerType {
   OWNER_TYPE_ORGANIZATION = 2;
 }
 
+// Permission defines how a resource can be used.
+message Permission {
+  // Defines whether the resource can be modified.
+  bool can_edit = 1;
+}
+
 // MembershipState describes the state of a user membership to an organization.
 enum MembershipState {
   // Unspecified.
@@ -705,6 +711,8 @@ message Organization {
   User owner = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Profile.
   OrganizationProfile profile = 12;
+  // Permission
+  Permission permission = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListOrganizationsRequest represents a request to list all organizations

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -699,6 +699,10 @@ paths:
               profile:
                 $ref: '#/definitions/v1betaOrganizationProfile'
                 description: Profile.
+              permission:
+                $ref: '#/definitions/v1betaPermission'
+                title: Permission
+                readOnly: true
             title: The organization fields that will replace the existing ones.
             required:
               - id
@@ -2334,6 +2338,10 @@ definitions:
       profile:
         $ref: '#/definitions/v1betaOrganizationProfile'
         description: Profile.
+      permission:
+        $ref: '#/definitions/v1betaPermission'
+        title: Permission
+        readOnly: true
     description: |-
       Organizations group several users. As entities, they can own resources such
       as pipelines or releases.
@@ -2440,6 +2448,13 @@ definitions:
     title: |-
       PatchAuthenticatedUserResponse contains the updated user.
       the authenticated user resource
+  v1betaPermission:
+    type: object
+    properties:
+      can_edit:
+        type: boolean
+        description: Defines whether the resource can be modified.
+    description: Permission defines how a resource can be used.
   v1betaPipelineData:
     type: object
     properties:

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -3267,6 +3267,10 @@ definitions:
       profile:
         $ref: '#/definitions/v1betaOrganizationProfile'
         description: Profile.
+      permission:
+        $ref: '#/definitions/v1betaPermission'
+        title: Permission
+        readOnly: true
     description: |-
       Organizations group several users. As entities, they can own resources such
       as pipelines or releases.
@@ -3307,6 +3311,13 @@ definitions:
         description: Organization.
         readOnly: true
     description: Owner is a wrapper for User and Organization, used to embed owner information in other resources.
+  v1betaPermission:
+    type: object
+    properties:
+      can_edit:
+        type: boolean
+        description: Defines whether the resource can be modified.
+    description: Permission defines how a resource can be used.
   v1betaUser:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -433,7 +433,7 @@ paths:
                 type: string
                 description: README holds the pipeline documentation.
               permission:
-                $ref: '#/definitions/v1betaPermission'
+                $ref: '#/definitions/vdppipelinev1betaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
               visibility:
@@ -1379,7 +1379,7 @@ paths:
                 type: string
                 description: README holds the pipeline documentation.
               permission:
-                $ref: '#/definitions/v1betaPermission'
+                $ref: '#/definitions/vdppipelinev1betaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
               visibility:
@@ -3095,6 +3095,13 @@ definitions:
         format: int32
         description: Instill UI order.
     description: Represents a field within the response.
+  coremgmtv1betaPermission:
+    type: object
+    properties:
+      can_edit:
+        type: boolean
+        description: Defines whether the resource can be modified.
+    description: Permission defines how a resource can be used.
   googlelongrunningOperation:
     type: object
     properties:
@@ -4217,6 +4224,10 @@ definitions:
       profile:
         $ref: '#/definitions/v1betaOrganizationProfile'
         description: Profile.
+      permission:
+        $ref: '#/definitions/coremgmtv1betaPermission'
+        title: Permission
+        readOnly: true
     description: |-
       Organizations group several users. As entities, they can own resources such
       as pipelines or releases.
@@ -4257,16 +4268,6 @@ definitions:
         description: Organization.
         readOnly: true
     description: Owner is a wrapper for User and Organization, used to embed owner information in other resources.
-  v1betaPermission:
-    type: object
-    properties:
-      can_edit:
-        type: boolean
-        description: Defines whether the resource can be modified.
-      can_trigger:
-        type: boolean
-        description: Defines whether the resource can be executed.
-    description: Permission defines how a resource can be used.
   v1betaPipeline:
     type: object
     properties:
@@ -4329,7 +4330,7 @@ definitions:
         type: string
         description: README holds the pipeline documentation.
       permission:
-        $ref: '#/definitions/v1betaPermission'
+        $ref: '#/definitions/vdppipelinev1betaPermission'
         description: Permission defines how a pipeline can be used.
         readOnly: true
       visibility:
@@ -4835,6 +4836,16 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The validated pipeline resource.
     description: ValidateUserPipelineResponse contains a validated pipeline.
+  vdppipelinev1betaPermission:
+    type: object
+    properties:
+      can_edit:
+        type: boolean
+        description: Defines whether the resource can be modified.
+      can_trigger:
+        type: boolean
+        description: Defines whether the resource can be executed.
+    description: Permission defines how a resource can be used.
 securityDefinitions:
   Bearer:
     type: apiKey


### PR DESCRIPTION
Because

- We need a `Permission` field to indicate whether the user has permission to edit the organization or not.

This commit

- Adds `Permission` field in organization response
