### PR TITLE
feat(pipeline): remove resource_specification field in ConnectorSpec

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -3598,9 +3598,6 @@ definitions:
   v1betaConnectorSpec:
     type: object
     properties:
-      resource_specification:
-        type: object
-        description: Resource specification.
       component_specification:
         type: object
         description: Component specification.
@@ -3613,7 +3610,6 @@ definitions:
           The key represents the task, and the value is the corresponding data_specification.
     description: ConnectorSpec represents a specification data model.
     required:
-      - resource_specification
       - component_specification
       - data_specifications
   v1betaConnectorType:

--- a/vdp/pipeline/v1beta/component_definition.proto
+++ b/vdp/pipeline/v1beta/component_definition.proto
@@ -90,8 +90,8 @@ message DataSpecification {
 
 // ConnectorSpec represents a specification data model.
 message ConnectorSpec {
-  // Resource specification.
-  google.protobuf.Struct resource_specification = 2 [(google.api.field_behavior) = REQUIRED];
+  // Deleted
+  reserved 2;
   // Component specification.
   google.protobuf.Struct component_specification = 3 [(google.api.field_behavior) = REQUIRED];
   // Deleted field.


### PR DESCRIPTION
Because

- We've merged the `resource_specification` data into `component_specification`.

This commit

- Removes `resource_specification` field in `ConnectorSpec`.
