### PR TITLE
WIP: feat(vdp): Implement streaming response of pipeline triggers

### DIFF
--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -656,6 +656,34 @@ message TriggerUserPipelineResponse {
   TriggerMetadata metadata = 2;
 }
 
+// TriggerUserPipelineStreamRequest represents a request to trigger a user-owned
+// pipeline synchronously.
+message TriggerUserPipelineStreamRequest {
+  // The resource name of the pipeline, which allows its access by parent user
+  // and ID.
+  // - Format: `users/{user.id}/pipelines/{pipeline.id}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_pipeline_name"}
+    }
+  ];
+  // Pipeline input parameters.
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// TriggerUserPipelineStreamResponse contains the pipeline execution results, i.e.,
+// the multiple model inference outputs.
+message TriggerUserPipelineStreamResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct outputs = 1;
+  // Traces of the pipeline inference.
+  TriggerMetadata metadata = 2;
+}
+
 // TriggerUserPipelineRequest represents a request to trigger a user-owned
 // pipeline synchronously.
 message TriggerAsyncUserPipelineRequest {

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -180,6 +180,27 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name,inputs";
   }
 
+ // Trigger a pipeline owned by a user
+//
+// Triggers the execution of a pipeline and streams the results back to the user.
+// This method is intended for real-time inference when low latency is of concern.
+//
+// The pipeline is identified by its resource name, formed by the parent user
+// and ID of the pipeline.
+//
+// The response is returned as a stream of data, allowing the client to receive
+// the results incrementally as they become available.
+//
+  // For more information, see [Trigger
+  // Pipeline](TODO: Add link).
+  rpc TriggerUserPipeline(TriggerUserPipelineRequest) returns (TriggerUserPipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{name=users/*/pipelines/*}/trigger:stream"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,inputs";
+  }
+
   // Trigger a pipeline owned by a user asynchronously
   //
   // Triggers the execution of a pipeline asynchronously, i.e., the result

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -180,20 +180,21 @@ service PipelinePublicService {
     option (google.api.method_signature) = "name,inputs";
   }
 
- // Trigger a pipeline owned by a user
-//
-// Triggers the execution of a pipeline and streams the results back to the user.
-// This method is intended for real-time inference when low latency is of concern.
-//
-// The pipeline is identified by its resource name, formed by the parent user
-// and ID of the pipeline.
-//
-// The response is returned as a stream of data, allowing the client to receive
-// the results incrementally as they become available.
-//
-  // For more information, see [Trigger
-  // Pipeline](TODO: Add link).
-  rpc TriggerUserPipeline(TriggerUserPipelineRequest) returns (TriggerUserPipelineResponse) {
+
+  // Trigger a pipeline owned by a user
+  //
+  // Triggers the execution of a pipeline and streams the results back to the user.
+  // This method is intended for real-time inference when low latency is of concern.
+  //
+  // The pipeline is identified by its resource name, formed by the parent user
+  // and ID of the pipeline.
+  //
+  // The response is returned as a stream of data, allowing the client to receive
+  // the results incrementally as they become available.
+  //
+  // For more information, see [Run
+  // Pipeline](https://www.instill.tech/docs/vdp/run).
+  rpc TriggerUserPipelineStream(TriggerUserPipelineRequest) returns (stream TriggerUserPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=users/*/pipelines/*}/trigger:stream"
       body: "*"


### PR DESCRIPTION
Modify the TriggerUserPipeline RPC method to return a stream of TriggerUserPipelineResponse messages instead of a single response. Update the URL to include the :stream suffix, indicating the streaming behavior of the endpoint.
The streaming response allows clients to receive pipeline results incrementally as they become available, reducing latency and improving real-time inference capabilities.

Because

- (write the reason why we need to consider this PR in a list)

This commit

- (write the summary of all commits in this PR in a list)
