### PR TITLE
feat(core): remove `/core`, `/vdp`, `/model` path prefix

### DIFF
--- a/.github/workflows/add-issue-to-prj.yml
+++ b/.github/workflows/add-issue-to-prj.yml
@@ -9,6 +9,6 @@ jobs:
   track_issue:
     uses: instill-ai/meta/.github/workflows/add-issue-to-prj.yml@main
     with:
-      project_number: 5 # Versatile Data Pipeline (VDP) project
+      project_number: 5 # Instill Core project
     secrets:
       botGitHubToken: ${{ secrets.botGitHubToken }}

--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -9,6 +9,6 @@ jobs:
   track_pr:
     uses: instill-ai/meta/.github/workflows/add-pr-to-prj.yml@main
     with:
-      project_number: 5 # Versatile Data Pipeline (VDP) project
+      project_number: 5 # Instill Core project
     secrets:
       botGitHubToken: ${{ secrets.botGitHubToken }}

--- a/buf.gen.openapi.yaml
+++ b/buf.gen.openapi.yaml
@@ -16,3 +16,4 @@ plugins:
       - version=true
       - omit_enum_default_value=true
       - preserve_rpc_order=true
+      - disable_service_tags=true

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -19,14 +19,6 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 service MgmtPublicService {
   option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {description: "Public Core endpoints"};
 
-  // Delete an organization membership
-  //
-  // Deletes a user membership within an organization.
-  rpc DeleteOrganizationMembership(DeleteOrganizationMembershipRequest) returns (DeleteOrganizationMembershipResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=organizations/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
   // Check if the MGMT server is alive
   //
   // See https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
@@ -51,24 +43,13 @@ service MgmtPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // Check if a namespace is in use
-  //
-  // Returns the availability of a namespace or, alternatively, the type of
-  // resource that is using it.
-  rpc CheckNamespace(CheckNamespaceRequest) returns (CheckNamespaceResponse) {
-    option (google.api.http) = {
-      post: "/v1beta/check-namespace"
-      body: "*"
-    };
-    option (google.api.method_signature) = "namespace";
-  }
-
   // Get the authenticated user
   //
   // Returns the details of the authenticated user.
   rpc GetAuthenticatedUser(GetAuthenticatedUserRequest) returns (GetAuthenticatedUserResponse) {
     option (google.api.http) = {get: "/v1beta/user"};
     option (google.api.method_signature) = "user,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
   // Update the authenticated user
@@ -83,6 +64,7 @@ service MgmtPublicService {
       body: "user"
     };
     option (google.api.method_signature) = "user,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
   // List users
@@ -90,6 +72,7 @@ service MgmtPublicService {
   // Returns a paginated list of users.
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option (google.api.http) = {get: "/v1beta/users"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
   // Get a user
@@ -98,49 +81,7 @@ service MgmtPublicService {
   rpc GetUser(GetUserRequest) returns (GetUserResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*}"};
     option (google.api.method_signature) = "name";
-  }
-
-  // List user memberships
-  //
-  // Returns the memberships of a user.
-  rpc ListUserMemberships(ListUserMembershipsRequest) returns (ListUserMembershipsResponse) {
-    option (google.api.http) = {get: "/v1beta/{parent=users/*}/memberships"};
-    option (google.api.method_signature) = "parent";
-  }
-
-  // Get a user membership
-  //
-  // Returns the details of the relationship between a user and an
-  // organization. The authenticated must match the membership parent.
-  rpc GetUserMembership(GetUserMembershipRequest) returns (GetUserMembershipResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=users/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
-  // Update a user membership
-  //
-  // Accesses and updates a user membership by parent and membership IDs.
-  rpc UpdateUserMembership(UpdateUserMembershipRequest) returns (UpdateUserMembershipResponse) {
-    option (google.api.http) = {
-      put: "/v1beta/{membership.name=users/*/memberships/*}"
-      body: "membership"
-    };
-    option (google.api.method_signature) = "membership,update_mask";
-  }
-
-  // Delete a user membership
-  //
-  // Accesses and deletes a user membership by parent and membership IDs.
-  rpc DeleteUserMembership(DeleteUserMembershipRequest) returns (DeleteUserMembershipResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=users/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
-  }
-
-  // List organizations
-  //
-  // Returns a paginated list of organizations.
-  rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse) {
-    option (google.api.http) = {get: "/v1beta/organizations"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
   // Create an organization
@@ -152,6 +93,15 @@ service MgmtPublicService {
       body: "organization"
     };
     option (google.api.method_signature) = "organization";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
+  }
+
+  // List organizations
+  //
+  // Returns a paginated list of organizations.
+  rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse) {
+    option (google.api.http) = {get: "/v1beta/organizations"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
   // Get an organization
@@ -160,6 +110,7 @@ service MgmtPublicService {
   rpc GetOrganization(GetOrganizationRequest) returns (GetOrganizationResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
   // Update an organization
@@ -174,6 +125,7 @@ service MgmtPublicService {
       body: "organization"
     };
     option (google.api.method_signature) = "organization,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
   // Delete an organization
@@ -182,6 +134,47 @@ service MgmtPublicService {
   rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
+  }
+
+  // List user memberships
+  //
+  // Returns the memberships of a user.
+  rpc ListUserMemberships(ListUserMembershipsRequest) returns (ListUserMembershipsResponse) {
+    option (google.api.http) = {get: "/v1beta/{parent=users/*}/memberships"};
+    option (google.api.method_signature) = "parent";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
+  }
+
+  // Get a user membership
+  //
+  // Returns the details of the relationship between a user and an
+  // organization. The authenticated must match the membership parent.
+  rpc GetUserMembership(GetUserMembershipRequest) returns (GetUserMembershipResponse) {
+    option (google.api.http) = {get: "/v1beta/{name=users/*/memberships/*}"};
+    option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
+  }
+
+  // Update a user membership
+  //
+  // Accesses and updates a user membership by parent and membership IDs.
+  rpc UpdateUserMembership(UpdateUserMembershipRequest) returns (UpdateUserMembershipResponse) {
+    option (google.api.http) = {
+      put: "/v1beta/{membership.name=users/*/memberships/*}"
+      body: "membership"
+    };
+    option (google.api.method_signature) = "membership,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
+  }
+
+  // Delete a user membership
+  //
+  // Accesses and deletes a user membership by parent and membership IDs.
+  rpc DeleteUserMembership(DeleteUserMembershipRequest) returns (DeleteUserMembershipResponse) {
+    option (google.api.http) = {delete: "/v1beta/{name=users/*/memberships/*}"};
+    option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
   // List organization memberships
@@ -190,6 +183,7 @@ service MgmtPublicService {
   rpc ListOrganizationMemberships(ListOrganizationMembershipsRequest) returns (ListOrganizationMembershipsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/memberships"};
     option (google.api.method_signature) = "parent";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
   // Get a an organization membership
@@ -198,6 +192,7 @@ service MgmtPublicService {
   rpc GetOrganizationMembership(GetOrganizationMembershipRequest) returns (GetOrganizationMembershipResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/memberships/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
   // Uppdate an organization membership
@@ -209,6 +204,16 @@ service MgmtPublicService {
       body: "membership"
     };
     option (google.api.method_signature) = "membership,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
+  }
+
+  // Delete an organization membership
+  //
+  // Deletes a user membership within an organization.
+  rpc DeleteOrganizationMembership(DeleteOrganizationMembershipRequest) returns (DeleteOrganizationMembershipResponse) {
+    option (google.api.http) = {delete: "/v1beta/{name=organizations/*/memberships/*}"};
+    option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
   // Get the subscription of the authenticated user
@@ -216,6 +221,7 @@ service MgmtPublicService {
   // Returns the subscription details of the authenticated user.
   rpc GetAuthenticatedUserSubscription(GetAuthenticatedUserSubscriptionRequest) returns (GetAuthenticatedUserSubscriptionResponse) {
     option (google.api.http) = {get: "/v1beta/user/subscription"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Subscription"};
   }
 
   // Get an organization subscription
@@ -224,6 +230,7 @@ service MgmtPublicService {
   rpc GetOrganizationSubscription(GetOrganizationSubscriptionRequest) returns (GetOrganizationSubscriptionResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/subscription"};
     option (google.api.method_signature) = "parent";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Subscription"};
   }
 
   // Create an API token
@@ -235,6 +242,7 @@ service MgmtPublicService {
       body: "token"
     };
     option (google.api.method_signature) = "token";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
   // List API tokens
@@ -242,6 +250,7 @@ service MgmtPublicService {
   // Returns a paginated list of the API tokens of the authenticated user.
   rpc ListTokens(ListTokensRequest) returns (ListTokensResponse) {
     option (google.api.http) = {get: "/v1beta/tokens"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
   // Get an API token
@@ -250,6 +259,7 @@ service MgmtPublicService {
   rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {
     option (google.api.http) = {get: "/v1beta/{name=tokens/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
   // Delete an API token
@@ -258,6 +268,7 @@ service MgmtPublicService {
   rpc DeleteToken(DeleteTokenRequest) returns (DeleteTokenResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=tokens/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
   // Validate an API token.
@@ -265,6 +276,7 @@ service MgmtPublicService {
   // Validates an API token.
   rpc ValidateToken(ValidateTokenRequest) returns (ValidateTokenResponse) {
     option (google.api.http) = {post: "/v1beta/validate_token"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
   // Get the remaining Instill Credit
@@ -279,9 +291,20 @@ service MgmtPublicService {
   rpc GetRemainingCredit(GetRemainingCreditRequest) returns (GetRemainingCreditResponse) {
     option (google.api.http) = {get: "/v1beta/{owner=*/*}/credit"};
     option (google.api.method_signature) = "owner";
-    // TODO we'll wait until the Credit feature is completed but this should be
-    // publicly available.
-    option (google.api.method_visibility).restriction = "INTERNAL";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Credit"};
+  }
+
+  // Check if a namespace is in use
+  //
+  // Returns the availability of a namespace or, alternatively, the type of
+  // resource that is using it.
+  rpc CheckNamespace(CheckNamespaceRequest) returns (CheckNamespaceResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/check-namespace"
+      body: "*"
+    };
+    option (google.api.method_signature) = "namespace";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils"};
   }
 
   // List pipeline triggers
@@ -289,6 +312,7 @@ service MgmtPublicService {
   // Returns a paginated list of pipeline executions.
   rpc ListPipelineTriggerRecords(ListPipelineTriggerRecordsRequest) returns (ListPipelineTriggerRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/triggers"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 
   // List pipeline trigger metrics
@@ -296,6 +320,7 @@ service MgmtPublicService {
   // Returns a paginated list of pipeline executions aggregated by pipeline ID.
   rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 
   // List pipeline trigger computation time charts
@@ -304,6 +329,7 @@ service MgmtPublicService {
   // by pipeline and time frames.
   rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 
   // Auth endpoints are only used in the community edition and the OpenAPI

--- a/core/mgmt/v1beta/openapi.proto.templ
+++ b/core/mgmt/v1beta/openapi.proto.templ
@@ -10,6 +10,31 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     description: "Core endpoints to manage user resources";
 {{$info}}
   };
-  base_path: "/core";
+  tags: [
+    {
+      name: "User"
+    },
+    {
+      name: "Organization"
+    },
+    {
+      name: "Membership"
+    },
+    {
+      name: "Token"
+    },
+    {
+      name: "Subscription"
+    },
+    {
+      name: "Credit"
+    },
+    {
+      name: "Metric"
+    },
+    {
+      name: "Utils"
+    }
+  ];
 {{$conf}}
 };

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -48,6 +48,7 @@ service ModelPublicService {
   // Returns a paginated list of model definitions.
   rpc ListModelDefinitions(ListModelDefinitionsRequest) returns (ListModelDefinitionsResponse) {
     option (google.api.http) = {get: "/v1alpha/model-definitions"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Get a model definition
@@ -56,6 +57,7 @@ service ModelPublicService {
   rpc GetModelDefinition(GetModelDefinitionRequest) returns (GetModelDefinitionResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=model-definitions/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // List models
@@ -63,6 +65,7 @@ service ModelPublicService {
   // Returns a paginated list of models.
   rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/models"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Get a model by UID
@@ -71,6 +74,7 @@ service ModelPublicService {
   rpc LookUpModel(LookUpModelRequest) returns (LookUpModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{permalink=models/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // List user models
@@ -81,6 +85,7 @@ service ModelPublicService {
   rpc ListUserModels(ListUserModelsRequest) returns (ListUserModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/{parent=users/*}/models"};
     option (google.api.method_signature) = "parent";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Create a new model
@@ -96,6 +101,7 @@ service ModelPublicService {
       body: "model"
     };
     option (google.api.method_signature) = "parent,model";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Get a model
@@ -104,6 +110,7 @@ service ModelPublicService {
   rpc GetUserModel(GetUserModelRequest) returns (GetUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Update a model
@@ -119,6 +126,7 @@ service ModelPublicService {
       body: "model"
     };
     option (google.api.method_signature) = "model,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Delete a model
@@ -128,6 +136,7 @@ service ModelPublicService {
   rpc DeleteUserModel(DeleteUserModelRequest) returns (DeleteUserModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Rename a model
@@ -140,6 +149,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,new_model_id";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Publish a model
@@ -152,6 +162,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Unpublish a model
@@ -164,6 +175,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Get a model card
@@ -173,6 +185,7 @@ service ModelPublicService {
   rpc GetUserModelCard(GetUserModelCardRequest) returns (GetUserModelCardResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*/readme}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Watch the state of a model
@@ -183,6 +196,7 @@ service ModelPublicService {
   rpc WatchUserModel(WatchUserModelRequest) returns (WatchUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions/{version=*}/watch"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // List user model versions
@@ -192,6 +206,7 @@ service ModelPublicService {
   rpc ListUserModelVersions(ListUserModelVersionsRequest) returns (ListUserModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   ///////////////////////////////////////////////////////
@@ -206,6 +221,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Trigger model inference asynchronously
@@ -218,6 +234,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Trigger model inference with a binary input
@@ -226,6 +243,7 @@ service ModelPublicService {
   // submitted as a binary file.
   rpc TriggerUserModelBinaryFileUpload(stream TriggerUserModelBinaryFileUploadRequest) returns (TriggerUserModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // List organization models
@@ -236,6 +254,7 @@ service ModelPublicService {
   rpc ListOrganizationModels(ListOrganizationModelsRequest) returns (ListOrganizationModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/{parent=organizations/*}/models"};
     option (google.api.method_signature) = "parent";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Create a new model
@@ -251,6 +270,7 @@ service ModelPublicService {
       body: "model"
     };
     option (google.api.method_signature) = "parent,model";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Get a model
@@ -259,6 +279,7 @@ service ModelPublicService {
   rpc GetOrganizationModel(GetOrganizationModelRequest) returns (GetOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Update a model
@@ -274,6 +295,7 @@ service ModelPublicService {
       body: "model"
     };
     option (google.api.method_signature) = "model,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Delete a model
@@ -283,6 +305,7 @@ service ModelPublicService {
   rpc DeleteOrganizationModel(DeleteOrganizationModelRequest) returns (DeleteOrganizationModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/models/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Rename a model
@@ -295,6 +318,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,new_model_id";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Publish a model
@@ -307,6 +331,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Unpublish a model
@@ -319,6 +344,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Get a model card
@@ -328,6 +354,7 @@ service ModelPublicService {
   rpc GetOrganizationModelCard(GetOrganizationModelCardRequest) returns (GetOrganizationModelCardResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*/readme}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Watch the state of a model
@@ -338,6 +365,7 @@ service ModelPublicService {
   rpc WatchOrganizationModel(WatchOrganizationModelRequest) returns (WatchOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}/watch"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // List organization model versions
@@ -347,6 +375,7 @@ service ModelPublicService {
   rpc ListOrganizationModelVersions(ListOrganizationModelVersionsRequest) returns (ListOrganizationModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   ///////////////////////////////////////////////////////
@@ -361,6 +390,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Trigger model inference asynchronously
@@ -373,6 +403,7 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Trigger model inference with a binary input
@@ -381,6 +412,7 @@ service ModelPublicService {
   // submitted as a binary file.
   rpc TriggerOrganizationModelBinaryFileUpload(stream TriggerOrganizationModelBinaryFileUploadRequest) returns (TriggerOrganizationModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
   // Get the details of a long-running operation
@@ -390,5 +422,6 @@ service ModelPublicService {
   rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 }

--- a/model/model/v1alpha/openapi.proto.templ
+++ b/model/model/v1alpha/openapi.proto.templ
@@ -11,6 +11,10 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     description: "Endpoints to manage the AI model-related resources and features working with Instill VDP.";
 {{$info}}
   };
-  base_path: "/model";
+  tags: [
+    {
+      name: "Model"
+    }
+  ];
 {{$conf}}
 };

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -2,9 +2,6 @@ swagger: "2.0"
 info:
   title: common/healthcheck/v1beta/healthcheck.proto
   version: version not set
-tags:
-  - name: ArtifactPublicService
-    description: Public Artifact endpoints
 consumes:
   - application/json
 produces:

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -11,10 +11,15 @@ info:
     name: Elastic License 2.0 (ELv2)
     url: https://github.com/instill-ai/protobufs/blob/main/LICENSE
 tags:
-  - name: MgmtPublicService
-    description: Public Core endpoints
+  - name: User
+  - name: Organization
+  - name: Membership
+  - name: Token
+  - name: Subscription
+  - name: Credit
+  - name: Metric
+  - name: Utils
 host: api.instill.tech
-basePath: /core
 schemes:
   - https
   - http
@@ -23,167 +28,6 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1beta/{organization_membership_name}:
-    get:
-      summary: Get a an organization membership
-      description: Returns the details of a user membership within an organization.
-      operationId: MgmtPublicService_GetOrganizationMembership
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetOrganizationMembershipResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by
-            organization and user ID.
-            - Format: `organizations/{organization.id}/memberships/{user.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/memberships/[^/]+
-        - name: view
-          description: |-
-            View allows clients to specify the desired resource view in the response.
-
-             - VIEW_BASIC: Default view, only includes basic information.
-             - VIEW_FULL: Full representation.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-      tags:
-        - MgmtPublicService
-    delete:
-      summary: Delete an organization membership
-      description: Deletes a user membership within an organization.
-      operationId: MgmtPublicService_DeleteOrganizationMembership
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaDeleteOrganizationMembershipResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by
-            organization and user ID.
-            - Format: `organizations/{organization.id}/memberships/{user.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/memberships/[^/]+
-      tags:
-        - MgmtPublicService
-    put:
-      summary: Uppdate an organization membership
-      description: Updates a user membership within an organization.
-      operationId: MgmtPublicService_UpdateOrganizationMembership
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaUpdateOrganizationMembershipResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by
-            organization and user ID.
-            - Format: `organizations/{organization.id}/memberships/{user.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/memberships/[^/]+
-        - name: membership
-          description: The membership fields to update.
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              role:
-                type: string
-                description: Role of the user in the organization.
-              state:
-                $ref: '#/definitions/v1betaMembershipState'
-                description: State of the membership.
-                readOnly: true
-              user:
-                $ref: '#/definitions/v1betaUser'
-                description: User information.
-                readOnly: true
-              organization:
-                $ref: '#/definitions/v1betaOrganization'
-                description: Organization information.
-                readOnly: true
-            title: The membership fields to update.
-            required:
-              - role
-        - name: update_mask
-          description: |-
-            The update mask specifies the subset of fields that should be modified.
-
-            For more information about this field, see
-            https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
-          in: query
-          required: true
-          type: string
-      tags:
-        - MgmtPublicService
-  /v1beta/check-namespace:
-    post:
-      summary: Check if a namespace is in use
-      description: |-
-        Returns the availability of a namespace or, alternatively, the type of
-        resource that is using it.
-      operationId: MgmtPublicService_CheckNamespace
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaCheckNamespaceResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: body
-          description: |-
-            CheckNamespaceRequest represents a request to verify if a namespace is
-            available.
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/v1betaCheckNamespaceRequest'
-      tags:
-        - MgmtPublicService
   /v1beta/user:
     get:
       summary: Get the authenticated user
@@ -202,7 +46,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       tags:
-        - MgmtPublicService
+        - User
     patch:
       summary: Update the authenticated user
       description: |-
@@ -231,7 +75,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaAuthenticatedUser'
       tags:
-        - MgmtPublicService
+        - User
   /v1beta/users:
     get:
       summary: List users
@@ -285,7 +129,7 @@ paths:
           required: false
           type: string
       tags:
-        - MgmtPublicService
+        - User
   /v1beta/{user_name}:
     get:
       summary: Get a user
@@ -325,168 +169,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - MgmtPublicService
-  /v1beta/{user_name}/memberships:
-    get:
-      summary: List user memberships
-      description: Returns the memberships of a user.
-      operationId: MgmtPublicService_ListUserMemberships
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaListUserMembershipsResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_name
-          description: |-
-            The parent resource, i.e., the user to which the memberships belong.
-            Format: `users/{user.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+
-      tags:
-        - MgmtPublicService
-  /v1beta/{user_membership_name}:
-    get:
-      summary: Get a user membership
-      description: |-
-        Returns the details of the relationship between a user and an
-        organization. The authenticated must match the membership parent.
-      operationId: MgmtPublicService_GetUserMembership
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetUserMembershipResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by user and
-            organization ID.
-            - Format: `users/{user.id}/memberships/{organization.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/memberships/[^/]+
-        - name: view
-          description: |-
-            View allows clients to specify the desired resource view in the response.
-
-             - VIEW_BASIC: Default view, only includes basic information.
-             - VIEW_FULL: Full representation.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-      tags:
-        - MgmtPublicService
-    delete:
-      summary: Delete a user membership
-      description: Accesses and deletes a user membership by parent and membership IDs.
-      operationId: MgmtPublicService_DeleteUserMembership
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaDeleteUserMembershipResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by user and
-            organization ID.
-            - Format: `users/{user.id}/memberships/{organization.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/memberships/[^/]+
-      tags:
-        - MgmtPublicService
-    put:
-      summary: Update a user membership
-      description: Accesses and updates a user membership by parent and membership IDs.
-      operationId: MgmtPublicService_UpdateUserMembership
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaUpdateUserMembershipResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by user and
-            organization ID.
-            - Format: `users/{user.id}/memberships/{organization.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/memberships/[^/]+
-        - name: membership
-          description: The membership fields to update.
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              role:
-                type: string
-                description: Role of the user in the organization.
-                readOnly: true
-              state:
-                $ref: '#/definitions/v1betaMembershipState'
-                description: State of the membership.
-              user:
-                $ref: '#/definitions/v1betaUser'
-                description: User information.
-                readOnly: true
-              organization:
-                $ref: '#/definitions/v1betaOrganization'
-                description: Organization information.
-                readOnly: true
-            title: The membership fields to update.
-            required:
-              - state
-        - name: update_mask
-          description: |-
-            The update mask specifies the subset of fields that should be modified.
-
-            For more information about this field, see
-            https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
-          in: query
-          required: true
-          type: string
-      tags:
-        - MgmtPublicService
+        - User
   /v1beta/organizations:
     get:
       summary: List organizations
@@ -540,7 +223,7 @@ paths:
           required: false
           type: string
       tags:
-        - MgmtPublicService
+        - Organization
     post:
       summary: Create an organization
       description: Creates an organization.
@@ -565,7 +248,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaOrganization'
       tags:
-        - MgmtPublicService
+        - Organization
   /v1beta/{organization_name}:
     get:
       summary: Get an organization
@@ -605,7 +288,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - MgmtPublicService
+        - Organization
     delete:
       summary: Delete an organization
       description: Accesses and deletes an organization by ID.
@@ -632,7 +315,7 @@ paths:
           type: string
           pattern: organizations/[^/]+
       tags:
-        - MgmtPublicService
+        - Organization
     patch:
       summary: Update an organization
       description: |-
@@ -707,7 +390,168 @@ paths:
             required:
               - id
       tags:
-        - MgmtPublicService
+        - Organization
+  /v1beta/{user_name}/memberships:
+    get:
+      summary: List user memberships
+      description: Returns the memberships of a user.
+      operationId: MgmtPublicService_ListUserMemberships
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaListUserMembershipsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_name
+          description: |-
+            The parent resource, i.e., the user to which the memberships belong.
+            Format: `users/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+
+      tags:
+        - Membership
+  /v1beta/{user_membership_name}:
+    get:
+      summary: Get a user membership
+      description: |-
+        Returns the details of the relationship between a user and an
+        organization. The authenticated must match the membership parent.
+      operationId: MgmtPublicService_GetUserMembership
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetUserMembershipResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_membership_name
+          description: |-
+            The resource name of the membership, which allows its access by user and
+            organization ID.
+            - Format: `users/{user.id}/memberships/{organization.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/memberships/[^/]+
+        - name: view
+          description: |-
+            View allows clients to specify the desired resource view in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+      tags:
+        - Membership
+    delete:
+      summary: Delete a user membership
+      description: Accesses and deletes a user membership by parent and membership IDs.
+      operationId: MgmtPublicService_DeleteUserMembership
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDeleteUserMembershipResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_membership_name
+          description: |-
+            The resource name of the membership, which allows its access by user and
+            organization ID.
+            - Format: `users/{user.id}/memberships/{organization.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/memberships/[^/]+
+      tags:
+        - Membership
+    put:
+      summary: Update a user membership
+      description: Accesses and updates a user membership by parent and membership IDs.
+      operationId: MgmtPublicService_UpdateUserMembership
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaUpdateUserMembershipResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_membership_name
+          description: |-
+            The resource name of the membership, which allows its access by user and
+            organization ID.
+            - Format: `users/{user.id}/memberships/{organization.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/memberships/[^/]+
+        - name: membership
+          description: The membership fields to update.
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              role:
+                type: string
+                description: Role of the user in the organization.
+                readOnly: true
+              state:
+                $ref: '#/definitions/v1betaMembershipState'
+                description: State of the membership.
+              user:
+                $ref: '#/definitions/v1betaUser'
+                description: User information.
+                readOnly: true
+              organization:
+                $ref: '#/definitions/v1betaOrganization'
+                description: Organization information.
+                readOnly: true
+            title: The membership fields to update.
+            required:
+              - state
+        - name: update_mask
+          description: |-
+            The update mask specifies the subset of fields that should be modified.
+
+            For more information about this field, see
+            https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+          in: query
+          required: true
+          type: string
+      tags:
+        - Membership
   /v1beta/{organization_name}/memberships:
     get:
       summary: List organization memberships
@@ -736,7 +580,138 @@ paths:
           type: string
           pattern: organizations/[^/]+
       tags:
-        - MgmtPublicService
+        - Membership
+  /v1beta/{organization_membership_name}:
+    get:
+      summary: Get a an organization membership
+      description: Returns the details of a user membership within an organization.
+      operationId: MgmtPublicService_GetOrganizationMembership
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetOrganizationMembershipResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_membership_name
+          description: |-
+            The resource name of the membership, which allows its access by
+            organization and user ID.
+            - Format: `organizations/{organization.id}/memberships/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/memberships/[^/]+
+        - name: view
+          description: |-
+            View allows clients to specify the desired resource view in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+      tags:
+        - Membership
+    delete:
+      summary: Delete an organization membership
+      description: Deletes a user membership within an organization.
+      operationId: MgmtPublicService_DeleteOrganizationMembership
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDeleteOrganizationMembershipResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_membership_name
+          description: |-
+            The resource name of the membership, which allows its access by
+            organization and user ID.
+            - Format: `organizations/{organization.id}/memberships/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/memberships/[^/]+
+      tags:
+        - Membership
+    put:
+      summary: Uppdate an organization membership
+      description: Updates a user membership within an organization.
+      operationId: MgmtPublicService_UpdateOrganizationMembership
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaUpdateOrganizationMembershipResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_membership_name
+          description: |-
+            The resource name of the membership, which allows its access by
+            organization and user ID.
+            - Format: `organizations/{organization.id}/memberships/{user.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/memberships/[^/]+
+        - name: membership
+          description: The membership fields to update.
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              role:
+                type: string
+                description: Role of the user in the organization.
+              state:
+                $ref: '#/definitions/v1betaMembershipState'
+                description: State of the membership.
+                readOnly: true
+              user:
+                $ref: '#/definitions/v1betaUser'
+                description: User information.
+                readOnly: true
+              organization:
+                $ref: '#/definitions/v1betaOrganization'
+                description: Organization information.
+                readOnly: true
+            title: The membership fields to update.
+            required:
+              - role
+        - name: update_mask
+          description: |-
+            The update mask specifies the subset of fields that should be modified.
+
+            For more information about this field, see
+            https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+          in: query
+          required: true
+          type: string
+      tags:
+        - Membership
   /v1beta/user/subscription:
     get:
       summary: Get the subscription of the authenticated user
@@ -755,7 +730,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       tags:
-        - MgmtPublicService
+        - Subscription
   /v1beta/{organization_name}/subscription:
     get:
       summary: Get an organization subscription
@@ -784,7 +759,7 @@ paths:
           type: string
           pattern: organizations/[^/]+
       tags:
-        - MgmtPublicService
+        - Subscription
   /v1beta/tokens:
     get:
       summary: List API tokens
@@ -818,7 +793,7 @@ paths:
           required: false
           type: string
       tags:
-        - MgmtPublicService
+        - Token
     post:
       summary: Create an API token
       description: Creates an API token for the authenticated user.
@@ -843,7 +818,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaApiToken'
       tags:
-        - MgmtPublicService
+        - Token
   /v1beta/{token_name}:
     get:
       summary: Get an API token
@@ -871,7 +846,7 @@ paths:
           type: string
           pattern: tokens/[^/]+
       tags:
-        - MgmtPublicService
+        - Token
     delete:
       summary: Delete an API token
       description: Deletes an API token.
@@ -898,7 +873,7 @@ paths:
           type: string
           pattern: tokens/[^/]+
       tags:
-        - MgmtPublicService
+        - Token
   /v1beta/validate_token:
     post:
       summary: Validate an API token.
@@ -917,7 +892,72 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       tags:
-        - MgmtPublicService
+        - Token
+  /v1beta/{owner_name}/credit:
+    get:
+      summary: Get the remaining Instill Credit
+      description: |-
+        On Instill Cloud, users can use Instill Credit to execute pre-configured
+        AI connectors. This simplifies the pipeline setup, removing the need to
+        subscribe to third-party AI services. This endpoint returns the remaining
+        Instill Credit of a given user or organization. The requested credit owner
+        must be either the authenticated user or an organization they belong to.
+
+        On Instill Core, this endpoint will return a 404 Not Found status.
+      operationId: MgmtPublicService_GetRemainingCredit
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetRemainingCreditResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: owner_name
+          description: |-
+            The user or organization to which the credit belongs.
+            Format: `{[users|organizations]}/{id}`.
+          in: path
+          required: true
+          type: string
+          pattern: '[^/]+/[^/]+'
+      tags:
+        - Credit
+  /v1beta/check-namespace:
+    post:
+      summary: Check if a namespace is in use
+      description: |-
+        Returns the availability of a namespace or, alternatively, the type of
+        resource that is using it.
+      operationId: MgmtPublicService_CheckNamespace
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCheckNamespaceResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: body
+          description: |-
+            CheckNamespaceRequest represents a request to verify if a namespace is
+            available.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1betaCheckNamespaceRequest'
+      tags:
+        - Utils
   /v1beta/metrics/vdp/pipeline/triggers:
     get:
       summary: List pipeline triggers
@@ -959,7 +999,7 @@ paths:
           required: false
           type: string
       tags:
-        - MgmtPublicService
+        - Metric
   /v1beta/metrics/vdp/pipeline/tables:
     get:
       summary: List pipeline trigger metrics
@@ -1001,7 +1041,7 @@ paths:
           required: false
           type: string
       tags:
-        - MgmtPublicService
+        - Metric
   /v1beta/metrics/vdp/pipeline/charts:
     get:
       summary: List pipeline trigger computation time charts
@@ -1037,7 +1077,7 @@ paths:
           required: false
           type: string
       tags:
-        - MgmtPublicService
+        - Metric
 definitions:
   ApiTokenState:
     type: string
@@ -1958,6 +1998,16 @@ definitions:
     title: GetPipelinesResponse represents a respond to GetPipelineRequest
     required:
       - pipelines
+  v1betaGetRemainingCreditResponse:
+    type: object
+    properties:
+      amount:
+        type: number
+        format: float
+        description: The requested credit.
+    description: |-
+      GetRemainingCreditResponse contains the remaining credit of a user or
+      organization.
   v1betaGetTokenResponse:
     type: object
     properties:

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -11,10 +11,8 @@ info:
     name: Elastic License 2.0 (ELv2)
     url: https://github.com/instill-ai/protobufs/blob/main/LICENSE
 tags:
-  - name: ModelPublicService
-    description: Public Model endpoints
+  - name: Model
 host: api.instill.tech
-basePath: /model
 schemes:
   - https
   - http
@@ -68,7 +66,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{model_definition_name}:
     get:
       summary: Get a model definition
@@ -108,7 +106,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/models:
     get:
       summary: List models
@@ -159,7 +157,7 @@ paths:
           required: false
           type: boolean
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{permalink}/lookUp:
     get:
       summary: Get a model by UID
@@ -199,7 +197,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_name}/models:
     get:
       summary: List user models
@@ -261,7 +259,7 @@ paths:
           required: false
           type: boolean
       tags:
-        - ModelPublicService
+        - Model
     post:
       summary: Create a new model
       description: |-
@@ -299,7 +297,7 @@ paths:
           schema:
             $ref: '#/definitions/v1alphaModel'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_name}:
     get:
       summary: Get a model
@@ -340,7 +338,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - ModelPublicService
+        - Model
     delete:
       summary: Delete a model
       description: |-
@@ -370,7 +368,7 @@ paths:
           type: string
           pattern: users/[^/]+/models/[^/]+
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{model_name}:
     patch:
       summary: Update a model
@@ -486,7 +484,7 @@ paths:
               - region
               - hardware
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_name}/rename:
     post:
       summary: Rename a model
@@ -522,7 +520,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceRenameUserModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_name}/publish:
     post:
       summary: Publish a model
@@ -558,7 +556,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServicePublishUserModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_name}/unpublish:
     post:
       summary: Unpublish a model
@@ -594,7 +592,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceUnpublishUserModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_card_name}:
     get:
       summary: Get a model card
@@ -625,7 +623,7 @@ paths:
           type: string
           pattern: users/[^/]+/models/[^/]+/readme
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_name}/versions/{version}/watch:
     get:
       summary: Watch the state of a model
@@ -663,7 +661,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_name}/versions:
     get:
       summary: List user model versions
@@ -710,7 +708,7 @@ paths:
           type: integer
           format: int32
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_name}/versions/{version}/trigger:
     post:
       summary: Trigger model inference
@@ -752,7 +750,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerUserModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_name}/versions/{version}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -794,7 +792,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerAsyncUserModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{organization_name}/models:
     get:
       summary: List organization models
@@ -856,7 +854,7 @@ paths:
           required: false
           type: boolean
       tags:
-        - ModelPublicService
+        - Model
     post:
       summary: Create a new model
       description: |-
@@ -894,7 +892,7 @@ paths:
           schema:
             $ref: '#/definitions/v1alphaModel'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{organization_model_name}:
     get:
       summary: Get a model
@@ -935,7 +933,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - ModelPublicService
+        - Model
     delete:
       summary: Delete a model
       description: |-
@@ -965,7 +963,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/models/[^/]+
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{model_name_1}:
     patch:
       summary: Update a model
@@ -1081,7 +1079,7 @@ paths:
               - region
               - hardware
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{organization_model_name}/rename:
     post:
       summary: Rename a model
@@ -1117,7 +1115,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceRenameOrganizationModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{organization_model_name}/publish:
     post:
       summary: Publish a model
@@ -1153,7 +1151,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServicePublishOrganizationModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{organization_model_name}/unpublish:
     post:
       summary: Unpublish a model
@@ -1189,7 +1187,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceUnpublishOrganizationModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{organization_model_card_name}:
     get:
       summary: Get a model card
@@ -1220,7 +1218,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/models/[^/]+/readme
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{organization_model_name}/versions/{version}/watch:
     get:
       summary: Watch the state of a model
@@ -1258,7 +1256,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{user_model_name_1}/versions:
     get:
       summary: List organization model versions
@@ -1305,7 +1303,7 @@ paths:
           type: integer
           format: int32
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{organization_model_name}/versions/{version}/trigger:
     post:
       summary: Trigger model inference
@@ -1347,7 +1345,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerOrganizationModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{organization_model_name}/versions/{version}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -1389,7 +1387,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerAsyncOrganizationModelBody'
       tags:
-        - ModelPublicService
+        - Model
   /v1alpha/{name}:
     get:
       summary: Get the details of a long-running operation
@@ -1431,7 +1429,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - ModelPublicService
+        - Model
 definitions:
   ModelPublicServicePublishOrganizationModelBody:
     type: object

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -11,10 +11,13 @@ info:
     name: Elastic License 2.0 (ELv2)
     url: https://github.com/instill-ai/protobufs/blob/main/LICENSE
 tags:
-  - name: PipelinePublicService
-    description: Public VDP endpoints
+  - name: Component
+  - name: Pipeline
+  - name: Release
+  - name: Trigger
+  - name: Secret
+  - name: Utils
 host: api.instill.tech
-basePath: /vdp
 schemes:
   - https
   - http
@@ -97,7 +100,7 @@ paths:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{permalink}/lookUp:
     get:
       summary: Get a pipeline by UID
@@ -141,7 +144,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{user_name}/pipelines:
     get:
       summary: List user pipelines
@@ -228,7 +231,7 @@ paths:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
       tags:
-        - PipelinePublicService
+        - Pipeline
     post:
       summary: Create a new user pipeline
       description: |-
@@ -264,7 +267,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaPipeline'
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{user_pipeline_name}:
     get:
       summary: Get a pipeline owned by a user
@@ -309,7 +312,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - PipelinePublicService
+        - Pipeline
     delete:
       summary: Delete a pipeline owned by a user
       description: |-
@@ -340,7 +343,7 @@ paths:
           type: string
           pattern: users/[^/]+/pipelines/[^/]+
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{pipeline_name}:
     patch:
       summary: Update a pipeline owned by a user
@@ -450,7 +453,7 @@ paths:
                 readOnly: true
             title: The pipeline fields that will replace the existing ones.
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{user_pipeline_name}/validate:
     post:
       summary: Validate a pipeline a pipeline owned by a user
@@ -488,7 +491,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceValidateUserPipelineBody'
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{user_pipeline_name}/rename:
     post:
       summary: Rename a pipeline owned by a user
@@ -531,7 +534,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceRenameUserPipelineBody'
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{user_pipeline_name}/clone:
     post:
       summary: Clone a pipeline owned by a user
@@ -567,7 +570,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceCloneUserPipelineBody'
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{user_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by a user
@@ -610,7 +613,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerUserPipelineBody'
       tags:
-        - PipelinePublicService
+        - Trigger
   /v1beta/{user_pipeline_name}/triggerAsync:
     post:
       summary: Trigger a pipeline owned by a user asynchronously
@@ -654,7 +657,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerAsyncUserPipelineBody'
       tags:
-        - PipelinePublicService
+        - Trigger
   /v1beta/{user_name}/releases:
     get:
       summary: List the releases in a pipeline owned by a user
@@ -725,7 +728,7 @@ paths:
           required: false
           type: boolean
       tags:
-        - PipelinePublicService
+        - Release
     post:
       summary: Release a version of a pipeline owned by a user
       description: |-
@@ -763,7 +766,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaPipelineRelease'
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{user_pipeline_release_name}:
     get:
       summary: Get a release in a pipeline owned by a user
@@ -808,7 +811,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - PipelinePublicService
+        - Release
     delete:
       summary: Delete a release in a pipeline owned by a user
       description: |-
@@ -841,7 +844,7 @@ paths:
           type: string
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{pipeline_release_name}:
     patch:
       summary: Update a release in a pipeline owned by a user
@@ -933,7 +936,7 @@ paths:
               The pipeline release fields that will replace the existing ones.
               A pipeline release resource to update
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{user_pipeline_release_name}/restore:
     post:
       summary: Set the version of a pipeline owned by a user to a pinned release
@@ -969,7 +972,7 @@ paths:
           type: string
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{user_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by a user
@@ -1013,7 +1016,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceRenameUserPipelineReleaseBody'
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{user_pipeline_release_name}/trigger:
     post:
       summary: Trigger a version of a pipeline owned by a user
@@ -1054,7 +1057,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerUserPipelineReleaseBody'
       tags:
-        - PipelinePublicService
+        - Trigger
   /v1beta/{user_pipeline_release_name}/triggerAsync:
     post:
       summary: Trigger a version of a pipeline owned by a user asynchronously
@@ -1095,7 +1098,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerAsyncUserPipelineReleaseBody'
       tags:
-        - PipelinePublicService
+        - Trigger
   /v1beta/{organization_name}/pipelines:
     get:
       summary: List organization pipelines
@@ -1180,7 +1183,7 @@ paths:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
       tags:
-        - PipelinePublicService
+        - Pipeline
     post:
       summary: Create a new organization pipeline
       description: Creates a new pipeline under the parenthood of an organization.
@@ -1213,7 +1216,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaPipeline'
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{organization_pipeline_name}:
     get:
       summary: Get a pipeline owned by an organization
@@ -1258,7 +1261,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - PipelinePublicService
+        - Pipeline
     delete:
       summary: Delete a pipeline owned by an organization
       description: |-
@@ -1288,7 +1291,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/pipelines/[^/]+
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{pipeline_name_1}:
     patch:
       summary: Update a pipeline owned by an organization
@@ -1396,7 +1399,7 @@ paths:
                 readOnly: true
             title: The pipeline fields that will replace the existing ones.
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{organization_pipeline_name}/validate:
     post:
       summary: Validate a pipeline a pipeline owned by an organization
@@ -1435,7 +1438,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceValidateOrganizationPipelineBody'
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{organization_pipeline_name}/rename:
     post:
       summary: Rename a pipeline owned by an organization
@@ -1475,7 +1478,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceRenameOrganizationPipelineBody'
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{user_pipeline_name_1}/clone:
     post:
       summary: Clone a pipeline owned by an organization
@@ -1511,7 +1514,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineBody'
       tags:
-        - PipelinePublicService
+        - Pipeline
   /v1beta/{organization_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by an organization
@@ -1554,7 +1557,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerOrganizationPipelineBody'
       tags:
-        - PipelinePublicService
+        - Trigger
   /v1beta/{organization_pipeline_name}/triggerAsync:
     post:
       summary: Trigger a pipeline owned by an organization asynchronously
@@ -1598,7 +1601,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerAsyncOrganizationPipelineBody'
       tags:
-        - PipelinePublicService
+        - Trigger
   /v1beta/{organization_name}/releases:
     get:
       summary: List the releases in a pipeline owned by an organization
@@ -1669,7 +1672,7 @@ paths:
           required: false
           type: boolean
       tags:
-        - PipelinePublicService
+        - Release
     post:
       summary: Release a version of a pipeline owned by an organization
       description: |-
@@ -1704,7 +1707,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaPipelineRelease'
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{organization_pipeline_release_name}:
     get:
       summary: Get a release in a pipeline owned by an organization
@@ -1750,7 +1753,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - PipelinePublicService
+        - Release
     delete:
       summary: Delete a release in a pipeline owned by an organization
       description: |-
@@ -1781,7 +1784,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{pipeline_release_name_1}:
     patch:
       summary: Update a release in a pipeline owned by an organization
@@ -1870,7 +1873,7 @@ paths:
               The pipeline release fields that will replace the existing ones.
               A pipeline release resource to update
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{organization_pipeline_release_name}/restore:
     post:
       summary: Set the version of a pipeline owned by an organization to a pinned release
@@ -1904,7 +1907,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{organization_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by an organization
@@ -1946,7 +1949,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceRenameOrganizationPipelineReleaseBody'
       tags:
-        - PipelinePublicService
+        - Release
   /v1beta/{organization_pipeline_release_name}/trigger:
     post:
       summary: Trigger a version of a pipeline owned by an organization
@@ -1988,7 +1991,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerOrganizationPipelineReleaseBody'
       tags:
-        - PipelinePublicService
+        - Trigger
   /v1beta/{organization_pipeline_release_name}/triggerAsync:
     post:
       summary: Trigger a version of a pipeline owned by an organization asynchronously
@@ -2030,7 +2033,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerAsyncOrganizationPipelineReleaseBody'
       tags:
-        - PipelinePublicService
+        - Trigger
   /v1beta/{name}:
     get:
       summary: Get the details of a long-running operation
@@ -2060,7 +2063,7 @@ paths:
           type: string
           pattern: operations/[^/]+
       tags:
-        - PipelinePublicService
+        - Trigger
   /v1beta/connector-definitions:
     get:
       summary: List connector definitions
@@ -2115,7 +2118,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - PipelinePublicService
+        - Component
   /v1beta/{connector_definition_name}:
     get:
       summary: Get connector definition
@@ -2156,7 +2159,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - PipelinePublicService
+        - Component
   /v1beta/operator-definitions:
     get:
       summary: List operator definitions
@@ -2212,7 +2215,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - PipelinePublicService
+        - Component
   /v1beta/component-definitions:
     get:
       summary: List component definitions
@@ -2272,7 +2275,7 @@ paths:
           type: integer
           format: int32
       tags:
-        - PipelinePublicService
+        - Component
   /v1beta/{operator_definition_name}:
     get:
       summary: Get operator definition
@@ -2313,7 +2316,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - PipelinePublicService
+        - Component
   /v1beta/check-name:
     post:
       summary: Check the availibity of a resource name
@@ -2343,7 +2346,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaCheckNameRequest'
       tags:
-        - PipelinePublicService
+        - Utils
   /v1beta/{user_name}/secrets:
     get:
       summary: List user secrets
@@ -2387,7 +2390,7 @@ paths:
           required: false
           type: string
       tags:
-        - PipelinePublicService
+        - Secret
     post:
       summary: Create a new user secret
       description: Creates a new secret under the parenthood of an user.
@@ -2420,7 +2423,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaSecret'
       tags:
-        - PipelinePublicService
+        - Secret
   /v1beta/{user_secret_name}:
     get:
       summary: Get a secret owned by an user
@@ -2450,7 +2453,7 @@ paths:
           type: string
           pattern: users/[^/]+/secrets/[^/]+
       tags:
-        - PipelinePublicService
+        - Secret
     delete:
       summary: Delete a secret owned by an user
       description: |-
@@ -2479,7 +2482,7 @@ paths:
           type: string
           pattern: users/[^/]+/secrets/[^/]+
       tags:
-        - PipelinePublicService
+        - Secret
   /v1beta/{secret.name}:
     patch:
       summary: Update a secret owned by an user
@@ -2546,7 +2549,7 @@ paths:
                 title: Description
             title: The secret fields to update.
       tags:
-        - PipelinePublicService
+        - Secret
   /v1beta/{organization_name}/secrets:
     get:
       summary: List organization secrets
@@ -2590,7 +2593,7 @@ paths:
           required: false
           type: string
       tags:
-        - PipelinePublicService
+        - Secret
     post:
       summary: Create a new organization secret
       description: Creates a new secret under the parenthood of an organization.
@@ -2623,7 +2626,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaSecret'
       tags:
-        - PipelinePublicService
+        - Secret
   /v1beta/{organization_secret_name}:
     get:
       summary: Get a secret owned by an organization
@@ -2653,7 +2656,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/secrets/[^/]+
       tags:
-        - PipelinePublicService
+        - Secret
     delete:
       summary: Delete a secret owned by an organization
       description: |-
@@ -2682,7 +2685,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/secrets/[^/]+
       tags:
-        - PipelinePublicService
+        - Secret
   /v1beta/{secret.name_1}:
     patch:
       summary: Update a secret owned by an organization
@@ -2749,7 +2752,7 @@ paths:
                 title: Description
             title: The secret fields to update.
       tags:
-        - PipelinePublicService
+        - Secret
 definitions:
   CheckNameResponseName:
     type: string

--- a/vdp/pipeline/v1beta/openapi.proto.templ
+++ b/vdp/pipeline/v1beta/openapi.proto.templ
@@ -6,11 +6,30 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 
 // These options define the OpenAPI definition document information.
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
-info: {
-title: "💧 VDP";
-description: "VDP endpoints to manage pipeline resources";
-{{$info}}
-      };
-base_path: "/vdp";
+  info: {
+    title: "💧 VDP";
+    description: "VDP endpoints to manage pipeline resources";
+    {{$info}}
+  };
+  tags: [
+    {
+      name: "Component"
+    },
+    {
+      name: "Pipeline"
+    },
+    {
+      name: "Release"
+    },
+    {
+      name: "Trigger"
+    },
+    {
+      name: "Secret"
+    },
+    {
+      name: "Utils"
+    }
+  ];
 {{$conf}}
 };

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -46,6 +46,7 @@ service PipelinePublicService {
   // Returns a paginated list of pipelines that are visible to the requester.
   rpc ListPipelines(ListPipelinesRequest) returns (ListPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/pipelines"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Get a pipeline by UID
@@ -55,6 +56,7 @@ service PipelinePublicService {
   rpc LookUpPipeline(LookUpPipelineRequest) returns (LookUpPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{permalink=pipelines/*}/lookUp"};
     option (google.api.method_signature) = "permalink";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Create a new user pipeline
@@ -68,6 +70,7 @@ service PipelinePublicService {
       body: "pipeline"
     };
     option (google.api.method_signature) = "parent,pipeline";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // List user pipelines
@@ -79,6 +82,7 @@ service PipelinePublicService {
   rpc ListUserPipelines(ListUserPipelinesRequest) returns (ListUserPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/pipelines"};
     option (google.api.method_signature) = "parent";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Get a pipeline owned by a user
@@ -88,6 +92,7 @@ service PipelinePublicService {
   rpc GetUserPipeline(GetUserPipelineRequest) returns (GetUserPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Update a pipeline owned by a user
@@ -104,6 +109,7 @@ service PipelinePublicService {
       body: "pipeline"
     };
     option (google.api.method_signature) = "pipeline,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Delete a pipeline owned by a user
@@ -114,6 +120,7 @@ service PipelinePublicService {
   rpc DeleteUserPipeline(DeleteUserPipelineRequest) returns (DeleteUserPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Validate a pipeline a pipeline owned by a user
@@ -128,6 +135,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Rename a pipeline owned by a user
@@ -147,6 +155,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,new_pipeline_id";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Clone a pipeline owned by a user
@@ -159,6 +168,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,target";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Trigger a pipeline owned by a user
@@ -178,6 +188,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Trigger a pipeline owned by a user asynchronously
@@ -198,6 +209,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Release a version of a pipeline owned by a user
@@ -213,6 +225,7 @@ service PipelinePublicService {
       body: "release"
     };
     option (google.api.method_signature) = "parent,release";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // List the releases in a pipeline owned by a user
@@ -222,6 +235,7 @@ service PipelinePublicService {
   rpc ListUserPipelineReleases(ListUserPipelineReleasesRequest) returns (ListUserPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*/pipelines/*}/releases"};
     option (google.api.method_signature) = "pipelines";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Get a release in a pipeline owned by a user
@@ -231,6 +245,7 @@ service PipelinePublicService {
   rpc GetUserPipelineRelease(GetUserPipelineReleaseRequest) returns (GetUserPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Update a release in a pipeline owned by a user
@@ -246,6 +261,7 @@ service PipelinePublicService {
       body: "release"
     };
     option (google.api.method_signature) = "release,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Delete a release in a pipeline owned by a user
@@ -258,6 +274,7 @@ service PipelinePublicService {
   rpc DeleteUserPipelineRelease(DeleteUserPipelineReleaseRequest) returns (DeleteUserPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Set the version of a pipeline owned by a user to a pinned release
@@ -272,6 +289,7 @@ service PipelinePublicService {
   rpc RestoreUserPipelineRelease(RestoreUserPipelineReleaseRequest) returns (RestoreUserPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=users/*/pipelines/*/releases/*}/restore"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Rename a release in a pipeline owned by a user
@@ -292,6 +310,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,new_pipeline_release_id";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Trigger a version of a pipeline owned by a user
@@ -309,6 +328,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Trigger a version of a pipeline owned by a user asynchronously
@@ -326,6 +346,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Create a new organization pipeline
@@ -337,6 +358,7 @@ service PipelinePublicService {
       body: "pipeline"
     };
     option (google.api.method_signature) = "parent,pipeline";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // List organization pipelines
@@ -346,6 +368,7 @@ service PipelinePublicService {
   rpc ListOrganizationPipelines(ListOrganizationPipelinesRequest) returns (ListOrganizationPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/pipelines"};
     option (google.api.method_signature) = "parent";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Get a pipeline owned by an organization
@@ -355,6 +378,7 @@ service PipelinePublicService {
   rpc GetOrganizationPipeline(GetOrganizationPipelineRequest) returns (GetOrganizationPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Update a pipeline owned by an organization
@@ -369,6 +393,7 @@ service PipelinePublicService {
       body: "pipeline"
     };
     option (google.api.method_signature) = "pipeline,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Delete a pipeline owned by an organization
@@ -378,6 +403,7 @@ service PipelinePublicService {
   rpc DeleteOrganizationPipeline(DeleteOrganizationPipelineRequest) returns (DeleteOrganizationPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Validate a pipeline a pipeline owned by an organization
@@ -393,6 +419,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Rename a pipeline owned by an organization
@@ -409,6 +436,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,new_pipeline_id";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Clone a pipeline owned by an organization
@@ -421,6 +449,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,target";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // Trigger a pipeline owned by an organization
@@ -440,6 +469,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Trigger a pipeline owned by an organization asynchronously
@@ -460,6 +490,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Release a version of a pipeline owned by an organization
@@ -472,6 +503,7 @@ service PipelinePublicService {
       body: "release"
     };
     option (google.api.method_signature) = "parent,release";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // List the releases in a pipeline owned by an organization
@@ -481,6 +513,7 @@ service PipelinePublicService {
   rpc ListOrganizationPipelineReleases(ListOrganizationPipelineReleasesRequest) returns (ListOrganizationPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*/pipelines/*}/releases"};
     option (google.api.method_signature) = "pipelines";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Get a release in a pipeline owned by an organization
@@ -490,6 +523,7 @@ service PipelinePublicService {
   rpc GetOrganizationPipelineRelease(GetOrganizationPipelineReleaseRequest) returns (GetOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Update a release in a pipeline owned by an organization
@@ -502,6 +536,7 @@ service PipelinePublicService {
       body: "release"
     };
     option (google.api.method_signature) = "release,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Delete a release in a pipeline owned by an organization
@@ -511,6 +546,7 @@ service PipelinePublicService {
   rpc DeleteOrganizationPipelineRelease(DeleteOrganizationPipelineReleaseRequest) returns (DeleteOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Set the version of a pipeline owned by an organization to a pinned release
@@ -522,6 +558,7 @@ service PipelinePublicService {
   rpc RestoreOrganizationPipelineRelease(RestoreOrganizationPipelineReleaseRequest) returns (RestoreOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/restore"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Rename a release in a pipeline owned by an organization
@@ -539,6 +576,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,new_pipeline_release_id";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
   // Trigger a version of a pipeline owned by an organization
@@ -556,6 +594,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Trigger a version of a pipeline owned by an organization asynchronously
@@ -573,6 +612,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Get the details of a long-running operation
@@ -582,6 +622,7 @@ service PipelinePublicService {
   rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
     option (google.api.http) = {get: "/v1beta/{name=operations/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // List connector definitions
@@ -589,6 +630,7 @@ service PipelinePublicService {
   // Returns a paginated list of connector definitions.
   rpc ListConnectorDefinitions(ListConnectorDefinitionsRequest) returns (ListConnectorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/connector-definitions"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
   }
 
   // Get connector definition
@@ -597,6 +639,7 @@ service PipelinePublicService {
   rpc GetConnectorDefinition(GetConnectorDefinitionRequest) returns (GetConnectorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=connector-definitions/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
   }
 
   // List operator definitions
@@ -604,6 +647,7 @@ service PipelinePublicService {
   // Returns a paginated list of operator definitions.
   rpc ListOperatorDefinitions(ListOperatorDefinitionsRequest) returns (ListOperatorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/operator-definitions"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
   }
 
   // List component definitions
@@ -613,6 +657,7 @@ service PipelinePublicService {
   // capabilities, for the components that might be used in a VDP pipeline.
   rpc ListComponentDefinitions(ListComponentDefinitionsRequest) returns (ListComponentDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/component-definitions"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
   }
 
   // Get operator definition
@@ -621,6 +666,7 @@ service PipelinePublicService {
   rpc GetOperatorDefinition(GetOperatorDefinitionRequest) returns (GetOperatorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=operator-definitions/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
   }
 
   // Check the availibity of a resource name
@@ -633,6 +679,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils"};
   }
 
   // Create a new user secret
@@ -644,6 +691,7 @@ service PipelinePublicService {
       body: "secret"
     };
     option (google.api.method_signature) = "parent,secret";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
   // List user secrets
@@ -653,6 +701,7 @@ service PipelinePublicService {
   rpc ListUserSecrets(ListUserSecretsRequest) returns (ListUserSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/secrets"};
     option (google.api.method_signature) = "parent";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
   // Get a secret owned by an user
@@ -662,6 +711,7 @@ service PipelinePublicService {
   rpc GetUserSecret(GetUserSecretRequest) returns (GetUserSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/secrets/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
   // Update a secret owned by an user
@@ -676,6 +726,7 @@ service PipelinePublicService {
       body: "secret"
     };
     option (google.api.method_signature) = "secret,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
   // Delete a secret owned by an user
@@ -685,6 +736,7 @@ service PipelinePublicService {
   rpc DeleteUserSecret(DeleteUserSecretRequest) returns (DeleteUserSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/secrets/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
   // Create a new organization secret
@@ -696,6 +748,7 @@ service PipelinePublicService {
       body: "secret"
     };
     option (google.api.method_signature) = "parent,secret";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
   // List organization secrets
@@ -705,6 +758,7 @@ service PipelinePublicService {
   rpc ListOrganizationSecrets(ListOrganizationSecretsRequest) returns (ListOrganizationSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/secrets"};
     option (google.api.method_signature) = "parent";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
   // Get a secret owned by an organization
@@ -714,6 +768,7 @@ service PipelinePublicService {
   rpc GetOrganizationSecret(GetOrganizationSecretRequest) returns (GetOrganizationSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/secrets/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
   // Update a secret owned by an organization
@@ -728,6 +783,7 @@ service PipelinePublicService {
       body: "secret"
     };
     option (google.api.method_signature) = "secret,update_mask";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
   // Delete a secret owned by an organization
@@ -737,5 +793,6 @@ service PipelinePublicService {
   rpc DeleteOrganizationSecret(DeleteOrganizationSecretRequest) returns (DeleteOrganizationSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/secrets/*}"};
     option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 }


### PR DESCRIPTION
Because

- We've unified our Core, VDP, and Model products into a single product, we no longer need to use different endpoint prefixes for them.
- Currently, all endpoints are grouped in the same section, which reduces readability.

This commit

- Removes the `/core`, `/vdp`, and `/model` path prefixes.
- Adds OpenAPI tags for each endpoint.
- Adds `tags` array in `openapi.proto.templ` to control the order of the tags.