### PR TITLE
chore(model): add resource spec in model definition message

### DIFF
--- a/model/model/v1alpha/model_definition.proto
+++ b/model/model/v1alpha/model_definition.proto
@@ -67,6 +67,10 @@ message ModelDefinition {
   google.protobuf.Timestamp create_time = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Update time.
   google.protobuf.Timestamp update_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The resource specification represented by a JSON schema. It is used to
+  // validate the resource spec of a model that is intended to be created on
+  google.protobuf.Struct resource_spec = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // View defines how a model definition is presented.

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2496,6 +2496,12 @@ definitions:
         format: date-time
         description: Update time.
         readOnly: true
+      resource_spec:
+        type: object
+        title: |-
+          The resource specification represented by a JSON schema. It is used to
+          validate the resource spec of a model that is intended to be created on
+        readOnly: true
     description: ModelDefinition defines how to configure and import a model.
   v1alphaModelVersion:
     type: object


### PR DESCRIPTION
Because

- To auto generate the model creation form on console, backend will need to provide spec for model resource

This commit

- add `resource_spec` in `ModelDefinition` message
