### PR TITLE
chore(model): revert addition of resource_spec

### DIFF
--- a/model/model/v1alpha/model_definition.proto
+++ b/model/model/v1alpha/model_definition.proto
@@ -59,7 +59,8 @@ message ModelDefinition {
 
   // The model specification represented by a JSON schema. It is used to
   // validate the JSON configurations of a model created from a specific model
-  // source. It must be a valid JSON that includes what fields are needed to
+  // source, and the resource spec which the model is desired to be deployed on.
+  // It must be a valid JSON that includes what fields are needed to
   // create or display a model.
   google.protobuf.Struct model_spec = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 
@@ -67,10 +68,6 @@ message ModelDefinition {
   google.protobuf.Timestamp create_time = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Update time.
   google.protobuf.Timestamp update_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // The resource specification represented by a JSON schema. It is used to
-  // validate the resource spec of a model that is intended to be created on
-  google.protobuf.Struct resource_spec = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // View defines how a model definition is presented.

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2483,7 +2483,8 @@ definitions:
         description: |-
           The model specification represented by a JSON schema. It is used to
           validate the JSON configurations of a model created from a specific model
-          source. It must be a valid JSON that includes what fields are needed to
+          source, and the resource spec which the model is desired to be deployed on.
+          It must be a valid JSON that includes what fields are needed to
           create or display a model.
         readOnly: true
       create_time:
@@ -2495,12 +2496,6 @@ definitions:
         type: string
         format: date-time
         description: Update time.
-        readOnly: true
-      resource_spec:
-        type: object
-        title: |-
-          The resource specification represented by a JSON schema. It is used to
-          validate the resource spec of a model that is intended to be created on
         readOnly: true
     description: ModelDefinition defines how to configure and import a model.
   v1alphaModelVersion:


### PR DESCRIPTION
Because

- We should combine the spec definition for `model` and `resource`

This commit

- revert the addition of `resource_spec` and add comments
