### PR TITLE
chore(model): make task as required input when creating model

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -129,20 +129,30 @@ message Model {
   // RFC-1034, which restricts to letters, numbers, and hyphen, with the first
   // character a letter, the last a letter or a number, and a 63 character
   // maximum.
-  string id = 3 [(google.api.field_behavior) = IMMUTABLE];
+  string id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
   // Model description.
   optional string description = 4 [(google.api.field_behavior) = OPTIONAL];
   // The model definition that has been used to import the model.
   string model_definition = 5 [
+    (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE,
     (google.api.resource_reference).type = "api.instill.tech/ModelDefinition"
   ];
   // Model configuration. This field is validated against the model
   // specification in the model definition (i.e. the `model_spec` field in the
   // model definition).
-  google.protobuf.Struct configuration = 6 [(google.api.field_behavior) = IMMUTABLE];
+  google.protobuf.Struct configuration = 6 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
   // Model task.
-  common.task.v1alpha.Task task = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  common.task.v1alpha.Task task = 7 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
   // Deprecated Model state.
   reserved 8;
   // Model visibility.

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -435,7 +435,6 @@ paths:
               task:
                 $ref: '#/definitions/v1alphaTask'
                 description: Model task.
-                readOnly: true
               visibility:
                 $ref: '#/definitions/v1alphaModelVisibility'
                 description: Model visibility.
@@ -482,6 +481,10 @@ paths:
                 description: License under which the model is distributed.
             title: The model to update
             required:
+              - id
+              - model_definition
+              - configuration
+              - task
               - visibility
               - region
               - hardware
@@ -1030,7 +1033,6 @@ paths:
               task:
                 $ref: '#/definitions/v1alphaTask'
                 description: Model task.
-                readOnly: true
               visibility:
                 $ref: '#/definitions/v1alphaModelVisibility'
                 description: Model visibility.
@@ -1077,6 +1079,10 @@ paths:
                 description: License under which the model is distributed.
             title: The model to update
             required:
+              - id
+              - model_definition
+              - configuration
+              - task
               - visibility
               - region
               - hardware
@@ -2354,7 +2360,6 @@ definitions:
       task:
         $ref: '#/definitions/v1alphaTask'
         description: Model task.
-        readOnly: true
       visibility:
         $ref: '#/definitions/v1alphaModelVisibility'
         description: Model visibility.
@@ -2403,6 +2408,10 @@ definitions:
       Model represents an AI model, i.e. a program that performs tasks as decision
       making or or pattern recognition based on its training data
     required:
+      - id
+      - model_definition
+      - configuration
+      - task
       - visibility
       - region
       - hardware


### PR DESCRIPTION
Because

- We now does not have README to extract `task` when creating model

This commit

- make `task` a required field
