### PR TITLE
chore(model): add sample input/output in model message

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -184,6 +184,10 @@ message Model {
   string documentation_url = 22 [(google.api.field_behavior) = OPTIONAL];
   // License under which the model is distributed.
   string license = 23 [(google.api.field_behavior) = OPTIONAL];
+  // Sample input for this model
+  TaskInput sample_input = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Sample output for this model
+  TaskOutput sample_output = 25 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ModelCard represents a README.md file that accompanies the model to describe

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -479,6 +479,14 @@ paths:
               license:
                 type: string
                 description: License under which the model is distributed.
+              sample_input:
+                $ref: '#/definitions/v1alphaTaskInput'
+                title: Sample input for this model
+                readOnly: true
+              sample_output:
+                $ref: '#/definitions/v1alphaTaskOutput'
+                title: Sample output for this model
+                readOnly: true
             title: The model to update
             required:
               - id
@@ -1077,6 +1085,14 @@ paths:
               license:
                 type: string
                 description: License under which the model is distributed.
+              sample_input:
+                $ref: '#/definitions/v1alphaTaskInput'
+                title: Sample input for this model
+                readOnly: true
+              sample_output:
+                $ref: '#/definitions/v1alphaTaskOutput'
+                title: Sample output for this model
+                readOnly: true
             title: The model to update
             required:
               - id
@@ -2404,6 +2420,14 @@ definitions:
       license:
         type: string
         description: License under which the model is distributed.
+      sample_input:
+        $ref: '#/definitions/v1alphaTaskInput'
+        title: Sample input for this model
+        readOnly: true
+      sample_output:
+        $ref: '#/definitions/v1alphaTaskOutput'
+        title: Sample output for this model
+        readOnly: true
     title: |-
       Model represents an AI model, i.e. a program that performs tasks as decision
       making or or pattern recognition based on its training data


### PR DESCRIPTION
Because

- Allow FE to display sample input/output on overview page

This commit

- add sample input/output in model message
