### PR TITLE
chore(model): support listing available region for model deployment

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -55,6 +55,15 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
+// Region describes the supported cloud provider and regions, with
+// their supported GPU respectively.
+message Region {
+  // Concate name of provider and region
+  string region_name = 1;
+  // Hardware describes the available hardware types in this region
+  repeated string hardware = 2;
+}
+
 // State describes the state of a model. See [Deploy
 // Models](https://www.instill.tech/docs/latest/model/deploy) for more
 // information.
@@ -1069,6 +1078,17 @@ message GetModelOperationRequest {
 message GetModelOperationResponse {
   // The long-running operation.
   google.longrunning.Operation operation = 1;
+}
+
+// ListAvailableRegionsRequest represents a request to fetch a list
+// of available regions and hardware types a model can be deployed on.
+message ListAvailableRegionsRequest {}
+
+// ListAvailableRegionsResponse contains a list of available
+// regions and hardware types a model can be deployed on.
+message ListAvailableRegionsResponse {
+  // A list of available region
+  repeated Region regions = 1;
 }
 
 // ========== Private endpoints

--- a/model/model/v1alpha/model_definition.proto
+++ b/model/model/v1alpha/model_definition.proto
@@ -84,7 +84,7 @@ enum View {
 // definitions.
 message ListModelDefinitionsRequest {
   // The maximum number of model definitions to return. If this parameter
-  // is unspecified, at most 10 pipelines will be returned. The cap value for
+  // is unspecified, at most 10 definitions will be returned. The cap value for
   // this parameter is 100 (i.e. any value above that will be coerced to 100).
   optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page token.

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -51,6 +51,14 @@ service ModelPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
+  // List available regions
+  //
+  // Returns a paginated list of available regions.
+  rpc ListAvailableRegions(ListAvailableRegionsRequest) returns (ListAvailableRegionsResponse) {
+    option (google.api.http) = {get: "/v1alpha/available-regions"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
   // Get a model definition
   //
   // Returns the details of a model definition.

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -42,7 +42,7 @@ paths:
         - name: page_size
           description: |-
             The maximum number of model definitions to return. If this parameter
-            is unspecified, at most 10 pipelines will be returned. The cap value for
+            is unspecified, at most 10 definitions will be returned. The cap value for
             this parameter is 100 (i.e. any value above that will be coerced to 100).
           in: query
           required: false
@@ -65,6 +65,25 @@ paths:
           enum:
             - VIEW_BASIC
             - VIEW_FULL
+      tags:
+        - Model
+  /v1alpha/available-regions:
+    get:
+      summary: List available regions
+      description: Returns a paginated list of available regions.
+      operationId: ModelPublicService_ListAvailableRegions
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListAvailableRegionsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
       tags:
         - Model
   /v1alpha/{model_definition_name}:
@@ -2224,6 +2243,18 @@ definitions:
         description: A list of keypoint objects.
         readOnly: true
     description: KeypointOutput represents the result of a keypoint detection task.
+  v1alphaListAvailableRegionsResponse:
+    type: object
+    properties:
+      regions:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaRegion'
+        title: A list of available region
+    description: |-
+      ListAvailableRegionsResponse contains a list of available
+      regions and hardware types a model can be deployed on.
   v1alphaListModelDefinitionsResponse:
     type: object
     properties:
@@ -2711,6 +2742,20 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         description: The published model resource.
     description: PublishUserModelResponse contains a published model.
+  v1alphaRegion:
+    type: object
+    properties:
+      region_name:
+        type: string
+        title: Concate name of provider and region
+      hardware:
+        type: array
+        items:
+          type: string
+        title: Hardware describes the available hardware types in this region
+    description: |-
+      Region describes the supported cloud provider and regions, with
+      their supported GPU respectively.
   v1alphaReleaseStage:
     type: string
     enum:


### PR DESCRIPTION
Because

- We need to provide the info about supported regions and hardware for FE to render the model creation page

This commit

- add list available region method
