### PR TITLE
fix(vdp): correct reference to credit owner id->uid

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -574,12 +574,13 @@ message ValidateTokenResponse {
 // GetRemainingCreditRequest represents a request to get the remaining credit
 // of a user or organization.
 message GetRemainingCreditRequest {
-  // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{id}`.
+  // The user or organization to which the credit belongs. Owners are
+  // referenced by UID.
+  // Format: `{[users|organizations]}/{uid}`.
   string owner = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "owner_name"}
+      field_configuration: {path_param_name: "owner_uid"}
     }
   ];
 }
@@ -594,8 +595,9 @@ message GetRemainingCreditResponse {
 // SubtractCreditRequest represents a request to subtract Instill Credit from
 // an account.
 message SubtractCreditRequest {
-  // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{id}`.
+  // The user or organization to which the credit belongs. Owners are
+  // referenced by UID.
+  // Format: `{[users|organizations]}/{uid}`.
   string owner = 1 [(google.api.field_behavior) = REQUIRED];
   // The credit amount to subtract.
   float amount = 2;

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -893,7 +893,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       tags:
         - Token
-  /v1beta/{owner_name}/credit:
+  /v1beta/{owner_uid}/credit:
     get:
       summary: Get the remaining Instill Credit
       description: |-
@@ -918,10 +918,11 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: owner_name
+        - name: owner_uid
           description: |-
-            The user or organization to which the credit belongs.
-            Format: `{[users|organizations]}/{id}`.
+            The user or organization to which the credit belongs. Owners are
+            referenced by UID.
+            Format: `{[users|organizations]}/{uid}`.
           in: path
           required: true
           type: string


### PR DESCRIPTION
Because

- Credit was updated to reference owners by UID but the endpoint documentation didn't.

This commit
- Replaces references to Credit owner ID by UID.
