### PR TITLE
feat(pipeline): return `can_release` permission in pipeline response

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4840,11 +4840,14 @@ definitions:
     properties:
       can_edit:
         type: boolean
-        description: Defines whether the resource can be modified.
+        description: Defines whether the pipeline can be modified.
       can_trigger:
         type: boolean
-        description: Defines whether the resource can be executed.
-    description: Permission defines how a resource can be used.
+        description: Defines whether the pipeline can be executed.
+      can_release:
+        type: boolean
+        description: Defines whether the pipeline can be released.
+    description: Permission defines how a pipeline can be used.
 securityDefinitions:
   Bearer:
     type: apiKey

--- a/vdp/pipeline/v1beta/common.proto
+++ b/vdp/pipeline/v1beta/common.proto
@@ -55,12 +55,14 @@ message Sharing {
   ShareCode share_code = 2;
 }
 
-// Permission defines how a resource can be used.
+// Permission defines how a pipeline can be used.
 message Permission {
-  // Defines whether the resource can be modified.
+  // Defines whether the pipeline can be modified.
   bool can_edit = 1;
-  // Defines whether the resource can be executed.
+  // Defines whether the pipeline can be executed.
   bool can_trigger = 2;
+  // Defines whether the pipeline can be released.
+  bool can_release = 3;
 }
 
 // CheckNameRequest represents a request to verify if a name is


### PR DESCRIPTION
Because

- We need to have a field to indicate whether the user can release the pipeline or not
 
This commit

- Returns the `can_release` permission in the pipeline response.