### PR TITLE
chore: rename non-paid to unpaid

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1080,8 +1080,8 @@ message OrganizationSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Non-paid
-    PLAN_NON_PAID = 1;
+    // Unpaid.
+    PLAN_UNPAID = 1;
     // Team plan.
     PLAN_TEAM = 2;
     // Enterprise plan.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -2472,14 +2472,14 @@ definitions:
   v1betaOrganizationSubscriptionPlan:
     type: string
     enum:
-      - PLAN_NON_PAID
+      - PLAN_UNPAID
       - PLAN_TEAM
       - PLAN_ENTERPRISE
       - PLAN_TEAM_PRO
     description: |-
       Enumerates the plan types for the organization subscription.
 
-       - PLAN_NON_PAID: Non-paid
+       - PLAN_UNPAID: Unpaid.
        - PLAN_TEAM: Team plan.
        - PLAN_ENTERPRISE: Enterprise plan.
        - PLAN_TEAM_PRO: Team pro plan.


### PR DESCRIPTION
Because

- The term `unpaid` is better than `non-paid`.

This commit

- Renames `non-paid` to `unpaid`.
