### PR TITLE
feat: add a contract for total pipeline count

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1080,8 +1080,8 @@ message OrganizationSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Deleted plan.
-    reserved 1;
+    // Non-paid
+    PLAN_NON_PAID = 1;
     // Team plan.
     PLAN_TEAM = 2;
     // Enterprise plan.

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1080,12 +1080,14 @@ message OrganizationSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Freemium plan.
-    PLAN_FREEMIUM = 1;
+    // Deleted plan.
+    reserved 1;
     // Team plan.
     PLAN_TEAM = 2;
     // Enterprise plan.
     PLAN_ENTERPRISE = 3;
+    // Team pro plan.
+    PLAN_TEAM_PRO = 4;
   }
 
   // Plan identifier.

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1062,10 +1062,10 @@ message UserSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Freemium plan.
-    PLAN_FREEMIUM = 1;
-    // Pro plan.
-    PLAN_PRO = 2;
+    // Free plan.
+    PLAN_FREE = 1;
+    // Starter plan.
+    PLAN_STARTER = 2;
   }
 
   // Plan identifier.

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -596,7 +596,7 @@ message GetRemainingCreditResponse {
 message GetRemainingCreditAdminRequest {
   // The user or organization to which the credit belongs.
   // Format: `{[users|organizations]}/{uid}`.
-  string owner = 1 [ (google.api.field_behavior) = REQUIRED ];
+  string owner = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetRemainingCreditAdminResponse contains the remaining credit of a user or
@@ -606,11 +606,11 @@ message GetRemainingCreditAdminResponse {
   float amount = 1;
 }
 
-// SubtractCreditRequest represents a request to subtract Instill Credit from
+// SubtractCreditAdminRequest represents a request to subtract Instill Credit from
 // an account.
-message SubtractCreditRequest {
+message SubtractCreditAdminRequest {
   // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{id}`.
+  // Format: `{[users|organizations]}/{uid}`.
   string owner = 1 [(google.api.field_behavior) = REQUIRED];
   // The credit amount to subtract.
   float amount = 2;
@@ -620,7 +620,7 @@ message SubtractCreditRequest {
 
 // SubtractCreditResponse contains the remaining credit of an account after the
 // subtraction.
-message SubtractCreditResponse {
+message SubtractCreditAdminResponse {
   // The remaining credit.
   float amount = 1;
 }

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1080,8 +1080,8 @@ message OrganizationSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Non-paid
-    PLAN_NON_PAID = 1;
+    // Unpaid.
+    PLAN_UNPAID = 1;
     // Team plan.
     PLAN_TEAM = 2;
     // Enterprise plan.

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -574,13 +574,12 @@ message ValidateTokenResponse {
 // GetRemainingCreditRequest represents a request to get the remaining credit
 // of a user or organization.
 message GetRemainingCreditRequest {
-  // The user or organization to which the credit belongs. Owners are
-  // referenced by UID.
-  // Format: `{[users|organizations]}/{uid}`.
+  // The user or organization to which the credit belongs.
+  // Format: `{[users|organizations]}/{id}`.
   string owner = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "owner_uid"}
+      field_configuration: {path_param_name: "owner_name"}
     }
   ];
 }
@@ -595,9 +594,8 @@ message GetRemainingCreditResponse {
 // SubtractCreditRequest represents a request to subtract Instill Credit from
 // an account.
 message SubtractCreditRequest {
-  // The user or organization to which the credit belongs. Owners are
-  // referenced by UID.
-  // Format: `{[users|organizations]}/{uid}`.
+  // The user or organization to which the credit belongs.
+  // Format: `{[users|organizations]}/{id}`.
   string owner = 1 [(google.api.field_behavior) = REQUIRED];
   // The credit amount to subtract.
   float amount = 2;

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -591,6 +591,21 @@ message GetRemainingCreditResponse {
   float amount = 1;
 }
 
+// GetRemainingCreditAdminRequest represents a request to get the remaining
+// credit of a user or organization without authentication.
+message GetRemainingCreditAdminRequest {
+  // The user or organization to which the credit belongs.
+  // Format: `{[users|organizations]}/{uid}`.
+  string owner = 1 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// GetRemainingCreditAdminResponse contains the remaining credit of a user or
+// organization.
+message GetRemainingCreditAdminResponse {
+  // The requested credit.
+  float amount = 1;
+}
+
 // SubtractCreditRequest represents a request to subtract Instill Credit from
 // an account.
 message SubtractCreditRequest {

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -72,7 +72,7 @@ service MgmtPrivateService {
   // credit at zero. A ResourceExhausted error will be returned in this case.
   //
   // On Instill Core, this endpoint will return an Unimplemented status.
-  rpc SubtractCredit(SubtractCreditRequest) returns (SubtractCreditResponse) {
+  rpc SubtractCreditAdmin(SubtractCreditAdminRequest) returns (SubtractCreditAdminResponse) {
     option (google.api.method_signature) = "owner,amount";
   }
 

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -76,5 +76,15 @@ service MgmtPrivateService {
     option (google.api.method_signature) = "owner,amount";
   }
 
+  // Get the remaining Instill Credit by owner UID
+  //
+  // This endpoint fetches the remaining unexpired credit of a user or
+  // organization, referenced by UID.
+  //
+  // On Instill Core, this endpoint will return a 404 Not Found status.
+  rpc GetRemainingCreditAdmin(GetRemainingCreditAdminRequest) returns (GetRemainingCreditAdminResponse) {
+    option (google.api.method_signature) = "owner";
+  }
+
   option (google.api.api_visibility).restriction = "INTERNAL";
 }

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -197,6 +197,8 @@ message Model {
   TaskInput sample_input = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Sample output for this model
   TaskOutput sample_output = 25 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Model profile image in base64 format.
+  optional string profile_image = 26 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ModelCard represents a README.md file that accompanies the model to describe

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -2472,15 +2472,15 @@ definitions:
   v1betaOrganizationSubscriptionPlan:
     type: string
     enum:
-      - PLAN_FREEMIUM
       - PLAN_TEAM
       - PLAN_ENTERPRISE
+      - PLAN_TEAM_PRO
     description: |-
       Enumerates the plan types for the organization subscription.
 
-       - PLAN_FREEMIUM: Freemium plan.
        - PLAN_TEAM: Team plan.
        - PLAN_ENTERPRISE: Enterprise plan.
+       - PLAN_TEAM_PRO: Team pro plan.
   v1betaOwnerType:
     type: string
     enum:

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -893,7 +893,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       tags:
         - Token
-  /v1beta/{owner_uid}/credit:
+  /v1beta/{owner_name}/credit:
     get:
       summary: Get the remaining Instill Credit
       description: |-
@@ -918,11 +918,10 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: owner_uid
+        - name: owner_name
           description: |-
-            The user or organization to which the credit belongs. Owners are
-            referenced by UID.
-            Format: `{[users|organizations]}/{uid}`.
+            The user or organization to which the credit belongs.
+            Format: `{[users|organizations]}/{id}`.
           in: path
           required: true
           type: string

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -2472,14 +2472,14 @@ definitions:
   v1betaOrganizationSubscriptionPlan:
     type: string
     enum:
-      - PLAN_NON_PAID
+      - PLAN_UNPAID
       - PLAN_TEAM
       - PLAN_ENTERPRISE
       - PLAN_TEAM_PRO
     description: |-
       Enumerates the plan types for the organization subscription.
 
-       - PLAN_NON_PAID: Non-paid
+       - PLAN_UNPAID: Unpaid.
        - PLAN_TEAM: Team plan.
        - PLAN_ENTERPRISE: Enterprise plan.
        - PLAN_TEAM_PRO: Team pro plan.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1998,6 +1998,16 @@ definitions:
     title: GetPipelinesResponse represents a respond to GetPipelineRequest
     required:
       - pipelines
+  v1betaGetRemainingCreditAdminResponse:
+    type: object
+    properties:
+      amount:
+        type: number
+        format: float
+        description: The requested credit.
+    description: |-
+      GetRemainingCreditAdminResponse contains the remaining credit of a user or
+      organization.
   v1betaGetRemainingCreditResponse:
     type: object
     properties:

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -3139,13 +3139,13 @@ definitions:
   v1betaUserSubscriptionPlan:
     type: string
     enum:
-      - PLAN_FREEMIUM
-      - PLAN_PRO
+      - PLAN_FREE
+      - PLAN_STARTER
     description: |-
       Enumerates the plan types for the user subscription.
 
-       - PLAN_FREEMIUM: Freemium plan.
-       - PLAN_PRO: Pro plan.
+       - PLAN_FREE: Free plan.
+       - PLAN_STARTER: Starter plan.
   v1betaValidateTokenResponse:
     type: object
     properties:

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -2472,12 +2472,14 @@ definitions:
   v1betaOrganizationSubscriptionPlan:
     type: string
     enum:
+      - PLAN_NON_PAID
       - PLAN_TEAM
       - PLAN_ENTERPRISE
       - PLAN_TEAM_PRO
     description: |-
       Enumerates the plan types for the organization subscription.
 
+       - PLAN_NON_PAID: Non-paid
        - PLAN_TEAM: Team plan.
        - PLAN_ENTERPRISE: Enterprise plan.
        - PLAN_TEAM_PRO: Team pro plan.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -2965,7 +2965,7 @@ definitions:
        - STATUS_CANCELED: Canceled.
        - STATUS_UNPAID: Unpaid.
        - STATUS_PAUSED: Paused.
-  v1betaSubtractCreditResponse:
+  v1betaSubtractCreditAdminResponse:
     type: object
     properties:
       amount:

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -544,6 +544,9 @@ paths:
                 $ref: '#/definitions/v1alphaTaskOutput'
                 title: Sample output for this model
                 readOnly: true
+              profile_image:
+                type: string
+                description: Model profile image in base64 format.
             title: The model to update
             required:
               - id
@@ -1170,6 +1173,9 @@ paths:
                 $ref: '#/definitions/v1alphaTaskOutput'
                 title: Sample output for this model
                 readOnly: true
+              profile_image:
+                type: string
+                description: Model profile image in base64 format.
             title: The model to update
             required:
               - id
@@ -2517,6 +2523,9 @@ definitions:
         $ref: '#/definitions/v1alphaTaskOutput'
         title: Sample output for this model
         readOnly: true
+      profile_image:
+        type: string
+        description: Model profile image in base64 format.
     title: |-
       Model represents an AI model, i.e. a program that performs tasks as decision
       making or or pattern recognition based on its training data

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -26,16 +26,16 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1beta/pipelines/count:
+  /v1beta/hub_stats:
     get:
-      summary: Get all pipelines count
-      description: Returns the total number of pipelines that are visible to the requester.
-      operationId: PipelinePublicService_CountPipelines
+      summary: Get all data for hub stats
+      description: Returns all data for hub stats
+      operationId: PipelinePublicService_GetHubStats
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCountPipelinesResponse'
+            $ref: '#/definitions/v1betaGetHubStatsResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -28,8 +28,8 @@ produces:
 paths:
   /v1beta/hub_stats:
     get:
-      summary: Get all data for hub stats
-      description: Returns all data for hub stats
+      summary: Get hub status
+      description: Return the stats of the hub
       operationId: PipelinePublicService_GetHubStats
       responses:
         "200":
@@ -3730,6 +3730,17 @@ definitions:
         $ref: '#/definitions/v1betaConnectorDefinition'
         description: The connector definition resource.
     description: GetConnectorDefinitionResponse contains the requested connector definition.
+  v1betaGetHubStatsResponse:
+    type: object
+    properties:
+      number_of_public_pipelines:
+        type: integer
+        format: int32
+        description: Total number of pipelines.
+      number_of_featured_pipelines:
+        type: integer
+        format: int32
+    description: GetHubStatsResponse represents a response to get hub stats.
   v1betaGetOperationResponse:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -118,6 +118,11 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
+        - name: order_by
+          description: Order by field.
+          in: query
+          required: false
+          type: string
       tags:
         - Pipeline
   /v1beta/{permalink}/lookUp:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4859,11 +4859,14 @@ definitions:
     properties:
       can_edit:
         type: boolean
-        description: Defines whether the resource can be modified.
+        description: Defines whether the pipeline can be modified.
       can_trigger:
         type: boolean
-        description: Defines whether the resource can be executed.
-    description: Permission defines how a resource can be used.
+        description: Defines whether the pipeline can be executed.
+      can_release:
+        type: boolean
+        description: Defines whether the pipeline can be released.
+    description: Permission defines how a pipeline can be used.
 securityDefinitions:
   Bearer:
     type: apiKey

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -26,6 +26,25 @@ consumes:
 produces:
   - application/json
 paths:
+  /v1beta/pipelines/count:
+    get:
+      summary: Get all pipelines count
+      description: Returns the total number of pipelines that are visible to the requester.
+      operationId: PipelinePublicService_CountPipelines
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCountPipelinesResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Pipeline
   /v1beta/pipelines:
     get:
       summary: List accessible pipelines

--- a/vdp/pipeline/v1beta/common.proto
+++ b/vdp/pipeline/v1beta/common.proto
@@ -55,12 +55,14 @@ message Sharing {
   ShareCode share_code = 2;
 }
 
-// Permission defines how a resource can be used.
+// Permission defines how a pipeline can be used.
 message Permission {
-  // Defines whether the resource can be modified.
+  // Defines whether the pipeline can be modified.
   bool can_edit = 1;
-  // Defines whether the resource can be executed.
+  // Defines whether the pipeline can be executed.
   bool can_trigger = 2;
+  // Defines whether the pipeline can be released.
+  bool can_release = 3;
 }
 
 // CheckNameRequest represents a request to verify if a name is

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -387,15 +387,16 @@ message PipelineRelease {
   DataSpecification data_specification = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// CountPipelinesRequest represents a request to count pipelines.
-message CountPipelinesRequest {
+// GetHubStatsRequest represents a request to get hub stats.
+message GetHubStatsRequest {
 
 }
 
-// CountPipelinesResponse represents a response to count pipelines.
-message CountPipelinesResponse {
+// GetHubStatsResponse represents a response to get hub stats.
+message GetHubStatsResponse {
   // Total number of pipelines.
-  int32 total_size = 1;
+  int32 number_of_public_pipelines = 1;
+  int32 number_of_featured_pipelines = 2;
 
 }
 

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -387,6 +387,18 @@ message PipelineRelease {
   DataSpecification data_specification = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// CountPipelinesRequest represents a request to count pipelines.
+message CountPipelinesRequest {
+
+}
+
+// CountPipelinesResponse represents a response to count pipelines.
+message CountPipelinesResponse {
+  // Total number of pipelines.
+  int32 total_size = 1;
+
+}
+
 // ListPipelinesRequest represents a request to list pipelines.
 message ListPipelinesRequest {
   // The maximum number of pipelines to return. If this parameter is

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -420,6 +420,8 @@ message ListPipelinesRequest {
   optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Pipeline.Visibility visibility = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field.
+  optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelinesResponse contains a list of pipelines.

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -6,6 +6,7 @@ package vdp.pipeline.v1beta;
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/visibility.proto";
+import "google/protobuf/empty.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
 // VDP definitions
@@ -39,6 +40,14 @@ service PipelinePublicService {
   rpc Readiness(ReadinessRequest) returns (v1beta.ReadinessResponse) {
     option (google.api.http) = {get: "/v1beta/__readiness"};
     option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Get total count of pipelines
+  //
+  // Returns the count of public pipeline
+  rpc CountPipelines(CountPipelinesRequest) returns (CountPipelinesResponse) {
+    option (google.api.http) = {get: "/v1beta/pipelines/count"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
   // List accessible pipelines

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -6,7 +6,6 @@ package vdp.pipeline.v1beta;
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/visibility.proto";
-import "google/protobuf/empty.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
 // VDP definitions
@@ -42,11 +41,11 @@ service PipelinePublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // Get total count of pipelines
+  // Get hub status
   //
-  // Returns the count of public pipeline
-  rpc CountPipelines(CountPipelinesRequest) returns (CountPipelinesResponse) {
-    option (google.api.http) = {get: "/v1beta/pipelines/count"};
+  // Return the stats of the hub
+  rpc GetHubStats(GetHubStatsRequest) returns (GetHubStatsResponse) {
+    option (google.api.http) = {get: "/v1beta/hub_stats"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 


### PR DESCRIPTION
Because

- We want to let the users know the count of public pipeline

This commit

- Define a contract for a new endpoint
