### PR TITLE
feat(core): update tier names

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1062,10 +1062,10 @@ message UserSubscription {
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Freemium plan.
-    PLAN_FREEMIUM = 1;
-    // Pro plan.
-    PLAN_PRO = 2;
+    // Free plan.
+    PLAN_FREE = 1;
+    // Starter plan.
+    PLAN_STARTER = 2;
   }
 
   // Plan identifier.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -3139,13 +3139,13 @@ definitions:
   v1betaUserSubscriptionPlan:
     type: string
     enum:
-      - PLAN_FREEMIUM
-      - PLAN_PRO
+      - PLAN_FREE
+      - PLAN_STARTER
     description: |-
       Enumerates the plan types for the user subscription.
 
-       - PLAN_FREEMIUM: Freemium plan.
-       - PLAN_PRO: Pro plan.
+       - PLAN_FREE: Free plan.
+       - PLAN_STARTER: Starter plan.
   v1betaValidateTokenResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- The tier names need to be updated to `free` and `starter`.

This commit

- Updates tier names.
