### PR TITLE
feat(vdp): support sorting pipelines options by id and update_time

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -100,11 +100,7 @@ paths:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
         - name: order_by
-          description: |-
-            Comma-separated list of fields to order by, with an optional `asc` or `desc`
-            direction. Supported fields are `create_time`, `update_time`, and `id`.
-            If not specified, results will be sorted by `create_time` in descending
-            order.
+          description: Order by field.
           in: query
           required: false
           type: string

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -99,6 +99,15 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
+        - name: order_by
+          description: |-
+            Comma-separated list of fields to order by, with an optional `asc` or `desc`
+            direction. Supported fields are `create_time`, `update_time`, and `id`.
+            If not specified, results will be sorted by `create_time` in descending
+            order.
+          in: query
+          required: false
+          type: string
       tags:
         - Pipeline
   /v1beta/{permalink}/lookUp:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -407,6 +407,8 @@ message ListPipelinesRequest {
   optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Pipeline.Visibility visibility = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field.
+  optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelinesResponse contains a list of pipelines.


### PR DESCRIPTION
Because

- we want users to sort the pipeline with a better UX

This commit

- add a params for frontend to sort the pipeline
