### PR TITLE
fix(mgmt): reference owner by ID in credit endpoints.

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -574,13 +574,12 @@ message ValidateTokenResponse {
 // GetRemainingCreditRequest represents a request to get the remaining credit
 // of a user or organization.
 message GetRemainingCreditRequest {
-  // The user or organization to which the credit belongs. Owners are
-  // referenced by UID.
-  // Format: `{[users|organizations]}/{uid}`.
+  // The user or organization to which the credit belongs.
+  // Format: `{[users|organizations]}/{id}`.
   string owner = 1 [
     (google.api.field_behavior) = REQUIRED,
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "owner_uid"}
+      field_configuration: {path_param_name: "owner_name"}
     }
   ];
 }
@@ -595,9 +594,8 @@ message GetRemainingCreditResponse {
 // SubtractCreditRequest represents a request to subtract Instill Credit from
 // an account.
 message SubtractCreditRequest {
-  // The user or organization to which the credit belongs. Owners are
-  // referenced by UID.
-  // Format: `{[users|organizations]}/{uid}`.
+  // The user or organization to which the credit belongs.
+  // Format: `{[users|organizations]}/{id}`.
   string owner = 1 [(google.api.field_behavior) = REQUIRED];
   // The credit amount to subtract.
   float amount = 2;

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -893,7 +893,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       tags:
         - Token
-  /v1beta/{owner_uid}/credit:
+  /v1beta/{owner_name}/credit:
     get:
       summary: Get the remaining Instill Credit
       description: |-
@@ -918,11 +918,10 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: owner_uid
+        - name: owner_name
           description: |-
-            The user or organization to which the credit belongs. Owners are
-            referenced by UID.
-            Format: `{[users|organizations]}/{uid}`.
+            The user or organization to which the credit belongs.
+            Format: `{[users|organizations]}/{id}`.
           in: path
           required: true
           type: string


### PR DESCRIPTION
Because

- There was a confusion in the API and database references to the Credit owner.  At the API level we reference the owner by ID, but the database will store the UID reference to be resilient against ID updates.

This commit

- Reverts commit 2b79ef096e60b509c3194a4712bcf8dd58832224 "fix(vdp): correct reference to credit owner id->uid (#321)"

