### PR TITLE
feat(vdp): add private remaining credit endpont

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -591,6 +591,21 @@ message GetRemainingCreditResponse {
   float amount = 1;
 }
 
+// GetRemainingCreditAdminRequest represents a request to get the remaining
+// credit of a user or organization without authentication.
+message GetRemainingCreditAdminRequest {
+  // The user or organization to which the credit belongs.
+  // Format: `{[users|organizations]}/{uid}`.
+  string owner = 1 [ (google.api.field_behavior) = REQUIRED ];
+}
+
+// GetRemainingCreditAdminResponse contains the remaining credit of a user or
+// organization.
+message GetRemainingCreditAdminResponse {
+  // The requested credit.
+  float amount = 1;
+}
+
 // SubtractCreditRequest represents a request to subtract Instill Credit from
 // an account.
 message SubtractCreditRequest {

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -76,5 +76,15 @@ service MgmtPrivateService {
     option (google.api.method_signature) = "owner,amount";
   }
 
+  // Get the remaining Instill Credit by owner UID
+  //
+  // This endpoint fetches the remaining unexpired credit of a user or
+  // organization, referenced by UID.
+  //
+  // On Instill Core, this endpoint will return a 404 Not Found status.
+  rpc GetRemainingCreditAdmin(GetRemainingCreditAdminRequest) returns (GetRemainingCreditAdminResponse) {
+    option (google.api.method_signature) = "owner";
+  }
+
   option (google.api.api_visibility).restriction = "INTERNAL";
 }

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1998,6 +1998,16 @@ definitions:
     title: GetPipelinesResponse represents a respond to GetPipelineRequest
     required:
       - pipelines
+  v1betaGetRemainingCreditAdminResponse:
+    type: object
+    properties:
+      amount:
+        type: number
+        format: float
+        description: The requested credit.
+    description: |-
+      GetRemainingCreditAdminResponse contains the remaining credit of a user or
+      organization.
   v1betaGetRemainingCreditResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- When checking the remaining credit during execution usage collection, we need round trips to fetch the user ID (user UID->user ID (mgmt)->remaining credit (mgmt)). Moreover, we need to add an authentication layer that shouldn't be needed from a backend service.

This commit

- Adds a private endpoint to fetch the remaining credit.
