### PR TITLE
feat(mgmt): update SubtractCredit endpoint

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -596,7 +596,7 @@ message GetRemainingCreditResponse {
 message GetRemainingCreditAdminRequest {
   // The user or organization to which the credit belongs.
   // Format: `{[users|organizations]}/{uid}`.
-  string owner = 1 [ (google.api.field_behavior) = REQUIRED ];
+  string owner = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetRemainingCreditAdminResponse contains the remaining credit of a user or
@@ -606,11 +606,11 @@ message GetRemainingCreditAdminResponse {
   float amount = 1;
 }
 
-// SubtractCreditRequest represents a request to subtract Instill Credit from
+// SubtractCreditAdminRequest represents a request to subtract Instill Credit from
 // an account.
-message SubtractCreditRequest {
+message SubtractCreditAdminRequest {
   // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{id}`.
+  // Format: `{[users|organizations]}/{uid}`.
   string owner = 1 [(google.api.field_behavior) = REQUIRED];
   // The credit amount to subtract.
   float amount = 2;
@@ -620,7 +620,7 @@ message SubtractCreditRequest {
 
 // SubtractCreditResponse contains the remaining credit of an account after the
 // subtraction.
-message SubtractCreditResponse {
+message SubtractCreditAdminResponse {
   // The remaining credit.
   float amount = 1;
 }

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -72,7 +72,7 @@ service MgmtPrivateService {
   // credit at zero. A ResourceExhausted error will be returned in this case.
   //
   // On Instill Core, this endpoint will return an Unimplemented status.
-  rpc SubtractCredit(SubtractCreditRequest) returns (SubtractCreditResponse) {
+  rpc SubtractCreditAdmin(SubtractCreditAdminRequest) returns (SubtractCreditAdminResponse) {
     option (google.api.method_signature) = "owner,amount";
   }
 


### PR DESCRIPTION
Because

- For consistency, we should use `xxxAdmin` as the private endpoint name.

This commit

- Renames `SubtractCredit` endpoint to `SubtractCreditAdmin`
