### PR TITLE
feat(vdp): Add hub stats contract

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -3730,6 +3730,18 @@ definitions:
         $ref: '#/definitions/v1betaConnectorDefinition'
         description: The connector definition resource.
     description: GetConnectorDefinitionResponse contains the requested connector definition.
+  v1betaGetHubStatsResponse:
+    type: object
+    properties:
+      number_of_public_pipelines:
+        type: integer
+        format: int32
+        description: Total number of public pipelines.
+      number_of_featured_pipelines:
+        type: integer
+        format: int32
+        description: Total number of featured pipelines.
+    description: GetHubStatsResponse represents a response to get hub stats.
   v1betaGetOperationResponse:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -26,6 +26,25 @@ consumes:
 produces:
   - application/json
 paths:
+  /v1beta/hub_stats:
+    get:
+      summary: Get hub status
+      description: Return the stats of the hub
+      operationId: PipelinePublicService_GetHubStats
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetHubStatsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Pipeline
   /v1beta/pipelines:
     get:
       summary: List accessible pipelines

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -343,6 +343,20 @@ message Trace {
   float compute_time_in_seconds = 5;
 }
 
+// GetHubStatsRequest represents a request to get hub stats.
+message GetHubStatsRequest {
+
+}
+
+// GetHubStatsResponse represents a response to get hub stats.
+message GetHubStatsResponse {
+  // Total number of public pipelines.
+  int32 number_of_public_pipelines = 1;
+  // Total number of featured pipelines.
+  int32 number_of_featured_pipelines = 2;
+
+}
+
 // Pipeline releases contain the version control information of a pipeline.
 // This allows users to track changes in the pipeline over time.
 message PipelineRelease {

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -41,6 +41,14 @@ service PipelinePublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
+  // Get hub status
+  //
+  // Return the stats of the hub
+  rpc GetHubStats(GetHubStatsRequest) returns (GetHubStatsResponse) {
+    option (google.api.http) = {get: "/v1beta/hub_stats"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
   // List accessible pipelines
   //
   // Returns a paginated list of pipelines that are visible to the requester.


### PR DESCRIPTION
Because:

- We'll provide a helper endpoint that returns metadata that Instill Hub needs.

This commit:

- Adds hub stats endpoints.