### PR TITLE
feat(vdp): support sorting pipelines under a namespace

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -100,7 +100,9 @@ paths:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
         - name: order_by
-          description: Order by field.
+          description: |-
+            Order by field, with options for ordering by `id` or `create_time`.
+            Format: `order_by=id ASC` or `order_by=create_time DESC`.
           in: query
           required: false
           type: string
@@ -732,6 +734,13 @@ paths:
           in: query
           required: false
           type: boolean
+        - name: order_by
+          description: |-
+            Order by field, with options for ordering by `id` or `create_time`.
+            Format: `order_by=id ASC` or `order_by=create_time DESC`.
+          in: query
+          required: false
+          type: string
       tags:
         - Release
     post:
@@ -1187,6 +1196,13 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
+        - name: order_by
+          description: |-
+            Order by field, with options for ordering by `id` or `create_time`.
+            Format: `order_by=id ASC` or `order_by=create_time DESC`.
+          in: query
+          required: false
+          type: string
       tags:
         - Pipeline
     post:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -407,7 +407,8 @@ message ListPipelinesRequest {
   optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Pipeline.Visibility visibility = 6 [(google.api.field_behavior) = OPTIONAL];
-  // Order by field.
+  // Order by field, with options for ordering by `id` or `create_time`.
+  // Format: `order_by=id ASC` or `order_by=create_time DESC`.
   optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -732,6 +733,9 @@ message ListUserPipelineReleasesRequest {
   ];
   // Include soft-deleted pipelines in the result.
   optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field, with options for ordering by `id` or `create_time`.
+  // Format: `order_by=id ASC` or `order_by=create_time DESC`.
+  optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUserPipelineReleasesResponse contains a list of pipeline releases.
@@ -955,6 +959,9 @@ message ListOrganizationPipelinesRequest {
   optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Pipeline.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field, with options for ordering by `id` or `create_time`.
+  // Format: `order_by=id ASC` or `order_by=create_time DESC`.
+  optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListOrganizationPipelinesResponse contains a list of pipelines.


### PR DESCRIPTION
Because

- We should support sorting pipelines under a namespace as well.

This commit

- Supports sorting pipelines under a namespace
