### PR TITLE
chore(vdp): fix sorting pipelines under a namesapce

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -237,6 +237,13 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
+        - name: order_by
+          description: |-
+            Order by field, with options for ordering by `id` or `create_time`.
+            Format: `order_by=id ASC` or `order_by=create_time DESC`.
+          in: query
+          required: false
+          type: string
       tags:
         - Pipeline
     post:
@@ -734,13 +741,6 @@ paths:
           in: query
           required: false
           type: boolean
-        - name: order_by
-          description: |-
-            Order by field, with options for ordering by `id` or `create_time`.
-            Format: `order_by=id ASC` or `order_by=create_time DESC`.
-          in: query
-          required: false
-          type: string
       tags:
         - Release
     post:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -489,6 +489,9 @@ message ListUserPipelinesRequest {
   optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Pipeline.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field, with options for ordering by `id` or `create_time`.
+  // Format: `order_by=id ASC` or `order_by=create_time DESC`.
+  optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUserPipelinesResponse contains a list of pipelines.
@@ -733,9 +736,6 @@ message ListUserPipelineReleasesRequest {
   ];
   // Include soft-deleted pipelines in the result.
   optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
-  // Order by field, with options for ordering by `id` or `create_time`.
-  // Format: `order_by=id ASC` or `order_by=create_time DESC`.
-  optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListUserPipelineReleasesResponse contains a list of pipeline releases.


### PR DESCRIPTION
Because

- The previous PR put the order_by field in wrong place.

This commit

- Fixes the bug
