### PR TITLE
chore(vdp): update description for pipeline ordering

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -101,8 +101,8 @@ paths:
             - VISIBILITY_PUBLIC
         - name: order_by
           description: |-
-            Order by field, with options for ordering by `id` or `create_time`.
-            Format: `order_by=id ASC` or `order_by=create_time DESC`.
+            Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+            Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
           in: query
           required: false
           type: string
@@ -239,8 +239,8 @@ paths:
             - VISIBILITY_PUBLIC
         - name: order_by
           description: |-
-            Order by field, with options for ordering by `id` or `create_time`.
-            Format: `order_by=id ASC` or `order_by=create_time DESC`.
+            Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+            Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
           in: query
           required: false
           type: string
@@ -1198,8 +1198,8 @@ paths:
             - VISIBILITY_PUBLIC
         - name: order_by
           description: |-
-            Order by field, with options for ordering by `id` or `create_time`.
-            Format: `order_by=id ASC` or `order_by=create_time DESC`.
+            Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+            Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
           in: query
           required: false
           type: string

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -407,8 +407,8 @@ message ListPipelinesRequest {
   optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Pipeline.Visibility visibility = 6 [(google.api.field_behavior) = OPTIONAL];
-  // Order by field, with options for ordering by `id` or `create_time`.
-  // Format: `order_by=id ASC` or `order_by=create_time DESC`.
+  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
   optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -489,8 +489,8 @@ message ListUserPipelinesRequest {
   optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Pipeline.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
-  // Order by field, with options for ordering by `id` or `create_time`.
-  // Format: `order_by=id ASC` or `order_by=create_time DESC`.
+  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
   optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -959,8 +959,8 @@ message ListOrganizationPipelinesRequest {
   optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Pipeline.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
-  // Order by field, with options for ordering by `id` or `create_time`.
-  // Format: `order_by=id ASC` or `order_by=create_time DESC`.
+  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
   optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 


### PR DESCRIPTION
Because

- The description for pipeline ordering is not correct.

This commit

- Updates description for pipeline ordering.
