### PR TITLE
chore(pipeline): update hub-stats endpoint

### DIFF
--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -346,9 +346,7 @@ message Trace {
 }
 
 // GetHubStatsRequest represents a request to get hub stats.
-message GetHubStatsRequest {
-
-}
+message GetHubStatsRequest {}
 
 // GetHubStatsResponse represents a response to get hub stats.
 message GetHubStatsResponse {
@@ -356,7 +354,6 @@ message GetHubStatsResponse {
   int32 number_of_public_pipelines = 1;
   // Total number of featured pipelines.
   int32 number_of_featured_pipelines = 2;
-
 }
 
 // Pipeline releases contain the version control information of a pipeline.

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -45,7 +45,7 @@ service PipelinePublicService {
   //
   // Return the stats of the hub
   rpc GetHubStats(GetHubStatsRequest) returns (GetHubStatsResponse) {
-    option (google.api.http) = {get: "/v1beta/hub_stats"};
+    option (google.api.http) = {get: "/v1beta/hub-stats"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 


### PR DESCRIPTION
Because

- We should use hyphen in the API path.

This commit

- Updates hub-stats endpoint.
