### PR TITLE
feat(vdp): refactor pipeline recipe and optimize the validation endpoint

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -2988,147 +2988,99 @@ definitions:
   PipelinePublicServiceTriggerAsyncOrganizationPipelineBody:
     type: object
     properties:
-      inputs:
+      data:
         type: array
         items:
           type: object
-        description: Pipeline input parameters.
-      secrets:
-        type: object
-        additionalProperties:
-          type: string
-        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
     description: |-
       TriggerOrganizationPipelineRequest represents a request to trigger an
       organization-owned pipeline synchronously.
-    required:
-      - inputs
   PipelinePublicServiceTriggerAsyncOrganizationPipelineReleaseBody:
     type: object
     properties:
-      inputs:
+      data:
         type: array
         items:
           type: object
-        description: Pipeline input parameters.
-      secrets:
-        type: object
-        additionalProperties:
-          type: string
-        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
     description: |-
       TriggerOrganizationPipelineReleaseRequest represents a request to trigger a
       pinned release of an organization-owned pipeline asynchronously.
-    required:
-      - inputs
   PipelinePublicServiceTriggerAsyncUserPipelineBody:
     type: object
     properties:
-      inputs:
+      data:
         type: array
         items:
           type: object
-        description: Pipeline input parameters.
-      secrets:
-        type: object
-        additionalProperties:
-          type: string
-        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
     description: |-
       TriggerUserPipelineRequest represents a request to trigger a user-owned
       pipeline synchronously.
-    required:
-      - inputs
   PipelinePublicServiceTriggerAsyncUserPipelineReleaseBody:
     type: object
     properties:
-      inputs:
+      data:
         type: array
         items:
           type: object
-        description: Pipeline input parameters.
-      secrets:
-        type: object
-        additionalProperties:
-          type: string
-        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
     description: |-
       TriggerUserPipelineReleaseRequest represents a request to trigger a pinned
       release of a user-owned pipeline asynchronously.
-    required:
-      - inputs
   PipelinePublicServiceTriggerOrganizationPipelineBody:
     type: object
     properties:
-      inputs:
+      data:
         type: array
         items:
           type: object
-        description: Pipeline input parameters.
-      secrets:
-        type: object
-        additionalProperties:
-          type: string
-        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
     description: |-
       TriggerOrganizationPipelineRequest represents a request to trigger an
       organization-owned pipeline synchronously.
-    required:
-      - inputs
   PipelinePublicServiceTriggerOrganizationPipelineReleaseBody:
     type: object
     properties:
-      inputs:
+      data:
         type: array
         items:
           type: object
-        description: Pipeline input parameters.
-      secrets:
-        type: object
-        additionalProperties:
-          type: string
-        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
     description: |-
       TriggerOrganizationPipelineReleaseRequest represents a request to trigger a
       pinned release of an organization-owned pipeline.
-    required:
-      - inputs
   PipelinePublicServiceTriggerUserPipelineBody:
     type: object
     properties:
-      inputs:
+      data:
         type: array
         items:
           type: object
-        description: Pipeline input parameters.
-      secrets:
-        type: object
-        additionalProperties:
-          type: string
-        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
     description: |-
       TriggerUserPipelineRequest represents a request to trigger a user-owned
       pipeline synchronously.
-    required:
-      - inputs
   PipelinePublicServiceTriggerUserPipelineReleaseBody:
     type: object
     properties:
-      inputs:
+      data:
         type: array
         items:
           type: object
-        description: Pipeline input parameters.
-      secrets:
-        type: object
-        additionalProperties:
-          type: string
-        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
     description: |-
       TriggerUserPipelineReleaseRequest represents a request to trigger a pinned
       release of a user-owned pipeline.
-    required:
-      - inputs
   PipelinePublicServiceTriggerUserPipelineWithStreamBody:
     type: object
     properties:
@@ -3177,43 +3129,6 @@ definitions:
         $ref: '#/definitions/v1betaRole'
         description: Defines the role users will have over the resource.
     description: ShareCode describes a sharing configuration through a link.
-  TriggerByRequestRequestField:
-    type: object
-    properties:
-      title:
-        type: string
-        description: Title of the field.
-      description:
-        type: string
-        description: Description of the field.
-      instill_format:
-        type: string
-        description: Instill format.
-      instill_ui_order:
-        type: integer
-        format: int32
-        description: Instill UI order.
-      instill_ui_multiline:
-        type: boolean
-        description: Instill UI Multiline.
-    description: Represents a field within the reqeuest.
-  TriggerByRequestResponseField:
-    type: object
-    properties:
-      title:
-        type: string
-        description: Title of the field.
-      description:
-        type: string
-        description: Description of the field.
-      value:
-        type: string
-        description: Value of the field.
-      instill_ui_order:
-        type: integer
-        format: int32
-        description: Instill UI order.
-    description: Represents a field within the response.
   coremgmtv1betaPermission:
     type: object
     properties:
@@ -3502,9 +3417,6 @@ definitions:
   v1betaComponent:
     type: object
     properties:
-      id:
-        type: string
-        description: Component ID, provided by the user on creation.
       metadata:
         type: object
         description: Metadata of the component.
@@ -3523,8 +3435,6 @@ definitions:
 
       For more information, see [Pipeline
       Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
-    required:
-      - id
   v1betaComponentDefinition:
     type: object
     properties:
@@ -3914,12 +3824,11 @@ definitions:
             "key1": [ ${element1.output.a},  ${element2.output.a} ... ],
             "key2": [ ${element1.output.b},  ${element2.output.b} ... ],
           }
-      components:
-        type: array
-        items:
-          type: object
+      component:
+        type: object
+        additionalProperties:
           $ref: '#/definitions/v1betaNestedComponent'
-        description: 'Components: These components will be executed for each input element.'
+        description: 'Component: These components will be executed for each input element.'
       condition:
         type: string
         description: Condition statement determining whether the component is executed or not.
@@ -4167,9 +4076,6 @@ definitions:
   v1betaNestedComponent:
     type: object
     properties:
-      id:
-        type: string
-        description: Component ID, provided by the user on creation.
       metadata:
         type: object
         description: Metadata of the component.
@@ -4182,8 +4088,9 @@ definitions:
     description: |-
       NestedComponent
       Fundamental building block in iterator component.
-    required:
-      - id
+  v1betaOn:
+    type: object
+    title: "On"
   v1betaOperatorComponent:
     type: object
     properties:
@@ -4383,6 +4290,31 @@ definitions:
           Social profile links list the links to the organization's social profiles.
           The key represents the provider, and the value is the corresponding URL.
     description: OrganizationProfile describes the public data of an organization.
+  v1betaOutput:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Title.
+      description:
+        type: string
+        description: Description.
+      value:
+        type: string
+        description: Value.
+      instill_short_description:
+        type: string
+        description: Short description.
+      instill_ui_order:
+        type: integer
+        format: int32
+        description: UI order.
+      instill_ui_multiline:
+        type: boolean
+        description: UI Multiline.
+    description: Output describe the output schema of a pipeline.
+    required:
+      - value
   v1betaOwner:
     type: object
     properties:
@@ -4572,20 +4504,29 @@ definitions:
       version:
         type: string
         description: Recipe schema version.
-      components:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaComponent'
-        description: List of pipeline components.
-      trigger:
-        $ref: '#/definitions/v1betaTrigger'
+      "on":
+        $ref: '#/definitions/v1betaOn'
         description: The component trigger method.
-      secrets:
+      secret:
         type: object
         additionalProperties:
           type: string
-        title: Local secrets
+        description: Secret.
+      variable:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1betaVariable'
+        description: Variable.
+      output:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1betaOutput'
+        description: Output.
+      component:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1betaComponent'
+        description: Component.
     description: Recipe describes the components of a Pipeline and how they are connected.
   v1betaRenameOrganizationPipelineReleaseResponse:
     type: object
@@ -4749,13 +4690,6 @@ definitions:
        - STATUS_COMPLETED: Successfully completed.
        - STATUS_SKIPPED: Skipped.
        - STATUS_ERROR: Aborted with error.
-  v1betaTrigger:
-    type: object
-    properties:
-      trigger_by_request:
-        $ref: '#/definitions/v1betaTriggerByRequest'
-        description: Triggered by reqeust.
-    title: Trigger
   v1betaTriggerAsyncOrganizationPipelineReleaseResponse:
     type: object
     properties:
@@ -4796,28 +4730,18 @@ definitions:
     description: |-
       TriggerAsyncUserPipelineResponse contains the information to access the
       status of an asynchronous pipeline execution.
-  v1betaTriggerByRequest:
+  v1betaTriggerData:
     type: object
     properties:
-      request_fields:
+      variable:
+        type: object
+        title: Variables
+      secret:
         type: object
         additionalProperties:
-          $ref: '#/definitions/TriggerByRequestRequestField'
-        description: |-
-          Fields configuration of request.
-          Key: Key of the input data.
-          Field: Field settings of the value.
-      response_fields:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/TriggerByRequestResponseField'
-        description: |-
-          Fields configuration of response.
-          Key: Key of the input data.
-          Field: Field settings of the value.
-    description: |-
-      TriggerByRequest
-      Configures the payload format of request when triggered by a request.
+          type: string
+        title: Variables
+    title: Data
   v1betaTriggerMetadata:
     type: object
     properties:
@@ -4983,6 +4907,37 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The validated pipeline resource.
     description: ValidateUserPipelineResponse contains a validated pipeline.
+  v1betaVariable:
+    type: object
+    properties:
+      type:
+        type: string
+        description: Type.
+      title:
+        type: string
+        description: Title.
+      description:
+        type: string
+        description: Description.
+      default:
+        type: string
+        description: Default value.
+      instill_format:
+        type: string
+        description: Instill format.
+      instill_ui_order:
+        type: integer
+        format: int32
+        description: UI order.
+      instill_ui_multiline:
+        type: boolean
+        description: UI Multiline.
+    description: |-
+      Variable describes the variable schema of a pipeline.
+      It is based on the standard JSON schema format, with additional xAttribute attributes.
+    required:
+      - type
+      - instill_format
   vdppipelinev1betaPermission:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -431,7 +431,7 @@ paths:
                 type: string
                 description: Pipeline description.
               recipe:
-                $ref: '#/definitions/v1betaRecipe'
+                type: object
                 description: Recipe describes the components of a Pipeline and how they are connected.
               create_time:
                 type: string
@@ -983,7 +983,7 @@ paths:
                 type: string
                 description: Release description.
               recipe:
-                $ref: '#/definitions/v1betaRecipe'
+                type: object
                 description: Recipe of the versioned pipeline.
                 readOnly: true
               create_time:
@@ -1436,7 +1436,7 @@ paths:
                 type: string
                 description: Pipeline description.
               recipe:
-                $ref: '#/definitions/v1betaRecipe'
+                type: object
                 description: Recipe describes the components of a Pipeline and how they are connected.
               create_time:
                 type: string
@@ -1933,7 +1933,7 @@ paths:
                 type: string
                 description: Release description.
               recipe:
-                $ref: '#/definitions/v1betaRecipe'
+                type: object
                 description: Recipe of the versioned pipeline.
                 readOnly: true
               create_time:
@@ -2988,6 +2988,11 @@ definitions:
   PipelinePublicServiceTriggerAsyncOrganizationPipelineBody:
     type: object
     properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
       data:
         type: array
         items:
@@ -3000,6 +3005,11 @@ definitions:
   PipelinePublicServiceTriggerAsyncOrganizationPipelineReleaseBody:
     type: object
     properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
       data:
         type: array
         items:
@@ -3012,6 +3022,11 @@ definitions:
   PipelinePublicServiceTriggerAsyncUserPipelineBody:
     type: object
     properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
       data:
         type: array
         items:
@@ -3024,6 +3039,11 @@ definitions:
   PipelinePublicServiceTriggerAsyncUserPipelineReleaseBody:
     type: object
     properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
       data:
         type: array
         items:
@@ -3036,6 +3056,11 @@ definitions:
   PipelinePublicServiceTriggerOrganizationPipelineBody:
     type: object
     properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
       data:
         type: array
         items:
@@ -3048,6 +3073,11 @@ definitions:
   PipelinePublicServiceTriggerOrganizationPipelineReleaseBody:
     type: object
     properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
       data:
         type: array
         items:
@@ -3060,6 +3090,11 @@ definitions:
   PipelinePublicServiceTriggerUserPipelineBody:
     type: object
     properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
       data:
         type: array
         items:
@@ -3072,6 +3107,11 @@ definitions:
   PipelinePublicServiceTriggerUserPipelineReleaseBody:
     type: object
     properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
       data:
         type: array
         items:
@@ -3414,27 +3454,6 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The cloned pipeline resource.
     description: CloneUserPipelineResponse contains a cloned pipeline.
-  v1betaComponent:
-    type: object
-    properties:
-      metadata:
-        type: object
-        description: Metadata of the component.
-      connector_component:
-        $ref: '#/definitions/v1betaConnectorComponent'
-        title: ConnectorComponent
-      operator_component:
-        $ref: '#/definitions/v1betaOperatorComponent'
-        title: OperatorComponent
-      iterator_component:
-        $ref: '#/definitions/v1betaIteratorComponent'
-        title: IteratorComponent
-    description: |-
-      Component
-      Fundamental building block in pipelines.
-
-      For more information, see [Pipeline
-      Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
   v1betaComponentDefinition:
     type: object
     properties:
@@ -3494,31 +3513,6 @@ definitions:
        - COMPONENT_TYPE_CONNECTOR_DATA: Connect with a remote data source.
        - COMPONENT_TYPE_OPERATOR: Manipulate data.
        - COMPONENT_TYPE_CONNECTOR_APPLICATION: Connect with an external application.
-  v1betaConnectorComponent:
-    type: object
-    properties:
-      definition_name:
-        type: string
-        description: Definition name.
-      definition:
-        $ref: '#/definitions/v1betaConnectorDefinition'
-        description: Connector definition.
-        readOnly: true
-      task:
-        type: string
-        description: Task.
-      input:
-        type: object
-        description: Input configuration of the component. JSON schema described in the connector definition.
-      condition:
-        type: string
-        description: Condition statement determining whether the component is executed or not.
-      connection:
-        type: object
-        description: Connection configuration of the component. JSON schema described in the connector definition.
-    description: |-
-      ConnectorComponent
-      Configures a connector component. Requires the creation of a connector resource first.
   v1betaConnectorDefinition:
     type: object
     properties:
@@ -3801,47 +3795,6 @@ definitions:
         $ref: '#/definitions/v1betaSecret'
         description: The secret resource.
     description: GetUserSecretResponse contains the requested secret.
-  v1betaIteratorComponent:
-    type: object
-    properties:
-      input:
-        type: string
-        description: 'Input: The iterator will iterate over the elements of the input (must be an array).'
-      output_elements:
-        type: object
-        additionalProperties:
-          type: string
-        title: |-
-          Output elements: Configure the output arrays of the iterator.
-          The key is the output element variable name, and the value is the data reference of the template.
-          Example:
-          output_elements: {
-            "key1": "${element.output.a}",
-            "key2": "${element.output.b}",
-          }
-          This will create the results:
-          output: {
-            "key1": [ ${element1.output.a},  ${element2.output.a} ... ],
-            "key2": [ ${element1.output.b},  ${element2.output.b} ... ],
-          }
-      component:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/v1betaNestedComponent'
-        description: 'Component: These components will be executed for each input element.'
-      condition:
-        type: string
-        description: Condition statement determining whether the component is executed or not.
-      data_specification:
-        $ref: '#/definitions/v1betaDataSpecification'
-        description: DataSpecification returns the JSON schema for the iterator input and output.
-        readOnly: true
-    description: |-
-      IteratorComponent
-      Configures an iterator component. An iterator takes an array and executes an
-      operation (defined by a set of nested components) on each of its elements.
-      It can be regarded as triggering a sub-pipeline using the elements of an
-      array as input.
   v1betaListComponentDefinitionsResponse:
     type: object
     properties:
@@ -4073,46 +4026,6 @@ definitions:
         $ref: '#/definitions/v1betaPipeline'
         description: The requested pipeline.
     description: LookUpPipelineResponse contains the requested pipeline.
-  v1betaNestedComponent:
-    type: object
-    properties:
-      metadata:
-        type: object
-        description: Metadata of the component.
-      connector_component:
-        $ref: '#/definitions/v1betaConnectorComponent'
-        title: ConnectorConfiguration
-      operator_component:
-        $ref: '#/definitions/v1betaOperatorComponent'
-        title: OperatorConfiguration
-    description: |-
-      NestedComponent
-      Fundamental building block in iterator component.
-  v1betaOn:
-    type: object
-    title: "On"
-  v1betaOperatorComponent:
-    type: object
-    properties:
-      definition_name:
-        type: string
-        description: Definition name.
-      definition:
-        $ref: '#/definitions/v1betaOperatorDefinition'
-        description: Operator definition.
-        readOnly: true
-      task:
-        type: string
-        description: Task.
-      input:
-        type: object
-        description: Input configuration of the component. JSON schema described in the operator definition.
-      condition:
-        type: string
-        description: Condition statement determining whether the component is executed or not.
-    description: |-
-      OperatorComponent
-      Configures an operator component.
   v1betaOperatorDefinition:
     type: object
     properties:
@@ -4290,31 +4203,6 @@ definitions:
           Social profile links list the links to the organization's social profiles.
           The key represents the provider, and the value is the corresponding URL.
     description: OrganizationProfile describes the public data of an organization.
-  v1betaOutput:
-    type: object
-    properties:
-      title:
-        type: string
-        description: Title.
-      description:
-        type: string
-        description: Description.
-      value:
-        type: string
-        description: Value.
-      instill_short_description:
-        type: string
-        description: Short description.
-      instill_ui_order:
-        type: integer
-        format: int32
-        description: UI order.
-      instill_ui_multiline:
-        type: boolean
-        description: UI Multiline.
-    description: Output describe the output schema of a pipeline.
-    required:
-      - value
   v1betaOwner:
     type: object
     properties:
@@ -4351,7 +4239,7 @@ definitions:
         type: string
         description: Pipeline description.
       recipe:
-        $ref: '#/definitions/v1betaRecipe'
+        type: object
         description: Recipe describes the components of a Pipeline and how they are connected.
       create_time:
         type: string
@@ -4439,7 +4327,7 @@ definitions:
         type: string
         description: Release description.
       recipe:
-        $ref: '#/definitions/v1betaRecipe'
+        type: object
         description: Recipe of the versioned pipeline.
         readOnly: true
       create_time:
@@ -4476,6 +4364,16 @@ definitions:
     description: |-
       Pipeline releases contain the version control information of a pipeline.
       This allows users to track changes in the pipeline over time.
+  v1betaPipelineValidationError:
+    type: object
+    properties:
+      location:
+        type: string
+        title: Location
+      error:
+        type: string
+        title: error
+    title: PipelineValidation
   v1betaPipelineView:
     type: string
     enum:
@@ -4498,36 +4396,6 @@ definitions:
 
        - VISIBILITY_PRIVATE: Only the user can see the pipeline.
        - VISIBILITY_PUBLIC: Other users can see the pipeline.
-  v1betaRecipe:
-    type: object
-    properties:
-      version:
-        type: string
-        description: Recipe schema version.
-      "on":
-        $ref: '#/definitions/v1betaOn'
-        description: The component trigger method.
-      secret:
-        type: object
-        additionalProperties:
-          type: string
-        description: Secret.
-      variable:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/v1betaVariable'
-        description: Variable.
-      output:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/v1betaOutput'
-        description: Output.
-      component:
-        type: object
-        additionalProperties:
-          $ref: '#/definitions/v1betaComponent'
-        description: Component.
-    description: Recipe describes the components of a Pipeline and how they are connected.
   v1betaRenameOrganizationPipelineReleaseResponse:
     type: object
     properties:
@@ -4896,48 +4764,29 @@ definitions:
   v1betaValidateOrganizationPipelineResponse:
     type: object
     properties:
-      pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+      success:
+        type: boolean
+        title: Success
+      errors:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipelineValidationError'
         description: The validated pipeline resource.
     description: ValidateOrganizationPipelineResponse contains a validated pipeline.
   v1betaValidateUserPipelineResponse:
     type: object
     properties:
-      pipeline:
-        $ref: '#/definitions/v1betaPipeline'
+      success:
+        type: boolean
+        title: Success
+      errors:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipelineValidationError'
         description: The validated pipeline resource.
     description: ValidateUserPipelineResponse contains a validated pipeline.
-  v1betaVariable:
-    type: object
-    properties:
-      type:
-        type: string
-        description: Type.
-      title:
-        type: string
-        description: Title.
-      description:
-        type: string
-        description: Description.
-      default:
-        type: string
-        description: Default value.
-      instill_format:
-        type: string
-        description: Instill format.
-      instill_ui_order:
-        type: integer
-        format: int32
-        description: UI order.
-      instill_ui_multiline:
-        type: boolean
-        description: UI Multiline.
-    description: |-
-      Variable describes the variable schema of a pipeline.
-      It is based on the standard JSON schema format, with additional xAttribute attributes.
-    required:
-      - type
-      - instill_format
   vdppipelinev1betaPermission:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -43,168 +43,6 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
-// ConnectorComponent
-// Configures a connector component. Requires the creation of a connector resource first.
-message ConnectorComponent {
-  // Definition name.
-  string definition_name = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Connector definition.
-  ConnectorDefinition definition = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Deleted fields
-  reserved 3, 4;
-  // Task.
-  string task = 5 [(google.api.field_behavior) = OPTIONAL];
-  // Input configuration of the component. JSON schema described in the connector definition.
-  google.protobuf.Struct input = 6 [(google.api.field_behavior) = OPTIONAL];
-  // Condition statement determining whether the component is executed or not.
-  string condition = 7 [(google.api.field_behavior) = OPTIONAL];
-  // Connection configuration of the component. JSON schema described in the connector definition.
-  google.protobuf.Struct connection = 8 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// OperatorComponent
-// Configures an operator component.
-message OperatorComponent {
-  // Definition name.
-  string definition_name = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Operator definition.
-  OperatorDefinition definition = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Task.
-  string task = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Input configuration of the component. JSON schema described in the operator definition.
-  google.protobuf.Struct input = 4 [(google.api.field_behavior) = OPTIONAL];
-  // Condition statement determining whether the component is executed or not.
-  string condition = 5 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// IteratorComponent
-// Configures an iterator component. An iterator takes an array and executes an
-// operation (defined by a set of nested components) on each of its elements.
-// It can be regarded as triggering a sub-pipeline using the elements of an
-// array as input.
-message IteratorComponent {
-  // Input: The iterator will iterate over the elements of the input (must be an array).
-  string input = 1 [(google.api.field_behavior) = OPTIONAL];
-
-  // Output elements: Configure the output arrays of the iterator.
-  // The key is the output element variable name, and the value is the data reference of the template.
-  // Example:
-  // output_elements: {
-  //   "key1": "${element.output.a}",
-  //   "key2": "${element.output.b}",
-  // }
-  // This will create the results:
-  // output: {
-  //   "key1": [ ${element1.output.a},  ${element2.output.a} ... ],
-  //   "key2": [ ${element1.output.b},  ${element2.output.b} ... ],
-  // }
-  map<string, string> output_elements = 2 [(google.api.field_behavior) = OPTIONAL];
-
-  // Component: These components will be executed for each input element.
-  map<string, NestedComponent> component = 3 [(google.api.field_behavior) = OPTIONAL];
-
-  // Condition statement determining whether the component is executed or not.
-  string condition = 4 [(google.api.field_behavior) = OPTIONAL];
-
-  // DataSpecification returns the JSON schema for the iterator input and output.
-  DataSpecification data_specification = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
-// Component
-// Fundamental building block in pipelines.
-//
-// For more information, see [Pipeline
-// Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
-message Component {
-  // Deleted fields
-  reserved 1 to 9;
-  // Metadata of the component.
-  google.protobuf.Struct metadata = 10 [(google.api.field_behavior) = OPTIONAL];
-  // Deleted fields
-  reserved 11, 12;
-  // The component configuration.
-  oneof component {
-    // ConnectorComponent
-    ConnectorComponent connector_component = 13;
-    // OperatorComponent
-    OperatorComponent operator_component = 14;
-    // IteratorComponent
-    IteratorComponent iterator_component = 15;
-  }
-}
-
-// NestedComponent
-// Fundamental building block in iterator component.
-message NestedComponent {
-  // Deleted field.
-  reserved 1;
-  // Metadata of the component.
-  google.protobuf.Struct metadata = 2 [(google.api.field_behavior) = OPTIONAL];
-  // The component configuration.
-  oneof component {
-    // ConnectorConfiguration
-    ConnectorComponent connector_component = 3;
-    // OperatorConfiguration
-    OperatorComponent operator_component = 4;
-  }
-}
-
-// On
-message On {}
-
-// Recipe describes the components of a Pipeline and how they are connected.
-message Recipe {
-  // Recipe schema version.
-  string version = 1;
-  // Deleted feild:
-  reserved 2;
-  // The component trigger method.
-  On on = 3;
-  // Secret.
-  map<string, string> secret = 4;
-  // Variable.
-  map<string, Variable> variable = 5;
-  // Output.
-  map<string, Output> output = 6;
-  // Component.
-  map<string, Component> component = 7;
-}
-
-// Variable describes the variable schema of a pipeline.
-// It is based on the standard JSON schema format, with additional xAttribute attributes.
-message Variable {
-  // Type.
-  string type = 1 [(google.api.field_behavior) = REQUIRED];
-  // Title.
-  string title = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Description.
-  string description = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Default value.
-  string default = 4 [(google.api.field_behavior) = OPTIONAL];
-  // Instill format.
-  string instill_format = 5 [(google.api.field_behavior) = REQUIRED];
-  // UI order.
-  int32 instill_ui_order = 6 [(google.api.field_behavior) = OPTIONAL];
-  // UI Multiline.
-  bool instill_ui_multiline = 7 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// Output describe the output schema of a pipeline.
-message Output {
-  // Title.
-  string title = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Description.
-  string description = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Value.
-  string value = 3 [(google.api.field_behavior) = REQUIRED];
-  // Short description.
-  string instill_short_description = 5 [(google.api.field_behavior) = OPTIONAL];
-  // UI order.
-  int32 instill_ui_order = 6 [(google.api.field_behavior) = OPTIONAL];
-  // UI Multiline.
-  bool instill_ui_multiline = 7 [(google.api.field_behavior) = OPTIONAL];
-}
-
 // State describes the state of a pipeline.
 enum State {
   // Unspecified.
@@ -271,7 +109,7 @@ message Pipeline {
   // Pipeline description.
   optional string description = 4 [(google.api.field_behavior) = OPTIONAL];
   // Recipe describes the components of a Pipeline and how they are connected.
-  Recipe recipe = 5 [(google.api.field_behavior) = IMMUTABLE];
+  google.protobuf.Struct recipe = 5 [(google.api.field_behavior) = IMMUTABLE];
   // Pipeline creation time.
   google.protobuf.Timestamp create_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline update time.
@@ -374,7 +212,7 @@ message PipelineRelease {
   // Release description.
   optional string description = 4 [(google.api.field_behavior) = OPTIONAL];
   // Recipe of the versioned pipeline.
-  Recipe recipe = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Struct recipe = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline creation time.
   google.protobuf.Timestamp create_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline update time.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -502,8 +502,10 @@ message TriggerUserPipelineRequest {
       field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
   // Data
-  repeated TriggerData data = 2;
+  repeated TriggerData data = 3;
 }
 
 // TriggerUserPipelineResponse contains the pipeline execution results, i.e.,
@@ -565,8 +567,10 @@ message TriggerAsyncUserPipelineRequest {
     }
   ];
 
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
   // Data
-  repeated TriggerData data = 2;
+  repeated TriggerData data = 3;
 }
 
 // TriggerAsyncUserPipelineResponse contains the information to access the
@@ -754,8 +758,11 @@ message TriggerUserPipelineReleaseRequest {
       field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
+
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
   // Data
-  repeated TriggerData data = 2;
+  repeated TriggerData data = 3;
 }
 
 // TriggerUserPipelineReleaseResponse contains the pipeline execution results,
@@ -780,8 +787,10 @@ message TriggerAsyncUserPipelineReleaseRequest {
       field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
   // Data
-  repeated TriggerData data = 2;
+  repeated TriggerData data = 3;
 }
 
 // TriggerAsyncUserPipelineReleaseResponse contains the information to access
@@ -1003,8 +1012,10 @@ message TriggerOrganizationPipelineRequest {
       field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
   // Data
-  repeated TriggerData data = 2;
+  repeated TriggerData data = 3;
 }
 
 // TriggerOrganizationPipelineResponse contains the pipeline execution results,
@@ -1029,8 +1040,10 @@ message TriggerAsyncOrganizationPipelineRequest {
       field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
   // Data
-  repeated TriggerData data = 2;
+  repeated TriggerData data = 3;
 }
 
 // TriggerAsyncOrganizationPipelineResponse contains the information to access
@@ -1225,8 +1238,10 @@ message TriggerOrganizationPipelineReleaseRequest {
       field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
   // Data
-  repeated TriggerData data = 2;
+  repeated TriggerData data = 3;
 }
 
 // TriggerOrganizationPipelineReleaseResponse contains the pipeline execution
@@ -1252,8 +1267,10 @@ message TriggerAsyncOrganizationPipelineReleaseRequest {
       field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
   // Data
-  repeated TriggerData data = 2;
+  repeated TriggerData data = 3;
 }
 
 // TriggerAsyncOrganizationPipelineReleaseResponse contains the information to

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -43,45 +43,6 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
-// TriggerByRequest
-// Configures the payload format of request when triggered by a request.
-message TriggerByRequest {
-  // Represents a field within the reqeuest.
-  message RequestField {
-    // Title of the field.
-    string title = 1 [(google.api.field_behavior) = OPTIONAL];
-    // Description of the field.
-    string description = 2 [(google.api.field_behavior) = OPTIONAL];
-    // Instill format.
-    string instill_format = 3 [(google.api.field_behavior) = OPTIONAL];
-    // Instill UI order.
-    int32 instill_ui_order = 4 [(google.api.field_behavior) = OPTIONAL];
-    // Instill UI Multiline.
-    bool instill_ui_multiline = 5 [(google.api.field_behavior) = OPTIONAL];
-  }
-  // Represents a field within the response.
-  message ResponseField {
-    // Title of the field.
-    string title = 1 [(google.api.field_behavior) = OPTIONAL];
-    // Description of the field.
-    string description = 2 [(google.api.field_behavior) = OPTIONAL];
-    // Value of the field.
-    string value = 3 [(google.api.field_behavior) = OPTIONAL];
-    // Instill UI order.
-    int32 instill_ui_order = 4 [(google.api.field_behavior) = OPTIONAL];
-  }
-
-  // Fields configuration of request.
-  // Key: Key of the input data.
-  // Field: Field settings of the value.
-  map<string, RequestField> request_fields = 1 [(google.api.field_behavior) = OPTIONAL];
-
-  // Fields configuration of response.
-  // Key: Key of the input data.
-  // Field: Field settings of the value.
-  map<string, ResponseField> response_fields = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
 // ConnectorComponent
 // Configures a connector component. Requires the creation of a connector resource first.
 message ConnectorComponent {
@@ -139,8 +100,8 @@ message IteratorComponent {
   // }
   map<string, string> output_elements = 2 [(google.api.field_behavior) = OPTIONAL];
 
-  // Components: These components will be executed for each input element.
-  repeated NestedComponent components = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Component: These components will be executed for each input element.
+  map<string, NestedComponent> component = 3 [(google.api.field_behavior) = OPTIONAL];
 
   // Condition statement determining whether the component is executed or not.
   string condition = 4 [(google.api.field_behavior) = OPTIONAL];
@@ -155,10 +116,8 @@ message IteratorComponent {
 // For more information, see [Pipeline
 // Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
 message Component {
-  // Component ID, provided by the user on creation.
-  string id = 1 [(google.api.field_behavior) = REQUIRED];
   // Deleted fields
-  reserved 2 to 9;
+  reserved 1 to 9;
   // Metadata of the component.
   google.protobuf.Struct metadata = 10 [(google.api.field_behavior) = OPTIONAL];
   // Deleted fields
@@ -177,8 +136,8 @@ message Component {
 // NestedComponent
 // Fundamental building block in iterator component.
 message NestedComponent {
-  // Component ID, provided by the user on creation.
-  string id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Deleted field.
+  reserved 1;
   // Metadata of the component.
   google.protobuf.Struct metadata = 2 [(google.api.field_behavior) = OPTIONAL];
   // The component configuration.
@@ -190,25 +149,60 @@ message NestedComponent {
   }
 }
 
-// Trigger
-message Trigger {
-  // Trigger Method
-  oneof trigger {
-    // Triggered by reqeust.
-    TriggerByRequest trigger_by_request = 1;
-  }
-}
+// On
+message On {}
 
 // Recipe describes the components of a Pipeline and how they are connected.
 message Recipe {
   // Recipe schema version.
   string version = 1;
-  // List of pipeline components.
-  repeated Component components = 2;
+  // Deleted feild:
+  reserved 2;
   // The component trigger method.
-  Trigger trigger = 3;
-  // Local secrets
-  map<string, string> secrets = 4;
+  On on = 3;
+  // Secret.
+  map<string, string> secret = 4;
+  // Variable.
+  map<string, Variable> variable = 5;
+  // Output.
+  map<string, Output> output = 6;
+  // Component.
+  map<string, Component> component = 7;
+}
+
+// Variable describes the variable schema of a pipeline.
+// It is based on the standard JSON schema format, with additional xAttribute attributes.
+message Variable {
+  // Type.
+  string type = 1 [(google.api.field_behavior) = REQUIRED];
+  // Title.
+  string title = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Description.
+  string description = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Default value.
+  string default = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Instill format.
+  string instill_format = 5 [(google.api.field_behavior) = REQUIRED];
+  // UI order.
+  int32 instill_ui_order = 6 [(google.api.field_behavior) = OPTIONAL];
+  // UI Multiline.
+  bool instill_ui_multiline = 7 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Output describe the output schema of a pipeline.
+message Output {
+  // Title.
+  string title = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Description.
+  string description = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Value.
+  string value = 3 [(google.api.field_behavior) = REQUIRED];
+  // Short description.
+  string instill_short_description = 5 [(google.api.field_behavior) = OPTIONAL];
+  // UI order.
+  int32 instill_ui_order = 6 [(google.api.field_behavior) = OPTIONAL];
+  // UI Multiline.
+  bool instill_ui_multiline = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // State describes the state of a pipeline.
@@ -660,10 +654,8 @@ message TriggerUserPipelineRequest {
       field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
-  // Pipeline input parameters.
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
-  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 2;
 }
 
 // TriggerUserPipelineResponse contains the pipeline execution results, i.e.,
@@ -703,6 +695,14 @@ message TriggerUserPipelineWithStreamResponse {
   TriggerMetadata metadata = 2;
 }
 
+// Data
+message TriggerData {
+  // Variables
+  google.protobuf.Struct variable = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Variables
+  map<string, string> secret = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
 // TriggerUserPipelineRequest represents a request to trigger a user-owned
 // pipeline synchronously.
 message TriggerAsyncUserPipelineRequest {
@@ -716,10 +716,9 @@ message TriggerAsyncUserPipelineRequest {
       field_configuration: {path_param_name: "user_pipeline_name"}
     }
   ];
-  // Pipeline input parameters.
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
-  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Data
+  repeated TriggerData data = 2;
 }
 
 // TriggerAsyncUserPipelineResponse contains the information to access the
@@ -907,10 +906,8 @@ message TriggerUserPipelineReleaseRequest {
       field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
-  // Pipeline input parameters.
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
-  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 2;
 }
 
 // TriggerUserPipelineReleaseResponse contains the pipeline execution results,
@@ -935,10 +932,8 @@ message TriggerAsyncUserPipelineReleaseRequest {
       field_configuration: {path_param_name: "user_pipeline_release_name"}
     }
   ];
-  // Pipeline input parameters.
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
-  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 2;
 }
 
 // TriggerAsyncUserPipelineReleaseResponse contains the information to access
@@ -1158,10 +1153,8 @@ message TriggerOrganizationPipelineRequest {
       field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
-  // Pipeline input parameters.
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
-  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 2;
 }
 
 // TriggerOrganizationPipelineResponse contains the pipeline execution results,
@@ -1186,10 +1179,8 @@ message TriggerAsyncOrganizationPipelineRequest {
       field_configuration: {path_param_name: "organization_pipeline_name"}
     }
   ];
-  // Pipeline input parameters.
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
-  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 2;
 }
 
 // TriggerAsyncOrganizationPipelineResponse contains the information to access
@@ -1384,10 +1375,8 @@ message TriggerOrganizationPipelineReleaseRequest {
       field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
-  // Pipeline input parameters.
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
-  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 2;
 }
 
 // TriggerOrganizationPipelineReleaseResponse contains the pipeline execution
@@ -1413,10 +1402,8 @@ message TriggerAsyncOrganizationPipelineReleaseRequest {
       field_configuration: {path_param_name: "organization_pipeline_release_name"}
     }
   ];
-  // Pipeline input parameters.
-  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline secrets parameters that will override the pipeline's or owner's secrets.
-  map<string, string> secrets = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 2;
 }
 
 // TriggerAsyncOrganizationPipelineReleaseResponse contains the information to

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -408,6 +408,14 @@ message DeleteUserPipelineRequest {
 // DeleteUserPipelineResponse is an empty response.
 message DeleteUserPipelineResponse {}
 
+// PipelineValidation
+message PipelineValidationError {
+  // Location
+  string location = 1;
+  // error
+  string error = 2;
+}
+
 // ValidateUserPipelineRequest represents a request to validate a pipeline
 // owned by a user.
 message ValidateUserPipelineRequest {
@@ -425,8 +433,10 @@ message ValidateUserPipelineRequest {
 
 // ValidateUserPipelineResponse contains a validated pipeline.
 message ValidateUserPipelineResponse {
+  // Success
+  bool success = 1;
   // The validated pipeline resource.
-  Pipeline pipeline = 1;
+  repeated PipelineValidationError errors = 2;
 }
 
 // RenameUserPipelineRequest represents a request to rename the name of a
@@ -924,8 +934,10 @@ message ValidateOrganizationPipelineRequest {
 
 // ValidateOrganizationPipelineResponse contains a validated pipeline.
 message ValidateOrganizationPipelineResponse {
+  // Success
+  bool success = 1;
   // The validated pipeline resource.
-  Pipeline pipeline = 1;
+  repeated PipelineValidationError errors = 2;
 }
 
 // RenameOrganizationPipelineRequest represents a request to rename the name of

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -195,7 +195,7 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
+    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
@@ -233,7 +233,7 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
+    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
@@ -352,7 +352,7 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
+    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
@@ -370,7 +370,7 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
+    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
@@ -493,7 +493,7 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
+    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
@@ -514,7 +514,7 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
+    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
@@ -618,7 +618,7 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
+    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
@@ -636,7 +636,7 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
+    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 


### PR DESCRIPTION
Because

- Originally, we used protobuf messages to fully describe the recipe, which is not suitable for our new recipe design. The protobuf `oneof` would introduce an additional nested structure in JSON when using grpc-gateway. This adds extra effort for users when they want to directly write a JSON recipe. We have decided to remove the messages, and the recipe format will now be validated by JSON-schema in the pipeline-backend instead. And in the near future, we'll also change to use YAML recipes, which will be a string and cannot be validated by protobufs anyway.
- We need to provide an endpoint for recipe validation that can return all errors in the recipe.

This commit

- Removes all recipe-related messages and use `structpb` for the recipe instead.
- Updates the response format of `validate` endpoint.

Note:
When using grpc-gateway, the corresponding JSON format for the oneof fields will be divided into different nested objects. This is not the same as the `oneOf` in JSON schema that we want, which don't have the nested structure.

protobuf
```
message XXX {
oneof component {
    // ConnectorComponent
    ConnectorComponent connector_component = 13;
    // OperatorComponent
    OperatorComponent operator_component = 14;
    // IteratorComponent
    IteratorComponent iterator_component = 15;
  }
}

```

JSON by grpc-gateway
```
{
  "connector_component": {},
  "operator_component": {},
  "iterator_component": {},
}
```