### PR TITLE
chore(model): add permission field in model message

### DIFF
--- a/model/model/v1alpha/common.proto
+++ b/model/model/v1alpha/common.proto
@@ -64,3 +64,11 @@ message Message {
   // Message content.
   repeated MessageContent content = 2;
 }
+
+// Permission defines how a pipeline can be used.
+message Permission {
+  // Defines whether the pipeline can be modified.
+  bool can_edit = 1;
+  // Defines whether the pipeline can be executed.
+  bool can_trigger = 2;
+}

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package model.model.v1alpha;
 
-// Model definitions
+// common definitions
 import "common/healthcheck/v1beta/healthcheck.proto";
 import "common/task/v1alpha/task.proto";
 // Core definitions
@@ -15,6 +15,8 @@ import "google/longrunning/operations.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+// Model definitions
+import "model/model/v1alpha/common.proto";
 import "model/model/v1alpha/model_definition.proto";
 import "model/model/v1alpha/task_classification.proto";
 import "model/model/v1alpha/task_detection.proto";
@@ -202,6 +204,8 @@ message Model {
   TaskOutput sample_output = 25 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model profile image in base64 format.
   optional string profile_image = 26 [(google.api.field_behavior) = OPTIONAL];
+  // Permission defines how a pipeline can be used.
+  Permission permission = 27 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ModelCard represents a README.md file that accompanies the model to describe

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -547,6 +547,10 @@ paths:
               profile_image:
                 type: string
                 description: Model profile image in base64 format.
+              permission:
+                $ref: '#/definitions/modelv1alphaPermission'
+                description: Permission defines how a pipeline can be used.
+                readOnly: true
             title: The model to update
             required:
               - id
@@ -1176,6 +1180,10 @@ paths:
               profile_image:
                 type: string
                 description: Model profile image in base64 format.
+              permission:
+                $ref: '#/definitions/modelv1alphaPermission'
+                description: Permission defines how a pipeline can be used.
+                readOnly: true
             title: The model to update
             required:
               - id
@@ -1695,6 +1703,23 @@ definitions:
 
       You can find out more about this error model and how to work with it in the
       [API Design Guide](https://cloud.google.com/apis/design/errors).
+  mgmtv1betaPermission:
+    type: object
+    properties:
+      can_edit:
+        type: boolean
+        description: Defines whether the resource can be modified.
+    description: Permission defines how a resource can be used.
+  modelv1alphaPermission:
+    type: object
+    properties:
+      can_edit:
+        type: boolean
+        description: Defines whether the pipeline can be modified.
+      can_trigger:
+        type: boolean
+        description: Defines whether the pipeline can be executed.
+    description: Permission defines how a pipeline can be used.
   modelv1alphaState:
     type: string
     enum:
@@ -2526,6 +2551,10 @@ definitions:
       profile_image:
         type: string
         description: Model profile image in base64 format.
+      permission:
+        $ref: '#/definitions/modelv1alphaPermission'
+        description: Permission defines how a pipeline can be used.
+        readOnly: true
     title: |-
       Model represents an AI model, i.e. a program that performs tasks as decision
       making or or pattern recognition based on its training data
@@ -3414,7 +3443,7 @@ definitions:
         $ref: '#/definitions/v1betaOrganizationProfile'
         description: Profile.
       permission:
-        $ref: '#/definitions/v1betaPermission'
+        $ref: '#/definitions/mgmtv1betaPermission'
         title: Permission
         readOnly: true
     description: |-
@@ -3457,13 +3486,6 @@ definitions:
         description: Organization.
         readOnly: true
     description: Owner is a wrapper for User and Organization, used to embed owner information in other resources.
-  v1betaPermission:
-    type: object
-    properties:
-      can_edit:
-        type: boolean
-        description: Defines whether the resource can be modified.
-    description: Permission defines how a resource can be used.
   v1betaUser:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -653,6 +653,52 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceTriggerUserPipelineBody'
       tags:
         - Trigger
+  /v1beta/{user_pipeline_name}/trigger:stream:
+    post:
+      summary: Trigger a pipeline owned by a user and stream back the response
+      description: |-
+        Triggers the execution of a pipeline asynchronously and streams back the response.
+        This method is intended for real-time inference when low latency is of concern
+        and the response needs to be processed incrementally.
+
+        The pipeline is identified by its resource name, formed by the parent user
+        and ID of the pipeline.
+      operationId: PipelinePublicService_TriggerUserPipelineWithStream
+      responses:
+        "200":
+          description: A successful response.(streaming responses)
+          schema:
+            type: object
+            properties:
+              result:
+                $ref: '#/definitions/v1betaTriggerUserPipelineWithStreamResponse'
+              error:
+                $ref: '#/definitions/googlerpcStatus'
+            title: Stream result of v1betaTriggerUserPipelineWithStreamResponse
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_pipeline_name
+          description: |-
+            The resource name of the pipeline, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/pipelines/{pipeline.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceTriggerUserPipelineWithStreamBody'
+      tags:
+        - Trigger
   /v1beta/{user_pipeline_name}/triggerAsync:
     post:
       summary: Trigger a pipeline owned by a user asynchronously
@@ -3083,6 +3129,24 @@ definitions:
       release of a user-owned pipeline.
     required:
       - inputs
+  PipelinePublicServiceTriggerUserPipelineWithStreamBody:
+    type: object
+    properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters.
+      secrets:
+        type: object
+        additionalProperties:
+          type: string
+        description: Pipeline secrets parameters that will override the pipeline's or owner's secrets.
+    description: |-
+      TriggerUserPipelineWithStreamRequest represents a request to trigger a user-owned
+      pipeline synchronously and streams back the results.
+    required:
+      - inputs
   PipelinePublicServiceValidateOrganizationPipelineBody:
     type: object
     description: |-
@@ -4820,6 +4884,20 @@ definitions:
         description: Traces of the pipeline inference.
     description: |-
       TriggerUserPipelineResponse contains the pipeline execution results, i.e.,
+      the multiple model inference outputs.
+  v1betaTriggerUserPipelineWithStreamResponse:
+    type: object
+    properties:
+      outputs:
+        type: array
+        items:
+          type: object
+        description: Model inference outputs.
+      metadata:
+        $ref: '#/definitions/v1betaTriggerMetadata'
+        description: Traces of the pipeline inference.
+    description: |-
+      TriggerUserPipelineWithStreamResponse contains the pipeline execution results, i.e.,
       the multiple model inference outputs.
   v1betaUpdateOrganizationPipelineReleaseResponse:
     type: object

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -703,7 +703,6 @@ message TriggerUserPipelineWithStreamResponse {
   TriggerMetadata metadata = 2;
 }
 
-
 // TriggerUserPipelineRequest represents a request to trigger a user-owned
 // pipeline synchronously.
 message TriggerAsyncUserPipelineRequest {

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -199,8 +199,6 @@ service PipelinePublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
-
-
   // Trigger a pipeline owned by a user and stream back the response
   //
   // Triggers the execution of a pipeline asynchronously and streams back the response.
@@ -209,7 +207,7 @@ service PipelinePublicService {
   //
   // The pipeline is identified by its resource name, formed by the parent user
   // and ID of the pipeline.
-  rpc TriggerUserPipelineWithStream(TriggerUserPipelineWithStreamRequest) returns ( stream TriggerUserPipelineWithStreamResponse) {
+  rpc TriggerUserPipelineWithStream(TriggerUserPipelineWithStreamRequest) returns (stream TriggerUserPipelineWithStreamResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=users/*/pipelines/*}/trigger:stream"
       body: "*"


### PR DESCRIPTION
Because

- Allow FE to determine if a user has the permission to edit or trigger a model

This commit

- add permission object in model message
