### PR TITLE
chore(model): add schema fields for model input and output

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -206,6 +206,10 @@ message Model {
   optional string profile_image = 26 [(google.api.field_behavior) = OPTIONAL];
   // Permission defines how a pipeline can be used.
   Permission permission = 27 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Input schema for the model
+  google.protobuf.Struct input_schema = 28 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Output schema for the model
+  google.protobuf.Struct output_schema = 29 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ModelCard represents a README.md file that accompanies the model to describe

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -551,6 +551,14 @@ paths:
                 $ref: '#/definitions/modelv1alphaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
+              input_schema:
+                type: object
+                title: Input schema for the model
+                readOnly: true
+              output_schema:
+                type: object
+                title: Output schema for the model
+                readOnly: true
             title: The model to update
             required:
               - id
@@ -1183,6 +1191,14 @@ paths:
               permission:
                 $ref: '#/definitions/modelv1alphaPermission'
                 description: Permission defines how a pipeline can be used.
+                readOnly: true
+              input_schema:
+                type: object
+                title: Input schema for the model
+                readOnly: true
+              output_schema:
+                type: object
+                title: Output schema for the model
                 readOnly: true
             title: The model to update
             required:
@@ -2554,6 +2570,14 @@ definitions:
       permission:
         $ref: '#/definitions/modelv1alphaPermission'
         description: Permission defines how a pipeline can be used.
+        readOnly: true
+      input_schema:
+        type: object
+        title: Input schema for the model
+        readOnly: true
+      output_schema:
+        type: object
+        title: Output schema for the model
         readOnly: true
     title: |-
       Model represents an AI model, i.e. a program that performs tasks as decision


### PR DESCRIPTION
Because

- FE needs input and output schema for trigger form rendering

This commit

- add schema fields for model input and output in model message
