### PR TITLE
feat(vdp): redesign component-definitions endpoint

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -2886,7 +2886,7 @@ definitions:
 
       The `version` field in the definition must have `alpha` as its first
       pre-release identifier, e.g., `0.1.0-alpha`, `0.1.3-alpha.1`.
-       - RELEASE_STAGE_BETA: The connector has reached stability and no backwards incompatible
+       - RELEASE_STAGE_BETA: The component has reached stability and no backwards incompatible
       changes are expected. Before reaching general availability, it should be
       validated by a broader group of users. Some fixes might be added during
       this process.
@@ -3478,7 +3478,7 @@ definitions:
         type: string
         title: |-
           The name of the component definition, defined by its ID.
-          - Format: `component-definitions/{id}
+          - Format: `component-definitions/{id}`
         readOnly: true
       uid:
         type: string
@@ -3502,8 +3502,8 @@ definitions:
       icon:
         type: string
         description: |-
-          ConnecComponenttor definition icon. This is a path that's relative to the root of
-          the connector implementation (see `source_url`) and that allows clients
+          Component definition icon. This is a path that's relative to the root of
+          the component implementation (see `source_url`) and that allows
           frontend applications to pull and locate the icons.
         readOnly: true
       spec:
@@ -3529,12 +3529,12 @@ definitions:
       custom:
         type: boolean
         description: |-
-          Connector definition custom flag, i.e., whether this is a custom
-          connector definition.
+          Component definition custom flag, i.e., whether this is a custom
+          component definition.
         readOnly: true
       vendor:
         type: string
-        description: Connector definition vendor name.
+        description: Component definition vendor name.
         readOnly: true
       vendor_attributes:
         type: object
@@ -3543,13 +3543,13 @@ definitions:
       source_url:
         type: string
         description: |-
-          Source code URL. This points to the source code where the connector is
+          Source code URL. This points to the source code where the component is
           implemented.
         readOnly: true
       version:
         type: string
         description: |-
-          Connector definition version. This is a string that fulfills the SemVer
+          Component definition version. This is a string that fulfills the SemVer
           specification (e.g. `1.0.0-beta`).
         readOnly: true
       tasks:
@@ -3557,11 +3557,11 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/v1betaComponentTask'
-        description: List of tasks that can be executed by the connector.
+        description: List of tasks that can be executed by the component.
         readOnly: true
       description:
         type: string
-        description: Short description of the connector.
+        description: Short description of the component.
         readOnly: true
       release_stage:
         $ref: '#/definitions/ComponentDefinitionReleaseStage'

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -2361,7 +2361,7 @@ paths:
           description: |-
             Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
             expression.
-            - Example: `component_type="COMPONENT_TYPE_CONNECTOR_AI"`.
+            - Example: `component_type="COMPONENT_TYPE_AI"`.
             - Example: `tasks:"TASK_TEXT_GENERATION"`.
           in: query
           required: false
@@ -2903,6 +2903,23 @@ definitions:
       within semantic versioning.
       See the documentation of each value for potential constraints between
       `version` and `release_stage` fields.`
+  ComponentDefinitionSpec:
+    type: object
+    properties:
+      component_specification:
+        type: object
+        description: Component specification.
+      data_specifications:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/v1betaDataSpecification'
+        description: |-
+          Data specifications.
+          The key represents the task, and the value is the corresponding data_specification.
+    description: Spec represents a specification data model.
+    required:
+      - component_specification
+      - data_specifications
   PipelinePublicServiceCloneOrganizationPipelineBody:
     type: object
     properties:
@@ -3457,17 +3474,98 @@ definitions:
   v1betaComponentDefinition:
     type: object
     properties:
+      name:
+        type: string
+        title: |-
+          The name of the component definition, defined by its ID.
+          - Format: `component-definitions/{id}
+        readOnly: true
+      uid:
+        type: string
+        description: Component definition UUID.
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          Component definition resource ID (used in `name` as the last segment). This
+          conforms to RFC-1034, which restricts to letters, numbers, and hyphen,
+          with the first character a letter, the last a letter or a number, and a 63
+          character maximum.
+      title:
+        type: string
+        description: Component definition title.
+        readOnly: true
+      documentation_url:
+        type: string
+        description: Component definition documentation URL.
+        readOnly: true
+      icon:
+        type: string
+        description: |-
+          ConnecComponenttor definition icon. This is a path that's relative to the root of
+          the connector implementation (see `source_url`) and that allows clients
+          frontend applications to pull and locate the icons.
+        readOnly: true
+      spec:
+        $ref: '#/definitions/ComponentDefinitionSpec'
+        description: Component definition specification.
+        readOnly: true
       type:
         $ref: '#/definitions/v1betaComponentType'
-        description: Defines the type of task the component will perform.
+        description: Component definition type.
         readOnly: true
-      operator_definition:
-        $ref: '#/definitions/v1betaOperatorDefinition'
-        title: operator definition detail
+      tombstone:
+        type: boolean
+        description: |-
+          Component definition tombstone. If true, this configuration is permanently
+          off. Otherwise, the configuration is active.
         readOnly: true
-      connector_definition:
-        $ref: '#/definitions/v1betaConnectorDefinition'
-        title: connector definition detail
+      public:
+        type: boolean
+        description: |-
+          The public flag determines whether this connector definition is available
+          to all workspaces.
+        readOnly: true
+      custom:
+        type: boolean
+        description: |-
+          Connector definition custom flag, i.e., whether this is a custom
+          connector definition.
+        readOnly: true
+      vendor:
+        type: string
+        description: Connector definition vendor name.
+        readOnly: true
+      vendor_attributes:
+        type: object
+        description: Vendor-specific attributes.
+        readOnly: true
+      source_url:
+        type: string
+        description: |-
+          Source code URL. This points to the source code where the connector is
+          implemented.
+        readOnly: true
+      version:
+        type: string
+        description: |-
+          Connector definition version. This is a string that fulfills the SemVer
+          specification (e.g. `1.0.0-beta`).
+        readOnly: true
+      tasks:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaComponentTask'
+        description: List of tasks that can be executed by the connector.
+        readOnly: true
+      description:
+        type: string
+        description: Short description of the connector.
+        readOnly: true
+      release_stage:
+        $ref: '#/definitions/ComponentDefinitionReleaseStage'
+        description: Release stage.
         readOnly: true
     description: ComponentDefinition describes a certain type of Component.
   v1betaComponentDefinitionView:
@@ -3502,17 +3600,17 @@ definitions:
   v1betaComponentType:
     type: string
     enum:
-      - COMPONENT_TYPE_CONNECTOR_AI
-      - COMPONENT_TYPE_CONNECTOR_DATA
+      - COMPONENT_TYPE_AI
+      - COMPONENT_TYPE_DATA
       - COMPONENT_TYPE_OPERATOR
-      - COMPONENT_TYPE_CONNECTOR_APPLICATION
+      - COMPONENT_TYPE_APPLICATION
     description: |-
       ComponentType defines the component type based on its task features.
 
-       - COMPONENT_TYPE_CONNECTOR_AI: Connect with an AI model.
-       - COMPONENT_TYPE_CONNECTOR_DATA: Connect with a remote data source.
+       - COMPONENT_TYPE_AI: Connect with an AI model.
+       - COMPONENT_TYPE_DATA: Connect with a remote data source.
        - COMPONENT_TYPE_OPERATOR: Manipulate data.
-       - COMPONENT_TYPE_CONNECTOR_APPLICATION: Connect with an external application.
+       - COMPONENT_TYPE_APPLICATION: Connect with an external application.
   v1betaConnectorDefinition:
     type: object
     properties:
@@ -3807,7 +3905,7 @@ definitions:
       total_size:
         type: integer
         format: int32
-        description: Total number of connector definitions.
+        description: Total number of component definitions.
       page_size:
         type: integer
         format: int32

--- a/vdp/pipeline/v1beta/common.proto
+++ b/vdp/pipeline/v1beta/common.proto
@@ -109,14 +109,14 @@ enum ComponentType {
   // Unspecified.
   COMPONENT_TYPE_UNSPECIFIED = 0;
   // Connect with an AI model.
-  COMPONENT_TYPE_CONNECTOR_AI = 1;
+  COMPONENT_TYPE_AI = 1;
   // Connect with a remote data source.
-  COMPONENT_TYPE_CONNECTOR_DATA = 2;
+  COMPONENT_TYPE_DATA = 2;
   // 3 Is reserved for the connector blockchain type, deprecated by
   // COMPONENT_TYPE_CONNECTOR_APPLICATION.
   reserved 3;
   // Manipulate data.
   COMPONENT_TYPE_OPERATOR = 4;
   // Connect with an external application.
-  COMPONENT_TYPE_CONNECTOR_APPLICATION = 5;
+  COMPONENT_TYPE_APPLICATION = 5;
 }

--- a/vdp/pipeline/v1beta/component_definition.proto
+++ b/vdp/pipeline/v1beta/component_definition.proto
@@ -56,7 +56,7 @@ message ComponentDefinition {
     // The `version` field in the definition must have `alpha` as its first
     // pre-release identifier, e.g., `0.1.0-alpha`, `0.1.3-alpha.1`.
     RELEASE_STAGE_ALPHA = 3;
-    // The connector has reached stability and no backwards incompatible
+    // The component has reached stability and no backwards incompatible
     // changes are expected. Before reaching general availability, it should be
     // validated by a broader group of users. Some fixes might be added during
     // this process.
@@ -79,7 +79,7 @@ message ComponentDefinition {
   }
 
   // The name of the component definition, defined by its ID.
-  // - Format: `component-definitions/{id}
+  // - Format: `component-definitions/{id}`
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Component definition UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -92,8 +92,8 @@ message ComponentDefinition {
   string title = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Component definition documentation URL.
   string documentation_url = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // ConnecComponenttor definition icon. This is a path that's relative to the root of
-  // the connector implementation (see `source_url`) and that allows clients
+  // Component definition icon. This is a path that's relative to the root of
+  // the component implementation (see `source_url`) and that allows
   // frontend applications to pull and locate the icons.
   string icon = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Component definition specification.
@@ -106,27 +106,25 @@ message ComponentDefinition {
   // The public flag determines whether this connector definition is available
   // to all workspaces.
   bool public = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition custom flag, i.e., whether this is a custom
-  // connector definition.
+  // Component definition custom flag, i.e., whether this is a custom
+  // component definition.
   bool custom = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // field 12 is reserved for 'icon_url'.
-  reserved 12;
-  // Connector definition vendor name.
-  string vendor = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component definition vendor name.
+  string vendor = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Vendor-specific attributes.
-  google.protobuf.Struct vendor_attributes = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Source code URL. This points to the source code where the connector is
+  google.protobuf.Struct vendor_attributes = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Source code URL. This points to the source code where the component is
   // implemented.
-  string source_url = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Connector definition version. This is a string that fulfills the SemVer
+  string source_url = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component definition version. This is a string that fulfills the SemVer
   // specification (e.g. `1.0.0-beta`).
-  string version = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // List of tasks that can be executed by the connector.
-  repeated ComponentTask tasks = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Short description of the connector.
-  string description = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string version = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // List of tasks that can be executed by the component.
+  repeated ComponentTask tasks = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Short description of the component.
+  string description = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Release stage.
-  ComponentDefinition.ReleaseStage release_stage = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
+  ComponentDefinition.ReleaseStage release_stage = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DataSpecification describes the JSON schema of component input and output.

--- a/vdp/pipeline/v1beta/component_definition.proto
+++ b/vdp/pipeline/v1beta/component_definition.proto
@@ -69,15 +69,64 @@ message ComponentDefinition {
     RELEASE_STAGE_GA = 5;
   }
 
-  // Defines the type of task the component will perform.
-  ComponentType type = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // The component definition details.
-  oneof definition {
-    // operator definition detail
-    OperatorDefinition operator_definition = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // connector definition detail
-    ConnectorDefinition connector_definition = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Spec represents a specification data model.
+  message Spec {
+    // Component specification.
+    google.protobuf.Struct component_specification = 3 [(google.api.field_behavior) = REQUIRED];
+    // Data specifications.
+    // The key represents the task, and the value is the corresponding data_specification.
+    map<string, DataSpecification> data_specifications = 5 [(google.api.field_behavior) = REQUIRED];
   }
+
+  // The name of the component definition, defined by its ID.
+  // - Format: `component-definitions/{id}
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component definition UUID.
+  string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component definition resource ID (used in `name` as the last segment). This
+  // conforms to RFC-1034, which restricts to letters, numbers, and hyphen,
+  // with the first character a letter, the last a letter or a number, and a 63
+  // character maximum.
+  string id = 3 [(google.api.field_behavior) = IMMUTABLE];
+  // Component definition title.
+  string title = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component definition documentation URL.
+  string documentation_url = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // ConnecComponenttor definition icon. This is a path that's relative to the root of
+  // the connector implementation (see `source_url`) and that allows clients
+  // frontend applications to pull and locate the icons.
+  string icon = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component definition specification.
+  Spec spec = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component definition type.
+  ComponentType type = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component definition tombstone. If true, this configuration is permanently
+  // off. Otherwise, the configuration is active.
+  bool tombstone = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The public flag determines whether this connector definition is available
+  // to all workspaces.
+  bool public = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Connector definition custom flag, i.e., whether this is a custom
+  // connector definition.
+  bool custom = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // field 12 is reserved for 'icon_url'.
+  reserved 12;
+  // Connector definition vendor name.
+  string vendor = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Vendor-specific attributes.
+  google.protobuf.Struct vendor_attributes = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Source code URL. This points to the source code where the connector is
+  // implemented.
+  string source_url = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Connector definition version. This is a string that fulfills the SemVer
+  // specification (e.g. `1.0.0-beta`).
+  string version = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // List of tasks that can be executed by the connector.
+  repeated ComponentTask tasks = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Short description of the connector.
+  string description = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Release stage.
+  ComponentDefinition.ReleaseStage release_stage = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DataSpecification describes the JSON schema of component input and output.
@@ -277,7 +326,7 @@ message ListComponentDefinitionsRequest {
   optional ComponentDefinition.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
-  // - Example: `component_type="COMPONENT_TYPE_CONNECTOR_AI"`.
+  // - Example: `component_type="COMPONENT_TYPE_AI"`.
   // - Example: `tasks:"TASK_TEXT_GENERATION"`.
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // Page number.
@@ -291,7 +340,7 @@ message ListComponentDefinitionsResponse {
   // Field 2 is reserved for `next_page_token`, which stopped being served
   // after the endpoint switched to offset-based pagination.
   reserved 2;
-  // Total number of connector definitions.
+  // Total number of component definitions.
   int32 total_size = 3;
   // The requested page size.
   int32 page_size = 4;

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -656,6 +656,7 @@ service PipelinePublicService {
   rpc ListConnectorDefinitions(ListConnectorDefinitionsRequest) returns (ListConnectorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/connector-definitions"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option deprecated = true;
   }
 
   // Get connector definition
@@ -665,6 +666,7 @@ service PipelinePublicService {
     option (google.api.http) = {get: "/v1beta/{name=connector-definitions/*}"};
     option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option deprecated = true;
   }
 
   // List operator definitions
@@ -673,6 +675,7 @@ service PipelinePublicService {
   rpc ListOperatorDefinitions(ListOperatorDefinitionsRequest) returns (ListOperatorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/operator-definitions"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option deprecated = true;
   }
 
   // List component definitions
@@ -692,6 +695,7 @@ service PipelinePublicService {
     option (google.api.http) = {get: "/v1beta/{name=operator-definitions/*}"};
     option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option deprecated = true;
   }
 
   // Check the availibity of a resource name


### PR DESCRIPTION
Because

- We are going to retire the component categorization of connector and operator and flatten the structure.
- The original `connector-definitions` and `operator-definitions` endpoints will be deprecated.

This commit

- Redesigns the `component-definitions` endpoint, merges the content from the old `connector-definitions` and `operator-definitions` endpoints.

Note

- The [website](https://github.com/instill-ai/instill.tech) will be affected by the endpoint refactor, so we'll update it accordingly.