### PR TITLE
feat(vdp): return pipeline run stats

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -159,6 +159,7 @@ message KnowledgeBasesList {
   // The list of knowledge bases.
   repeated KnowledgeBase knowledge_bases = 1;
 }
+
 // CreateKnowledgeBaseRequest represents a request to create a knowledge base.
 message CreateKnowledgeBaseRequest {
   // The knowledge base name.
@@ -182,7 +183,7 @@ message CreateKnowledgeBaseResponse {
 // Request message for ListKnowledgeBases
 message ListKnowledgeBasesRequest {
   // User ID for which to list the knowledge bases
-  string uid = 1; 
+  string uid = 1;
 }
 
 // GetKnowledgeBasesResponse represents a response for getting all knowledge bases from users.
@@ -194,6 +195,7 @@ message ListKnowledgeBasesResponse {
   // The status code.
   int32 status_code = 3;
 }
+
 // UpdateKnowledgeBaseRequest represents a request to update a knowledge base.
 message UpdateKnowledgeBaseRequest {
   // The knowledge base identifier.

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -490,6 +490,9 @@ paths:
                   type: string
                 description: Tags.
                 readOnly: true
+              stats:
+                $ref: '#/definitions/PipelineStats'
+                description: Statistic data.
             title: The pipeline fields that will replace the existing ones.
       tags:
         - Pipeline
@@ -1495,6 +1498,9 @@ paths:
                   type: string
                 description: Tags.
                 readOnly: true
+              stats:
+                $ref: '#/definitions/PipelineStats'
+                description: Statistic data.
             title: The pipeline fields that will replace the existing ones.
       tags:
         - Pipeline
@@ -3166,6 +3172,18 @@ definitions:
     description: |-
       ValidateUserPipelineRequest represents a request to validate a pipeline
       owned by a user.
+  PipelineStats:
+    type: object
+    properties:
+      number_of_runs:
+        type: integer
+        format: int32
+        description: Number of pipeline runs.
+      last_run_time:
+        type: string
+        format: date-time
+        description: Last run time.
+    title: Statistic data
   SharingShareCode:
     type: object
     properties:
@@ -4396,6 +4414,9 @@ definitions:
           type: string
         description: Tags.
         readOnly: true
+      stats:
+        $ref: '#/definitions/PipelineStats'
+        description: Statistic data.
     description: |-
       A Pipeline is an end-to-end workflow that automates a sequence of components
       to process data.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -90,6 +90,14 @@ message Pipeline {
     VISIBILITY_PUBLIC = 2;
   }
 
+  // Statistic data
+  message Stats {
+    // Number of pipeline runs.
+    int32 number_of_runs = 1;
+    // Last run time.
+    google.protobuf.Timestamp last_run_time = 2;
+  }
+
   // The name of the pipeline, defined by its parent and ID.
   // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
   string name = 1 [
@@ -143,6 +151,8 @@ message Pipeline {
   DataSpecification data_specification = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Tags.
   repeated string tags = 25 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Statistic data.
+  Stats stats = 26;
 }
 
 // TriggerMetadata contains the traces of the pipeline inference.


### PR DESCRIPTION
Because

- We'd like to show some pipeline run statistic data, including `number_of_runs` and `last_run_time`.

This commit

- Returns pipeline run stats.
