### PR TITLE
chore(model): add get latest model operation

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1229,7 +1229,7 @@ message TriggerOrganizationModelBinaryFileUploadResponse {
   repeated TaskOutput task_outputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// GerModelOperationRequest represents a request to fetch a long-running
+// GetModelOperationRequest represents a request to fetch a long-running
 // operation performed on a model.
 message GetModelOperationRequest {
   // The resource name of the model, which allows its access ID.
@@ -1245,6 +1245,62 @@ message GetModelOperationRequest {
 // GetModelOperationRequest represents a request to query a long-running
 // operation.
 message GetModelOperationResponse {
+  // The long-running operation.
+  google.longrunning.Operation operation = 1;
+}
+
+// LatestOperation represents an internal message for GetLatestModelOperation Response
+message LatestOperation {
+  // Input request
+  TriggerUserModelRequest request = 1;
+  // Output response
+  TriggerUserModelResponse response = 2;
+}
+
+// GetUserLatestModelOperationRequest represents a request to fetch the latest long-running
+// operation performed on a model for a user.
+message GetUserLatestModelOperationRequest {
+  // The resource name of the model, which allows its access by parent user
+  // and ID.
+  // - Format: `users/{user.id}/models/{model.id}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Model",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_model_name"}
+    }
+  ];
+  // View allows clients to specify the desired operation result in the response.
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetUserLatestModelOperationRequest represents a request to query a long-running
+// operation.
+message GetUserLatestModelOperationResponse {
+  // The long-running operation.
+  google.longrunning.Operation operation = 1;
+}
+
+// GetOrganizationLatestModelOperationRequest represents a request to fetch the latest long-running
+// operation performed on a model for a user.
+message GetOrganizationLatestModelOperationRequest {
+  // The resource name of the model, which allows its access by parent organization
+  // and ID.
+  // - Format: `organizations/{organization.id}/models/{model.id}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Model",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "organization_model_name"}
+    }
+  ];
+  // View allows clients to specify the desired operation result in the response.
+  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetOrganizationLatestModelOperationRequest represents a request to query a long-running
+// operation.
+message GetOrganizationLatestModelOperationResponse {
   // The long-running operation.
   google.longrunning.Operation operation = 1;
 }

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -506,4 +506,24 @@ service ModelPublicService {
     option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
+
+  // Get the details of the latest long-running operation from a user model
+  //
+  // This method allows requesters to request the status and outcome of
+  // long-running operations in a model, such as deployment.
+  rpc GetUserLatestModelOperation(GetUserLatestModelOperationRequest) returns (GetUserLatestModelOperationResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/operation"};
+    option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Get the details of the latest long-running operation from a organization model
+  //
+  // This method allows requesters to request the status and outcome of
+  // long-running operations in a model, such as deployment.
+  rpc GetOrganizationLatestModelOperation(GetOrganizationLatestModelOperationRequest) returns (GetOrganizationLatestModelOperationResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/operation"};
+    option (google.api.method_signature) = "name";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
 }

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -1790,6 +1790,92 @@ paths:
             - VIEW_FULL
       tags:
         - Model
+  /v1alpha/{user_model_name}/operation:
+    get:
+      summary: Get the details of the latest long-running operation from a user model
+      description: |-
+        This method allows requesters to request the status and outcome of
+        long-running operations in a model, such as deployment.
+      operationId: ModelPublicService_GetUserLatestModelOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetUserLatestModelOperationResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_model_name
+          description: |-
+            The resource name of the model, which allows its access by parent user
+            and ID.
+            - Format: `users/{user.id}/models/{model.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/models/[^/]+
+        - name: view
+          description: |-
+            View allows clients to specify the desired operation result in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+      tags:
+        - Model
+  /v1alpha/{organization_model_name}/operation:
+    get:
+      summary: Get the details of the latest long-running operation from a organization model
+      description: |-
+        This method allows requesters to request the status and outcome of
+        long-running operations in a model, such as deployment.
+      operationId: ModelPublicService_GetOrganizationLatestModelOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetOrganizationLatestModelOperationResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_model_name
+          description: |-
+            The resource name of the model, which allows its access by parent organization
+            and ID.
+            - Format: `organizations/{organization.id}/models/{model.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/models/[^/]+
+        - name: view
+          description: |-
+            View allows clients to specify the desired operation result in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+      tags:
+        - Model
 definitions:
   ModelPublicServicePublishOrganizationModelBody:
     type: object
@@ -2339,6 +2425,15 @@ definitions:
     description: |-
       GetModelOperationRequest represents a request to query a long-running
       operation.
+  v1alphaGetOrganizationLatestModelOperationResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        description: The long-running operation.
+    description: |-
+      GetOrganizationLatestModelOperationRequest represents a request to query a long-running
+      operation.
   v1alphaGetOrganizationModelCardResponse:
     type: object
     properties:
@@ -2353,6 +2448,15 @@ definitions:
         $ref: '#/definitions/v1alphaModel'
         description: The model resource.
     description: GetOrganizationModelResponse contains the requested model.
+  v1alphaGetUserLatestModelOperationResponse:
+    type: object
+    properties:
+      operation:
+        $ref: '#/definitions/googlelongrunningOperation'
+        description: The long-running operation.
+    description: |-
+      GetUserLatestModelOperationRequest represents a request to query a long-running
+      operation.
   v1alphaGetUserModelCardResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- Model overview page needs to retrieve input and output data from latest model async trigger

This commit

- add endpoints to get latest operation result