### PR TITLE
feat(mgmt): add credit consumption chart endpoint

### DIFF
--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -7,6 +7,8 @@ on:
       # pushed to the `main` branch.
       - main
     paths:
+      - 'openapiv2/artifact/**'
+      - 'openapiv2/common/**'
       - 'openapiv2/core/**'
       - 'openapiv2/model/**'
       - 'openapiv2/vdp/**'

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -6,6 +6,7 @@ package core.mgmt.v1beta;
 import "google/api/field_behavior.proto";
 // Protobuf standard
 import "google/protobuf/timestamp.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
 
 // Mode describes the execution mode of the pipeline (sync or async).
 enum Mode {
@@ -162,8 +163,8 @@ message ListPipelineTriggerChartRecordsResponse {
 // CreditConsumptionChartRecord contains credit consumption metrics, aggregated
 // by owner and time frame.
 message CreditConsumptionChartRecord {
-  // Credit owner UUID.
-  string credit_owner_uid = 1;
+  // Credit owner ID, e.g. `users/chef-wombat`.
+  string credit_owner= 1;
   // Time buckets.
   repeated google.protobuf.Timestamp time_buckets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total credit consumed in each time bucket.
@@ -173,14 +174,17 @@ message CreditConsumptionChartRecord {
 // ListCreditConsumptionChartRecordsRequest represents a request to list pipeline
 // trigger metrics, aggregated by pipeline ID and time frame.
 message ListCreditConsumptionChartRecordsRequest {
+  // The user or organization to which the credit belongs.
+  // Format: `{[users|organizations]}/{id}`.
+  string owner = 1 [(google.api.field_behavior) = REQUIRED];
   // Aggregation window. The value is a positive duration string, i.e. a
   // sequence of decimal numbers, each with optional fraction and a unit
-  // suffix, such as "300ms", "-1.5h" or "2h45m".
-  string aggregation_window = 1;
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  string aggregation_window = 2 [(google.api.field_behavior) = REQUIRED];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression to determine the credit owner and time range for the charts.
-  // - Example: `owner_name='users/jay-wombat' AND start='2024-06-04T10:000:00Z' AND stop='2024-06-11T10:00:00Z`
-  optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+  // expression to determine the time range for the charts.
+  // - Example: `start='2024-06-04T10:000:00Z' AND stop='2024-06-11T10:00:00Z`
+  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListCreditConsumptionChartRecordsResponse contains a list of pipeline trigger

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -191,7 +191,7 @@ message ListCreditConsumptionChartRecordsRequest {
 // chart records.
 message ListCreditConsumptionChartRecordsResponse {
   // A list of pipeline trigger records.
-  repeated CreditConsumptionChartRecord pipeline_trigger_chart_records = 1;
+  repeated CreditConsumptionChartRecord credit_consumption_chart_records = 1;
   // Sum of the total credit consumed within the time range.
   float total_amount = 2;
 }

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -180,11 +180,12 @@ message ListCreditConsumptionChartRecordsRequest {
   // Aggregation window. The value is a positive duration string, i.e. a
   // sequence of decimal numbers, each with optional fraction and a unit
   // suffix, such as "300ms", "1.5h" or "2h45m".
-  string aggregation_window = 2 [(google.api.field_behavior) = REQUIRED];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression to determine the time range for the charts.
-  // - Example: `start='2024-06-04T10:000:00Z' AND stop='2024-06-11T10:00:00Z`
-  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Beginning of the time range from which the records will be fetched.
+  optional google.protobuf.Timestamp start = 3 [(google.api.field_behavior) = OPTIONAL];
+  // End of the time range from which the records will be fetched.
+  optional google.protobuf.Timestamp stop = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListCreditConsumptionChartRecordsResponse contains a list of pipeline trigger

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -6,7 +6,6 @@ package core.mgmt.v1beta;
 import "google/api/field_behavior.proto";
 // Protobuf standard
 import "google/protobuf/timestamp.proto";
-import "protoc-gen-openapiv2/options/annotations.proto";
 
 // Mode describes the execution mode of the pipeline (sync or async).
 enum Mode {

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -158,3 +158,36 @@ message ListPipelineTriggerChartRecordsResponse {
   // A list of pipeline trigger records.
   repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
 }
+
+// CreditConsumptionChartRecord contains credit consumption metrics, aggregated
+// by owner and time frame.
+message CreditConsumptionChartRecord {
+  // Credit owner UUID.
+  string credit_owner_uid = 1;
+  // Time buckets.
+  repeated google.protobuf.Timestamp time_buckets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total credit consumed in each time bucket.
+  repeated float amount = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListCreditConsumptionChartRecordsRequest represents a request to list pipeline
+// trigger metrics, aggregated by pipeline ID and time frame.
+message ListCreditConsumptionChartRecordsRequest {
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "-1.5h" or "2h45m".
+  string aggregation_window = 1;
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression to determine the credit owner and time range for the charts.
+  // - Example: `owner_name='users/jay-wombat' AND start='2024-06-04T10:000:00Z' AND stop='2024-06-11T10:00:00Z`
+  optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListCreditConsumptionChartRecordsResponse contains a list of pipeline trigger
+// chart records.
+message ListCreditConsumptionChartRecordsResponse {
+  // A list of pipeline trigger records.
+  repeated CreditConsumptionChartRecord pipeline_trigger_chart_records = 1;
+  // Sum of the total credit consumed within the time range.
+  float total_amount = 2;
+}

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -339,6 +339,7 @@ service MgmtPublicService {
   // credit consumption.
   rpc ListCreditConsumptionChartRecords(ListCreditConsumptionChartRecordsRequest) returns (ListCreditConsumptionChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/credit/charts"};
+    option (google.api.method_signature) = "owner,aggregation_window,filter";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -332,6 +332,16 @@ service MgmtPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 
+  // List Instill Credit consumption time charts
+  //
+  // Returns a timeline of Instill Credit consumption for a given owner. The
+  // timeline consists of a list of time frames that contain the aggregated
+  // credit consumption.
+  rpc ListCreditConsumptionChartRecords(ListCreditConsumptionChartRecordsRequest) returns (ListCreditConsumptionChartRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/credit/charts"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
+  }
+
   // Auth endpoints are only used in the community edition and the OpenAPI
   // documentation references Instill Cloud. Therefore, these endpoints are
   // hidden.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -2146,7 +2146,7 @@ definitions:
   v1betaListCreditConsumptionChartRecordsResponse:
     type: object
     properties:
-      pipeline_trigger_chart_records:
+      credit_consumption_chart_records:
         type: array
         items:
           type: object

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1111,17 +1111,22 @@ paths:
             Aggregation window. The value is a positive duration string, i.e. a
             sequence of decimal numbers, each with optional fraction and a unit
             suffix, such as "300ms", "1.5h" or "2h45m".
-          in: query
-          required: true
-          type: string
-        - name: filter
-          description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression to determine the time range for the charts.
-            - Example: `start='2024-06-04T10:000:00Z' AND stop='2024-06-11T10:00:00Z`
+            The minimum (and default) window is 1h.
           in: query
           required: false
           type: string
+        - name: start
+          description: Beginning of the time range from which the records will be fetched.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: stop
+          description: End of the time range from which the records will be fetched.
+          in: query
+          required: false
+          type: string
+          format: date-time
       tags:
         - Metric
 definitions:

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1099,19 +1099,26 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
+        - name: owner
+          description: |-
+            The user or organization to which the credit belongs.
+            Format: `{[users|organizations]}/{id}`.
+          in: query
+          required: true
+          type: string
         - name: aggregation_window
           description: |-
             Aggregation window. The value is a positive duration string, i.e. a
             sequence of decimal numbers, each with optional fraction and a unit
-            suffix, such as "300ms", "-1.5h" or "2h45m".
+            suffix, such as "300ms", "1.5h" or "2h45m".
           in: query
-          required: false
+          required: true
           type: string
         - name: filter
           description: |-
             Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression to determine the credit owner and time range for the charts.
-            - Example: `owner_name='users/jay-wombat' AND start='2024-06-04T10:000:00Z' AND stop='2024-06-11T10:00:00Z`
+            expression to determine the time range for the charts.
+            - Example: `start='2024-06-04T10:000:00Z' AND stop='2024-06-11T10:00:00Z`
           in: query
           required: false
           type: string
@@ -1595,9 +1602,9 @@ definitions:
   v1betaCreditConsumptionChartRecord:
     type: object
     properties:
-      credit_owner_uid:
+      credit_owner:
         type: string
-        description: Credit owner UUID.
+        description: Credit owner ID, e.g. `users/chef-wombat`.
       time_buckets:
         type: array
         items:

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1078,6 +1078,45 @@ paths:
           type: string
       tags:
         - Metric
+  /v1beta/metrics/credit/charts:
+    get:
+      summary: List Instill Credit consumption time charts
+      description: |-
+        Returns a timeline of Instill Credit consumption for a given owner. The
+        timeline consists of a list of time frames that contain the aggregated
+        credit consumption.
+      operationId: MgmtPublicService_ListCreditConsumptionChartRecords
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaListCreditConsumptionChartRecordsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: aggregation_window
+          description: |-
+            Aggregation window. The value is a positive duration string, i.e. a
+            sequence of decimal numbers, each with optional fraction and a unit
+            suffix, such as "300ms", "-1.5h" or "2h45m".
+          in: query
+          required: false
+          type: string
+        - name: filter
+          description: |-
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression to determine the credit owner and time range for the charts.
+            - Example: `owner_name='users/jay-wombat' AND start='2024-06-04T10:000:00Z' AND stop='2024-06-11T10:00:00Z`
+          in: query
+          required: false
+          type: string
+      tags:
+        - Metric
 definitions:
   ApiTokenState:
     type: string
@@ -1553,6 +1592,29 @@ definitions:
         $ref: '#/definitions/v1betaApiToken'
         description: The created API token resource.
     description: CreateTokenResponse contains the created token.
+  v1betaCreditConsumptionChartRecord:
+    type: object
+    properties:
+      credit_owner_uid:
+        type: string
+        description: Credit owner UUID.
+      time_buckets:
+        type: array
+        items:
+          type: string
+          format: date-time
+        description: Time buckets.
+        readOnly: true
+      amount:
+        type: array
+        items:
+          type: number
+          format: float
+        description: Total credit consumed in each time bucket.
+        readOnly: true
+    description: |-
+      CreditConsumptionChartRecord contains credit consumption metrics, aggregated
+      by owner and time frame.
   v1betaDeleteOrganizationMembershipResponse:
     type: object
     description: DeleteOrganizationMembershipResponse is an empty response.
@@ -2074,6 +2136,22 @@ definitions:
         $ref: '#/definitions/HealthCheckResponseServingStatus'
         title: Status is the instance of the enum type ServingStatus
     title: HealthCheckResponse represents a response for a service heath status
+  v1betaListCreditConsumptionChartRecordsResponse:
+    type: object
+    properties:
+      pipeline_trigger_chart_records:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaCreditConsumptionChartRecord'
+        description: A list of pipeline trigger records.
+      total_amount:
+        type: number
+        format: float
+        description: Sum of the total credit consumed within the time range.
+    description: |-
+      ListCreditConsumptionChartRecordsResponse contains a list of pipeline trigger
+      chart records.
   v1betaListOrganizationMembershipsResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- Instill Cloud needs to display the credit consumption of an owner as a chart.

This commit

- Adds the contract for the chart information. In pipeline metrics the total
  count is served by a different endpoint. For now, we only want to sum amounts
  by time slot so a single endpoint fits our use case.

![CleanShot 2024-06-11 at 10 09 45](https://github.com/instill-ai/pipeline-backend-cloud/assets/3977183/b210429d-139c-4690-a298-c049bdf946dd)


### Info

Rough example of the returned data (without the total sum):

```
Result: _result
Table: keys: [_time]
                    _time:time                  amount:float
------------------------------  ----------------------------
2024-06-10T18:15:00.000000000Z                         20.85
Table: keys: [_time]
                    _time:time                  amount:float
------------------------------  ----------------------------
2024-06-10T18:20:00.000000000Z                         20.45
Table: keys: [_time]
                    _time:time                  amount:float
------------------------------  ----------------------------
2024-06-10T18:25:00.000000000Z                          58.5
Table: keys: [_time]
                    _time:time                  amount:float
------------------------------  ----------------------------
2024-06-10T18:30:00.000000000Z                          45.6
Table: keys: [_time]
                    _time:time                  amount:float
------------------------------  ----------------------------
2024-06-10T18:40:00.000000000Z                         15.75
```