### PR TITLE
chore(kb): change parameter name

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -305,9 +305,9 @@ message File {
 // upload file request
 message UploadKnowledgeBaseFileRequest {
   // owenr uid
-  string owner_uid = 1 [(google.api.field_behavior) = REQUIRED];
+  string owner_id = 1 [(google.api.field_behavior) = REQUIRED];
   // knowledge base uid
-  string kb_uid = 2 [(google.api.field_behavior) = REQUIRED];
+  string kb_id = 2 [(google.api.field_behavior) = REQUIRED];
   // file
   File file = 3;
 }
@@ -352,9 +352,9 @@ message ListKnowledgeBaseFilesFilter {
 // list files request
 message ListKnowledgeBaseFilesRequest {
   // The owner uid.
-  string owner_uid = 1;
+  string owner_id = 1;
   // The knowledge base uid.
-  string kb_uid = 2;
+  string kb_id = 2;
   // The page size (default:10; max 100).
   int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
   // The next page token(default from first file's token).

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -73,10 +73,10 @@ service ArtifactPublicService {
   // Create a file
   rpc UploadKnowledgeBaseFile(UploadKnowledgeBaseFileRequest) returns (UploadKnowledgeBaseFileResponse) {
     option (google.api.http) = {
-    post: "/v1alpha/owners/{owner_uid}/knowledge-bases/{kb_uid}/files"
+    post: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/files"
     body: "file"
     };
-    option (google.api.method_signature) = "owner_uid,kb_uid,file";
+    option (google.api.method_signature) = "owner_id,kb_id,file";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags:"KnowledgeBase"};
   }
 
@@ -100,7 +100,7 @@ service ArtifactPublicService {
   // list files
   rpc ListKnowledgeBaseFiles(ListKnowledgeBaseFilesRequest) returns (ListKnowledgeBaseFilesResponse) {
     option (google.api.http) = {
-      get: "/v1alpha/owners/{owner_uid}/knowledge-bases/{kb_uid}/files"
+      get: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/files"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -96,7 +96,7 @@ paths:
             $ref: '#/definitions/ArtifactPublicServiceUpdateKnowledgeBaseBody'
       tags:
         - KnowledgeBase
-  /v1alpha/owners/{owner_uid}/knowledge-bases/{kb_uid}/files:
+  /v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/files:
     get:
       summary: list files
       operationId: ArtifactPublicService_ListKnowledgeBaseFiles
@@ -110,12 +110,12 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: owner_uid
+        - name: owner_id
           description: The owner uid.
           in: path
           required: true
           type: string
-        - name: kb_uid
+        - name: kb_id
           description: The knowledge base uid.
           in: path
           required: true
@@ -154,12 +154,12 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: owner_uid
+        - name: owner_id
           description: owenr uid
           in: path
           required: true
           type: string
-        - name: kb_uid
+        - name: kb_id
           description: knowledge base uid
           in: path
           required: true


### PR DESCRIPTION
Because

other backend apps use `id` instead of `uid` to communicate with FE.

This commit

follow the convention

