### PR TITLE
feat(all): use camelCase in HTTP bodies

### DIFF
--- a/buf.gen.openapi.yaml
+++ b/buf.gen.openapi.yaml
@@ -11,7 +11,6 @@ plugins:
     out: .
     opt:
       - output_format=yaml
-      - json_names_for_fields=false
       - allow_merge=true,merge_file_name=service
       - version=true
       - omit_enum_default_value=true

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -96,7 +96,7 @@ paths:
             $ref: '#/definitions/ArtifactPublicServiceUpdateKnowledgeBaseBody'
       tags:
         - KnowledgeBase
-  /v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/files:
+  /v1alpha/owners/{ownerId}/knowledge-bases/{kbId}/files:
     get:
       summary: list files
       operationId: ArtifactPublicService_ListKnowledgeBaseFiles
@@ -110,28 +110,28 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: owner_id
+        - name: ownerId
           description: The owner uid.
           in: path
           required: true
           type: string
-        - name: kb_id
+        - name: kbId
           description: The knowledge base uid.
           in: path
           required: true
           type: string
-        - name: page_size
+        - name: pageSize
           description: The page size (default:10; max 100).
           in: query
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: The next page token(default from first file's token).
           in: query
           required: false
           type: string
-        - name: filter.file_uids
+        - name: filter.fileUids
           description: The file uids.
           in: query
           required: false
@@ -154,12 +154,12 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: owner_id
+        - name: ownerId
           description: owenr uid
           in: path
           required: true
           type: string
-        - name: kb_id
+        - name: kbId
           description: knowledge base uid
           in: path
           required: true
@@ -186,7 +186,7 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: file_uid
+        - name: fileUid
           description: The file uid.
           in: query
           required: true
@@ -229,7 +229,7 @@ definitions:
         items:
           type: string
         description: The knowledge base tags.
-      owner_name:
+      ownerName:
         type: string
         description: The knowledge base owner.
     description: UpdateKnowledgeBaseRequest represents a request to update a knowledge base.
@@ -273,10 +273,10 @@ definitions:
       body:
         $ref: '#/definitions/v1alphaKnowledgeBase'
         description: The created knowledge base.
-      error_msg:
+      errorMsg:
         type: string
         description: The error message.
-      status_code:
+      statusCode:
         type: integer
         format: int32
         description: The status code.
@@ -291,17 +291,17 @@ definitions:
   v1alphaDeleteKnowledgeBaseFileResponse:
     type: object
     properties:
-      file_uid:
+      fileUid:
         type: string
         description: The file uid.
     title: delete file response
   v1alphaDeleteKnowledgeBaseResponse:
     type: object
     properties:
-      error_msg:
+      errorMsg:
         type: string
         description: The error message.
-      status_code:
+      statusCode:
         type: integer
         format: int32
         description: The status code.
@@ -309,7 +309,7 @@ definitions:
   v1alphaFile:
     type: object
     properties:
-      file_uid:
+      fileUid:
         type: string
         title: file uid
         readOnly: true
@@ -319,11 +319,11 @@ definitions:
       type:
         $ref: '#/definitions/v1alphaFileType'
         title: file type
-      process_status:
+      processStatus:
         $ref: '#/definitions/v1alphaFileProcessStatus'
         title: file process status
         readOnly: true
-      process_outcome:
+      processOutcome:
         type: string
         title: file process message
         readOnly: true
@@ -334,29 +334,29 @@ definitions:
       content:
         type: string
         title: contect(this is reserved for future use)
-      owner_uid:
+      ownerUid:
         type: string
         title: owner uid
         readOnly: true
-      creator_uid:
+      creatorUid:
         type: string
         title: cretor uid from authn token
         readOnly: true
-      kb_uid:
+      kbUid:
         type: string
         title: knowledge base uid
         readOnly: true
-      create_time:
+      createTime:
         type: string
         format: date-time
         title: create time
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         title: update time
         readOnly: true
-      delete_time:
+      deleteTime:
         type: string
         format: date-time
         title: delete time
@@ -411,13 +411,13 @@ definitions:
       description:
         type: string
         description: The knowledge base description.
-      create_time:
+      createTime:
         type: string
         description: The creation time of the knowledge base.
-      update_time:
+      updateTime:
         type: string
         description: The last update time of the knowledge base.
-      owner_name:
+      ownerName:
         type: string
         description: The owner of the knowledge base.
       tags:
@@ -429,7 +429,7 @@ definitions:
   v1alphaKnowledgeBasesList:
     type: object
     properties:
-      knowledge_bases:
+      knowledgeBases:
         type: array
         items:
           type: object
@@ -439,7 +439,7 @@ definitions:
   v1alphaListKnowledgeBaseFilesFilter:
     type: object
     properties:
-      file_uids:
+      fileUids:
         type: array
         items:
           type: string
@@ -456,15 +456,15 @@ definitions:
           type: object
           $ref: '#/definitions/v1alphaFile'
         description: The list of files.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: The total number of files.
-      page_size:
+      pageSize:
         type: integer
         format: int32
         description: The requested page size.
-      next_page_token:
+      nextPageToken:
         type: string
         title: next page token
       filter:
@@ -477,10 +477,10 @@ definitions:
       body:
         $ref: '#/definitions/v1alphaKnowledgeBasesList'
         description: The knowledge bases container.
-      error_msg:
+      errorMsg:
         type: string
         description: The error message.
-      status_code:
+      statusCode:
         type: integer
         format: int32
         description: The status code.
@@ -494,11 +494,11 @@ definitions:
           type: object
           $ref: '#/definitions/v1alphaRepositoryTag'
         description: A list of repository tags.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of tags.
-      page_size:
+      pageSize:
         type: integer
         format: int32
         description: The requested page size.
@@ -510,14 +510,14 @@ definitions:
   v1alphaProcessKnowledgeBaseFilesRequest:
     type: object
     properties:
-      file_uids:
+      fileUids:
         type: array
         items:
           type: string
         description: The file uid.
     title: Process KnowledgeBase File Request
     required:
-      - file_uids
+      - fileUids
   v1alphaProcessKnowledgeBaseFilesResponse:
     type: object
     properties:
@@ -542,7 +542,7 @@ definitions:
       digest:
         type: string
         description: Unique identifier, computed from the manifest the tag refers to.
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Tag update time, i.e. timestamp of the last push.
@@ -556,10 +556,10 @@ definitions:
       body:
         $ref: '#/definitions/v1alphaKnowledgeBase'
         description: The updated knowledge base.
-      error_msg:
+      errorMsg:
         type: string
         description: The error message.
-      status_code:
+      statusCode:
         type: integer
         format: int32
         description: The status code.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -94,7 +94,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of users to return. If this parameter is unspecified,
             at most 10 pipelines will be returned. The cap value for this parameter is
@@ -103,7 +103,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -188,7 +188,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of organizations to return. If this parameter is
             unspecified, at most 10 pipelines will be returned. The cap value for this
@@ -197,7 +197,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -365,12 +365,12 @@ paths:
                   maximum.
 
                   Note that the ID can be updated.
-              create_time:
+              createTime:
                 type: string
                 format: date-time
                 description: Creation time.
                 readOnly: true
-              update_time:
+              updateTime:
                 type: string
                 format: date-time
                 description: Update time.
@@ -541,7 +541,7 @@ paths:
             title: The membership fields to update.
             required:
               - state
-        - name: update_mask
+        - name: updateMask
           description: |-
             The update mask specifies the subset of fields that should be modified.
 
@@ -701,7 +701,7 @@ paths:
             title: The membership fields to update.
             required:
               - role
-        - name: update_mask
+        - name: updateMask
           description: |-
             The update mask specifies the subset of fields that should be modified.
 
@@ -778,7 +778,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of tokens to return. If this parameter is unspecified,
             at most 10 pipelines will be returned. The cap value for this parameter is
@@ -787,7 +787,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -976,7 +976,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of triggers to return. If this parameter is unspecified,
             at most 100 pipelines will be returned. The cap value for this parameter is
@@ -985,7 +985,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -1018,7 +1018,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of results to return. If this parameter is unspecified,
             at most 100 pipelines will be returned. The cap value for this parameter
@@ -1027,7 +1027,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -1062,7 +1062,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: aggregation_window
+        - name: aggregationWindow
           description: Aggregation window in nanoseconds.
           in: query
           required: false
@@ -1132,132 +1132,132 @@ definitions:
   UserUsageDataConnectorExecuteData:
     type: object
     properties:
-      connector_uid:
+      connectorUid:
         type: string
         title: UID for the executed connector
-      execute_uid:
+      executeUid:
         type: string
         title: UID for the execute log
-      execute_time:
+      executeTime:
         type: string
         format: date-time
         title: Timestamp for the execution
-      connector_definition_uid:
+      connectorDefinitionUid:
         type: string
         title: Definition UID of the connector
       status:
         $ref: '#/definitions/mgmtv1betaStatus'
         title: Final status of the execution
-      user_uid:
+      userUid:
         type: string
         title: UUID of the user who execute the connector
-      user_type:
+      userType:
         $ref: '#/definitions/v1betaOwnerType'
         title: Type of the user who execute the connector
     title: Per execute usage metadata
     required:
-      - connector_uid
-      - execute_uid
-      - execute_time
-      - connector_definition_uid
+      - connectorUid
+      - executeUid
+      - executeTime
+      - connectorDefinitionUid
       - status
-      - user_uid
-      - user_type
+      - userUid
+      - userType
   UserUsageDataModelTriggerData:
     type: object
     properties:
-      model_uid:
+      modelUid:
         type: string
         title: UID for the trigged model
-      trigger_uid:
+      triggerUid:
         type: string
         title: UID for the trigger log
-      trigger_time:
+      triggerTime:
         type: string
         format: date-time
         title: Timestamp for the trigger
-      model_definition_uid:
+      modelDefinitionUid:
         type: string
         title: Definition UID of the model
-      model_task:
+      modelTask:
         $ref: '#/definitions/v1alphaTask'
         title: Task of the model
       status:
         $ref: '#/definitions/mgmtv1betaStatus'
         title: Final status of the execution
-      user_uid:
+      userUid:
         type: string
         title: UUID of the user who trigger the model
-      user_type:
+      userType:
         $ref: '#/definitions/v1betaOwnerType'
         title: Type of the user who trigger the model
     title: Per trigger usage metadata
     required:
-      - model_uid
-      - trigger_uid
-      - trigger_time
-      - model_definition_uid
-      - model_task
+      - modelUid
+      - triggerUid
+      - triggerTime
+      - modelDefinitionUid
+      - modelTask
       - status
-      - user_uid
-      - user_type
+      - userUid
+      - userType
   UserUsageDataPipelineTriggerData:
     type: object
     properties:
-      pipeline_uid:
+      pipelineUid:
         type: string
         title: UID for the triggered pipeline
-      trigger_uid:
+      triggerUid:
         type: string
         title: UID for the trigger log
-      trigger_time:
+      triggerTime:
         type: string
         format: date-time
         title: Timestamp for the trigger
-      trigger_mode:
+      triggerMode:
         $ref: '#/definitions/v1betaMode'
         title: Trigger mode
       status:
         $ref: '#/definitions/mgmtv1betaStatus'
         title: Final status of the execution
-      pipeline_release_id:
+      pipelineReleaseId:
         type: string
         title: Version for the triggered release pipeline, empty string if not release
-      pipeline_release_uid:
+      pipelineReleaseUid:
         type: string
         title: UID for the triggered release pipeline, empty string if not release
-      user_uid:
+      userUid:
         type: string
         title: UUID of the user who trigger the pipeline
-      user_type:
+      userType:
         $ref: '#/definitions/v1betaOwnerType'
         title: Type of the user who trigger the pipeline
-      pipeline_id:
+      pipelineId:
         type: string
         title: ID for the triggered pipeline
     title: Per trigger usage metadata
     required:
-      - pipeline_uid
-      - trigger_uid
-      - trigger_time
-      - trigger_mode
+      - pipelineUid
+      - triggerUid
+      - triggerTime
+      - triggerMode
       - status
-      - pipeline_release_id
-      - pipeline_release_uid
-      - user_uid
-      - user_type
-      - pipeline_id
+      - pipelineReleaseId
+      - pipelineReleaseUid
+      - userUid
+      - userType
+      - pipelineId
   coreusagev1betaLivenessResponse:
     type: object
     properties:
-      health_check_response:
+      healthCheckResponse:
         $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: LivenessResponse represents a response for a service liveness status
   coreusagev1betaReadinessResponse:
     type: object
     properties:
-      health_check_response:
+      healthCheckResponse:
         $ref: '#/definitions/v1betaHealthCheckResponse'
         title: HealthCheckResponse message
     title: ReadinessResponse represents a response for a service readiness status
@@ -1325,7 +1325,7 @@ definitions:
   v1betaApiToken:
     type: object
     properties:
-      last_use_time:
+      lastUseTime:
         type: string
         format: date-time
         description: |-
@@ -1351,17 +1351,17 @@ definitions:
           character maximum.
 
           This field can reflect the client(s) that will use the token.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
         readOnly: true
-      access_token:
+      accessToken:
         type: string
         description: |-
           An opaque access token representing the API token string.
@@ -1373,7 +1373,7 @@ definitions:
         $ref: '#/definitions/ApiTokenState'
         description: State.
         readOnly: true
-      token_type:
+      tokenType:
         type: string
         description: Token type. Value is fixed to "Bearer".
         readOnly: true
@@ -1381,7 +1381,7 @@ definitions:
         type: integer
         format: int32
         description: The time-to-live in seconds for this resource.
-      expire_time:
+      expireTime:
         type: string
         format: date-time
         description: Expiration time.
@@ -1399,16 +1399,16 @@ definitions:
   v1betaArtifactUsageDataUserUsageData:
     type: object
     properties:
-      owner_uid:
+      ownerUid:
         type: string
         title: Owner UUID
-      owner_type:
+      ownerType:
         $ref: '#/definitions/v1betaOwnerType'
         title: Owner type
     title: Per user usage data in the artifact service
     required:
-      - owner_uid
-      - owner_type
+      - ownerUid
+      - ownerType
   v1betaAuthenticatedUser:
     type: object
     properties:
@@ -1432,12 +1432,12 @@ definitions:
           maximum.
 
           Note that the ID can be updated.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
@@ -1445,7 +1445,7 @@ definitions:
       email:
         type: string
         description: Email.
-      customer_id:
+      customerId:
         type: string
         description: Stripe customer ID. This field is used in Instill Cloud.
         readOnly: true
@@ -1462,13 +1462,13 @@ definitions:
           - `data-scientist`
           - `analytics-engineer`
           - `hobbyist`
-      newsletter_subscription:
+      newsletterSubscription:
         type: boolean
         description: This defines whether the user is subscribed to Instill AI's newsletter.
-      cookie_token:
+      cookieToken:
         type: string
         description: Console cookie token.
-      onboarding_status:
+      onboardingStatus:
         $ref: '#/definitions/v1betaOnboardingStatus'
         description: Onboarding Status.
       profile:
@@ -1481,7 +1481,7 @@ definitions:
     required:
       - id
       - email
-      - newsletter_subscription
+      - newsletterSubscription
   v1betaCheckNamespaceRequest:
     type: object
     properties:
@@ -1515,23 +1515,23 @@ definitions:
   v1betaConnectorUsageDataUserUsageData:
     type: object
     properties:
-      owner_uid:
+      ownerUid:
         type: string
         title: Owner UUID
-      connector_execute_data:
+      connectorExecuteData:
         type: array
         items:
           type: object
           $ref: '#/definitions/UserUsageDataConnectorExecuteData'
         title: Execution data for each user
-      owner_type:
+      ownerType:
         $ref: '#/definitions/v1betaOwnerType'
         title: Owner type
     title: Per user usage data in the connector service
     required:
-      - owner_uid
-      - connector_execute_data
-      - owner_type
+      - ownerUid
+      - connectorExecuteData
+      - ownerType
   v1betaCreateOrganizationResponse:
     type: object
     properties:
@@ -1582,7 +1582,7 @@ definitions:
   v1betaGetBulkCumulativeModelOnlineRecordsResponse:
     type: object
     properties:
-      bulk_cumulative_records:
+      bulkCumulativeRecords:
         type: array
         items:
           type: object
@@ -1592,11 +1592,11 @@ definitions:
       GetBulkCumulativeModelOnlineRecordsResponse represents a response to
       GetBulkCumulativeModelOnlineRecordsRequest
     required:
-      - bulk_cumulative_records
+      - bulkCumulativeRecords
   v1betaGetBulkCumulativePipelineTriggerRecordsResponse:
     type: object
     properties:
-      bulk_cumulative_records:
+      bulkCumulativeRecords:
         type: array
         items:
           type: object
@@ -1606,11 +1606,11 @@ definitions:
       GetBulkCumulativePipelineTriggerRecordsResponse represents a response to
       GetBulkCumulativePipelineTriggerRecordsRequest
     required:
-      - bulk_cumulative_records
+      - bulkCumulativeRecords
   v1betaGetBulkModelOnlinePriceResponse:
     type: object
     properties:
-      bulk_prices:
+      bulkPrices:
         type: array
         items:
           type: object
@@ -1620,11 +1620,11 @@ definitions:
       GetBulkModelOnlinePriceResponse represents a response to
       GetBulkModelOnlinePriceRequest
     required:
-      - bulk_prices
+      - bulkPrices
   v1betaGetBulkModelOnlineRecordsResponse:
     type: object
     properties:
-      bulk_records:
+      bulkRecords:
         type: array
         items:
           type: object
@@ -1634,11 +1634,11 @@ definitions:
       GetBulkModelOnlineRecordsResponse represents a response to
       GetBulkModelOnlineRecordsRequest
     required:
-      - bulk_records
+      - bulkRecords
   v1betaGetBulkModelOnlineSummaryResponse:
     type: object
     properties:
-      bulk_summaries:
+      bulkSummaries:
         type: array
         items:
           type: object
@@ -1648,11 +1648,11 @@ definitions:
       GetBulkModelOnlineSummaryResponse represents a response to
       GetBulkModelOnlineSummaryRequest
     required:
-      - bulk_summaries
+      - bulkSummaries
   v1betaGetBulkPipelineTriggerPriceResponse:
     type: object
     properties:
-      bulk_prices:
+      bulkPrices:
         type: array
         items:
           type: object
@@ -1662,11 +1662,11 @@ definitions:
       GetBulkPipelineTriggerPriceResponse represents a response to
       GetBulkPipelineTriggerPriceRequest
     required:
-      - bulk_prices
+      - bulkPrices
   v1betaGetBulkPipelineTriggerRecordsResponse:
     type: object
     properties:
-      bulk_records:
+      bulkRecords:
         type: array
         items:
           type: object
@@ -1676,11 +1676,11 @@ definitions:
       GetBulkPipelineTriggerRecordsResponse represents a response to
       GetBulkPipelineTriggerRecordsRequest
     required:
-      - bulk_records
+      - bulkRecords
   v1betaGetBulkPipelineTriggerSummariesResponse:
     type: object
     properties:
-      bulk_summaries:
+      bulkSummaries:
         type: array
         items:
           type: object
@@ -1690,7 +1690,7 @@ definitions:
       GetBulkPipelineTriggerSummariesResponse represents a response to
       GetBulkPipelineTriggerSummariesRequest
     required:
-      - bulk_summaries
+      - bulkSummaries
   v1betaGetCumulativeModelOnlineRecordsRequest:
     type: object
     properties:
@@ -1700,7 +1700,7 @@ definitions:
       model:
         $ref: '#/definitions/v1betaModelData'
         title: Model information
-      time_interval:
+      timeInterval:
         $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
@@ -1709,11 +1709,11 @@ definitions:
     required:
       - user
       - model
-      - time_interval
+      - timeInterval
   v1betaGetCumulativeModelOnlineRecordsResponse:
     type: object
     properties:
-      cumulative_records:
+      cumulativeRecords:
         type: array
         items:
           type: object
@@ -1723,7 +1723,7 @@ definitions:
       GetCumulativeModelOnlineRecordsResponse represents a response to
       GetCumulativeModelOnlineRecordsRequest
     required:
-      - cumulative_records
+      - cumulativeRecords
   v1betaGetCumulativePipelineTriggerRecordsRequest:
     type: object
     properties:
@@ -1733,7 +1733,7 @@ definitions:
       pipeline:
         $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
-      time_interval:
+      timeInterval:
         $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
@@ -1745,7 +1745,7 @@ definitions:
   v1betaGetCumulativePipelineTriggerRecordsResponse:
     type: object
     properties:
-      cumulative_records:
+      cumulativeRecords:
         type: array
         items:
           type: object
@@ -1755,7 +1755,7 @@ definitions:
       GetCumulativePipelineTriggerRecordsResponse represents a response to
       GetCumulativePipelineTriggerRecordsRequest
     required:
-      - cumulative_records
+      - cumulativeRecords
   v1betaGetModelOnlinePriceRequest:
     type: object
     properties:
@@ -1765,7 +1765,7 @@ definitions:
       model:
         $ref: '#/definitions/v1betaModelData'
         title: Pipeline information
-      time_interval:
+      timeInterval:
         $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
@@ -1774,7 +1774,7 @@ definitions:
     required:
       - user
       - model
-      - time_interval
+      - timeInterval
   v1betaGetModelOnlinePriceResponse:
     type: object
     properties:
@@ -1800,14 +1800,14 @@ definitions:
       model:
         $ref: '#/definitions/v1betaModelData'
         title: Model information
-      time_interval:
+      timeInterval:
         $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: GetModelOnlineRecordsRequest represent a query for model online records
     required:
       - user
       - model
-      - time_interval
+      - timeInterval
   v1betaGetModelOnlineRecordsResponse:
     type: object
     properties:
@@ -1831,14 +1831,14 @@ definitions:
       model:
         $ref: '#/definitions/v1betaModelData'
         title: Pipeline information
-      time_interval:
+      timeInterval:
         $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: GetModelOnlineSummaryRequest represents a query for model online summary
     required:
       - user
       - model
-      - time_interval
+      - timeInterval
   v1betaGetModelOnlineSummaryResponse:
     type: object
     properties:
@@ -1906,7 +1906,7 @@ definitions:
       pipeline:
         $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
-      time_interval:
+      timeInterval:
         $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
@@ -1915,7 +1915,7 @@ definitions:
     required:
       - user
       - pipeline
-      - time_interval
+      - timeInterval
   v1betaGetPipelineTriggerPriceResponse:
     type: object
     properties:
@@ -1941,7 +1941,7 @@ definitions:
       pipeline:
         $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
-      time_interval:
+      timeInterval:
         $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
@@ -1973,7 +1973,7 @@ definitions:
       pipeline:
         $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
-      time_interval:
+      timeInterval:
         $ref: '#/definitions/v1betaTimeInterval'
         title: Time interval
     title: |-
@@ -2095,10 +2095,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaOrganization'
         title: A list of organizations
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of organizations.
@@ -2112,10 +2112,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaOrganization'
         title: A list of organizations
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of organizations.
@@ -2123,7 +2123,7 @@ definitions:
   v1betaListPipelineTriggerChartRecordsResponse:
     type: object
     properties:
-      pipeline_trigger_chart_records:
+      pipelineTriggerChartRecords:
         type: array
         items:
           type: object
@@ -2135,16 +2135,16 @@ definitions:
   v1betaListPipelineTriggerRecordsResponse:
     type: object
     properties:
-      pipeline_trigger_records:
+      pipelineTriggerRecords:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaPipelineTriggerRecord'
         description: A list of pipeline triggers.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of pipeline triggers.
@@ -2152,16 +2152,16 @@ definitions:
   v1betaListPipelineTriggerTableRecordsResponse:
     type: object
     properties:
-      pipeline_trigger_table_records:
+      pipelineTriggerTableRecords:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaPipelineTriggerTableRecord'
         description: A list of pipeline trigger tables.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         title: Total number of pipeline trigger records
@@ -2175,10 +2175,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaApiToken'
         description: A list of API token resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of API token resources.
@@ -2202,10 +2202,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaUser'
         title: A list of users
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of users.
@@ -2219,10 +2219,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaUser'
         description: A list of user resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of users.
@@ -2255,13 +2255,13 @@ definitions:
   v1betaMgmtUsageData:
     type: object
     properties:
-      user_usages:
+      userUsages:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaAuthenticatedUser'
         title: Repeated user usage data
-      org_usages:
+      orgUsages:
         type: array
         items:
           type: object
@@ -2287,7 +2287,7 @@ definitions:
       id:
         type: string
         title: Model id that is given by the users
-      instance_id:
+      instanceId:
         type: string
         title: The id of the model instance that is deployed
       task:
@@ -2297,7 +2297,7 @@ definitions:
     required:
       - uid
       - id
-      - instance_id
+      - instanceId
       - task
   v1betaModelUsageData:
     type: object
@@ -2312,31 +2312,31 @@ definitions:
   v1betaModelUsageDataUserUsageData:
     type: object
     properties:
-      owner_uid:
+      ownerUid:
         type: string
         title: Owner UUID
-      model_trigger_data:
+      modelTriggerData:
         type: array
         items:
           type: object
           $ref: '#/definitions/UserUsageDataModelTriggerData'
         title: Trigger data for each user
-      owner_type:
+      ownerType:
         $ref: '#/definitions/v1betaOwnerType'
         title: Owner type
     title: Per user usage data in the model service
     required:
-      - owner_uid
-      - model_trigger_data
-      - owner_type
+      - ownerUid
+      - modelTriggerData
+      - ownerType
   v1betaModelUsageRecord:
     type: object
     properties:
-      deploy_time:
+      deployTime:
         type: string
         format: date-time
         title: Time when the model is ONLINE
-      record_time:
+      recordTime:
         type: string
         format: date-time
         title: Time when model online usage is recorded
@@ -2349,8 +2349,8 @@ definitions:
           billing period
     title: Model online usage record definition
     required:
-      - deploy_time
-      - record_time
+      - deployTime
+      - recordTime
       - value
   v1betaNullMessage:
     type: object
@@ -2388,12 +2388,12 @@ definitions:
           maximum.
 
           Note that the ID can be updated.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
@@ -2447,7 +2447,7 @@ definitions:
   v1betaOrganizationProfile:
     type: object
     properties:
-      display_name:
+      displayName:
         type: string
         description: Display name.
       bio:
@@ -2456,10 +2456,10 @@ definitions:
       avatar:
         type: string
         description: Avatar in base64 format.
-      public_email:
+      publicEmail:
         type: string
         description: Public email.
-      social_profile_links:
+      socialProfileLinks:
         type: object
         additionalProperties:
           type: string
@@ -2476,11 +2476,11 @@ definitions:
       detail:
         $ref: '#/definitions/v1betaStripeSubscriptionDetail'
         description: Details of the associated Stripe subscription.
-      max_seats:
+      maxSeats:
         type: integer
         format: int32
         description: Maximum number of seats allowed.
-      used_seats:
+      usedSeats:
         type: integer
         format: int32
         description: Number of used seats within the organization subscription.
@@ -2520,7 +2520,7 @@ definitions:
   v1betaPermission:
     type: object
     properties:
-      can_edit:
+      canEdit:
         type: boolean
         description: Defines whether the resource can be modified.
     description: Permission defines how a resource can be used.
@@ -2544,45 +2544,45 @@ definitions:
   v1betaPipelineTriggerChartRecord:
     type: object
     properties:
-      pipeline_id:
+      pipelineId:
         type: string
         description: Pipeline ID.
-      pipeline_uid:
+      pipelineUid:
         type: string
         description: Pipeline UUID.
-      trigger_mode:
+      triggerMode:
         $ref: '#/definitions/v1betaMode'
         description: Trigger mode.
       status:
         $ref: '#/definitions/mgmtv1betaStatus'
         description: Final status.
         readOnly: true
-      time_buckets:
+      timeBuckets:
         type: array
         items:
           type: string
           format: date-time
         description: Time buckets.
         readOnly: true
-      trigger_counts:
+      triggerCounts:
         type: array
         items:
           type: integer
           format: int32
         description: Aggregated trigger count in each time bucket.
         readOnly: true
-      compute_time_duration:
+      computeTimeDuration:
         type: array
         items:
           type: number
           format: float
         description: Total computation time duration in each time bucket.
         readOnly: true
-      pipeline_release_id:
+      pipelineReleaseId:
         type: string
         description: Version for the triggered pipeline if it is a release pipeline.
         readOnly: true
-      pipeline_release_uid:
+      pipelineReleaseUid:
         type: string
         description: Release UUID for the triggered pipeline if it is a release pipeline.
         readOnly: true
@@ -2592,23 +2592,23 @@ definitions:
   v1betaPipelineTriggerRecord:
     type: object
     properties:
-      trigger_time:
+      triggerTime:
         type: string
         format: date-time
         description: The moment when the pipeline was triggered.
-      pipeline_trigger_id:
+      pipelineTriggerId:
         type: string
         description: UUID of the trigger.
-      pipeline_id:
+      pipelineId:
         type: string
         description: Pipeline ID.
-      pipeline_uid:
+      pipelineUid:
         type: string
         description: Pipeline UUID.
-      trigger_mode:
+      triggerMode:
         $ref: '#/definitions/v1betaMode'
         description: Trigger mode.
-      compute_time_duration:
+      computeTimeDuration:
         type: number
         format: float
         description: Total execution duration.
@@ -2617,11 +2617,11 @@ definitions:
         $ref: '#/definitions/mgmtv1betaStatus'
         description: Final status.
         readOnly: true
-      pipeline_release_id:
+      pipelineReleaseId:
         type: string
         description: If a release of the pipeline was triggered, pipeline version.
         readOnly: true
-      pipeline_release_uid:
+      pipelineReleaseUid:
         type: string
         description: If a release of the pipeline was triggered, release UUID.
         readOnly: true
@@ -2629,27 +2629,27 @@ definitions:
   v1betaPipelineTriggerTableRecord:
     type: object
     properties:
-      pipeline_id:
+      pipelineId:
         type: string
         description: Pipeline ID.
-      pipeline_uid:
+      pipelineUid:
         type: string
         description: Pipeline UUID.
-      trigger_count_completed:
+      triggerCountCompleted:
         type: integer
         format: int32
         description: Number of triggers with `STATUS_COMPLETED`.
         readOnly: true
-      trigger_count_errored:
+      triggerCountErrored:
         type: integer
         format: int32
         description: Number of triggers with `STATUS_ERRORED`.
         readOnly: true
-      pipeline_release_id:
+      pipelineReleaseId:
         type: string
         description: Version for the triggered pipeline if it is a release pipeline.
         readOnly: true
-      pipeline_release_uid:
+      pipelineReleaseUid:
         type: string
         description: Release UUID for the triggered pipeline if it is a release pipeline.
         readOnly: true
@@ -2669,40 +2669,40 @@ definitions:
   v1betaPipelineUsageDataUserUsageData:
     type: object
     properties:
-      owner_uid:
+      ownerUid:
         type: string
         title: Owner UUID
-      pipeline_trigger_data:
+      pipelineTriggerData:
         type: array
         items:
           type: object
           $ref: '#/definitions/UserUsageDataPipelineTriggerData'
         title: Trigger data for each user
-      owner_type:
+      ownerType:
         $ref: '#/definitions/v1betaOwnerType'
         title: Owner type
     title: Per user usage data in the pipeline service
     required:
-      - owner_uid
-      - pipeline_trigger_data
-      - owner_type
+      - ownerUid
+      - pipelineTriggerData
+      - ownerType
   v1betaPipelineUsageRecord:
     type: object
     properties:
-      request_id:
+      requestId:
         type: string
         description: A unique request id given by vdp when trigger the pipeline.
-      operation_id:
+      operationId:
         type: string
         title: A unique operation id given by vdp
       status:
         type: string
         title: The HTTP status received when user trigger the pipeline
-      trigger_time:
+      triggerTime:
         type: string
         format: date-time
         title: Time when the pipeline is triggered
-      record_time:
+      recordTime:
         type: string
         format: date-time
         title: Time when the pipeline trigger usage is recorded
@@ -2714,11 +2714,11 @@ definitions:
           consistent with Stripe
     title: Pipeline trigger usage record definition
     required:
-      - request_id
-      - operation_id
+      - requestId
+      - operationId
       - status
-      - trigger_time
-      - record_time
+      - triggerTime
+      - recordTime
       - value
   v1betaPriceData:
     type: object
@@ -2747,7 +2747,7 @@ definitions:
       model:
         $ref: '#/definitions/v1betaModelData'
         title: Model information
-      cum_usage_record:
+      cumUsageRecord:
         $ref: '#/definitions/v1betaModelUsageRecord'
         title: Model online record
     title: |-
@@ -2756,7 +2756,7 @@ definitions:
     required:
       - user
       - model
-      - cum_usage_record
+      - cumUsageRecord
   v1betaReportModelOnlineResponse:
     type: object
     properties:
@@ -2784,7 +2784,7 @@ definitions:
       pipeline:
         $ref: '#/definitions/v1betaPipelineData'
         title: Pipeline information
-      usage_record:
+      usageRecord:
         $ref: '#/definitions/v1betaPipelineUsageRecord'
         title: Pipeline trigger record
     title: |-
@@ -2793,7 +2793,7 @@ definitions:
     required:
       - user
       - pipeline
-      - usage_record
+      - usageRecord
   v1betaReportPipelineTriggerResponse:
     type: object
     properties:
@@ -2845,7 +2845,7 @@ definitions:
         type: string
         format: int64
         title: Session service uptime
-      report_time:
+      reportTime:
         type: string
         format: date-time
         title: Report time
@@ -2855,17 +2855,17 @@ definitions:
           Token to send report. The token is generated by the server and sent to
           the client. Client needs to use the token to send report to the server.
         readOnly: true
-      create_time:
+      createTime:
         type: string
         format: date-time
         title: Session creation time
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         title: Session update time
         readOnly: true
-      owner_uid:
+      ownerUid:
         type: string
         title: Owner UUID of the instance, can also be considered as instance UUID
     title: |-
@@ -2879,12 +2879,12 @@ definitions:
       - arch
       - os
       - uptime
-      - report_time
-      - owner_uid
+      - reportTime
+      - ownerUid
   v1betaSessionReport:
     type: object
     properties:
-      session_uid:
+      sessionUid:
         type: string
         title: Session uid
       token:
@@ -2896,50 +2896,50 @@ definitions:
       session:
         $ref: '#/definitions/v1betaSession'
         title: Session
-      mgmt_usage_data:
+      mgmtUsageData:
         $ref: '#/definitions/v1betaMgmtUsageData'
         title: Management service usage data
-      connector_usage_data:
+      connectorUsageData:
         $ref: '#/definitions/v1betaConnectorUsageData'
         title: Connector service usage data
-      model_usage_data:
+      modelUsageData:
         $ref: '#/definitions/v1betaModelUsageData'
         title: Model service usage data
-      pipeline_usage_data:
+      pipelineUsageData:
         $ref: '#/definitions/v1betaPipelineUsageData'
         title: Pipeline service usage data
-      artifact_usage_data:
+      artifactUsageData:
         $ref: '#/definitions/v1betaArtifactUsageData'
         title: Artifact service usage data
     title: |-
       SessionReport represents a report to be sent to the server that includes the
       usage data of a session
     required:
-      - session_uid
+      - sessionUid
       - token
       - pow
       - session
   v1betaStripeSubscriptionDetail:
     type: object
     properties:
-      product_name:
+      productName:
         type: string
         description: Product name associated with the subscription in Stripe.
       id:
         type: string
         description: Unique identifier for the subscription.
-      item_id:
+      itemId:
         type: string
         description: Identifier for the specific item within the subscription.
       price:
         type: number
         format: float
         description: Price of the subscription.
-      canceled_at:
+      canceledAt:
         type: integer
         format: int32
         description: Optional timestamp indicating when the subscription was canceled, if applicable.
-      trial_end:
+      trialEnd:
         type: integer
         format: int32
         description: Optional timestamp indicating when the trial ended, if applicable.
@@ -2985,18 +2985,18 @@ definitions:
   v1betaTimeInterval:
     type: object
     properties:
-      start_time:
+      startTime:
         type: string
         format: date-time
         title: Start time of the interval
-      end_time:
+      endTime:
         type: string
         format: date-time
         title: End time of the interval
     title: Time interval
     required:
-      - start_time
-      - end_time
+      - startTime
+      - endTime
   v1betaUpdateOrganizationMembershipResponse:
     type: object
     properties:
@@ -3056,12 +3056,12 @@ definitions:
           maximum.
 
           Note that the ID can be updated.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
@@ -3119,7 +3119,7 @@ definitions:
   v1betaUserProfile:
     type: object
     properties:
-      display_name:
+      displayName:
         type: string
         description: Display name.
       bio:
@@ -3128,13 +3128,13 @@ definitions:
       avatar:
         type: string
         description: Avatar in base64 format.
-      public_email:
+      publicEmail:
         type: string
         description: Public email.
-      company_name:
+      companyName:
         type: string
         description: Company name.
-      social_profile_links:
+      socialProfileLinks:
         type: object
         additionalProperties:
           type: string
@@ -3165,7 +3165,7 @@ definitions:
   v1betaValidateTokenResponse:
     type: object
     properties:
-      user_uid:
+      userUid:
         type: string
         description: If token is valid, UUID of the user that owns it.
         readOnly: true

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -39,7 +39,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of model definitions to return. If this parameter
             is unspecified, at most 10 definitions will be returned. The cap value for
@@ -48,7 +48,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -144,7 +144,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of models to return. If this parameter is unspecified,
             at most 10 models will be returned. The cap value for this parameter is
@@ -153,7 +153,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -170,7 +170,7 @@ paths:
           enum:
             - VIEW_BASIC
             - VIEW_FULL
-        - name: show_deleted
+        - name: showDeleted
           description: Include soft-deleted models in the result.
           in: query
           required: false
@@ -195,7 +195,7 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
-        - name: order_by
+        - name: orderBy
           description: |-
             Order by field, with options for ordering by `id`, `create_time` or `update_time`.
             Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
@@ -273,7 +273,7 @@ paths:
           required: true
           type: string
           pattern: users/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of models to return. If this parameter is unspecified,
             at most 10 models will be returned. The cap value for this parameter is
@@ -282,7 +282,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -299,7 +299,7 @@ paths:
           enum:
             - VIEW_BASIC
             - VIEW_FULL
-        - name: show_deleted
+        - name: showDeleted
           description: Include soft-deleted models in the result.
           in: query
           required: false
@@ -324,7 +324,7 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
-        - name: order_by
+        - name: orderBy
           description: |-
             Order by field, with options for ordering by `id`, `create_time` or `update_time`.
             Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
@@ -494,7 +494,7 @@ paths:
               description:
                 type: string
                 description: Model description.
-              model_definition:
+              modelDefinition:
                 type: string
                 description: The model definition that has been used to import the model.
               configuration:
@@ -509,22 +509,22 @@ paths:
               visibility:
                 $ref: '#/definitions/v1alphaModelVisibility'
                 description: Model visibility.
-              create_time:
+              createTime:
                 type: string
                 format: date-time
                 description: Model creation time.
                 readOnly: true
-              update_time:
+              updateTime:
                 type: string
                 format: date-time
                 description: Model update time.
                 readOnly: true
-              delete_time:
+              deleteTime:
                 type: string
                 format: date-time
                 description: Model deletion time.
                 readOnly: true
-              owner_name:
+              ownerName:
                 type: string
                 description: Resource name of the owner.
                 readOnly: true
@@ -541,42 +541,42 @@ paths:
               readme:
                 type: string
                 description: README holds the model documentation.
-              source_url:
+              sourceUrl:
                 type: string
                 description: A link to the source code of the model (e.g. to a GitHub repository).
-              documentation_url:
+              documentationUrl:
                 type: string
                 description: A link to any extra information.
               license:
                 type: string
                 description: License under which the model is distributed.
-              sample_input:
+              sampleInput:
                 $ref: '#/definitions/v1alphaTaskInput'
                 title: Sample input for this model
                 readOnly: true
-              sample_output:
+              sampleOutput:
                 $ref: '#/definitions/v1alphaTaskOutput'
                 title: Sample output for this model
                 readOnly: true
-              profile_image:
+              profileImage:
                 type: string
                 description: Model profile image in base64 format.
               permission:
                 $ref: '#/definitions/modelv1alphaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
-              input_schema:
+              inputSchema:
                 type: object
                 title: Input schema for the model
                 readOnly: true
-              output_schema:
+              outputSchema:
                 type: object
                 title: Output schema for the model
                 readOnly: true
             title: The model to update
             required:
               - id
-              - model_definition
+              - modelDefinition
               - configuration
               - task
               - visibility
@@ -824,7 +824,7 @@ paths:
           required: true
           type: string
           pattern: users/[^/]+/models/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of tags to return. The default and cap values are 10
             and 100, respectively.
@@ -1025,7 +1025,7 @@ paths:
           required: true
           type: string
           pattern: organizations/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of models to return. If this parameter is unspecified,
             at most 10 models will be returned. The cap value for this parameter is
@@ -1034,7 +1034,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -1051,7 +1051,7 @@ paths:
           enum:
             - VIEW_BASIC
             - VIEW_FULL
-        - name: show_deleted
+        - name: showDeleted
           description: Include soft-deleted models in the result.
           in: query
           required: false
@@ -1076,7 +1076,7 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
-        - name: order_by
+        - name: orderBy
           description: |-
             Order by field, with options for ordering by `id`, `create_time` or `update_time`.
             Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
@@ -1246,7 +1246,7 @@ paths:
               description:
                 type: string
                 description: Model description.
-              model_definition:
+              modelDefinition:
                 type: string
                 description: The model definition that has been used to import the model.
               configuration:
@@ -1261,22 +1261,22 @@ paths:
               visibility:
                 $ref: '#/definitions/v1alphaModelVisibility'
                 description: Model visibility.
-              create_time:
+              createTime:
                 type: string
                 format: date-time
                 description: Model creation time.
                 readOnly: true
-              update_time:
+              updateTime:
                 type: string
                 format: date-time
                 description: Model update time.
                 readOnly: true
-              delete_time:
+              deleteTime:
                 type: string
                 format: date-time
                 description: Model deletion time.
                 readOnly: true
-              owner_name:
+              ownerName:
                 type: string
                 description: Resource name of the owner.
                 readOnly: true
@@ -1293,42 +1293,42 @@ paths:
               readme:
                 type: string
                 description: README holds the model documentation.
-              source_url:
+              sourceUrl:
                 type: string
                 description: A link to the source code of the model (e.g. to a GitHub repository).
-              documentation_url:
+              documentationUrl:
                 type: string
                 description: A link to any extra information.
               license:
                 type: string
                 description: License under which the model is distributed.
-              sample_input:
+              sampleInput:
                 $ref: '#/definitions/v1alphaTaskInput'
                 title: Sample input for this model
                 readOnly: true
-              sample_output:
+              sampleOutput:
                 $ref: '#/definitions/v1alphaTaskOutput'
                 title: Sample output for this model
                 readOnly: true
-              profile_image:
+              profileImage:
                 type: string
                 description: Model profile image in base64 format.
               permission:
                 $ref: '#/definitions/modelv1alphaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
-              input_schema:
+              inputSchema:
                 type: object
                 title: Input schema for the model
                 readOnly: true
-              output_schema:
+              outputSchema:
                 type: object
                 title: Output schema for the model
                 readOnly: true
             title: The model to update
             required:
               - id
-              - model_definition
+              - modelDefinition
               - configuration
               - task
               - visibility
@@ -1576,7 +1576,7 @@ paths:
           required: true
           type: string
           pattern: organizations/[^/]+/models/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of tags to return. The default and cap values are 10
             and 100, respectively.
@@ -1886,29 +1886,29 @@ definitions:
   ModelPublicServiceRenameOrganizationModelBody:
     type: object
     properties:
-      new_model_id:
+      newModelId:
         type: string
         description: |-
           The new resource ID. This will transform the resource name into
           `organizations/{organization.id}/models/{new_model_id}`.
     title: RenameOrganizationModelRequest represents a request to rename a model
     required:
-      - new_model_id
+      - newModelId
   ModelPublicServiceRenameUserModelBody:
     type: object
     properties:
-      new_model_id:
+      newModelId:
         type: string
         description: |-
           The new resource ID. This will transform the resource name into
           `users/{user.id}/models/{new_model_id}`.
     title: RenameUserModelRequest represents a request to rename a model
     required:
-      - new_model_id
+      - newModelId
   ModelPublicServiceTriggerAsyncOrganizationLatestModelBody:
     type: object
     properties:
-      task_inputs:
+      taskInputs:
         type: array
         items:
           type: object
@@ -1918,11 +1918,11 @@ definitions:
       TriggerAsyncOrganizationLatestModelRequest represents a request to trigger a model inference
       asynchronously
     required:
-      - task_inputs
+      - taskInputs
   ModelPublicServiceTriggerAsyncOrganizationModelBody:
     type: object
     properties:
-      task_inputs:
+      taskInputs:
         type: array
         items:
           type: object
@@ -1932,11 +1932,11 @@ definitions:
       TriggerAsyncOrganizationModelRequest represents a request to trigger a model inference
       asynchronously
     required:
-      - task_inputs
+      - taskInputs
   ModelPublicServiceTriggerAsyncUserLatestModelBody:
     type: object
     properties:
-      task_inputs:
+      taskInputs:
         type: array
         items:
           type: object
@@ -1946,11 +1946,11 @@ definitions:
       TriggerAsyncUserLatestModelRequest represents a request to trigger a model inference
       asynchronously with the latest uploaded version.
     required:
-      - task_inputs
+      - taskInputs
   ModelPublicServiceTriggerAsyncUserModelBody:
     type: object
     properties:
-      task_inputs:
+      taskInputs:
         type: array
         items:
           type: object
@@ -1960,11 +1960,11 @@ definitions:
       TriggerAsyncUserModelRequest represents a request to trigger a model inference
       asynchronously.
     required:
-      - task_inputs
+      - taskInputs
   ModelPublicServiceTriggerOrganizationLatestModelBody:
     type: object
     properties:
-      task_inputs:
+      taskInputs:
         type: array
         items:
           type: object
@@ -1972,11 +1972,11 @@ definitions:
         description: Inference input parameters.
     description: TriggerOrganizationLatestModelRequest represents a request to trigger a model inference.
     required:
-      - task_inputs
+      - taskInputs
   ModelPublicServiceTriggerOrganizationModelBody:
     type: object
     properties:
-      task_inputs:
+      taskInputs:
         type: array
         items:
           type: object
@@ -1984,11 +1984,11 @@ definitions:
         description: Inference input parameters.
     description: TriggerOrganizationModelRequest represents a request to trigger a model inference.
     required:
-      - task_inputs
+      - taskInputs
   ModelPublicServiceTriggerUserLatestModelBody:
     type: object
     properties:
-      task_inputs:
+      taskInputs:
         type: array
         items:
           type: object
@@ -1998,11 +1998,11 @@ definitions:
       TriggerUserLatestModelRequest represents a request to trigger a model inference
       with the latest uploaded version.
     required:
-      - task_inputs
+      - taskInputs
   ModelPublicServiceTriggerUserModelBody:
     type: object
     properties:
-      task_inputs:
+      taskInputs:
         type: array
         items:
           type: object
@@ -2010,7 +2010,7 @@ definitions:
         description: Inference input parameters.
     description: TriggerUserModelRequest represents a request to trigger a model inference.
     required:
-      - task_inputs
+      - taskInputs
   ModelPublicServiceUnpublishOrganizationModelBody:
     type: object
     description: UnpublishOrganizationModelRequest represents a request to unpublish a model.
@@ -2091,17 +2091,17 @@ definitions:
   mgmtv1betaPermission:
     type: object
     properties:
-      can_edit:
+      canEdit:
         type: boolean
         description: Defines whether the resource can be modified.
     description: Permission defines how a resource can be used.
   modelv1alphaPermission:
     type: object
     properties:
-      can_edit:
+      canEdit:
         type: boolean
         description: Defines whether the pipeline can be modified.
-      can_trigger:
+      canTrigger:
         type: boolean
         description: Defines whether the pipeline can be executed.
     description: Permission defines how a pipeline can be used.
@@ -2293,17 +2293,17 @@ definitions:
   v1alphaClassificationInput:
     type: object
     properties:
-      image_url:
+      imageUrl:
         type: string
         description: Image URL.
-      image_base64:
+      imageBase64:
         type: string
         description: Base64-encoded image.
     description: ClassificationInput is the input of an image classification task.
   v1alphaClassificationInputStream:
     type: object
     properties:
-      file_lengths:
+      fileLengths:
         type: array
         items:
           type: integer
@@ -2317,7 +2317,7 @@ definitions:
       ClassificationInputStream represents the input of an image classification
       task when the input is streamed as a binary files.
     required:
-      - file_lengths
+      - fileLengths
       - content
   v1alphaClassificationOutput:
     type: object
@@ -2358,17 +2358,17 @@ definitions:
   v1alphaDetectionInput:
     type: object
     properties:
-      image_url:
+      imageUrl:
         type: string
         description: Image URL.
-      image_base64:
+      imageBase64:
         type: string
         description: Base64-encoded image.
     description: DetectionInput represents the input of an object detection task.
   v1alphaDetectionInputStream:
     type: object
     properties:
-      file_lengths:
+      fileLengths:
         type: array
         items:
           type: integer
@@ -2382,7 +2382,7 @@ definitions:
       DetectionInputStream represents the input of an object detection task when
       the input is streamed as binary files.
     required:
-      - file_lengths
+      - fileLengths
       - content
   v1alphaDetectionObject:
     type: object
@@ -2396,7 +2396,7 @@ definitions:
         format: float
         description: Score.
         readOnly: true
-      bounding_box:
+      boundingBox:
         $ref: '#/definitions/v1alphaBoundingBox'
         description: Bounding box.
         readOnly: true
@@ -2415,7 +2415,7 @@ definitions:
   v1alphaGetModelDefinitionResponse:
     type: object
     properties:
-      model_definition:
+      modelDefinition:
         $ref: '#/definitions/v1alphaModelDefinition'
         description: The model definition resource.
     description: GetModelDefinitionResponse contains the requested model definition.
@@ -2477,7 +2477,7 @@ definitions:
   v1alphaImageContent:
     type: object
     properties:
-      image_url:
+      imageUrl:
         $ref: '#/definitions/v1alphaPromptImage'
         description: |-
           Image as URL or base64 code.
@@ -2491,10 +2491,10 @@ definitions:
   v1alphaImageToImageInput:
     type: object
     properties:
-      prompt_image_url:
+      promptImageUrl:
         type: string
         description: Image URL.
-      prompt_image_base64:
+      promptImageBase64:
         type: string
         description: Base64-encoded image.
       prompt:
@@ -2504,7 +2504,7 @@ definitions:
         type: integer
         format: int32
         description: Steps, defaults to 5.
-      cfg_scale:
+      cfgScale:
         type: number
         format: float
         title: Guidance scale, defaults to 7.5
@@ -2516,7 +2516,7 @@ definitions:
         type: integer
         format: int32
         description: Number of generated samples, defaults to 1.
-      extra_params:
+      extraParams:
         type: object
         description: Extra parameters.
     description: ImageToImageInput represents the input of an image-to-image task.
@@ -2535,10 +2535,10 @@ definitions:
   v1alphaInstanceSegmentationInput:
     type: object
     properties:
-      image_url:
+      imageUrl:
         type: string
         description: Image URL.
-      image_base64:
+      imageBase64:
         type: string
         description: Base64-encoded image.
     description: |-
@@ -2547,7 +2547,7 @@ definitions:
   v1alphaInstanceSegmentationInputStream:
     type: object
     properties:
-      file_lengths:
+      fileLengths:
         type: array
         items:
           type: integer
@@ -2561,7 +2561,7 @@ definitions:
       InstanceSegmentationInputStream represents the input of an instance
       segmentation task when the input is streamed as binary files.
     required:
-      - file_lengths
+      - fileLengths
       - content
   v1alphaInstanceSegmentationObject:
     type: object
@@ -2579,7 +2579,7 @@ definitions:
         format: float
         description: Score.
         readOnly: true
-      bounding_box:
+      boundingBox:
         $ref: '#/definitions/v1alphaBoundingBox'
         description: Bounding box.
         readOnly: true
@@ -2621,17 +2621,17 @@ definitions:
   v1alphaKeypointInput:
     type: object
     properties:
-      image_url:
+      imageUrl:
         type: string
         description: Image URL.
-      image_base64:
+      imageBase64:
         type: string
         description: Base64-encoded image.
     description: KeypointInput represents the input of a keypoint detection task.
   v1alphaKeypointInputStream:
     type: object
     properties:
-      file_lengths:
+      fileLengths:
         type: array
         items:
           type: integer
@@ -2645,7 +2645,7 @@ definitions:
       KeypointInputStream represents the input of a keypoint detection task when
       the input is streamed as binary files.
     required:
-      - file_lengths
+      - fileLengths
       - content
   v1alphaKeypointObject:
     type: object
@@ -2662,7 +2662,7 @@ definitions:
         format: float
         description: Score.
         readOnly: true
-      bounding_box:
+      boundingBox:
         $ref: '#/definitions/v1alphaBoundingBox'
         description: Bounding box.
         readOnly: true
@@ -2695,16 +2695,16 @@ definitions:
   v1alphaListModelDefinitionsResponse:
     type: object
     properties:
-      model_definitions:
+      modelDefinitions:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1alphaModelDefinition'
         description: A list of model definition resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of model definitions.
@@ -2718,10 +2718,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1alphaModel'
         title: a list of Models
-      next_page_token:
+      nextPageToken:
         type: string
         title: Next page token
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of models.
@@ -2735,10 +2735,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1alphaModel'
         description: A list of model resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of models.
@@ -2752,11 +2752,11 @@ definitions:
           type: object
           $ref: '#/definitions/v1alphaModelVersion'
         description: A list of model resources.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of tags.
-      page_size:
+      pageSize:
         type: integer
         format: int32
         description: The requested page size.
@@ -2774,10 +2774,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1alphaModel'
         description: A list of model resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of models.
@@ -2791,11 +2791,11 @@ definitions:
           type: object
           $ref: '#/definitions/v1alphaModelVersion'
         description: A list of model resources.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of tags.
-      page_size:
+      pageSize:
         type: integer
         format: int32
         description: The requested page size.
@@ -2813,10 +2813,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1alphaModel'
         description: A list of model resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of models.
@@ -2854,7 +2854,7 @@ definitions:
       type:
         type: string
         description: Content type.
-      image_url:
+      imageUrl:
         $ref: '#/definitions/v1alphaImageContent'
         description: |-
           Image content.
@@ -2890,7 +2890,7 @@ definitions:
       description:
         type: string
         description: Model description.
-      model_definition:
+      modelDefinition:
         type: string
         description: The model definition that has been used to import the model.
       configuration:
@@ -2905,22 +2905,22 @@ definitions:
       visibility:
         $ref: '#/definitions/v1alphaModelVisibility'
         description: Model visibility.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Model creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Model update time.
         readOnly: true
-      delete_time:
+      deleteTime:
         type: string
         format: date-time
         description: Model deletion time.
         readOnly: true
-      owner_name:
+      ownerName:
         type: string
         description: Resource name of the owner.
         readOnly: true
@@ -2937,35 +2937,35 @@ definitions:
       readme:
         type: string
         description: README holds the model documentation.
-      source_url:
+      sourceUrl:
         type: string
         description: A link to the source code of the model (e.g. to a GitHub repository).
-      documentation_url:
+      documentationUrl:
         type: string
         description: A link to any extra information.
       license:
         type: string
         description: License under which the model is distributed.
-      sample_input:
+      sampleInput:
         $ref: '#/definitions/v1alphaTaskInput'
         title: Sample input for this model
         readOnly: true
-      sample_output:
+      sampleOutput:
         $ref: '#/definitions/v1alphaTaskOutput'
         title: Sample output for this model
         readOnly: true
-      profile_image:
+      profileImage:
         type: string
         description: Model profile image in base64 format.
       permission:
         $ref: '#/definitions/modelv1alphaPermission'
         description: Permission defines how a pipeline can be used.
         readOnly: true
-      input_schema:
+      inputSchema:
         type: object
         title: Input schema for the model
         readOnly: true
-      output_schema:
+      outputSchema:
         type: object
         title: Output schema for the model
         readOnly: true
@@ -2974,7 +2974,7 @@ definitions:
       making or or pattern recognition based on its training data
     required:
       - id
-      - model_definition
+      - modelDefinition
       - configuration
       - task
       - visibility
@@ -3040,7 +3040,7 @@ definitions:
         type: string
         description: Official display title.
         readOnly: true
-      documentation_url:
+      documentationUrl:
         type: string
         description: Documentation URL.
         readOnly: true
@@ -3048,11 +3048,11 @@ definitions:
         type: string
         description: Display icon.
         readOnly: true
-      release_stage:
+      releaseStage:
         $ref: '#/definitions/v1alphaReleaseStage'
         description: Release stage.
         readOnly: true
-      model_spec:
+      modelSpec:
         type: object
         description: |-
           The model specification represented by a JSON schema. It is used to
@@ -3061,12 +3061,12 @@ definitions:
           It must be a valid JSON that includes what fields are needed to
           create or display a model.
         readOnly: true
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
@@ -3095,7 +3095,7 @@ definitions:
         $ref: '#/definitions/modelv1alphaState'
         description: Current state of this model version.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Tag update time, i.e. timestamp of the last push.
@@ -3114,17 +3114,17 @@ definitions:
   v1alphaOcrInput:
     type: object
     properties:
-      image_url:
+      imageUrl:
         type: string
         description: Image URL.
-      image_base64:
+      imageBase64:
         type: string
         description: Base64-encoded image.
     description: OcrInput represents the input of an OCR task.
   v1alphaOcrInputStream:
     type: object
     properties:
-      file_lengths:
+      fileLengths:
         type: array
         items:
           type: integer
@@ -3138,7 +3138,7 @@ definitions:
       OcrInputStream represents the input of an OCR task when the input is
       streamed as binary files.
     required:
-      - file_lengths
+      - fileLengths
       - content
   v1alphaOcrObject:
     type: object
@@ -3152,7 +3152,7 @@ definitions:
         format: float
         description: Score.
         readOnly: true
-      bounding_box:
+      boundingBox:
         $ref: '#/definitions/v1alphaBoundingBox'
         description: Bounding box.
         readOnly: true
@@ -3173,10 +3173,10 @@ definitions:
   v1alphaPromptImage:
     type: object
     properties:
-      prompt_image_url:
+      promptImageUrl:
         type: string
         description: Image URL.
-      prompt_image_base64:
+      promptImageBase64:
         type: string
         description: Base64-encoded image.
     description: PromptImage is an image input for model inference.
@@ -3197,7 +3197,7 @@ definitions:
   v1alphaRegion:
     type: object
     properties:
-      region_name:
+      regionName:
         type: string
         title: Concate name of provider and region
       hardware:
@@ -3239,10 +3239,10 @@ definitions:
   v1alphaSemanticSegmentationInput:
     type: object
     properties:
-      image_url:
+      imageUrl:
         type: string
         description: Image URL.
-      image_base64:
+      imageBase64:
         type: string
         description: Base64-encoded image.
     description: |-
@@ -3251,7 +3251,7 @@ definitions:
   v1alphaSemanticSegmentationInputStream:
     type: object
     properties:
-      file_lengths:
+      fileLengths:
         type: array
         items:
           type: integer
@@ -3265,7 +3265,7 @@ definitions:
       SemanticSegmentationInputStream represents the input of a semantic
       segmentation task when the input is streamed as a binary files.
     required:
-      - file_lengths
+      - fileLengths
       - content
   v1alphaSemanticSegmentationOutput:
     type: object
@@ -3341,25 +3341,25 @@ definitions:
       ocr:
         $ref: '#/definitions/v1alphaOcrInput'
         description: Optical Character Recognition input.
-      instance_segmentation:
+      instanceSegmentation:
         $ref: '#/definitions/v1alphaInstanceSegmentationInput'
         description: Instance segmentation input.
-      semantic_segmentation:
+      semanticSegmentation:
         $ref: '#/definitions/v1alphaSemanticSegmentationInput'
         description: Semantic segmentation input.
-      text_to_image:
+      textToImage:
         $ref: '#/definitions/v1alphaTextToImageInput'
         description: Text to image input.
-      image_to_image:
+      imageToImage:
         $ref: '#/definitions/v1alphaImageToImageInput'
         description: Image to image input.
-      text_generation:
+      textGeneration:
         $ref: '#/definitions/v1alphaTextGenerationInput'
         description: Text generation input.
-      text_generation_chat:
+      textGenerationChat:
         $ref: '#/definitions/v1alphaTextGenerationChatInput'
         description: Conversational text generation input.
-      visual_question_answering:
+      visualQuestionAnswering:
         $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
         description: Visual question answering input.
       unspecified:
@@ -3381,25 +3381,25 @@ definitions:
       ocr:
         $ref: '#/definitions/v1alphaOcrInputStream'
         title: The ocr input
-      instance_segmentation:
+      instanceSegmentation:
         $ref: '#/definitions/v1alphaInstanceSegmentationInputStream'
         title: The instance segmentation input
-      semantic_segmentation:
+      semanticSegmentation:
         $ref: '#/definitions/v1alphaSemanticSegmentationInputStream'
         title: The semantic segmentation input
-      text_to_image:
+      textToImage:
         $ref: '#/definitions/v1alphaTextToImageInput'
         title: The text to image input
-      image_to_image:
+      imageToImage:
         $ref: '#/definitions/v1alphaImageToImageInput'
         title: The image to image input
-      text_generation:
+      textGeneration:
         $ref: '#/definitions/v1alphaTextGenerationInput'
         title: The text generation input
-      text_generation_chat:
+      textGenerationChat:
         $ref: '#/definitions/v1alphaTextGenerationChatInput'
         title: The text generation chat input
-      visual_question_answering:
+      visualQuestionAnswering:
         $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
         title: The visual question answering input
       unspecified:
@@ -3425,31 +3425,31 @@ definitions:
         $ref: '#/definitions/v1alphaOcrOutput'
         description: Optical Character Recognition output.
         readOnly: true
-      instance_segmentation:
+      instanceSegmentation:
         $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
         description: Instance segmentation output.
         readOnly: true
-      semantic_segmentation:
+      semanticSegmentation:
         $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
         description: Semantic segmentation output.
         readOnly: true
-      text_to_image:
+      textToImage:
         $ref: '#/definitions/v1alphaTextToImageOutput'
         description: Text to image output.
         readOnly: true
-      image_to_image:
+      imageToImage:
         $ref: '#/definitions/v1alphaImageToImageOutput'
         description: Image to image output.
         readOnly: true
-      text_generation:
+      textGeneration:
         $ref: '#/definitions/v1alphaTextGenerationOutput'
         description: Text generation output.
         readOnly: true
-      text_generation_chat:
+      textGenerationChat:
         $ref: '#/definitions/v1alphaTextGenerationChatOutput'
         description: Conversational text generation output.
         readOnly: true
-      visual_question_answering:
+      visualQuestionAnswering:
         $ref: '#/definitions/v1alphaVisualQuestionAnsweringOutput'
         description: Visual question answering output.
         readOnly: true
@@ -3464,22 +3464,22 @@ definitions:
       prompt:
         type: string
         description: Prompt text.
-      prompt_images:
+      promptImages:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1alphaPromptImage'
         description: Prompt images.
-      chat_history:
+      chatHistory:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1alphaMessage'
         description: Chat history.
-      system_message:
+      systemMessage:
         type: string
         description: System message, which sets the behaviour of the assistant.
-      max_new_tokens:
+      maxNewTokens:
         type: integer
         format: int32
         description: Maximum number of generation tokens.
@@ -3487,7 +3487,7 @@ definitions:
         type: number
         format: float
         description: Sampling temperature.
-      top_k:
+      topK:
         type: integer
         format: int32
         description: |-
@@ -3497,7 +3497,7 @@ definitions:
         type: integer
         format: int32
         description: Seed.
-      extra_params:
+      extraParams:
         type: object
         description: Extra parameters.
     description: TextGenerationChatInput represents the input of a text generation chat task.
@@ -3517,22 +3517,22 @@ definitions:
       prompt:
         type: string
         description: Prompt text.
-      prompt_images:
+      promptImages:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1alphaPromptImage'
         description: Prompt images.
-      chat_history:
+      chatHistory:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1alphaMessage'
         description: Chat history.
-      system_message:
+      systemMessage:
         type: string
         description: System message, which sets the behaviour of the assistant.
-      max_new_tokens:
+      maxNewTokens:
         type: integer
         format: int32
         description: Maximum number of generation tokens.
@@ -3540,7 +3540,7 @@ definitions:
         type: number
         format: float
         description: Sampling temperature.
-      top_k:
+      topK:
         type: integer
         format: int32
         description: |-
@@ -3550,7 +3550,7 @@ definitions:
         type: integer
         format: int32
         description: Seed.
-      extra_params:
+      extraParams:
         type: object
         description: Extra parameters.
     description: TextGenerationInput represents the input of a text generation task.
@@ -3570,17 +3570,17 @@ definitions:
       prompt:
         type: string
         description: Prompt text.
-      prompt_image_url:
+      promptImageUrl:
         type: string
         description: Image URL.
-      prompt_image_base64:
+      promptImageBase64:
         type: string
         description: Base64-encoded image.
       steps:
         type: integer
         format: int32
         description: Steps, defaults to 5.
-      cfg_scale:
+      cfgScale:
         type: number
         format: float
         description: Guidance scale, defaults to 7.5.
@@ -3592,7 +3592,7 @@ definitions:
         type: integer
         format: int32
         description: Number of generated samples, default is 1.
-      extra_params:
+      extraParams:
         type: object
         description: Extra parameters.
     description: TextToImageInput represents the input of a text-to-image task.
@@ -3654,7 +3654,7 @@ definitions:
       task:
         $ref: '#/definitions/v1alphaTask'
         description: Task type.
-      task_outputs:
+      taskOutputs:
         type: array
         items:
           type: object
@@ -3667,7 +3667,7 @@ definitions:
       task:
         $ref: '#/definitions/v1alphaTask'
         description: Task type.
-      task_outputs:
+      taskOutputs:
         type: array
         items:
           type: object
@@ -3676,14 +3676,14 @@ definitions:
     description: TriggerOrganizationModelBinaryFileUploadResponse contains the model inference results.
     required:
       - task
-      - task_outputs
+      - taskOutputs
   v1alphaTriggerOrganizationModelResponse:
     type: object
     properties:
       task:
         $ref: '#/definitions/v1alphaTask'
         description: Task type.
-      task_outputs:
+      taskOutputs:
         type: array
         items:
           type: object
@@ -3696,7 +3696,7 @@ definitions:
       task:
         $ref: '#/definitions/v1alphaTask'
         description: Task type.
-      task_outputs:
+      taskOutputs:
         type: array
         items:
           type: object
@@ -3709,7 +3709,7 @@ definitions:
       task:
         $ref: '#/definitions/v1alphaTask'
         description: Task type.
-      task_outputs:
+      taskOutputs:
         type: array
         items:
           type: object
@@ -3721,7 +3721,7 @@ definitions:
     description: TriggerUserModelBinaryFileUploadResponse contains the model inference results.
     required:
       - task
-      - task_outputs
+      - taskOutputs
       - version
   v1alphaTriggerUserModelResponse:
     type: object
@@ -3729,7 +3729,7 @@ definitions:
       task:
         $ref: '#/definitions/v1alphaTask'
         description: Task type.
-      task_outputs:
+      taskOutputs:
         type: array
         items:
           type: object
@@ -3756,7 +3756,7 @@ definitions:
   v1alphaUnspecifiedInput:
     type: object
     properties:
-      raw_inputs:
+      rawInputs:
         type: array
         items:
           type: object
@@ -3765,7 +3765,7 @@ definitions:
   v1alphaUnspecifiedOutput:
     type: object
     properties:
-      raw_outputs:
+      rawOutputs:
         type: array
         items:
           type: object
@@ -3792,22 +3792,22 @@ definitions:
       prompt:
         type: string
         description: Prompt text.
-      prompt_images:
+      promptImages:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1alphaPromptImage'
         description: Prompt images.
-      chat_history:
+      chatHistory:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1alphaMessage'
         description: Chat history.
-      system_message:
+      systemMessage:
         type: string
         description: System message, which sets the behaviour of the assistant.
-      max_new_tokens:
+      maxNewTokens:
         type: integer
         format: int32
         description: Maximum number of generation tokens.
@@ -3815,7 +3815,7 @@ definitions:
         type: number
         format: float
         description: Sampling temperature.
-      top_k:
+      topK:
         type: integer
         format: int32
         description: |-
@@ -3825,7 +3825,7 @@ definitions:
         type: integer
         format: int32
         description: Seed.
-      extra_params:
+      extraParams:
         type: object
         description: Extra parameters.
     description: |-
@@ -3905,12 +3905,12 @@ definitions:
           maximum.
 
           Note that the ID can be updated.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
@@ -3934,7 +3934,7 @@ definitions:
   v1betaOrganizationProfile:
     type: object
     properties:
-      display_name:
+      displayName:
         type: string
         description: Display name.
       bio:
@@ -3943,10 +3943,10 @@ definitions:
       avatar:
         type: string
         description: Avatar in base64 format.
-      public_email:
+      publicEmail:
         type: string
         description: Public email.
-      social_profile_links:
+      socialProfileLinks:
         type: object
         additionalProperties:
           type: string
@@ -3989,12 +3989,12 @@ definitions:
           maximum.
 
           Note that the ID can be updated.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
@@ -4010,7 +4010,7 @@ definitions:
   v1betaUserProfile:
     type: object
     properties:
-      display_name:
+      displayName:
         type: string
         description: Display name.
       bio:
@@ -4019,13 +4019,13 @@ definitions:
       avatar:
         type: string
         description: Avatar in base64 format.
-      public_email:
+      publicEmail:
         type: string
         description: Public email.
-      company_name:
+      companyName:
         type: string
         description: Company name.
-      social_profile_links:
+      socialProfileLinks:
         type: object
         additionalProperties:
           type: string

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -63,7 +63,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of pipelines to return. If this parameter is
             unspecified, at most 10 pipelines will be returned. The cap value for this
@@ -72,7 +72,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -101,7 +101,7 @@ paths:
           in: query
           required: false
           type: string
-        - name: show_deleted
+        - name: showDeleted
           description: Include soft-deleted pipelines in the result.
           in: query
           required: false
@@ -118,7 +118,7 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
-        - name: order_by
+        - name: orderBy
           description: |-
             Order by field, with options for ordering by `id`, `create_time` or `update_time`.
             Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
@@ -201,7 +201,7 @@ paths:
           required: true
           type: string
           pattern: users/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of pipelines to return. If this parameter is
             unspecified, at most 10 pipelines will be returned. The cap value for this
@@ -210,7 +210,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -239,7 +239,7 @@ paths:
           in: query
           required: false
           type: string
-        - name: show_deleted
+        - name: showDeleted
           description: Include soft-deleted pipelines in the result.
           in: query
           required: false
@@ -256,7 +256,7 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
-        - name: order_by
+        - name: orderBy
           description: |-
             Order by field, with options for ordering by `id`, `create_time` or `update_time`.
             Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
@@ -433,17 +433,17 @@ paths:
               recipe:
                 type: object
                 description: Recipe describes the components of a Pipeline and how they are connected.
-              create_time:
+              createTime:
                 type: string
                 format: date-time
                 description: Pipeline creation time.
                 readOnly: true
-              update_time:
+              updateTime:
                 type: string
                 format: date-time
                 description: Pipeline update time.
                 readOnly: true
-              delete_time:
+              deleteTime:
                 type: string
                 format: date-time
                 description: Pipeline delete time.
@@ -454,7 +454,7 @@ paths:
               metadata:
                 type: object
                 description: Metadata holds console-related data such as the pipeline builder layout.
-              owner_name:
+              ownerName:
                 type: string
                 description: Owner Name.
                 readOnly: true
@@ -480,7 +480,7 @@ paths:
                 $ref: '#/definitions/v1betaOwner'
                 description: Pipeline owner.
                 readOnly: true
-              data_specification:
+              dataSpecification:
                 $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
@@ -774,7 +774,7 @@ paths:
           required: true
           type: string
           pattern: users/[^/]+/pipelines/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of releases to return. If this parameter is
             unspecified, at most 10 pipelines will be returned. The cap value for this
@@ -783,7 +783,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -810,7 +810,7 @@ paths:
           in: query
           required: false
           type: string
-        - name: show_deleted
+        - name: showDeleted
           description: Include soft-deleted pipelines in the result.
           in: query
           required: false
@@ -989,17 +989,17 @@ paths:
                 type: object
                 description: Recipe of the versioned pipeline.
                 readOnly: true
-              create_time:
+              createTime:
                 type: string
                 format: date-time
                 description: Pipeline creation time.
                 readOnly: true
-              update_time:
+              updateTime:
                 type: string
                 format: date-time
                 description: Pipeline update time.
                 readOnly: true
-              delete_time:
+              deleteTime:
                 type: string
                 format: date-time
                 description: Pipeline deletion time.
@@ -1016,7 +1016,7 @@ paths:
               readme:
                 type: string
                 description: README.
-              data_specification:
+              dataSpecification:
                 $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
@@ -1215,7 +1215,7 @@ paths:
           required: true
           type: string
           pattern: organizations/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of pipelines to return. If this parameter is
             unspecified, at most 10 pipelines will be returned. The cap value for this
@@ -1224,7 +1224,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -1253,7 +1253,7 @@ paths:
           in: query
           required: false
           type: string
-        - name: show_deleted
+        - name: showDeleted
           description: Include soft-deleted pipelines in the result.
           in: query
           required: false
@@ -1270,7 +1270,7 @@ paths:
           enum:
             - VISIBILITY_PRIVATE
             - VISIBILITY_PUBLIC
-        - name: order_by
+        - name: orderBy
           description: |-
             Order by field, with options for ordering by `id`, `create_time` or `update_time`.
             Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
@@ -1441,17 +1441,17 @@ paths:
               recipe:
                 type: object
                 description: Recipe describes the components of a Pipeline and how they are connected.
-              create_time:
+              createTime:
                 type: string
                 format: date-time
                 description: Pipeline creation time.
                 readOnly: true
-              update_time:
+              updateTime:
                 type: string
                 format: date-time
                 description: Pipeline update time.
                 readOnly: true
-              delete_time:
+              deleteTime:
                 type: string
                 format: date-time
                 description: Pipeline delete time.
@@ -1462,7 +1462,7 @@ paths:
               metadata:
                 type: object
                 description: Metadata holds console-related data such as the pipeline builder layout.
-              owner_name:
+              ownerName:
                 type: string
                 description: Owner Name.
                 readOnly: true
@@ -1488,7 +1488,7 @@ paths:
                 $ref: '#/definitions/v1betaOwner'
                 description: Pipeline owner.
                 readOnly: true
-              data_specification:
+              dataSpecification:
                 $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
@@ -1734,7 +1734,7 @@ paths:
           required: true
           type: string
           pattern: organizations/[^/]+/pipelines/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of releases to return. If this parameter is
             unspecified, at most 10 pipelines will be returned. The cap value for this
@@ -1743,7 +1743,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -1770,7 +1770,7 @@ paths:
           in: query
           required: false
           type: string
-        - name: show_deleted
+        - name: showDeleted
           description: Include soft-deleted pipelines in the result.
           in: query
           required: false
@@ -1942,17 +1942,17 @@ paths:
                 type: object
                 description: Recipe of the versioned pipeline.
                 readOnly: true
-              create_time:
+              createTime:
                 type: string
                 format: date-time
                 description: Pipeline creation time.
                 readOnly: true
-              update_time:
+              updateTime:
                 type: string
                 format: date-time
                 description: Pipeline update time.
                 readOnly: true
-              delete_time:
+              deleteTime:
                 type: string
                 format: date-time
                 description: Pipeline deletion time.
@@ -1969,7 +1969,7 @@ paths:
               readme:
                 type: string
                 description: README.
-              data_specification:
+              dataSpecification:
                 $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
@@ -2186,7 +2186,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of connector definitions to return. If this parameter
             is unspecified, at most 10 definitions will be returned. The cap value for
@@ -2195,7 +2195,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -2282,7 +2282,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of OperatorDefinitions to return. The
             service may return fewer than this value. If unspecified, at most 10
@@ -2292,7 +2292,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page token.
           in: query
           required: false
@@ -2341,7 +2341,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of component definitions to return. If this parameter
             is unspecified, at most 10 definitions will be returned. The cap value for
@@ -2479,7 +2479,7 @@ paths:
           required: true
           type: string
           pattern: users/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of secrets to return. If this parameter is unspecified,
             at most 10 pipelines will be returned. The cap value for this parameter is
@@ -2488,7 +2488,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page secret.
           in: query
           required: false
@@ -2635,12 +2635,12 @@ paths:
                   to RFC-1034, which restricts to letters, numbers, and hyphen, with the
                   first character a letter, the last a letter or a number, and a 63
                   character maximum.
-              create_time:
+              createTime:
                 type: string
                 format: date-time
                 description: Creation time.
                 readOnly: true
-              update_time:
+              updateTime:
                 type: string
                 format: date-time
                 description: Update time.
@@ -2682,7 +2682,7 @@ paths:
           required: true
           type: string
           pattern: organizations/[^/]+
-        - name: page_size
+        - name: pageSize
           description: |-
             The maximum number of secrets to return. If this parameter is unspecified,
             at most 10 pipelines will be returned. The cap value for this parameter is
@@ -2691,7 +2691,7 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: page_token
+        - name: pageToken
           description: Page secret.
           in: query
           required: false
@@ -2838,12 +2838,12 @@ paths:
                   to RFC-1034, which restricts to letters, numbers, and hyphen, with the
                   first character a letter, the last a letter or a number, and a 63
                   character maximum.
-              create_time:
+              createTime:
                 type: string
                 format: date-time
                 description: Creation time.
                 readOnly: true
-              update_time:
+              updateTime:
                 type: string
                 format: date-time
                 description: Update time.
@@ -2912,10 +2912,10 @@ definitions:
   ComponentDefinitionSpec:
     type: object
     properties:
-      component_specification:
+      componentSpecification:
         type: object
         description: Component specification.
-      data_specifications:
+      dataSpecifications:
         type: object
         additionalProperties:
           $ref: '#/definitions/v1betaDataSpecification'
@@ -2924,8 +2924,8 @@ definitions:
           The key represents the task, and the value is the corresponding data_specification.
     description: Spec represents a specification data model.
     required:
-      - component_specification
-      - data_specifications
+      - componentSpecification
+      - dataSpecifications
   PipelinePublicServiceCloneOrganizationPipelineBody:
     type: object
     properties:
@@ -2959,7 +2959,7 @@ definitions:
   PipelinePublicServiceRenameOrganizationPipelineBody:
     type: object
     properties:
-      new_pipeline_id:
+      newPipelineId:
         type: string
         description: |-
           The new resource ID. This will transform the resource name into
@@ -2968,11 +2968,11 @@ definitions:
       RenameOrganizationPipelineRequest represents a request to rename the name of
       a pipeline owned by an organization.
     required:
-      - new_pipeline_id
+      - newPipelineId
   PipelinePublicServiceRenameOrganizationPipelineReleaseBody:
     type: object
     properties:
-      new_pipeline_release_id:
+      newPipelineReleaseId:
         type: string
         description: |-
           The new resource ID. This will transform the resource name into
@@ -2981,11 +2981,11 @@ definitions:
       RenameOrganizationPipelineReleaseRequest represents a request to rename a
       release in an organization-owned pipeline.
     required:
-      - new_pipeline_release_id
+      - newPipelineReleaseId
   PipelinePublicServiceRenameUserPipelineBody:
     type: object
     properties:
-      new_pipeline_id:
+      newPipelineId:
         type: string
         description: |-
           The new resource ID. This will transform the resource name into
@@ -2994,11 +2994,11 @@ definitions:
       RenameUserPipelineRequest represents a request to rename the name of a
       pipeline owned by a user.
     required:
-      - new_pipeline_id
+      - newPipelineId
   PipelinePublicServiceRenameUserPipelineReleaseBody:
     type: object
     properties:
-      new_pipeline_release_id:
+      newPipelineReleaseId:
         type: string
         description: |-
           The new resource ID. This will transform the resource name into
@@ -3007,7 +3007,7 @@ definitions:
       RenameUserPipelineReleaseRequest represents a request to rename a release in
       a user-owned pipeline.
     required:
-      - new_pipeline_release_id
+      - newPipelineReleaseId
   PipelinePublicServiceTriggerAsyncOrganizationPipelineBody:
     type: object
     properties:
@@ -3174,11 +3174,11 @@ definitions:
   PipelineStats:
     type: object
     properties:
-      number_of_runs:
+      numberOfRuns:
         type: integer
         format: int32
         description: Number of pipeline runs.
-      last_run_time:
+      lastRunTime:
         type: string
         format: date-time
         description: Last run time.
@@ -3206,7 +3206,7 @@ definitions:
   coremgmtv1betaPermission:
     type: object
     properties:
-      can_edit:
+      canEdit:
         type: boolean
         description: Defines whether the resource can be modified.
     description: Permission defines how a resource can be used.
@@ -3304,12 +3304,12 @@ definitions:
           maximum.
 
           Note that the ID can be updated.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
@@ -3512,7 +3512,7 @@ definitions:
         type: string
         description: Component definition title.
         readOnly: true
-      documentation_url:
+      documentationUrl:
         type: string
         description: Component definition documentation URL.
         readOnly: true
@@ -3553,11 +3553,11 @@ definitions:
         type: string
         description: Component definition vendor name.
         readOnly: true
-      vendor_attributes:
+      vendorAttributes:
         type: object
         description: Vendor-specific attributes.
         readOnly: true
-      source_url:
+      sourceUrl:
         type: string
         description: |-
           Source code URL. This points to the source code where the component is
@@ -3580,7 +3580,7 @@ definitions:
         type: string
         description: Short description of the component.
         readOnly: true
-      release_stage:
+      releaseStage:
         $ref: '#/definitions/ComponentDefinitionReleaseStage'
         description: Release stage.
         readOnly: true
@@ -3652,7 +3652,7 @@ definitions:
         type: string
         description: Connector definition title.
         readOnly: true
-      documentation_url:
+      documentationUrl:
         type: string
         description: Connector definition documentation URL.
         readOnly: true
@@ -3693,11 +3693,11 @@ definitions:
         type: string
         description: Connector definition vendor name.
         readOnly: true
-      vendor_attributes:
+      vendorAttributes:
         type: object
         description: Vendor-specific attributes.
         readOnly: true
-      source_url:
+      sourceUrl:
         type: string
         description: |-
           Source code URL. This points to the source code where the connector is
@@ -3720,7 +3720,7 @@ definitions:
         type: string
         description: Short description of the connector.
         readOnly: true
-      release_stage:
+      releaseStage:
         $ref: '#/definitions/ComponentDefinitionReleaseStage'
         description: Release stage.
         readOnly: true
@@ -3736,10 +3736,10 @@ definitions:
   v1betaConnectorSpec:
     type: object
     properties:
-      component_specification:
+      componentSpecification:
         type: object
         description: Component specification.
-      data_specifications:
+      dataSpecifications:
         type: object
         additionalProperties:
           $ref: '#/definitions/v1betaDataSpecification'
@@ -3748,8 +3748,8 @@ definitions:
           The key represents the task, and the value is the corresponding data_specification.
     description: ConnectorSpec represents a specification data model.
     required:
-      - component_specification
-      - data_specifications
+      - componentSpecification
+      - dataSpecifications
   v1betaConnectorType:
     type: string
     enum:
@@ -3837,18 +3837,18 @@ definitions:
   v1betaGetConnectorDefinitionResponse:
     type: object
     properties:
-      connector_definition:
+      connectorDefinition:
         $ref: '#/definitions/v1betaConnectorDefinition'
         description: The connector definition resource.
     description: GetConnectorDefinitionResponse contains the requested connector definition.
   v1betaGetHubStatsResponse:
     type: object
     properties:
-      number_of_public_pipelines:
+      numberOfPublicPipelines:
         type: integer
         format: int32
         description: Total number of public pipelines.
-      number_of_featured_pipelines:
+      numberOfFeaturedPipelines:
         type: integer
         format: int32
         description: Total number of featured pipelines.
@@ -3864,7 +3864,7 @@ definitions:
   v1betaGetOperatorDefinitionResponse:
     type: object
     properties:
-      operator_definition:
+      operatorDefinition:
         $ref: '#/definitions/v1betaOperatorDefinition'
         description: The operator definition resource.
     description: GetOperatorDefinitionResponse contains the requested operator definition.
@@ -3913,17 +3913,17 @@ definitions:
   v1betaListComponentDefinitionsResponse:
     type: object
     properties:
-      component_definitions:
+      componentDefinitions:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaComponentDefinition'
         description: A list of component definition resources.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of component definitions.
-      page_size:
+      pageSize:
         type: integer
         format: int32
         description: The requested page size.
@@ -3935,16 +3935,16 @@ definitions:
   v1betaListConnectorDefinitionsResponse:
     type: object
     properties:
-      connector_definitions:
+      connectorDefinitions:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaConnectorDefinition'
         description: A list of connector definition resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of connector definitions.
@@ -3952,16 +3952,16 @@ definitions:
   v1betaListOperatorDefinitionsResponse:
     type: object
     properties:
-      operator_definitions:
+      operatorDefinitions:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaOperatorDefinition'
         description: A list of operator definition resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of operator definitions.
@@ -3975,10 +3975,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaPipelineRelease'
         description: A list of pipeline release resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of pipeline releases.
@@ -3992,10 +3992,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaPipeline'
         description: A list of pipeline resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of pipelines.
@@ -4009,10 +4009,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaSecret'
         description: A list of secret resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page secret.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of secret resources.
@@ -4026,10 +4026,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaPipelineRelease'
         description: A list of pipeline releases.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of pipeline releases.
@@ -4047,10 +4047,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaPipeline'
         description: A list of pipeline resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of pipelines.
@@ -4068,10 +4068,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaPipeline'
         description: A list of pipeline resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of pipelines.
@@ -4085,10 +4085,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaPipelineRelease'
         description: A list of pipeline release resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of pipeline releases.
@@ -4102,10 +4102,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaPipeline'
         description: A list of pipeline resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page token.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of pipelines.
@@ -4119,10 +4119,10 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaSecret'
         description: A list of secret resources.
-      next_page_token:
+      nextPageToken:
         type: string
         description: Next page secret.
-      total_size:
+      totalSize:
         type: integer
         format: int32
         description: Total number of secret resources.
@@ -4165,7 +4165,7 @@ definitions:
         type: string
         description: Operator definition title.
         readOnly: true
-      documentation_url:
+      documentationUrl:
         type: string
         description: Operator definition documentation URL.
         readOnly: true
@@ -4196,7 +4196,7 @@ definitions:
         type: boolean
         description: The custom flag determines whether this is a custom operator definition.
         readOnly: true
-      source_url:
+      sourceUrl:
         type: string
         description: |-
           Source code URL. This points to the source code where the operator is
@@ -4219,7 +4219,7 @@ definitions:
         type: string
         description: Short description of the operator.
         readOnly: true
-      release_stage:
+      releaseStage:
         $ref: '#/definitions/ComponentDefinitionReleaseStage'
         description: Release stage.
         readOnly: true
@@ -4233,10 +4233,10 @@ definitions:
   v1betaOperatorSpec:
     type: object
     properties:
-      component_specification:
+      componentSpecification:
         type: object
         description: Component specification.
-      data_specifications:
+      dataSpecifications:
         type: object
         additionalProperties:
           $ref: '#/definitions/v1betaDataSpecification'
@@ -4245,8 +4245,8 @@ definitions:
           The key represents the task, and the value is the corresponding data_specification.
     description: OperatorSpec represents a specification data model.
     required:
-      - component_specification
-      - data_specifications
+      - componentSpecification
+      - dataSpecifications
   v1betaOrganization:
     type: object
     properties:
@@ -4269,12 +4269,12 @@ definitions:
           maximum.
 
           Note that the ID can be updated.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
@@ -4298,7 +4298,7 @@ definitions:
   v1betaOrganizationProfile:
     type: object
     properties:
-      display_name:
+      displayName:
         type: string
         description: Display name.
       bio:
@@ -4307,10 +4307,10 @@ definitions:
       avatar:
         type: string
         description: Avatar in base64 format.
-      public_email:
+      publicEmail:
         type: string
         description: Public email.
-      social_profile_links:
+      socialProfileLinks:
         type: object
         additionalProperties:
           type: string
@@ -4356,17 +4356,17 @@ definitions:
       recipe:
         type: object
         description: Recipe describes the components of a Pipeline and how they are connected.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Pipeline creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Pipeline update time.
         readOnly: true
-      delete_time:
+      deleteTime:
         type: string
         format: date-time
         description: Pipeline delete time.
@@ -4377,7 +4377,7 @@ definitions:
       metadata:
         type: object
         description: Metadata holds console-related data such as the pipeline builder layout.
-      owner_name:
+      ownerName:
         type: string
         description: Owner Name.
         readOnly: true
@@ -4403,7 +4403,7 @@ definitions:
         $ref: '#/definitions/v1betaOwner'
         description: Pipeline owner.
         readOnly: true
-      data_specification:
+      dataSpecification:
         $ref: '#/definitions/v1betaDataSpecification'
         description: Data specifications.
         readOnly: true
@@ -4448,17 +4448,17 @@ definitions:
         type: object
         description: Recipe of the versioned pipeline.
         readOnly: true
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Pipeline creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Pipeline update time.
         readOnly: true
-      delete_time:
+      deleteTime:
         type: string
         format: date-time
         description: Pipeline deletion time.
@@ -4475,7 +4475,7 @@ definitions:
       readme:
         type: string
         description: README.
-      data_specification:
+      dataSpecification:
         $ref: '#/definitions/v1betaDataSpecification'
         description: Data specifications.
         readOnly: true
@@ -4588,12 +4588,12 @@ definitions:
           to RFC-1034, which restricts to letters, numbers, and hyphen, with the
           first character a letter, the last a letter or a number, and a 63
           character maximum.
-      create_time:
+      createTime:
         type: string
         format: date-time
         description: Creation time.
         readOnly: true
-      update_time:
+      updateTime:
         type: string
         format: date-time
         description: Update time.
@@ -4621,7 +4621,7 @@ definitions:
           Each value is a user sharing configuration.
 
           **NOTE**: For now, the only accepted key is `*/*`.
-      share_code:
+      shareCode:
         $ref: '#/definitions/SharingShareCode'
         description: Defines the configuration to share a resource via link.
     description: |-
@@ -4659,7 +4659,7 @@ definitions:
       error:
         type: object
         description: Error details.
-      compute_time_in_seconds:
+      computeTimeInSeconds:
         type: number
         format: float
         description: Computation time in seconds.
@@ -4856,7 +4856,7 @@ definitions:
   v1betaUserProfile:
     type: object
     properties:
-      display_name:
+      displayName:
         type: string
         description: Display name.
       bio:
@@ -4865,13 +4865,13 @@ definitions:
       avatar:
         type: string
         description: Avatar in base64 format.
-      public_email:
+      publicEmail:
         type: string
         description: Public email.
-      company_name:
+      companyName:
         type: string
         description: Company name.
-      social_profile_links:
+      socialProfileLinks:
         type: object
         additionalProperties:
           type: string
@@ -4908,13 +4908,13 @@ definitions:
   vdppipelinev1betaPermission:
     type: object
     properties:
-      can_edit:
+      canEdit:
         type: boolean
         description: Defines whether the pipeline can be modified.
-      can_trigger:
+      canTrigger:
         type: boolean
         description: Defines whether the pipeline can be executed.
-      can_release:
+      canRelease:
         type: boolean
         description: Defines whether the pipeline can be released.
     description: Permission defines how a pipeline can be used.


### PR DESCRIPTION
Because

- Currently, our API HTTP request and response bodies are a mix of camelCase and snake_case, which is not consistent.

This commit

- Uses camelCase for HTTP bodies.