### PR TITLE
fix(docs): regenerate OpenAPI with camelCase

### DIFF
--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1106,7 +1106,7 @@ paths:
           in: query
           required: true
           type: string
-        - name: aggregation_window
+        - name: aggregationWindow
           description: |-
             Aggregation window. The value is a positive duration string, i.e. a
             sequence of decimal numbers, each with optional fraction and a unit
@@ -1607,10 +1607,10 @@ definitions:
   v1betaCreditConsumptionChartRecord:
     type: object
     properties:
-      credit_owner:
+      creditOwner:
         type: string
         description: Credit owner ID, e.g. `users/chef-wombat`.
-      time_buckets:
+      timeBuckets:
         type: array
         items:
           type: string
@@ -2151,13 +2151,13 @@ definitions:
   v1betaListCreditConsumptionChartRecordsResponse:
     type: object
     properties:
-      credit_consumption_chart_records:
+      creditConsumptionChartRecords:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaCreditConsumptionChartRecord'
         description: A list of pipeline trigger records.
-      total_amount:
+      totalAmount:
         type: number
         format: float
         description: Sum of the total credit consumed within the time range.


### PR DESCRIPTION
Because

- The last commit, which transformed params to camelCase, didn't take into
account a previous merge.

This commit

- Regenerate OpenAPI to transform credit chart endpoint to camelCase
