### PR TITLE
chore(model): add missing admin org model methods

### DIFF
--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -163,7 +163,7 @@ message ListPipelineTriggerChartRecordsResponse {
 // by owner and time frame.
 message CreditConsumptionChartRecord {
   // Credit owner ID, e.g. `users/chef-wombat`.
-  string credit_owner= 1;
+  string credit_owner = 1;
   // Time buckets.
   repeated google.protobuf.Timestamp time_buckets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total credit consumed in each time bucket.

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1373,8 +1373,8 @@ message LookUpModelAdminResponse {
   Model model = 1;
 }
 
-// DeployModelAdminRequest represents a request to deploy a model to online state
-message DeployModelAdminRequest {
+// DeployUserModelAdminRequest represents a request to deploy a model to online state
+message DeployUserModelAdminRequest {
   reserved 1;
   // The resource name of the model, which allows its access by parent user
   // and ID.
@@ -1392,15 +1392,37 @@ message DeployModelAdminRequest {
   string digest = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// DeployModelAdminResponse represents a response for a deployed model
-message DeployModelAdminResponse {
+// DeployUserModelAdminResponse represents a response for a deployed model
+message DeployUserModelAdminResponse {
   // Deprecated operation
   reserved 1;
 }
 
-// UndeployModelAdminRequest represents a request to undeploy a model to offline
+// DeployOrganizationModelAdminRequest represents a request to deploy a model to online state
+message DeployOrganizationModelAdminRequest {
+  reserved 1;
+  // The resource name of the model, which allows its access by parent user
+  // and ID.
+  // - Format: `organizations/{user.id}/models/{model.id}`.
+  string name = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Model",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_model_name"}
+    }
+  ];
+  // Model version tag
+  string version = 3 [(google.api.field_behavior) = REQUIRED];
+  // Model image digest
+  string digest = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// DeployOrganizationModelAdminResponse represents a response for a deployed model
+message DeployOrganizationModelAdminResponse {}
+
+// UndeployUserModelAdminRequest represents a request to undeploy a model to offline
 // state
-message UndeployModelAdminRequest {
+message UndeployUserModelAdminRequest {
   reserved 1;
   // The resource name of the model, which allows its access by parent user
   // and ID.
@@ -1418,8 +1440,31 @@ message UndeployModelAdminRequest {
   string digest = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// UndeployModelAdminResponse represents a response for a undeployed model
-message UndeployModelAdminResponse {
+// UndeployUserModelAdminResponse represents a response for a undeployed model
+message UndeployUserModelAdminResponse {
   // Deprecated operation
   reserved 1;
 }
+
+// UndeployOrganizationModelAdminRequest represents a request to undeploy a model to offline
+// state
+message UndeployOrganizationModelAdminRequest {
+  reserved 1;
+  // The resource name of the model, which allows its access by parent user
+  // and ID.
+  // - Format: `organizations/{organization.id}/models/{model.id}`.
+  string name = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Model",
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_model_name"}
+    }
+  ];
+  // Model version tag
+  string version = 3 [(google.api.field_behavior) = REQUIRED];
+  // Model image digest
+  string digest = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// UndeployOrganizationModelAdminResponse represents a response for a undeployed model
+message UndeployOrganizationModelAdminResponse {}

--- a/model/model/v1alpha/model_private_service.proto
+++ b/model/model/v1alpha/model_private_service.proto
@@ -25,18 +25,34 @@ service ModelPrivateService {
     option (google.api.method_signature) = "permalink";
   }
 
-  // DeployModelAdmin deploy a model to online state
-  rpc DeployModelAdmin(DeployModelAdminRequest) returns (DeployModelAdminResponse) {
+  // DeployUserModelAdmin deploy a model to online state
+  rpc DeployUserModelAdmin(DeployUserModelAdminRequest) returns (DeployUserModelAdminResponse) {
     option (google.api.http) = {
       post: "/v1alpha/admin/{name=users/*/models/*}/{version=*}/deploy"
       body: "*"
     };
   }
 
-  // UndeployModelAdmin undeploy a model to offline state
-  rpc UndeployModelAdmin(UndeployModelAdminRequest) returns (UndeployModelAdminResponse) {
+  // DeployOrganizationModelAdmin deploy a model to online state
+  rpc DeployOrganizationModelAdmin(DeployOrganizationModelAdminRequest) returns (DeployOrganizationModelAdminResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/admin/{name=organizations/*/models/*}/{version=*}/deploy"
+      body: "*"
+    };
+  }
+
+  // UndeployUserModelAdmin undeploy a model to offline state
+  rpc UndeployUserModelAdmin(UndeployUserModelAdminRequest) returns (UndeployUserModelAdminResponse) {
     option (google.api.http) = {
       post: "/v1alpha/admin/{name=users/*/models/*}/{version=*}/undeploy"
+      body: "*"
+    };
+  }
+
+  // UndeployOrganizationModelAdmin undeploy a model to offline state
+  rpc UndeployOrganizationModelAdmin(UndeployOrganizationModelAdminRequest) returns (UndeployOrganizationModelAdminResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/admin/{name=organizations/*/models/*}/{version=*}/undeploy"
       body: "*"
     };
   }

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2364,9 +2364,12 @@ definitions:
   v1alphaDeleteUserModelResponse:
     type: object
     description: DeleteUserModelResponse is an empty response.
-  v1alphaDeployModelAdminResponse:
+  v1alphaDeployOrganizationModelAdminResponse:
     type: object
-    title: DeployModelAdminResponse represents a response for a deployed model
+    title: DeployOrganizationModelAdminResponse represents a response for a deployed model
+  v1alphaDeployUserModelAdminResponse:
+    type: object
+    title: DeployUserModelAdminResponse represents a response for a deployed model
   v1alphaDetectionInput:
     type: object
     properties:
@@ -3754,9 +3757,12 @@ definitions:
           $ref: '#/definitions/v1alphaTaskOutput'
         description: Model inference outputs.
     description: TriggerUserModelResponse contains the model inference results.
-  v1alphaUndeployModelAdminResponse:
+  v1alphaUndeployOrganizationModelAdminResponse:
     type: object
-    title: UndeployModelAdminResponse represents a response for a undeployed model
+    title: UndeployOrganizationModelAdminResponse represents a response for a undeployed model
+  v1alphaUndeployUserModelAdminResponse:
+    type: object
+    title: UndeployUserModelAdminResponse represents a response for a undeployed model
   v1alphaUnpublishOrganizationModelResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- We are missing an endpoint to deploy org models

This commit

- add missing admin org model methods
