### PR TITLE
feat(vdp): stream Organization pipeline trigger response

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -656,7 +656,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceTriggerUserPipelineBody'
       tags:
         - Trigger
-  /v1beta/{user_pipeline_name}/trigger:stream:
+  /v1beta/{user_pipeline_name}/triggerStream:
     post:
       summary: Trigger a pipeline owned by a user and stream back the response
       description: |-
@@ -1619,6 +1619,55 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineBody'
       tags:
         - Pipeline
+  /v1beta/{organization_pipeline_name}/triggerStream:
+    post:
+      summary: Trigger a pipeline owned by an organization
+      description: |-
+        Triggers the execution of a pipeline synchronously, i.e., the result is sent
+        back to the organization right after the data is processed. This method is
+        intended for real-time inference when low latency is of concern.
+
+        The pipeline is identified by its resource name, formed by the parent
+        organization and ID of the pipeline.
+
+        For more information, see [Trigger
+        Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+      operationId: PipelinePublicService_TriggerOrganizationPipelineStream
+      responses:
+        "200":
+          description: A successful response.(streaming responses)
+          schema:
+            type: object
+            properties:
+              result:
+                $ref: '#/definitions/v1betaTriggerOrganizationPipelineStreamResponse'
+              error:
+                $ref: '#/definitions/googlerpcStatus'
+            title: Stream result of v1betaTriggerOrganizationPipelineStreamResponse
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: organization_pipeline_name
+          description: |-
+            The resource name of the pipeline, which allows its access by parent
+            organization and ID.
+            - Format: `organizations/{organization.id}/pipelines/{pipeline.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceTriggerOrganizationPipelineStreamBody'
+      tags:
+        - Trigger
   /v1beta/{organization_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by an organization
@@ -3110,6 +3159,23 @@ definitions:
     description: |-
       TriggerOrganizationPipelineReleaseRequest represents a request to trigger a
       pinned release of an organization-owned pipeline.
+  PipelinePublicServiceTriggerOrganizationPipelineStreamBody:
+    type: object
+    properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
+      data:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
+    description: |-
+      TriggerOrganizationPipelineRequest represents a request to trigger an
+      organization-owned pipeline synchronously.
   PipelinePublicServiceTriggerUserPipelineBody:
     type: object
     properties:
@@ -4754,6 +4820,20 @@ definitions:
       TriggerOrganizationPipelineReleaseResponse contains the pipeline execution
       results, i.e., the multiple model inference outputs.
   v1betaTriggerOrganizationPipelineResponse:
+    type: object
+    properties:
+      outputs:
+        type: array
+        items:
+          type: object
+        description: Model inference outputs.
+      metadata:
+        $ref: '#/definitions/v1betaTriggerMetadata'
+        description: Traces of the pipeline inference.
+    description: |-
+      TriggerOrganizationPipelineResponse contains the pipeline execution results,
+      i.e., the multiple model inference outputs.
+  v1betaTriggerOrganizationPipelineStreamResponse:
     type: object
     properties:
       outputs:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -656,7 +656,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceTriggerUserPipelineBody'
       tags:
         - Trigger
-  /v1beta/{user_pipeline_name}/triggerStream:
+  /v1beta/{user_pipeline_name}/trigger-stream:
     post:
       summary: Trigger a pipeline owned by a user and stream back the response
       description: |-
@@ -1619,7 +1619,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineBody'
       tags:
         - Pipeline
-  /v1beta/{organization_pipeline_name}/triggerStream:
+  /v1beta/{organization_pipeline_name}/trigger-stream:
     post:
       summary: Trigger a pipeline owned by an organization
       description: |-

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1037,6 +1037,35 @@ message TriggerOrganizationPipelineResponse {
   TriggerMetadata metadata = 2;
 }
 
+
+// TriggerOrganizationPipelineRequest represents a request to trigger an
+// organization-owned pipeline synchronously.
+message TriggerOrganizationPipelineStreamRequest {
+  // The resource name of the pipeline, which allows its access by parent
+  // organization and ID.
+  // - Format: `organizations/{organization.id}/pipelines/{pipeline.id}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "organization_pipeline_name"}
+    }
+  ];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 2;
+  // Data
+  repeated TriggerData data = 3;
+}
+
+// TriggerOrganizationPipelineResponse contains the pipeline execution results,
+// i.e., the multiple model inference outputs.
+message TriggerOrganizationPipelineStreamResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct outputs = 1;
+  // Traces of the pipeline inference.
+  TriggerMetadata metadata = 2;
+}
+
 // TriggerOrganizationPipelineRequest represents a request to trigger an
 // organization-owned pipeline synchronously.
 message TriggerAsyncOrganizationPipelineRequest {

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -209,7 +209,7 @@ service PipelinePublicService {
   // and ID of the pipeline.
   rpc TriggerUserPipelineWithStream(TriggerUserPipelineWithStreamRequest) returns (stream TriggerUserPipelineWithStreamResponse) {
     option (google.api.http) = {
-      post: "/v1beta/{name=users/*/pipelines/*}/triggerStream"
+      post: "/v1beta/{name=users/*/pipelines/*}/trigger-stream"
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
@@ -490,7 +490,7 @@ service PipelinePublicService {
   // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
   rpc TriggerOrganizationPipelineStream(TriggerOrganizationPipelineStreamRequest) returns (stream TriggerOrganizationPipelineStreamResponse) {
     option (google.api.http) = {
-      post: "/v1beta/{name=organizations/*/pipelines/*}/triggerStream"
+      post: "/v1beta/{name=organizations/*/pipelines/*}/trigger-stream"
       body: "*"
     };
     option (google.api.method_signature) = "name,data";

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -209,7 +209,7 @@ service PipelinePublicService {
   // and ID of the pipeline.
   rpc TriggerUserPipelineWithStream(TriggerUserPipelineWithStreamRequest) returns (stream TriggerUserPipelineWithStreamResponse) {
     option (google.api.http) = {
-      post: "/v1beta/{name=users/*/pipelines/*}/trigger:stream"
+      post: "/v1beta/{name=users/*/pipelines/*}/triggerStream"
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
@@ -475,6 +475,26 @@ service PipelinePublicService {
     };
     option (google.api.method_signature) = "name,target";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Trigger a pipeline owned by an organization
+  //
+  // Triggers the execution of a pipeline synchronously, i.e., the result is sent
+  // back to the organization right after the data is processed. This method is
+  // intended for real-time inference when low latency is of concern.
+  //
+  // The pipeline is identified by its resource name, formed by the parent
+  // organization and ID of the pipeline.
+  //
+  // For more information, see [Trigger
+  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  rpc TriggerOrganizationPipelineStream(TriggerOrganizationPipelineStreamRequest) returns (stream TriggerOrganizationPipelineStreamResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{name=organizations/*/pipelines/*}/triggerStream"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,data";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Trigger a pipeline owned by an organization


### PR DESCRIPTION
Because:
- We want to support streaming responses for triggering user pipelines, which is useful for real-time inference when low latency is a concern.
- The current RPC method for triggering user pipelines returns the response synchronously, which is unsuitable for streaming.