### PR TITLE
chore(mgmt): make ApiToken `last_use_time` optional

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -448,7 +448,7 @@ message ApiToken {
   // When users trigger a pipeline which uses an API token, the token is
   // updated with the current time. This field is used to track the last time
   // the token was used.
-  google.protobuf.Timestamp last_use_time = 6;
+  optional google.protobuf.Timestamp last_use_time = 6;
 
   // State describes the state of an API token.
   enum State {

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1037,7 +1037,6 @@ message TriggerOrganizationPipelineResponse {
   TriggerMetadata metadata = 2;
 }
 
-
 // TriggerOrganizationPipelineRequest represents a request to trigger an
 // organization-owned pipeline synchronously.
 message TriggerOrganizationPipelineStreamRequest {


### PR DESCRIPTION
Because

- The `last_use_time` of `ApiToken` should be optional since it might never be used.

This commit

- Makes `last_use_time` in `ApiToken` optional.