### PR TITLE
chore(model): rename model version id to version

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -162,7 +162,6 @@ message KnowledgeBase {
   repeated string downstream_apps = 12;
 }
 
-
 // CreateKnowledgeBaseRequest represents a request to create a knowledge base.
 message CreateKnowledgeBaseRequest {
   // The knowledge base owner(nammespace).

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -40,21 +40,21 @@ service ArtifactPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-    // Create a knowledge base
+  // Create a knowledge base
   rpc CreateKnowledgeBase(CreateKnowledgeBaseRequest) returns (CreateKnowledgeBaseResponse) {
-      option (google.api.http) = {
-        post: "/v1alpha/owners/{owner_id}/knowledge-bases"
-        body: "*"
-      };
-      option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
-    }
-  
-    // Get all knowledge bases info
+    option (google.api.http) = {
+      post: "/v1alpha/owners/{owner_id}/knowledge-bases"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
+  }
+
+  // Get all knowledge bases info
   rpc ListKnowledgeBases(ListKnowledgeBasesRequest) returns (ListKnowledgeBasesResponse) {
-      option (google.api.http) = {get: "/v1alpha/owners/{owner_id}/knowledge-bases"};
-      option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
-    }
-  
+    option (google.api.http) = {get: "/v1alpha/owners/{owner_id}/knowledge-bases"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
+  }
+
   // Update a knowledge base info
   rpc UpdateKnowledgeBase(UpdateKnowledgeBaseRequest) returns (UpdateKnowledgeBaseResponse) {
     option (google.api.http) = {
@@ -63,7 +63,7 @@ service ArtifactPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
-  
+
   // Delete a knowledge base
   rpc DeleteKnowledgeBase(DeleteKnowledgeBaseRequest) returns (DeleteKnowledgeBaseResponse) {
     option (google.api.http) = {delete: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}"};

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -97,8 +97,8 @@ message ModelVersion {
   // The name of the tag.
   // - Format: `users/{user.id}/models/{model.id}/versions/{version.id}`.
   string name = 1 [(google.api.field_behavior) = IMMUTABLE];
-  // The tag identifier.
-  string id = 2 [(google.api.field_behavior) = IMMUTABLE];
+  // The model version identifier, which is equal to image tag.
+  string version = 2 [(google.api.field_behavior) = IMMUTABLE];
   // Unique identifier, computed from the manifest the tag refers to.
   string digest = 3 [(google.api.field_behavior) = OPTIONAL];
   // Current state of this model version.

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -198,9 +198,9 @@ service ModelPublicService {
 
   // Watch the state of a model version
   //
-  // Returns the state of a model. The deploy / undeploy actions take some
-  // time, during which a model will be in an UNSPECIFIED state. This endpoint
-  // allows clients to track the state and progress of the model.
+  // Returns the state of a model. The model resource allocation and scaling actions take some
+  // time, during which a model will be in various state. This endpoint
+  // allows clients to track the state.
   rpc WatchUserModel(WatchUserModelRequest) returns (WatchUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions/{version=*}/watch"};
     option (google.api.method_signature) = "name";
@@ -209,9 +209,9 @@ service ModelPublicService {
 
   // Watch the state of the latest model version
   //
-  // Returns the state of the latest model version. The deploy / undeploy actions take some
-  // time, during which a model will be in an UNSPECIFIED state. This endpoint
-  // allows clients to track the state and progress of the model.
+  // Returns the state of the latest model version. The model resource allocation and scaling actions
+  // take some time, during which a model will be in various state. This endpoint
+  // allows clients to track the state.
   rpc WatchUserLatestModel(WatchUserLatestModelRequest) returns (WatchUserLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/watch"};
     option (google.api.method_signature) = "name";
@@ -404,9 +404,9 @@ service ModelPublicService {
 
   // Watch the state of a model version
   //
-  // Returns the state of a model. The deploy / undeploy actions take some
-  // time, during which a model will be in an UNSPECIFIED state. This endpoint
-  // allows clients to track the state and progress of the model.
+  // Returns the state of a model.  The model resource allocation and scaling actions
+  // take some time, during which a model will be in various state. This endpoint
+  // allows clients to track the state.
   rpc WatchOrganizationModel(WatchOrganizationModelRequest) returns (WatchOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}/watch"};
     option (google.api.method_signature) = "name";
@@ -415,9 +415,9 @@ service ModelPublicService {
 
   // Watch the state of the latest model version
   //
-  // Returns the state of the latest model version. The deploy / undeploy actions take some
-  // time, during which a model will be in an UNSPECIFIED state. This endpoint
-  // allows clients to track the state and progress of the model.
+  // Returns the state of the latest model version.  The model resource allocation and scaling actions
+  // take some time, during which a model will be in various state. This endpoint
+  // allows clients to track the state.
   rpc WatchOrganizationLatestModel(WatchOrganizationLatestModelRequest) returns (WatchOrganizationLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/watch"};
     option (google.api.method_signature) = "name";

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -733,9 +733,9 @@ paths:
     get:
       summary: Watch the state of a model version
       description: |-
-        Returns the state of a model. The deploy / undeploy actions take some
-        time, during which a model will be in an UNSPECIFIED state. This endpoint
-        allows clients to track the state and progress of the model.
+        Returns the state of a model. The model resource allocation and scaling actions take some
+        time, during which a model will be in various state. This endpoint
+        allows clients to track the state.
       operationId: ModelPublicService_WatchUserModel
       responses:
         "200":
@@ -771,9 +771,9 @@ paths:
     get:
       summary: Watch the state of the latest model version
       description: |-
-        Returns the state of the latest model version. The deploy / undeploy actions take some
-        time, during which a model will be in an UNSPECIFIED state. This endpoint
-        allows clients to track the state and progress of the model.
+        Returns the state of the latest model version. The model resource allocation and scaling actions
+        take some time, during which a model will be in various state. This endpoint
+        allows clients to track the state.
       operationId: ModelPublicService_WatchUserLatestModel
       responses:
         "200":
@@ -1491,9 +1491,9 @@ paths:
     get:
       summary: Watch the state of a model version
       description: |-
-        Returns the state of a model. The deploy / undeploy actions take some
-        time, during which a model will be in an UNSPECIFIED state. This endpoint
-        allows clients to track the state and progress of the model.
+        Returns the state of a model.  The model resource allocation and scaling actions
+        take some time, during which a model will be in various state. This endpoint
+        allows clients to track the state.
       operationId: ModelPublicService_WatchOrganizationModel
       responses:
         "200":
@@ -1529,9 +1529,9 @@ paths:
     get:
       summary: Watch the state of the latest model version
       description: |-
-        Returns the state of the latest model version. The deploy / undeploy actions take some
-        time, during which a model will be in an UNSPECIFIED state. This endpoint
-        allows clients to track the state and progress of the model.
+        Returns the state of the latest model version.  The model resource allocation and scaling actions
+        take some time, during which a model will be in various state. This endpoint
+        allows clients to track the state.
       operationId: ModelPublicService_WatchOrganizationLatestModel
       responses:
         "200":
@@ -3106,9 +3106,9 @@ definitions:
           - Format: `users/{user.id}/models/{model.id}`.
           The name of the tag.
           - Format: `users/{user.id}/models/{model.id}/versions/{version.id}`.
-      id:
+      version:
         type: string
-        description: The tag identifier.
+        description: The model version identifier, which is equal to image tag.
       digest:
         type: string
         description: Unique identifier, computed from the manifest the tag refers to.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1037,7 +1037,6 @@ message TriggerOrganizationPipelineResponse {
   TriggerMetadata metadata = 2;
 }
 
-
 // TriggerOrganizationPipelineRequest represents a request to trigger an
 // organization-owned pipeline synchronously.
 message TriggerOrganizationPipelineStreamRequest {


### PR DESCRIPTION
Because

- id is ambiguous, use `version` instead

This commit

- rename `id` to `version`
