### PR TITLE
feat(vdp): expose `raw_recipe` field in pipeline endpoint

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -493,6 +493,11 @@ paths:
               stats:
                 $ref: '#/definitions/PipelineStats'
                 description: Statistic data.
+              rawRecipe:
+                type: string
+                description: |-
+                  Recipe in YAML format describes the components of a pipeline and how they
+                  are connected.
             title: The pipeline fields that will replace the existing ones.
       tags:
         - Pipeline
@@ -1020,6 +1025,11 @@ paths:
                 $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
+              rawRecipe:
+                type: string
+                description: |-
+                  Recipe in YAML format describes the components of a pipeline and how they
+                  are connected.
             title: |-
               The pipeline release fields that will replace the existing ones.
               A pipeline release resource to update
@@ -1501,6 +1511,11 @@ paths:
               stats:
                 $ref: '#/definitions/PipelineStats'
                 description: Statistic data.
+              rawRecipe:
+                type: string
+                description: |-
+                  Recipe in YAML format describes the components of a pipeline and how they
+                  are connected.
             title: The pipeline fields that will replace the existing ones.
       tags:
         - Pipeline
@@ -2022,6 +2037,11 @@ paths:
                 $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
+              rawRecipe:
+                type: string
+                description: |-
+                  Recipe in YAML format describes the components of a pipeline and how they
+                  are connected.
             title: |-
               The pipeline release fields that will replace the existing ones.
               A pipeline release resource to update
@@ -4482,6 +4502,11 @@ definitions:
       stats:
         $ref: '#/definitions/PipelineStats'
         description: Statistic data.
+      rawRecipe:
+        type: string
+        description: |-
+          Recipe in YAML format describes the components of a pipeline and how they
+          are connected.
     description: |-
       A Pipeline is an end-to-end workflow that automates a sequence of components
       to process data.
@@ -4545,6 +4570,11 @@ definitions:
         $ref: '#/definitions/v1betaDataSpecification'
         description: Data specifications.
         readOnly: true
+      rawRecipe:
+        type: string
+        description: |-
+          Recipe in YAML format describes the components of a pipeline and how they
+          are connected.
     description: |-
       Pipeline releases contain the version control information of a pipeline.
       This allows users to track changes in the pipeline over time.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -153,6 +153,9 @@ message Pipeline {
   repeated string tags = 25 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Statistic data.
   Stats stats = 26;
+  // Recipe in YAML format describes the components of a pipeline and how they
+  // are connected.
+  string raw_recipe = 27 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerMetadata contains the traces of the pipeline inference.
@@ -240,6 +243,9 @@ message PipelineRelease {
   string readme = 13 [(google.api.field_behavior) = OPTIONAL];
   // Data specifications.
   DataSpecification data_specification = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Recipe in YAML format describes the components of a pipeline and how they
+  // are connected.
+  string raw_recipe = 15 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelinesRequest represents a request to list pipelines.
@@ -1036,7 +1042,6 @@ message TriggerOrganizationPipelineResponse {
   // Traces of the pipeline inference.
   TriggerMetadata metadata = 2;
 }
-
 
 // TriggerOrganizationPipelineRequest represents a request to trigger an
 // organization-owned pipeline synchronously.


### PR DESCRIPTION
Because

- We are going to support pipeline recipes in YAML format. We will return the recipe in YAML format in the response and also allow users to create/update recipes using YAML format.

This commit

- Exposes the `raw_recipe` field in the pipeline and pipeline_release messages.