### PR TITLE
feat(mgmt): add CheckNamespaceAdmin endpoint

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -438,6 +438,34 @@ message CheckNamespaceResponse {
   Namespace type = 1;
 }
 
+// CheckNamespaceAdminRequest represents a request to verify if a namespace is
+// available.
+message CheckNamespaceAdminRequest {
+  // The namespace ID to be checked.
+  string id = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CheckNamespaceAdminResponse contains the availability of a namespace or the type
+// of resource that's using it.
+message CheckNamespaceAdminResponse {
+  // Namespace contains information about the availability of a namespace.
+  enum Namespace {
+    // Unspecified.
+    NAMESPACE_UNSPECIFIED = 0;
+    // Available.
+    NAMESPACE_AVAILABLE = 1;
+    // Namespace belongs to a user.
+    NAMESPACE_USER = 2;
+    // Namespace belongs to an organization.
+    NAMESPACE_ORGANIZATION = 3;
+    // Reserved.
+    NAMESPACE_RESERVED = 4;
+  }
+
+  // Namespace type.
+  Namespace type = 1;
+}
+
 // API tokens allow users to make requests to the Instill AI API.
 message ApiToken {
   option (google.api.resource) = {

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -86,5 +86,13 @@ service MgmtPrivateService {
     option (google.api.method_signature) = "owner";
   }
 
+  // Check if a namespace is in use
+  //
+  // Returns the availability of a namespace or, alternatively, the type of
+  // resource that is using it.
+  rpc CheckNamespaceAdmin(CheckNamespaceAdminRequest) returns (CheckNamespaceAdminResponse) {
+    option (google.api.method_signature) = "namespace";
+  }
+
   option (google.api.api_visibility).restriction = "INTERNAL";
 }

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1140,20 +1140,6 @@ definitions:
        - STATE_INACTIVE: Inactive.
        - STATE_ACTIVE: Active.
        - STATE_EXPIRED: Expired.
-  CheckNamespaceResponseNamespace:
-    type: string
-    enum:
-      - NAMESPACE_AVAILABLE
-      - NAMESPACE_USER
-      - NAMESPACE_ORGANIZATION
-      - NAMESPACE_RESERVED
-    description: |-
-      Namespace contains information about the availability of a namespace.
-
-       - NAMESPACE_AVAILABLE: Available.
-       - NAMESPACE_USER: Namespace belongs to a user.
-       - NAMESPACE_ORGANIZATION: Namespace belongs to an organization.
-       - NAMESPACE_RESERVED: Reserved.
   HealthCheckResponseServingStatus:
     type: string
     enum:
@@ -1531,6 +1517,29 @@ definitions:
       - id
       - email
       - newsletterSubscription
+  v1betaCheckNamespaceAdminResponse:
+    type: object
+    properties:
+      type:
+        $ref: '#/definitions/v1betaCheckNamespaceAdminResponseNamespace'
+        description: Namespace type.
+    description: |-
+      CheckNamespaceAdminResponse contains the availability of a namespace or the type
+      of resource that's using it.
+  v1betaCheckNamespaceAdminResponseNamespace:
+    type: string
+    enum:
+      - NAMESPACE_AVAILABLE
+      - NAMESPACE_USER
+      - NAMESPACE_ORGANIZATION
+      - NAMESPACE_RESERVED
+    description: |-
+      Namespace contains information about the availability of a namespace.
+
+       - NAMESPACE_AVAILABLE: Available.
+       - NAMESPACE_USER: Namespace belongs to a user.
+       - NAMESPACE_ORGANIZATION: Namespace belongs to an organization.
+       - NAMESPACE_RESERVED: Reserved.
   v1betaCheckNamespaceRequest:
     type: object
     properties:
@@ -1546,11 +1555,25 @@ definitions:
     type: object
     properties:
       type:
-        $ref: '#/definitions/CheckNamespaceResponseNamespace'
+        $ref: '#/definitions/v1betaCheckNamespaceResponseNamespace'
         description: Namespace type.
     description: |-
       CheckNamespaceResponse contains the availability of a namespace or the type
       of resource that's using it.
+  v1betaCheckNamespaceResponseNamespace:
+    type: string
+    enum:
+      - NAMESPACE_AVAILABLE
+      - NAMESPACE_USER
+      - NAMESPACE_ORGANIZATION
+      - NAMESPACE_RESERVED
+    description: |-
+      Namespace contains information about the availability of a namespace.
+
+       - NAMESPACE_AVAILABLE: Available.
+       - NAMESPACE_USER: Namespace belongs to a user.
+       - NAMESPACE_ORGANIZATION: Namespace belongs to an organization.
+       - NAMESPACE_RESERVED: Reserved.
   v1betaConnectorUsageData:
     type: object
     properties:


### PR DESCRIPTION
Because

- In pipeline, model, and artifact backends, we might need to verify the namespace type when provided with the namespace UID.

This Commit

- Adds the `CheckNamespaceAdmin` endpoint to `MgmtPrivateService`.
