### PR TITLE
chore(mgmt): return UID in CheckNamespaceAdminResponse

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -464,6 +464,8 @@ message CheckNamespaceAdminResponse {
 
   // Namespace type.
   Namespace type = 1;
+  // Namespace UID.
+  string uid = 2;
 }
 
 // API tokens allow users to make requests to the Instill AI API.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1523,6 +1523,9 @@ definitions:
       type:
         $ref: '#/definitions/v1betaCheckNamespaceAdminResponseNamespace'
         description: Namespace type.
+      uid:
+        type: string
+        description: Namespace UID.
     description: |-
       CheckNamespaceAdminResponse contains the availability of a namespace or the type
       of resource that's using it.


### PR DESCRIPTION
Because

- Sometimes, the client will want to get the namespace type and namespace UID at the same time.

This commit

- Adds `UID` to the `CheckNamespaceAdminResponse`.