### PR TITLE
feat(vdp): add endpoints for cloning pipeline release

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -619,6 +619,41 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceCloneUserPipelineBody'
       tags:
         - Pipeline
+  /v1beta/{user_pipeline_release_name}/clone:
+    post:
+      summary: Clone a pipeline release owned by a user
+      description: |-
+        Clones a pipeline release owned by a user. The new pipeline may have a different
+        parent, and this can be either a user or an organization.
+      operationId: PipelinePublicService_CloneUserPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCloneUserPipelineReleaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: user_pipeline_release_name
+          description: |-
+            The resource name of the pipeline release.
+            - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{version}`.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceCloneUserPipelineReleaseBody'
+      tags:
+        - Pipeline
   /v1beta/{user_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by a user
@@ -1600,7 +1635,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceRenameOrganizationPipelineBody'
       tags:
         - Pipeline
-  /v1beta/{user_pipeline_name_1}/clone:
+  /v1beta/{org_pipeline_name}/clone:
     post:
       summary: Clone a pipeline owned by an organization
       description: |-
@@ -1620,7 +1655,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_pipeline_name_1
+        - name: org_pipeline_name
           description: |-
             The resource name of the pipeline, which allows its access by parent
             organization and ID.
@@ -1634,6 +1669,41 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineBody'
+      tags:
+        - Pipeline
+  /v1beta/{org_pipeline_release_name}/clone:
+    post:
+      summary: Clone a pipeline release owned by an organization
+      description: |-
+        Clones a pipeline release owned by an organization. The new pipeline may
+        have a different parent, and this can be either a user or an organization.
+      operationId: PipelinePublicService_CloneOrganizationPipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCloneOrganizationPipelineReleaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: org_pipeline_release_name
+          description: |-
+            The resource name of the pipeline release
+            - Format: `organizations/{org.id}/pipelines/{pipeline.id}/releases/{version}`.
+          in: path
+          required: true
+          type: string
+          pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineReleaseBody'
       tags:
         - Pipeline
   /v1beta/{organization_pipeline_name}/trigger-stream:
@@ -3018,6 +3088,27 @@ definitions:
       owned by an organization.
     required:
       - target
+  PipelinePublicServiceCloneOrganizationPipelineReleaseBody:
+    type: object
+    properties:
+      target:
+        type: string
+        title: |-
+          The target pipeline. It can be under a user or an organization
+          namespace, so the following formats are accepted:
+          - `{user.id}/{pipeline.id}`
+          - `{organization.id}/{pipeline.id}`
+      description:
+        type: string
+        description: Pipeline description.
+      sharing:
+        $ref: '#/definitions/v1betaSharing'
+        description: Pipeline sharing information.
+    description: |-
+      CloneOrganizationPipelineReleaseRequest represents a request to clone a pipeline
+      release owned by an organization.
+    required:
+      - target
   PipelinePublicServiceCloneUserPipelineBody:
     type: object
     properties:
@@ -3037,6 +3128,27 @@ definitions:
     description: |-
       CloneUserPipelineRequest represents a request to clone a pipeline owned by a
       user.
+    required:
+      - target
+  PipelinePublicServiceCloneUserPipelineReleaseBody:
+    type: object
+    properties:
+      target:
+        type: string
+        title: |-
+          The target pipeline. It can be under a user or an organization
+          namespace, so the following formats are accepted:
+          - `{user.id}/{pipeline.id}`
+          - `{organization.id}/{pipeline.id}`
+      description:
+        type: string
+        description: Pipeline description.
+      sharing:
+        $ref: '#/definitions/v1betaSharing'
+        description: Pipeline sharing information.
+    description: |-
+      CloneUserPipelineReleaseRequest represents a request to clone a pipeline
+      release owned by a user.
     required:
       - target
   PipelinePublicServiceRenameOrganizationPipelineBody:
@@ -3578,19 +3690,17 @@ definitions:
         $ref: '#/definitions/CheckNameResponseName'
         description: The availability of the requested name.
     description: CheckNameResponse contains the availability of a resource name.
+  v1betaCloneOrganizationPipelineReleaseResponse:
+    type: object
+    description: CloneOrganizationPipelineReleaseResponse contains a cloned pipeline.
   v1betaCloneOrganizationPipelineResponse:
     type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1betaPipeline'
-        description: The cloned pipeline resource.
     description: CloneOrganizationPipelineResponse contains a cloned pipeline.
+  v1betaCloneUserPipelineReleaseResponse:
+    type: object
+    description: CloneUserPipelineReleaseResponse contains a cloned pipeline.
   v1betaCloneUserPipelineResponse:
     type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1betaPipeline'
-        description: The cloned pipeline resource.
     description: CloneUserPipelineResponse contains a cloned pipeline.
   v1betaComponentDefinition:
     type: object

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -506,10 +506,33 @@ message CloneUserPipelineRequest {
 }
 
 // CloneUserPipelineResponse contains a cloned pipeline.
-message CloneUserPipelineResponse {
-  // The cloned pipeline resource.
-  Pipeline pipeline = 1;
+message CloneUserPipelineResponse {}
+
+// CloneUserPipelineReleaseRequest represents a request to clone a pipeline
+// release owned by a user.
+message CloneUserPipelineReleaseRequest {
+  // The resource name of the pipeline release.
+  // - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{version}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "user_pipeline_release_name"}
+    }
+  ];
+  // The target pipeline. It can be under a user or an organization
+  // namespace, so the following formats are accepted:
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
+  string target = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
 }
+
+// CloneUserPipelineReleaseResponse contains a cloned pipeline.
+message CloneUserPipelineReleaseResponse {}
 
 // TriggerUserPipelineRequest represents a request to trigger a user-owned
 // pipeline synchronously.
@@ -1005,7 +1028,7 @@ message CloneOrganizationPipelineRequest {
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_name"}
+      field_configuration: {path_param_name: "org_pipeline_name"}
     }
   ];
   // The target pipeline. It can be under a user or an organization
@@ -1020,10 +1043,33 @@ message CloneOrganizationPipelineRequest {
 }
 
 // CloneOrganizationPipelineResponse contains a cloned pipeline.
-message CloneOrganizationPipelineResponse {
-  // The cloned pipeline resource.
-  Pipeline pipeline = 1;
+message CloneOrganizationPipelineResponse {}
+
+// CloneOrganizationPipelineReleaseRequest represents a request to clone a pipeline
+// release owned by an organization.
+message CloneOrganizationPipelineReleaseRequest {
+  // The resource name of the pipeline release
+  // - Format: `organizations/{org.id}/pipelines/{pipeline.id}/releases/{version}`.
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      field_configuration: {path_param_name: "org_pipeline_release_name"}
+    }
+  ];
+  // The target pipeline. It can be under a user or an organization
+  // namespace, so the following formats are accepted:
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
+  string target = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
 }
+
+// CloneOrganizationPipelineReleaseResponse contains a cloned pipeline.
+message CloneOrganizationPipelineReleaseResponse {}
 
 // TriggerOrganizationPipelineRequest represents a request to trigger an
 // organization-owned pipeline synchronously.

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -179,6 +179,19 @@ service PipelinePublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
+  // Clone a pipeline release owned by a user
+  //
+  // Clones a pipeline release owned by a user. The new pipeline may have a different
+  // parent, and this can be either a user or an organization.
+  rpc CloneUserPipelineRelease(CloneUserPipelineReleaseRequest) returns (CloneUserPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{name=users/*/pipelines/*/releases/*}/clone"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,target";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
   // Trigger a pipeline owned by a user
   //
   // Triggers the execution of a pipeline synchronously, i.e., the result is
@@ -471,6 +484,19 @@ service PipelinePublicService {
   rpc CloneOrganizationPipeline(CloneOrganizationPipelineRequest) returns (CloneOrganizationPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/clone"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name,target";
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Clone a pipeline release owned by an organization
+  //
+  // Clones a pipeline release owned by an organization. The new pipeline may
+  // have a different parent, and this can be either a user or an organization.
+  rpc CloneOrganizationPipelineRelease(CloneOrganizationPipelineReleaseRequest) returns (CloneOrganizationPipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/clone"
       body: "*"
     };
     option (google.api.method_signature) = "name,target";


### PR DESCRIPTION
Because

- We will allow users to clone a pipeline from a pipeline release.

This commit

- Adds endpoints for cloning pipeline releases.