### PR TITLE
chore(pipeline): add requester UID header to trigger endpoints

### DIFF
--- a/common/openapi/v1beta/api_config.conf
+++ b/common/openapi/v1beta/api_config.conf
@@ -18,7 +18,7 @@
         description: "Enter the token with the `Bearer ` prefix, e.g. `Bearer abcde12345`";
         extensions: {
           key: "x-default";
-          value {string_value: "Bearer instill_sk_***"}
+          value {string_value: "Bearer instill_sk_***"};
         }
       }
     }
@@ -31,5 +31,5 @@
   }
   responses: {
     key: "401";
-    value: {description: "Returned when the client credentials are not valid."},
+    value: {description: "Returned when the client credentials are not valid."};
   }

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -250,7 +250,16 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger model inference asynchronously
@@ -263,7 +272,16 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger model inference
@@ -276,7 +294,16 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger model inference asynchronously
@@ -289,7 +316,16 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger model inference with a binary input
@@ -298,7 +334,16 @@ service ModelPublicService {
   // submitted as a binary file.
   rpc TriggerUserModelBinaryFileUpload(stream TriggerUserModelBinaryFileUploadRequest) returns (TriggerUserModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // List organization models
@@ -466,7 +511,16 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger model inference asynchronously
@@ -479,7 +533,16 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger model inference
@@ -492,7 +555,16 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger model inference asynchronously
@@ -505,7 +577,16 @@ service ModelPublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger model inference with a binary input
@@ -514,7 +595,16 @@ service ModelPublicService {
   // submitted as a binary file.
   rpc TriggerOrganizationModelBinaryFileUpload(stream TriggerOrganizationModelBinaryFileUploadRequest) returns (TriggerOrganizationModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Get the details of a long-running operation

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -923,6 +923,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerUserModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Model
   /v1alpha/{user_model_name}/versions/{version}/triggerAsync:
@@ -965,6 +970,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerAsyncUserModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Model
   /v1alpha/{user_model_name}/trigger:
@@ -1001,6 +1011,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerUserLatestModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Model
   /v1alpha/{user_model_name}/triggerAsync:
@@ -1037,6 +1052,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerAsyncUserLatestModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Model
   /v1alpha/{organization_name}/models:
@@ -1720,6 +1740,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerOrganizationModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Model
   /v1alpha/{organization_model_name}/versions/{version}/triggerAsync:
@@ -1762,6 +1787,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerAsyncOrganizationModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Model
   /v1alpha/{organization_model_name}/trigger:
@@ -1798,6 +1828,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerOrganizationLatestModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Model
   /v1alpha/{organization_model_name}/triggerAsync:
@@ -1834,6 +1869,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ModelPublicServiceTriggerAsyncOrganizationLatestModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Model
   /v1alpha/{name}:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -695,6 +695,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerUserPipelineBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{user_pipeline_name}/trigger-stream:
@@ -741,6 +746,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerUserPipelineWithStreamBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{user_pipeline_name}/triggerAsync:
@@ -785,6 +795,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerAsyncUserPipelineBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{user_name}/releases:
@@ -1190,6 +1205,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerUserPipelineReleaseBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{user_pipeline_release_name}/triggerAsync:
@@ -1231,6 +1251,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerAsyncUserPipelineReleaseBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{organization_name}/pipelines:
@@ -1753,6 +1778,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerOrganizationPipelineStreamBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{organization_pipeline_name}/trigger:
@@ -1796,6 +1826,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerOrganizationPipelineBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{organization_pipeline_name}/triggerAsync:
@@ -1840,6 +1875,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerAsyncOrganizationPipelineBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{organization_name}/releases:
@@ -2235,6 +2275,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerOrganizationPipelineReleaseBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{organization_pipeline_release_name}/triggerAsync:
@@ -2277,6 +2322,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/PipelinePublicServiceTriggerAsyncOrganizationPipelineReleaseBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/{name}:
@@ -2307,6 +2357,11 @@ paths:
           required: true
           type: string
           pattern: operations/[^/]+
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/connector-definitions:

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -209,7 +209,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger a pipeline owned by a user and stream back the response
@@ -226,7 +235,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,inputs";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger a pipeline owned by a user asynchronously
@@ -247,7 +265,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Release a version of a pipeline owned by a user
@@ -366,7 +393,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger a version of a pipeline owned by a user asynchronously
@@ -384,7 +420,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Create a new organization pipeline
@@ -520,7 +565,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger a pipeline owned by an organization
@@ -540,7 +594,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger a pipeline owned by an organization asynchronously
@@ -561,7 +624,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Release a version of a pipeline owned by an organization
@@ -665,7 +737,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Trigger a version of a pipeline owned by an organization asynchronously
@@ -683,7 +764,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (google.api.method_signature) = "name,data";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // Get the details of a long-running operation
@@ -693,7 +783,16 @@ service PipelinePublicService {
   rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
     option (google.api.http) = {get: "/v1beta/{name=operations/*}"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger";
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid";
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
+          type: STRING;
+        };
+      };
+    };
   }
 
   // List connector definitions


### PR DESCRIPTION
Because

- The `Instill-Requester-Uid` header was added to unlock namespace switch in `pipeline-backend`. `model-backend` will also consume it in the model usage handler.

This commit

- Documents the header in the endpoints that use it. There's plenty of duplication but I didn't find a way to extract an option value to a variable, in the proto documentation it states clearly that [option values are literals](https://protobuf.com/docs/language-spec#option-values).
