### PR TITLE
chore(artifact): add get repo tag endpoint

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -136,6 +136,20 @@ message CreateRepositoryTagResponse {
   RepositoryTag tag = 1;
 }
 
+// GetRepositoryTagRequest represents a request to add a tag to a given
+// repository.
+message GetRepositoryTagRequest {
+  // The name of the tag, defined by its parent repository and ID.
+  // - Format: `repositories/{repository.id}/tags/{tag.id}`.
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetRepositoryTagResponse contains the created tag.
+message GetRepositoryTagResponse {
+  // The created tag.
+  RepositoryTag tag = 1;
+}
+
 // DeleteRepositoryTagRequest represents a request to delete a tag to a given
 // repository.
 message DeleteRepositoryTagRequest {

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -13,6 +13,9 @@ service ArtifactPrivateService {
   // Returns a portion of the versions that the specified repository holds.
   rpc ListRepositoryTags(ListRepositoryTagsRequest) returns (ListRepositoryTagsResponse);
 
+  // Get details of repository tag.
+  rpc GetRepositoryTag(GetRepositoryTagRequest) returns (GetRepositoryTagResponse);
+
   // Create a new repository tag.
   //
   // Adds a tag to a given repository. Note that this operation is only

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -398,6 +398,13 @@ definitions:
        - FILE_TYPE_JPEG: JPEG
        - FILE_TYPE_JPG: JPG
     title: file type
+  v1alphaGetRepositoryTagResponse:
+    type: object
+    properties:
+      tag:
+        $ref: '#/definitions/v1alphaRepositoryTag'
+        description: The created tag.
+    description: GetRepositoryTagResponse contains the created tag.
   v1alphaKnowledgeBase:
     type: object
     properties:


### PR DESCRIPTION
Because

- model-backend requires method to get detail repo tag

This commit

- add get repo tag
