### PR TITLE
feat(vdp): add profile_image and other profile fields

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -489,7 +489,6 @@ paths:
                 items:
                   type: string
                 description: Tags.
-                readOnly: true
               stats:
                 $ref: '#/definitions/PipelineStats'
                 description: Statistic data.
@@ -499,6 +498,18 @@ paths:
                 description: |-
                   Recipe in YAML format describes the components of a pipeline and how they
                   are connected.
+              sourceUrl:
+                type: string
+                description: A link to the source code of the pipeline (e.g. to a GitHub repository).
+              documentationUrl:
+                type: string
+                description: A link to any extra information.
+              license:
+                type: string
+                description: License under which the pipeline is distributed.
+              profileImage:
+                type: string
+                description: Pipeline profile image in base64 format.
             title: The pipeline fields that will replace the existing ones.
       tags:
         - Pipeline
@@ -1568,7 +1579,6 @@ paths:
                 items:
                   type: string
                 description: Tags.
-                readOnly: true
               stats:
                 $ref: '#/definitions/PipelineStats'
                 description: Statistic data.
@@ -1578,6 +1588,18 @@ paths:
                 description: |-
                   Recipe in YAML format describes the components of a pipeline and how they
                   are connected.
+              sourceUrl:
+                type: string
+                description: A link to the source code of the pipeline (e.g. to a GitHub repository).
+              documentationUrl:
+                type: string
+                description: A link to any extra information.
+              license:
+                type: string
+                description: License under which the pipeline is distributed.
+              profileImage:
+                type: string
+                description: Pipeline profile image in base64 format.
             title: The pipeline fields that will replace the existing ones.
       tags:
         - Pipeline
@@ -4681,7 +4703,6 @@ definitions:
         items:
           type: string
         description: Tags.
-        readOnly: true
       stats:
         $ref: '#/definitions/PipelineStats'
         description: Statistic data.
@@ -4691,6 +4712,18 @@ definitions:
         description: |-
           Recipe in YAML format describes the components of a pipeline and how they
           are connected.
+      sourceUrl:
+        type: string
+        description: A link to the source code of the pipeline (e.g. to a GitHub repository).
+      documentationUrl:
+        type: string
+        description: A link to any extra information.
+      license:
+        type: string
+        description: License under which the pipeline is distributed.
+      profileImage:
+        type: string
+        description: Pipeline profile image in base64 format.
     description: |-
       A Pipeline is an end-to-end workflow that automates a sequence of components
       to process data.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -152,12 +152,20 @@ message Pipeline {
   // Data specifications.
   DataSpecification data_specification = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Tags.
-  repeated string tags = 25 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated string tags = 25 [(google.api.field_behavior) = OPTIONAL];
   // Statistic data.
   Stats stats = 26 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Recipe in YAML format describes the components of a pipeline and how they
   // are connected.
   string raw_recipe = 27 [(google.api.field_behavior) = OPTIONAL];
+  // A link to the source code of the pipeline (e.g. to a GitHub repository).
+  optional string source_url = 28 [(google.api.field_behavior) = OPTIONAL];
+  // A link to any extra information.
+  optional string documentation_url = 29 [(google.api.field_behavior) = OPTIONAL];
+  // License under which the pipeline is distributed.
+  optional string license = 30 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline profile image in base64 format.
+  optional string profile_image = 31 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // TriggerMetadata contains the traces of the pipeline inference.


### PR DESCRIPTION
Because

- We'd like to allow users to save pipeline profile images and more profile data.

This commit

- Adds `profile_image` and more profile fields.