### PR TITLE
feat(kb): add chunk related api

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -272,7 +272,7 @@ enum FileProcessStatus {
   // COMPLETED
   FILE_PROCESS_STATUS_COMPLETED = 6;
   // Failed
-  FILE_PROCESS_STATUS_Failed = 7;
+  FILE_PROCESS_STATUS_FAILED = 7;
 }
 
 // file type

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -185,6 +185,12 @@ message KnowledgeBase {
   repeated string embedding_pipelines = 11;
   // The downstream apps
   repeated string downstream_apps = 12;
+  // The total files in knowledge base.
+  uint32 total_files = 13;
+  // The total tokens in knowledge base.
+  uint32 total_tokens = 14;
+  // The current used storage in knowledge base.
+  uint64 used_storage = 15;
 }
 
 // CreateKnowledgeBaseRequest represents a request to create a knowledge base.
@@ -265,6 +271,8 @@ enum FileProcessStatus {
   FILE_PROCESS_STATUS_EMBEDDING = 5;
   // COMPLETED
   FILE_PROCESS_STATUS_COMPLETED = 6;
+  // Failed
+  FILE_PROCESS_STATUS_Failed = 7;
 }
 
 // file type
@@ -313,6 +321,8 @@ message File {
   google.protobuf.Timestamp update_time = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
   // delete time
   google.protobuf.Timestamp delete_time = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // file size in bytes
+  int64 size = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // upload file request

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -4,6 +4,7 @@ package artifact.artifact.v1alpha;
 
 // Artifact definitions
 import "artifact/artifact/v1alpha/artifact.proto";
+import "artifact/artifact/v1alpha/chunk.proto";
 // Google API
 import "google/api/annotations.proto";
 import "google/api/client.proto";
@@ -102,4 +103,29 @@ service ArtifactPublicService {
     option (google.api.http) = {get: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/files"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
+  // List chunks
+  rpc ListChunks(ListChunksRequest) returns (ListChunksResponse) {
+    option (google.api.http) = {
+      get: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/chunks"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
+  }
+
+  // Get source file
+  rpc GetSourceFile(GetSourceFileRequest) returns (GetSourceFileResponse) {
+    option (google.api.http) = {
+      get: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/files/{file_uid}/source"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
+  }
+
+  // Update chunk
+  rpc UpdateChunk(UpdateChunkRequest) returns (UpdateChunkResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/chunks/{chunk_uid}"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
+  }
 }
+

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -1,0 +1,88 @@
+syntax = "proto3";
+
+package artifact.artifact.v1alpha;
+
+import "common/healthcheck/v1beta/healthcheck.proto";
+import "artifact/artifact/v1alpha/artifact.proto";
+// Google API
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+// Protocol Buffers Well-Known Types
+import "google/protobuf/timestamp.proto";
+
+// The Chunk message represents a chunk of data in the artifact system.
+message Chunk {
+    // unique identifier of the chunk
+    string chunk_uid = 1;
+    // whether the chunk is retrievable
+    bool retrievable = 2;
+    // start position of the chunk in the source file
+    uint32 start_pos = 4;
+    // end position of the chunk in the source file
+    uint32 end_pos = 5;
+    // tokens of the chunk
+    uint32 tokens = 6;
+    // creation time of the chunk
+    google.protobuf.Timestamp create_time = 7;
+    // original file unique identifier
+    string original_file_uid = 8;
+}
+
+// The ListChunksRequest message represents a request to list chunks in the artifact system.
+message ListChunksRequest {
+    // owner id (not uid)
+    string owner_id = 1;
+    // knowledge base name (not uid)
+    string kb_id = 2;
+    // unique identifier of the file
+    string file_uid = 3; 
+}
+
+// The ListChunksResponse message represents a response containing a list of chunks in the artifact system.
+message ListChunksResponse {
+    // repeated chunks
+    repeated Chunk chunks = 1;
+}
+
+
+// The SourceFile message represents a source file in the artifact system.
+message SourceFile {
+    // original file unique identifier
+    string original_file_uid = 1;
+    // content
+    string content = 3;
+    // creation time of the source file
+    google.protobuf.Timestamp create_time = 5;
+    // update time of the source file
+    google.protobuf.Timestamp update_time = 6;
+}
+
+// get source file request
+message GetSourceFileRequest {
+    // owner id
+    string owner_id = 1;
+    // knowledge base name
+    string kb_id = 2;
+    // unique identifier of the file
+    string original_file_uid = 3;
+  }
+
+// get source file response
+message GetSourceFileResponse {
+    // source file(either orignal file or converted file)
+    SourceFile source_file = 1;
+  }
+
+// Create chunk response
+message UpdateChunkRequest {
+    // chunk uid
+    string chunk_uid = 1;
+    // whether the chunk is retrievable
+    bool retrievable = 2;
+  }
+
+// Updae chunk response
+message UpdateChunkResponse {
+    // chunk
+    Chunk chunk = 1;
+  }

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -2,11 +2,6 @@ syntax = "proto3";
 
 package artifact.artifact.v1alpha;
 
-import "common/healthcheck/v1beta/healthcheck.proto";
-import "artifact/artifact/v1alpha/artifact.proto";
-// Google API
-import "google/api/field_behavior.proto";
-import "google/api/resource.proto";
 // Protocol Buffers Well-Known Types
 import "google/protobuf/timestamp.proto";
 
@@ -63,8 +58,8 @@ message GetSourceFileRequest {
     string owner_id = 1;
     // knowledge base name
     string kb_id = 2;
-    // unique identifier of the file
-    string original_file_uid = 3;
+    // unique identifier of the original uploaded file
+    string file_uid = 3;
   }
 
 // get source file response

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -227,6 +227,94 @@ paths:
             $ref: '#/definitions/v1alphaProcessKnowledgeBaseFilesRequest'
       tags:
         - KnowledgeBase
+  /v1alpha/owners/{ownerId}/knowledge-bases/{kbId}/chunks:
+    get:
+      summary: List chunks
+      operationId: ArtifactPublicService_ListChunks
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListChunksResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: ownerId
+          description: owner id (not uid)
+          in: path
+          required: true
+          type: string
+        - name: kbId
+          description: knowledge base name (not uid)
+          in: path
+          required: true
+          type: string
+        - name: fileUid
+          description: unique identifier of the file
+          in: query
+          required: false
+          type: string
+      tags:
+        - KnowledgeBase
+  /v1alpha/owners/{ownerId}/knowledge-bases/{kbId}/files/{fileUid}/source:
+    get:
+      summary: Get source file
+      operationId: ArtifactPublicService_GetSourceFile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetSourceFileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: ownerId
+          description: owner id
+          in: path
+          required: true
+          type: string
+        - name: kbId
+          description: knowledge base name
+          in: path
+          required: true
+          type: string
+        - name: fileUid
+          description: unique identifier of the original uploaded file
+          in: path
+          required: true
+          type: string
+      tags:
+        - KnowledgeBase
+  /v1alpha/chunks/{chunkUid}:
+    post:
+      summary: Update chunk
+      operationId: ArtifactPublicService_UpdateChunk
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateChunkResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: chunkUid
+          description: chunk uid
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ArtifactPublicServiceUpdateChunkBody'
+      tags:
+        - KnowledgeBase
 definitions:
   ArtifactPublicServiceCreateKnowledgeBaseBody:
     type: object
@@ -243,6 +331,13 @@ definitions:
           type: string
         description: The knowledge base tags.
     description: CreateKnowledgeBaseRequest represents a request to create a knowledge base.
+  ArtifactPublicServiceUpdateChunkBody:
+    type: object
+    properties:
+      retrievable:
+        type: boolean
+        title: whether the chunk is retrievable
+    title: Create chunk response
   ArtifactPublicServiceUpdateKnowledgeBaseBody:
     type: object
     properties:
@@ -274,6 +369,35 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/protobufAny'
+  v1alphaChunk:
+    type: object
+    properties:
+      chunkUid:
+        type: string
+        title: unique identifier of the chunk
+      retrievable:
+        type: boolean
+        title: whether the chunk is retrievable
+      startPos:
+        type: integer
+        format: int64
+        title: start position of the chunk in the source file
+      endPos:
+        type: integer
+        format: int64
+        title: end position of the chunk in the source file
+      tokens:
+        type: integer
+        format: int64
+        title: tokens of the chunk
+      createTime:
+        type: string
+        format: date-time
+        title: creation time of the chunk
+      originalFileUid:
+        type: string
+        title: original file unique identifier
+    description: The Chunk message represents a chunk of data in the artifact system.
   v1alphaCreateKnowledgeBaseResponse:
     type: object
     properties:
@@ -360,6 +484,11 @@ definitions:
         format: date-time
         title: delete time
         readOnly: true
+      size:
+        type: string
+        format: int64
+        title: file size in bytes
+        readOnly: true
     title: file mata data
     required:
       - name
@@ -373,6 +502,7 @@ definitions:
       - FILE_PROCESS_STATUS_CHUNKING
       - FILE_PROCESS_STATUS_EMBEDDING
       - FILE_PROCESS_STATUS_COMPLETED
+      - FILE_PROCESS_STATUS_FAILED
     description: |-
       - FILE_PROCESS_STATUS_NOTSTARTED: NOTSTARTED
        - FILE_PROCESS_STATUS_WAITING: waiting
@@ -380,6 +510,7 @@ definitions:
        - FILE_PROCESS_STATUS_CHUNKING: embedding process is done
        - FILE_PROCESS_STATUS_EMBEDDING: embedding process is failed
        - FILE_PROCESS_STATUS_COMPLETED: COMPLETED
+       - FILE_PROCESS_STATUS_FAILED: Failed
     title: file embedding process status
   v1alphaFileType:
     type: string
@@ -405,6 +536,13 @@ definitions:
         $ref: '#/definitions/v1alphaRepositoryTag'
         description: The created tag.
     description: GetRepositoryTagResponse contains the created tag.
+  v1alphaGetSourceFileResponse:
+    type: object
+    properties:
+      sourceFile:
+        $ref: '#/definitions/v1alphaSourceFile'
+        title: source file(either orignal file or converted file)
+    title: get source file response
   v1alphaKnowledgeBase:
     type: object
     properties:
@@ -451,7 +589,29 @@ definitions:
         items:
           type: string
         title: The downstream apps
+      totalFiles:
+        type: integer
+        format: int64
+        description: The total files in knowledge base.
+      totalTokens:
+        type: integer
+        format: int64
+        description: The total tokens in knowledge base.
+      usedStorage:
+        type: string
+        format: uint64
+        description: The current used storage in knowledge base.
     description: KnowledgeBase represents a knowledge base.
+  v1alphaListChunksResponse:
+    type: object
+    properties:
+      chunks:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaChunk'
+        title: repeated chunks
+    description: The ListChunksResponse message represents a response containing a list of chunks in the artifact system.
   v1alphaListKnowledgeBaseFilesFilter:
     type: object
     properties:
@@ -562,6 +722,31 @@ definitions:
     description: |-
       RepositoryTag contains information about the version of some content in a
       repository.
+  v1alphaSourceFile:
+    type: object
+    properties:
+      originalFileUid:
+        type: string
+        title: original file unique identifier
+      content:
+        type: string
+        title: content
+      createTime:
+        type: string
+        format: date-time
+        title: creation time of the source file
+      updateTime:
+        type: string
+        format: date-time
+        title: update time of the source file
+    description: The SourceFile message represents a source file in the artifact system.
+  v1alphaUpdateChunkResponse:
+    type: object
+    properties:
+      chunk:
+        $ref: '#/definitions/v1alphaChunk'
+        title: chunk
+    title: Updae chunk response
   v1alphaUpdateKnowledgeBaseResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

1. file process has fail status
2. ui need to display chunk info
3. ui need to display chunk highlight

This commit

1. add fail status in file process
2. add chunk related endpoints and its message
3. add source api and its message
