### PR TITLE
feat(mgmt): unify credit and pipeline metric endpoints

### DIFF
--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -7,7 +7,6 @@ import "artifact/artifact/v1alpha/artifact.proto";
 import "artifact/artifact/v1alpha/chunk.proto";
 // Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
 import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -77,14 +76,12 @@ service ArtifactPublicService {
       post: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/files"
       body: "file"
     };
-    option (google.api.method_signature) = "owner_id,kb_id,file";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
 
   // Delete a file
   rpc DeleteKnowledgeBaseFile(DeleteKnowledgeBaseFileRequest) returns (DeleteKnowledgeBaseFileResponse) {
     option (google.api.http) = {delete: "/v1alpha/knowledge-bases/files"};
-    option (google.api.method_signature) = "file_uid";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
 
@@ -94,7 +91,6 @@ service ArtifactPublicService {
       post: "/v1alpha/knowledge-bases/files/processAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "file_uids";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
 

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -29,28 +29,6 @@ enum Status {
 
 // ========== Pipeline endpoints
 
-// PipelineTriggerRecord represents a pipeline execution event.
-message PipelineTriggerRecord {
-  // The moment when the pipeline was triggered.
-  google.protobuf.Timestamp trigger_time = 1;
-  // UUID of the trigger.
-  string pipeline_trigger_id = 2;
-  // Pipeline ID.
-  string pipeline_id = 3;
-  // Pipeline UUID.
-  string pipeline_uid = 4;
-  // Trigger mode.
-  Mode trigger_mode = 5;
-  // Total execution duration.
-  float compute_time_duration = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Final status.
-  Status status = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // If a release of the pipeline was triggered, pipeline version.
-  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // If a release of the pipeline was triggered, release UUID.
-  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
 // PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
 // pipeline ID.
 message PipelineTriggerTableRecord {

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -29,6 +29,15 @@ enum Status {
 
 // ========== Pipeline endpoints
 
+// PipelineTriggerCount represents a pipeline execution count with some
+// aggregation params (e.g. trigger status).
+message PipelineTriggerCount {
+  // Number og triggers
+  int32 trigger_count = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // This field will be present when results are grouped by trigger status;
+  optional Status status = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
 // pipeline ID.
 message PipelineTriggerTableRecord {
@@ -77,54 +86,30 @@ message PipelineTriggerChartRecord {
   string requester = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ListPipelineTriggerRecordsRequest represents a request to list the triggers
-// of a pipeline.
-message ListPipelineTriggerRecordsRequest {
-  // The maximum number of triggers to return. If this parameter is unspecified,
-  // at most 100 pipelines will be returned. The cap value for this parameter is
-  // 1000 (i.e. any value above that will be coerced to 100).
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token.
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+// GetPipelineTriggerCountRequest represents a request to fetch the trigger
+// count of a requester over a time period.
+message GetPipelineTriggerCountRequest {
+  // The ID of the pipeline trigger requester.
+  // Format: `{[users|organizations]}/{id}`.
+  string requester = 1 [(google.api.field_behavior) = REQUIRED];
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 2;
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 3;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 4;
 }
 
-// ListPipelineTriggerRecordsResponse contains a list of pipeline triggers.
-message ListPipelineTriggerRecordsResponse {
-  // A list of pipeline triggers.
-  repeated PipelineTriggerRecord pipeline_trigger_records = 1;
-  // Next page token.
-  string next_page_token = 2;
-  // Total number of pipeline triggers.
-  int32 total_size = 3;
-}
-
-// ListPipelineTriggerTableRecordsRequest represents a request to list the
-// pipeline triggers metrics, aggregated by pipeline ID.
-message ListPipelineTriggerTableRecordsRequest {
-  // The maximum number of results to return. If this parameter is unspecified,
-  // at most 100 pipelines will be returned. The cap value for this parameter
-  // is 1000 (i.e. any value above that will be coerced to 1000).
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token.
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// ListPipelineTriggerTableRecordsResponse contains the pipeline metrics.
-message ListPipelineTriggerTableRecordsResponse {
-  // A list of pipeline trigger tables.
-  repeated PipelineTriggerTableRecord pipeline_trigger_table_records = 1;
-  // Next page token.
-  string next_page_token = 2;
-  // Total number of pipeline trigger records
-  int32 total_size = 3;
+// GetPipelineTriggerCountResponse contains the trigger count, grouped by
+// trigger status.
+message GetPipelineTriggerCountResponse {
+  // The trigger counts, grouped by status.
+  repeated PipelineTriggerCount pipeline_trigger_counts = 1;
 }
 
 // ListPipelineTriggerChartRecordsRequest represents a request to list pipeline

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -68,27 +68,35 @@ message PipelineTriggerTableRecord {
   string pipeline_release_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
+// PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
+// contains a collection of (timestamp, count) pairs that represent the total
+// pipeline triggers in a given time bucket.
 // pipeline ID and time frame.
 message PipelineTriggerChartRecord {
-  // Pipeline ID.
-  string pipeline_id = 1;
-  // Pipeline UUID.
-  string pipeline_uid = 2;
-  // Trigger mode.
-  Mode trigger_mode = 3;
-  // Final status.
-  Status status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // This field will be present present when the information is grouped by pipeline.
+  optional string pipeline_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // 2 is reserved for the pipeline UUID.
+  reserved 2;
+  // 3 is reserved for the trigger mode. The server wasn't grouping results by this
+  // field.
+  reserved 3;
+  // 4 is reserved for the trigger status. The server wasn't grouping results
+  // by this field.
+  reserved 4;
   // Time buckets.
   repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Aggregated trigger count in each time bucket.
   repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Total computation time duration in each time bucket.
-  repeated float compute_time_duration = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Version for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Release UUID for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // 7 is reserved for the trigger execution duration.
+  reserved 7;
+  // 8 is reserved for the pipeline release ID. The server wasn't grouping
+  // results by this field.
+  reserved 8;
+  // 9 is reserved for the pipeline release UUID. The server wasn't grouping
+  // results by this field.
+  reserved 9;
+  // Trigger requester ID, e.g. `users/specialist-wombat`.
+  string requester = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListPipelineTriggerRecordsRequest represents a request to list the triggers
@@ -142,20 +150,40 @@ message ListPipelineTriggerTableRecordsResponse {
 }
 
 // ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
-// trigger metrics, aggregated by pipeline ID and time frame.
+// trigger chart records for a given requester, grouped by time buckets.
 message ListPipelineTriggerChartRecordsRequest {
-  // Aggregation window in nanoseconds.
-  int32 aggregation_window = 1;
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+  // 1 is reserved for the aggregation window in nanoseconds. This is
+  // deprecated in favour of an aggregation window string that represents a
+  // duration.
+  reserved 1;
+  // 2 is reserved for the filter. For now, this endpoint won't allow filtering
+  // but in the future we might implement a filter to show the trigger count of
+  // only certain pipelines and to group by the pipeline ID.
+  reserved 2;
+
+  // The ID of the pipeline trigger requester.
+  // Format: `{[users|organizations]}/{id}`.
+  string requester = 3 [(google.api.field_behavior) = REQUIRED];
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 4;
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 5;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 6;
 }
 
 // ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
 // chart records.
 message ListPipelineTriggerChartRecordsResponse {
-  // A list of pipeline trigger records.
+  // Pipeline trigger counts. Until we allow filtering or grouping by fields
+  // like pipeline ID, this list will contain only one element with the
+  // timeline of trigger counts for a given requester, regardless the pipeline
+  // ID, trigger mode, final status or other fields.
   repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
 }
 

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -5,7 +5,6 @@ package core.mgmt.v1beta;
 import "core/mgmt/v1beta/mgmt.proto";
 // Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
 import "google/api/visibility.proto";
 
 // Mgmt service responds to internal access
@@ -20,14 +19,12 @@ service MgmtPrivateService {
   // a GetUserAdminResponse message.
   rpc GetUserAdmin(GetUserAdminRequest) returns (GetUserAdminResponse) {
     option (google.api.http) = {get: "/v1beta/admin/{name=users/*}"};
-    option (google.api.method_signature) = "name";
   }
 
   // LookUpUserAdmin method receives a LookUpUserAdminRequest message and
   // returns a LookUpUserAdminResponse
   rpc LookUpUserAdmin(LookUpUserAdminRequest) returns (LookUpUserAdminResponse) {
     option (google.api.http) = {get: "/v1beta/admin/{permalink=users/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
   }
 
   // ListOrganizationsAdmin method receives a ListOrganizationsAdminRequest message and returns
@@ -40,26 +37,22 @@ service MgmtPrivateService {
   // a GetOrganizationAdminResponse message.
   rpc GetOrganizationAdmin(GetOrganizationAdminRequest) returns (GetOrganizationAdminResponse) {
     option (google.api.http) = {get: "/v1beta/admin/{name=organizations/*}"};
-    option (google.api.method_signature) = "name";
   }
 
   // LookUpOrganizationAdmin method receives a LookUpOrganizationAdminRequest message and
   // returns a LookUpOrganizationAdminResponse
   rpc LookUpOrganizationAdmin(LookUpOrganizationAdminRequest) returns (LookUpOrganizationAdminResponse) {
     option (google.api.http) = {get: "/v1beta/admin/{permalink=organizations/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
   }
 
   // GetUserSubscriptionAdmin
   rpc GetUserSubscriptionAdmin(GetUserSubscriptionAdminRequest) returns (GetUserSubscriptionAdminResponse) {
     option (google.api.http) = {get: "/v1beta/admin/{parent=users/*}/subscription"};
-    option (google.api.method_signature) = "parent";
   }
 
   // GetOrganizationSubscriptionAdmin
   rpc GetOrganizationSubscriptionAdmin(GetOrganizationSubscriptionAdminRequest) returns (GetOrganizationSubscriptionAdminResponse) {
     option (google.api.http) = {get: "/v1beta/admin/{parent=organizations/*}/subscription"};
-    option (google.api.method_signature) = "parent";
   }
 
   // Subtract Instill Credit from a user or organization account.
@@ -73,7 +66,6 @@ service MgmtPrivateService {
   //
   // On Instill Core, this endpoint will return an Unimplemented status.
   rpc SubtractCreditAdmin(SubtractCreditAdminRequest) returns (SubtractCreditAdminResponse) {
-    option (google.api.method_signature) = "owner,amount";
   }
 
   // Get the remaining Instill Credit by owner UID
@@ -83,7 +75,6 @@ service MgmtPrivateService {
   //
   // On Instill Core, this endpoint will return a 404 Not Found status.
   rpc GetRemainingCreditAdmin(GetRemainingCreditAdminRequest) returns (GetRemainingCreditAdminResponse) {
-    option (google.api.method_signature) = "owner";
   }
 
   // Check if a namespace is in use
@@ -91,7 +82,6 @@ service MgmtPrivateService {
   // Returns the availability of a namespace or, alternatively, the type of
   // resource that is using it.
   rpc CheckNamespaceAdmin(CheckNamespaceAdminRequest) returns (CheckNamespaceAdminResponse) {
-    option (google.api.method_signature) = "namespace";
   }
 
   option (google.api.api_visibility).restriction = "INTERNAL";

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -305,11 +305,13 @@ service MgmtPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils"};
   }
 
-  // List pipeline trigger metrics
+  // Get pipeline trigger count
   //
-  // Returns a paginated list of pipeline executions aggregated by pipeline ID.
-  rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
+  // Returns the pipeline trigger count of a given requester within a timespan.
+  // Results are grouped by trigger status.
+  rpc GetPipelineTriggerCount(GetPipelineTriggerCountRequest) returns (GetPipelineTriggerCountResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/trigger-count"};
+    option (google.api.method_signature) = "requester,start,stop";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -321,12 +321,14 @@ service MgmtPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 
-  // List pipeline trigger computation time charts
+  // List pipeline trigger time charts
   //
-  // Returns a paginated list with pipeline trigger execution times, aggregated
-  // by pipeline and time frames.
+  // Returns a timeline of pipline trigger counts for a given requester. The
+  // response will contain one set of records (datapoints), representing the
+  // amount of triggers in a time bucket.
   rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
+    option (google.api.method_signature) = "requester,aggregation_window,start,stop";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -7,7 +7,6 @@ import "core/mgmt/v1beta/metric.proto";
 import "core/mgmt/v1beta/mgmt.proto";
 // Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
 import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -48,7 +47,6 @@ service MgmtPublicService {
   // Returns the details of the authenticated user.
   rpc GetAuthenticatedUser(GetAuthenticatedUserRequest) returns (GetAuthenticatedUserResponse) {
     option (google.api.http) = {get: "/v1beta/user"};
-    option (google.api.method_signature) = "user,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
@@ -63,7 +61,6 @@ service MgmtPublicService {
       patch: "/v1beta/user"
       body: "user"
     };
-    option (google.api.method_signature) = "user,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
@@ -80,7 +77,6 @@ service MgmtPublicService {
   // Returns the details of a user by their ID.
   rpc GetUser(GetUserRequest) returns (GetUserResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
@@ -92,7 +88,6 @@ service MgmtPublicService {
       post: "/v1beta/organizations"
       body: "organization"
     };
-    option (google.api.method_signature) = "organization";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
@@ -109,7 +104,6 @@ service MgmtPublicService {
   // Returns the organization details by its ID.
   rpc GetOrganization(GetOrganizationRequest) returns (GetOrganizationResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
@@ -124,7 +118,6 @@ service MgmtPublicService {
       patch: "/v1beta/{organization.name=organizations/*}"
       body: "organization"
     };
-    option (google.api.method_signature) = "organization,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
@@ -133,7 +126,6 @@ service MgmtPublicService {
   // Accesses and deletes an organization by ID.
   rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
@@ -142,7 +134,6 @@ service MgmtPublicService {
   // Returns the memberships of a user.
   rpc ListUserMemberships(ListUserMembershipsRequest) returns (ListUserMembershipsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/memberships"};
-    option (google.api.method_signature) = "parent";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -152,7 +143,6 @@ service MgmtPublicService {
   // organization. The authenticated must match the membership parent.
   rpc GetUserMembership(GetUserMembershipRequest) returns (GetUserMembershipResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -164,7 +154,6 @@ service MgmtPublicService {
       put: "/v1beta/{membership.name=users/*/memberships/*}"
       body: "membership"
     };
-    option (google.api.method_signature) = "membership,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -173,7 +162,6 @@ service MgmtPublicService {
   // Accesses and deletes a user membership by parent and membership IDs.
   rpc DeleteUserMembership(DeleteUserMembershipRequest) returns (DeleteUserMembershipResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -182,7 +170,6 @@ service MgmtPublicService {
   // Returns a paginated list of the user memberships in an organization.
   rpc ListOrganizationMemberships(ListOrganizationMembershipsRequest) returns (ListOrganizationMembershipsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/memberships"};
-    option (google.api.method_signature) = "parent";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -191,7 +178,6 @@ service MgmtPublicService {
   // Returns the details of a user membership within an organization.
   rpc GetOrganizationMembership(GetOrganizationMembershipRequest) returns (GetOrganizationMembershipResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -203,7 +189,6 @@ service MgmtPublicService {
       put: "/v1beta/{membership.name=organizations/*/memberships/*}"
       body: "membership"
     };
-    option (google.api.method_signature) = "membership,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -212,7 +197,6 @@ service MgmtPublicService {
   // Deletes a user membership within an organization.
   rpc DeleteOrganizationMembership(DeleteOrganizationMembershipRequest) returns (DeleteOrganizationMembershipResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/memberships/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -229,7 +213,6 @@ service MgmtPublicService {
   // Returns the subscription details of an organization.
   rpc GetOrganizationSubscription(GetOrganizationSubscriptionRequest) returns (GetOrganizationSubscriptionResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/subscription"};
-    option (google.api.method_signature) = "parent";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Subscription"};
   }
 
@@ -241,7 +224,6 @@ service MgmtPublicService {
       post: "/v1beta/tokens"
       body: "token"
     };
-    option (google.api.method_signature) = "token";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
@@ -258,7 +240,6 @@ service MgmtPublicService {
   // Returns the details of an API token.
   rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {
     option (google.api.http) = {get: "/v1beta/{name=tokens/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
@@ -267,7 +248,6 @@ service MgmtPublicService {
   // Deletes an API token.
   rpc DeleteToken(DeleteTokenRequest) returns (DeleteTokenResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=tokens/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
@@ -288,7 +268,6 @@ service MgmtPublicService {
   // On Instill Core, this endpoint will return a 404 Not Found status.
   rpc GetRemainingCredit(GetRemainingCreditRequest) returns (GetRemainingCreditResponse) {
     option (google.api.http) = {get: "/v1beta/{owner=*/*}/credit"};
-    option (google.api.method_signature) = "owner";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Credit"};
   }
 
@@ -301,7 +280,6 @@ service MgmtPublicService {
       post: "/v1beta/check-namespace"
       body: "*"
     };
-    option (google.api.method_signature) = "namespace";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils"};
   }
 
@@ -311,7 +289,6 @@ service MgmtPublicService {
   // Results are grouped by trigger status.
   rpc GetPipelineTriggerCount(GetPipelineTriggerCountRequest) returns (GetPipelineTriggerCountResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/trigger-count"};
-    option (google.api.method_signature) = "requester,start,stop";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 
@@ -322,7 +299,6 @@ service MgmtPublicService {
   // amount of triggers in a time bucket.
   rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
-    option (google.api.method_signature) = "requester,aggregation_window,start,stop";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 
@@ -334,7 +310,6 @@ service MgmtPublicService {
   // consumed in a time bucket.
   rpc ListCreditConsumptionChartRecords(ListCreditConsumptionChartRecordsRequest) returns (ListCreditConsumptionChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/credit/charts"};
-    option (google.api.method_signature) = "owner,aggregation_window,start,stop";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
   }
 

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -305,14 +305,6 @@ service MgmtPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils"};
   }
 
-  // List pipeline triggers
-  //
-  // Returns a paginated list of pipeline executions.
-  rpc ListPipelineTriggerRecords(ListPipelineTriggerRecordsRequest) returns (ListPipelineTriggerRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/triggers"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
-  }
-
   // List pipeline trigger metrics
   //
   // Returns a paginated list of pipeline executions aggregated by pipeline ID.

--- a/core/usage/v1beta/usage_service.proto
+++ b/core/usage/v1beta/usage_service.proto
@@ -37,7 +37,6 @@ service UsageService {
       post: "/v1beta/sessions"
       body: "session"
     };
-    option (google.api.method_signature) = "session";
   }
 
   // SendSessionReport method receives a SendSessionReportRequest message and
@@ -47,7 +46,6 @@ service UsageService {
       post: "/v1beta/reports"
       body: "report"
     };
-    option (google.api.method_signature) = "report";
   }
 
   option (google.api.api_visibility).restriction = "INTERNAL";

--- a/model/model/v1alpha/model_private_service.proto
+++ b/model/model/v1alpha/model_private_service.proto
@@ -4,7 +4,6 @@ package model.model.v1alpha;
 
 // Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
 import "google/api/visibility.proto";
 import "model/model/v1alpha/model.proto";
 
@@ -22,7 +21,6 @@ service ModelPrivateService {
   // returns a LookUpModelAdminResponse
   rpc LookUpModelAdmin(LookUpModelAdminRequest) returns (LookUpModelAdminResponse) {
     option (google.api.http) = {get: "/v1alpha/admin/{permalink=models/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
   }
 
   // DeployUserModelAdmin deploy a model to online state

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -4,7 +4,6 @@ package model.model.v1alpha;
 
 // Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
 import "google/api/visibility.proto";
 // Model definitions
 import "model/model/v1alpha/model.proto";
@@ -64,7 +63,6 @@ service ModelPublicService {
   // Returns the details of a model definition.
   rpc GetModelDefinition(GetModelDefinitionRequest) returns (GetModelDefinitionResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=model-definitions/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model Definition"};
   }
 
@@ -81,7 +79,6 @@ service ModelPublicService {
   // Returns the details of a model by a permalink defined by the resource UID.
   rpc LookUpModel(LookUpModelRequest) returns (LookUpModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{permalink=models/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -92,7 +89,6 @@ service ModelPublicService {
   // the results will contain the models that are visible to the latter.
   rpc ListUserModels(ListUserModelsRequest) returns (ListUserModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/{parent=users/*}/models"};
-    option (google.api.method_signature) = "parent";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -108,7 +104,6 @@ service ModelPublicService {
       post: "/v1alpha/{parent=users/*}/models"
       body: "model"
     };
-    option (google.api.method_signature) = "parent,model";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -117,7 +112,6 @@ service ModelPublicService {
   // Returns the detail of a model, accessing it by the model ID and its parent user.
   rpc GetUserModel(GetUserModelRequest) returns (GetUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -133,7 +127,6 @@ service ModelPublicService {
       patch: "/v1alpha/{model.name=users/*/models/*}"
       body: "model"
     };
-    option (google.api.method_signature) = "model,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -143,7 +136,6 @@ service ModelPublicService {
   // parent user and the ID of the model.
   rpc DeleteUserModel(DeleteUserModelRequest) returns (DeleteUserModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -156,7 +148,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_model_id";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -169,7 +160,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/publish"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -182,7 +172,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/unpublish"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -192,7 +181,6 @@ service ModelPublicService {
   // enhancing it with metadata. The model is accessed by its resource name.
   rpc GetUserModelCard(GetUserModelCardRequest) returns (GetUserModelCardResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*/readme}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -203,7 +191,6 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchUserModel(WatchUserModelRequest) returns (WatchUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions/{version=*}/watch"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
@@ -214,7 +201,6 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchUserLatestModel(WatchUserLatestModelRequest) returns (WatchUserLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/watch"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
@@ -224,7 +210,6 @@ service ModelPublicService {
   // Contains model version and digest.
   rpc ListUserModelVersions(ListUserModelVersionsRequest) returns (ListUserModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
@@ -234,7 +219,6 @@ service ModelPublicService {
   // parent user and the ID of the model, and version.
   rpc DeleteUserModelVersion(DeleteUserModelVersionRequest) returns (DeleteUserModelVersionResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}/versions/{version=*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
@@ -249,7 +233,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/versions/{version=*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -271,7 +254,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/versions/{version=*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -293,7 +275,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -315,7 +296,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -333,7 +313,6 @@ service ModelPublicService {
   // Triggers a deployed model to infer the result of a task or question,
   // submitted as a binary file.
   rpc TriggerUserModelBinaryFileUpload(stream TriggerUserModelBinaryFileUploadRequest) returns (TriggerUserModelBinaryFileUploadResponse) {
-    option (google.api.method_signature) = "name,file";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -353,7 +332,6 @@ service ModelPublicService {
   // the results will contain the models that are visible to the latter.
   rpc ListOrganizationModels(ListOrganizationModelsRequest) returns (ListOrganizationModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/{parent=organizations/*}/models"};
-    option (google.api.method_signature) = "parent";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -369,7 +347,6 @@ service ModelPublicService {
       post: "/v1alpha/{parent=organizations/*}/models"
       body: "model"
     };
-    option (google.api.method_signature) = "parent,model";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -378,7 +355,6 @@ service ModelPublicService {
   // Returns the detail of a model, accessing it by the model ID and its parent organization.
   rpc GetOrganizationModel(GetOrganizationModelRequest) returns (GetOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -394,7 +370,6 @@ service ModelPublicService {
       patch: "/v1alpha/{model.name=organizations/*/models/*}"
       body: "model"
     };
-    option (google.api.method_signature) = "model,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -404,7 +379,6 @@ service ModelPublicService {
   // parent organization and the ID of the model.
   rpc DeleteOrganizationModel(DeleteOrganizationModelRequest) returns (DeleteOrganizationModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/models/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -417,7 +391,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_model_id";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -430,7 +403,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/publish"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -443,7 +415,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/unpublish"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -453,7 +424,6 @@ service ModelPublicService {
   // enhancing it with metadata. The model is accessed by its resource name.
   rpc GetOrganizationModelCard(GetOrganizationModelCardRequest) returns (GetOrganizationModelCardResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*/readme}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -464,7 +434,6 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchOrganizationModel(WatchOrganizationModelRequest) returns (WatchOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}/watch"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
@@ -475,7 +444,6 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchOrganizationLatestModel(WatchOrganizationLatestModelRequest) returns (WatchOrganizationLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/watch"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
@@ -485,7 +453,6 @@ service ModelPublicService {
   // Contains model version and digest.
   rpc ListOrganizationModelVersions(ListOrganizationModelVersionsRequest) returns (ListOrganizationModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
@@ -495,7 +462,6 @@ service ModelPublicService {
   // parent organization and the ID of the model, and version.
   rpc DeleteOrganizationModelVersion(DeleteOrganizationModelVersionRequest) returns (DeleteOrganizationModelVersionResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
@@ -510,7 +476,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -532,7 +497,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -554,7 +518,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -576,7 +539,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -594,7 +556,6 @@ service ModelPublicService {
   // Triggers a deployed model to infer the result of a task or question,
   // submitted as a binary file.
   rpc TriggerOrganizationModelBinaryFileUpload(stream TriggerOrganizationModelBinaryFileUploadRequest) returns (TriggerOrganizationModelBinaryFileUploadResponse) {
-    option (google.api.method_signature) = "name,file";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -613,7 +574,6 @@ service ModelPublicService {
   // long-running operations in a model, such as deployment.
   rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
@@ -623,7 +583,6 @@ service ModelPublicService {
   // long-running operations in a model, such as deployment.
   rpc GetUserLatestModelOperation(GetUserLatestModelOperationRequest) returns (GetUserLatestModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/operation"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
@@ -633,7 +592,6 @@ service ModelPublicService {
   // long-running operations in a model, such as deployment.
   rpc GetOrganizationLatestModelOperation(GetOrganizationLatestModelOperationRequest) returns (GetOrganizationLatestModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/operation"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 }

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -956,16 +956,18 @@ paths:
             $ref: '#/definitions/v1betaCheckNamespaceRequest'
       tags:
         - Utils
-  /v1beta/metrics/vdp/pipeline/triggers:
+  /v1beta/metrics/vdp/pipeline/trigger-count:
     get:
-      summary: List pipeline triggers
-      description: Returns a paginated list of pipeline executions.
-      operationId: MgmtPublicService_ListPipelineTriggerRecords
+      summary: Get pipeline trigger count
+      description: |-
+        Returns the pipeline trigger count of a given requester within a timespan.
+        Results are grouped by trigger status.
+      operationId: MgmtPublicService_GetPipelineTriggerCount
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListPipelineTriggerRecordsResponse'
+            $ref: '#/definitions/v1betaGetPipelineTriggerCountResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -974,78 +976,47 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: pageSize
+        - name: requester
           description: |-
-            The maximum number of triggers to return. If this parameter is unspecified,
-            at most 100 pipelines will be returned. The cap value for this parameter is
-            1000 (i.e. any value above that will be coerced to 100).
+            The ID of the pipeline trigger requester.
+            Format: `{[users|organizations]}/{id}`.
           in: query
-          required: false
-          type: integer
-          format: int32
-        - name: pageToken
-          description: Page token.
+          required: true
+          type: string
+        - name: aggregationWindow
+          description: |-
+            Aggregation window. The value is a positive duration string, i.e. a
+            sequence of decimal numbers, each with optional fraction and a unit
+            suffix, such as "300ms", "1.5h" or "2h45m".
+            The minimum (and default) window is 1h.
           in: query
           required: false
           type: string
-        - name: filter
+        - name: start
           description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
-            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+            Beginning of the time range from which the records will be fetched.
+            The default value is the beginning of the current day, in UTC.
           in: query
           required: false
           type: string
-      tags:
-        - Metric
-  /v1beta/metrics/vdp/pipeline/tables:
-    get:
-      summary: List pipeline trigger metrics
-      description: Returns a paginated list of pipeline executions aggregated by pipeline ID.
-      operationId: MgmtPublicService_ListPipelineTriggerTableRecords
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaListPipelineTriggerTableRecordsResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: pageSize
+          format: date-time
+        - name: stop
           description: |-
-            The maximum number of results to return. If this parameter is unspecified,
-            at most 100 pipelines will be returned. The cap value for this parameter
-            is 1000 (i.e. any value above that will be coerced to 1000).
-          in: query
-          required: false
-          type: integer
-          format: int32
-        - name: pageToken
-          description: Page token.
+            End of the time range from which the records will be fetched.
+            The default value is the current timestamp.
           in: query
           required: false
           type: string
-        - name: filter
-          description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
-            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-          in: query
-          required: false
-          type: string
+          format: date-time
       tags:
         - Metric
   /v1beta/metrics/vdp/pipeline/charts:
     get:
-      summary: List pipeline trigger computation time charts
+      summary: List pipeline trigger time charts
       description: |-
-        Returns a paginated list with pipeline trigger execution times, aggregated
-        by pipeline and time frames.
+        Returns a timeline of pipline trigger counts for a given requester. The
+        response will contain one set of records (datapoints), representing the
+        amount of triggers in a time bucket.
       operationId: MgmtPublicService_ListPipelineTriggerChartRecords
       responses:
         "200":
@@ -1060,20 +1031,38 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: aggregationWindow
-          description: Aggregation window in nanoseconds.
-          in: query
-          required: false
-          type: integer
-          format: int32
-        - name: filter
+        - name: requester
           description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
-            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+            The ID of the pipeline trigger requester.
+            Format: `{[users|organizations]}/{id}`.
+          in: query
+          required: true
+          type: string
+        - name: aggregationWindow
+          description: |-
+            Aggregation window. The value is a positive duration string, i.e. a
+            sequence of decimal numbers, each with optional fraction and a unit
+            suffix, such as "300ms", "1.5h" or "2h45m".
+            The minimum (and default) window is 1h.
           in: query
           required: false
           type: string
+        - name: start
+          description: |-
+            Beginning of the time range from which the records will be fetched.
+            The default value is the beginning of the current day, in UTC.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: stop
+          description: |-
+            End of the time range from which the records will be fetched.
+            The default value is the current timestamp.
+          in: query
+          required: false
+          type: string
+          format: date-time
       tags:
         - Metric
   /v1beta/metrics/credit/charts:
@@ -2006,6 +1995,18 @@ definitions:
         $ref: '#/definitions/v1betaOrganizationSubscription'
         description: The subscription resource.
     description: GetOrganizationSubscriptionResponse contains the requested subscription.
+  v1betaGetPipelineTriggerCountResponse:
+    type: object
+    properties:
+      pipelineTriggerCounts:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipelineTriggerCount'
+        description: The trigger counts, grouped by status.
+    description: |-
+      GetPipelineTriggerCountResponse contains the trigger count, grouped by
+      trigger status.
   v1betaGetPipelineTriggerPriceRequest:
     type: object
     properties:
@@ -2259,44 +2260,14 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/v1betaPipelineTriggerChartRecord'
-        description: A list of pipeline trigger records.
+        description: |-
+          Pipeline trigger counts. Until we allow filtering or grouping by fields
+          like pipeline ID, this list will contain only one element with the
+          timeline of trigger counts for a given requester, regardless the pipeline
+          ID, trigger mode, final status or other fields.
     description: |-
       ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
       chart records.
-  v1betaListPipelineTriggerRecordsResponse:
-    type: object
-    properties:
-      pipelineTriggerRecords:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaPipelineTriggerRecord'
-        description: A list of pipeline triggers.
-      nextPageToken:
-        type: string
-        description: Next page token.
-      totalSize:
-        type: integer
-        format: int32
-        description: Total number of pipeline triggers.
-    description: ListPipelineTriggerRecordsResponse contains a list of pipeline triggers.
-  v1betaListPipelineTriggerTableRecordsResponse:
-    type: object
-    properties:
-      pipelineTriggerTableRecords:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaPipelineTriggerTableRecord'
-        description: A list of pipeline trigger tables.
-      nextPageToken:
-        type: string
-        description: Next page token.
-      totalSize:
-        type: integer
-        format: int32
-        title: Total number of pipeline trigger records
-    description: ListPipelineTriggerTableRecordsResponse contains the pipeline metrics.
   v1betaListTokensResponse:
     type: object
     properties:
@@ -2677,16 +2648,7 @@ definitions:
     properties:
       pipelineId:
         type: string
-        description: Pipeline ID.
-      pipelineUid:
-        type: string
-        description: Pipeline UUID.
-      triggerMode:
-        $ref: '#/definitions/v1betaMode'
-        description: Trigger mode.
-      status:
-        $ref: '#/definitions/mgmtv1betaStatus'
-        description: Final status.
+        description: This field will be present present when the information is grouped by pipeline.
         readOnly: true
       timeBuckets:
         type: array
@@ -2702,91 +2664,30 @@ definitions:
           format: int32
         description: Aggregated trigger count in each time bucket.
         readOnly: true
-      computeTimeDuration:
-        type: array
-        items:
-          type: number
-          format: float
-        description: Total computation time duration in each time bucket.
-        readOnly: true
-      pipelineReleaseId:
+      requester:
         type: string
-        description: Version for the triggered pipeline if it is a release pipeline.
-        readOnly: true
-      pipelineReleaseUid:
-        type: string
-        description: Release UUID for the triggered pipeline if it is a release pipeline.
+        description: Trigger requester ID, e.g. `users/specialist-wombat`.
         readOnly: true
     description: |-
-      PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
+      PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
+      contains a collection of (timestamp, count) pairs that represent the total
+      pipeline triggers in a given time bucket.
       pipeline ID and time frame.
-  v1betaPipelineTriggerRecord:
+  v1betaPipelineTriggerCount:
     type: object
     properties:
-      triggerTime:
-        type: string
-        format: date-time
-        description: The moment when the pipeline was triggered.
-      pipelineTriggerId:
-        type: string
-        description: UUID of the trigger.
-      pipelineId:
-        type: string
-        description: Pipeline ID.
-      pipelineUid:
-        type: string
-        description: Pipeline UUID.
-      triggerMode:
-        $ref: '#/definitions/v1betaMode'
-        description: Trigger mode.
-      computeTimeDuration:
-        type: number
-        format: float
-        description: Total execution duration.
+      triggerCount:
+        type: integer
+        format: int32
+        title: Number og triggers
         readOnly: true
       status:
         $ref: '#/definitions/mgmtv1betaStatus'
-        description: Final status.
-        readOnly: true
-      pipelineReleaseId:
-        type: string
-        description: If a release of the pipeline was triggered, pipeline version.
-        readOnly: true
-      pipelineReleaseUid:
-        type: string
-        description: If a release of the pipeline was triggered, release UUID.
-        readOnly: true
-    description: PipelineTriggerRecord represents a pipeline execution event.
-  v1betaPipelineTriggerTableRecord:
-    type: object
-    properties:
-      pipelineId:
-        type: string
-        description: Pipeline ID.
-      pipelineUid:
-        type: string
-        description: Pipeline UUID.
-      triggerCountCompleted:
-        type: integer
-        format: int32
-        description: Number of triggers with `STATUS_COMPLETED`.
-        readOnly: true
-      triggerCountErrored:
-        type: integer
-        format: int32
-        description: Number of triggers with `STATUS_ERRORED`.
-        readOnly: true
-      pipelineReleaseId:
-        type: string
-        description: Version for the triggered pipeline if it is a release pipeline.
-        readOnly: true
-      pipelineReleaseUid:
-        type: string
-        description: Release UUID for the triggered pipeline if it is a release pipeline.
+        title: This field will be present when results are grouped by trigger status;
         readOnly: true
     description: |-
-      PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
-      pipeline ID.
+      PipelineTriggerCount represents a pipeline execution count with some
+      aggregation params (e.g. trigger status).
   v1betaPipelineUsageData:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline_private_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_private_service.proto
@@ -4,7 +4,6 @@ package vdp.pipeline.v1beta;
 
 // Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
 import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -29,7 +28,6 @@ service PipelinePrivateService {
   // resource by its UID.
   rpc LookUpPipelineAdmin(LookUpPipelineAdminRequest) returns (LookUpPipelineAdminResponse) {
     option (google.api.http) = {get: "/v1beta/admin/{permalink=pipelines/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
   }
 
   // List pipeline releases (admin only)

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -4,7 +4,6 @@ package vdp.pipeline.v1beta;
 
 // Google API
 import "google/api/annotations.proto";
-import "google/api/client.proto";
 import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -63,7 +62,6 @@ service PipelinePublicService {
   // UID.
   rpc LookUpPipeline(LookUpPipelineRequest) returns (LookUpPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{permalink=pipelines/*}/lookUp"};
-    option (google.api.method_signature) = "permalink";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -77,7 +75,6 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*}/pipelines"
       body: "pipeline"
     };
-    option (google.api.method_signature) = "parent,pipeline";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -89,7 +86,6 @@ service PipelinePublicService {
   // latter.
   rpc ListUserPipelines(ListUserPipelinesRequest) returns (ListUserPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/pipelines"};
-    option (google.api.method_signature) = "parent";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -99,7 +95,6 @@ service PipelinePublicService {
   // by the parent user and the ID of the pipeline.
   rpc GetUserPipeline(GetUserPipelineRequest) returns (GetUserPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -116,7 +111,6 @@ service PipelinePublicService {
       patch: "/v1beta/{pipeline.name=users/*/pipelines/*}"
       body: "pipeline"
     };
-    option (google.api.method_signature) = "pipeline,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -127,7 +121,6 @@ service PipelinePublicService {
   // the parent of the pipeline in order to delete it.
   rpc DeleteUserPipeline(DeleteUserPipelineRequest) returns (DeleteUserPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -142,7 +135,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/validate"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -162,7 +154,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_pipeline_id";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -175,7 +166,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/clone"
       body: "*"
     };
-    option (google.api.method_signature) = "name,target";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -188,7 +178,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/clone"
       body: "*"
     };
-    option (google.api.method_signature) = "name,target";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -208,7 +197,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -234,7 +222,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/trigger-stream"
       body: "*"
     };
-    option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -264,7 +251,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -289,7 +275,6 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*/pipelines/*}/releases"
       body: "release"
     };
-    option (google.api.method_signature) = "parent,release";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -299,7 +284,6 @@ service PipelinePublicService {
   // name, which is formed by the parent user and ID of the pipeline.
   rpc ListUserPipelineReleases(ListUserPipelineReleasesRequest) returns (ListUserPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*/pipelines/*}/releases"};
-    option (google.api.method_signature) = "pipelines";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -309,7 +293,6 @@ service PipelinePublicService {
   // by its resource name, formed by its parent user and ID.
   rpc GetUserPipelineRelease(GetUserPipelineReleaseRequest) returns (GetUserPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -325,7 +308,6 @@ service PipelinePublicService {
       patch: "/v1beta/{release.name=users/*/pipelines/*/releases/*}"
       body: "release"
     };
-    option (google.api.method_signature) = "release,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -338,7 +320,6 @@ service PipelinePublicService {
   // perform this action.
   rpc DeleteUserPipelineRelease(DeleteUserPipelineReleaseRequest) returns (DeleteUserPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -353,7 +334,6 @@ service PipelinePublicService {
   // perform this action.
   rpc RestoreUserPipelineRelease(RestoreUserPipelineReleaseRequest) returns (RestoreUserPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=users/*/pipelines/*/releases/*}/restore"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -374,7 +354,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_pipeline_release_id";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -392,7 +371,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -419,7 +397,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -440,7 +417,6 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*}/pipelines"
       body: "pipeline"
     };
-    option (google.api.method_signature) = "parent,pipeline";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -450,7 +426,6 @@ service PipelinePublicService {
   // organization.
   rpc ListOrganizationPipelines(ListOrganizationPipelinesRequest) returns (ListOrganizationPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/pipelines"};
-    option (google.api.method_signature) = "parent";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -460,7 +435,6 @@ service PipelinePublicService {
   // which is defined by the parent organization and the ID of the pipeline.
   rpc GetOrganizationPipeline(GetOrganizationPipelineRequest) returns (GetOrganizationPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -475,7 +449,6 @@ service PipelinePublicService {
       patch: "/v1beta/{pipeline.name=organizations/*/pipelines/*}"
       body: "pipeline"
     };
-    option (google.api.method_signature) = "pipeline,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -485,7 +458,6 @@ service PipelinePublicService {
   // the parent organization and the ID of the pipeline.
   rpc DeleteOrganizationPipeline(DeleteOrganizationPipelineRequest) returns (DeleteOrganizationPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -501,7 +473,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/validate"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -518,7 +489,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_pipeline_id";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -531,7 +501,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/clone"
       body: "*"
     };
-    option (google.api.method_signature) = "name,target";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -544,7 +513,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/clone"
       body: "*"
     };
-    option (google.api.method_signature) = "name,target";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
@@ -564,7 +532,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/trigger-stream"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -593,7 +560,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -623,7 +589,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -645,7 +610,6 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*/pipelines/*}/releases"
       body: "release"
     };
-    option (google.api.method_signature) = "parent,release";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -655,7 +619,6 @@ service PipelinePublicService {
   // which is formed by the parent organization and ID of the pipeline.
   rpc ListOrganizationPipelineReleases(ListOrganizationPipelineReleasesRequest) returns (ListOrganizationPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*/pipelines/*}/releases"};
-    option (google.api.method_signature) = "pipelines";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -665,7 +628,6 @@ service PipelinePublicService {
   // its resource name, formed by its parent organization and ID.
   rpc GetOrganizationPipelineRelease(GetOrganizationPipelineReleaseRequest) returns (GetOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -678,7 +640,6 @@ service PipelinePublicService {
       patch: "/v1beta/{release.name=organizations/*/pipelines/*/releases/*}"
       body: "release"
     };
-    option (google.api.method_signature) = "release,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -688,7 +649,6 @@ service PipelinePublicService {
   // name, formed by its parent organization and ID.
   rpc DeleteOrganizationPipelineRelease(DeleteOrganizationPipelineReleaseRequest) returns (DeleteOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -700,7 +660,6 @@ service PipelinePublicService {
   // organization and ID.
   rpc RestoreOrganizationPipelineRelease(RestoreOrganizationPipelineReleaseRequest) returns (RestoreOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/restore"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -718,7 +677,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/rename"
       body: "*"
     };
-    option (google.api.method_signature) = "name,new_pipeline_release_id";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
   }
 
@@ -736,7 +694,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/trigger"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -763,7 +720,6 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/triggerAsync"
       body: "*"
     };
-    option (google.api.method_signature) = "name,data";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -782,7 +738,6 @@ service PipelinePublicService {
   // long-running operations such as asynchronous pipeline triggers.
   rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
     option (google.api.http) = {get: "/v1beta/{name=operations/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger";
       parameters: {
@@ -809,7 +764,6 @@ service PipelinePublicService {
   // Returns the details of a connector definition.
   rpc GetConnectorDefinition(GetConnectorDefinitionRequest) returns (GetConnectorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=connector-definitions/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
     option deprecated = true;
   }
@@ -838,7 +792,6 @@ service PipelinePublicService {
   // Returns the details of an operator definition.
   rpc GetOperatorDefinition(GetOperatorDefinitionRequest) returns (GetOperatorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=operator-definitions/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
     option deprecated = true;
   }
@@ -852,7 +805,6 @@ service PipelinePublicService {
       post: "/v1beta/check-name"
       body: "*"
     };
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils"};
   }
 
@@ -864,7 +816,6 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*}/secrets"
       body: "secret"
     };
-    option (google.api.method_signature) = "parent,secret";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
@@ -874,7 +825,6 @@ service PipelinePublicService {
   // user.
   rpc ListUserSecrets(ListUserSecretsRequest) returns (ListUserSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/secrets"};
-    option (google.api.method_signature) = "parent";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
@@ -884,7 +834,6 @@ service PipelinePublicService {
   // which is defined by the parent user and the ID of the secret.
   rpc GetUserSecret(GetUserSecretRequest) returns (GetUserSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/secrets/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
@@ -899,7 +848,6 @@ service PipelinePublicService {
       patch: "/v1beta/{secret.name=users/*/secrets/*}"
       body: "secret"
     };
-    option (google.api.method_signature) = "secret,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
@@ -909,7 +857,6 @@ service PipelinePublicService {
   // the parent user and the ID of the secret.
   rpc DeleteUserSecret(DeleteUserSecretRequest) returns (DeleteUserSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/secrets/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
@@ -921,7 +868,6 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*}/secrets"
       body: "secret"
     };
-    option (google.api.method_signature) = "parent,secret";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
@@ -931,7 +877,6 @@ service PipelinePublicService {
   // organization.
   rpc ListOrganizationSecrets(ListOrganizationSecretsRequest) returns (ListOrganizationSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/secrets"};
-    option (google.api.method_signature) = "parent";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
@@ -941,7 +886,6 @@ service PipelinePublicService {
   // which is defined by the parent organization and the ID of the secret.
   rpc GetOrganizationSecret(GetOrganizationSecretRequest) returns (GetOrganizationSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/secrets/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
@@ -956,7 +900,6 @@ service PipelinePublicService {
       patch: "/v1beta/{secret.name=organizations/*/secrets/*}"
       body: "secret"
     };
-    option (google.api.method_signature) = "secret,update_mask";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 
@@ -966,7 +909,6 @@ service PipelinePublicService {
   // the parent organization and the ID of the secret.
   rpc DeleteOrganizationSecret(DeleteOrganizationSecretRequest) returns (DeleteOrganizationSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/secrets/*}"};
-    option (google.api.method_signature) = "name";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
 }


### PR DESCRIPTION
Because

- A new dashboard page is going to be implemented, where credit, model and pipeline metrics are displayed.

This commit

- Unifies the shape of the credit and pipeline endpoints in order to reduce the complexity on the client and server.
- Removes unused fields / endpoints.
  - The source of truth for the trigger list isn't the metrics endpoint anymore, the logging domain is. The dashboard will redirect to the trigger list powered by the log tables.
  - We don't need the success / failure count _per pipeline_ anymore. Instead of a `*TableRecords` endpoint, a new `Count` endpoint is added.
  - The `*ChartRecords` endpoints are unified. All the params that are needed in the query (all those that were required or had a default value) are explicit. Though the dashboard won't have a filter initially, we might filter by other fields in the future through an AIP filter param.
