### PR TITLE
chore(model): group model endpoints by subdomains

### DIFF
--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -48,7 +48,7 @@ service ModelPublicService {
   // Returns a paginated list of model definitions.
   rpc ListModelDefinitions(ListModelDefinitionsRequest) returns (ListModelDefinitionsResponse) {
     option (google.api.http) = {get: "/v1alpha/model-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model Definition"};
   }
 
   // List available regions
@@ -56,7 +56,7 @@ service ModelPublicService {
   // Returns a paginated list of available regions.
   rpc ListAvailableRegions(ListAvailableRegionsRequest) returns (ListAvailableRegionsResponse) {
     option (google.api.http) = {get: "/v1alpha/available-regions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Region"};
   }
 
   // Get a model definition
@@ -65,7 +65,7 @@ service ModelPublicService {
   rpc GetModelDefinition(GetModelDefinitionRequest) returns (GetModelDefinitionResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=model-definitions/*}"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model Definition"};
   }
 
   // List models
@@ -204,7 +204,7 @@ service ModelPublicService {
   rpc WatchUserModel(WatchUserModelRequest) returns (WatchUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions/{version=*}/watch"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
   // Watch the state of the latest model version
@@ -215,7 +215,7 @@ service ModelPublicService {
   rpc WatchUserLatestModel(WatchUserLatestModelRequest) returns (WatchUserLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/watch"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
   // List user model versions
@@ -225,7 +225,7 @@ service ModelPublicService {
   rpc ListUserModelVersions(ListUserModelVersionsRequest) returns (ListUserModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
   // Delete a model version
@@ -235,7 +235,7 @@ service ModelPublicService {
   rpc DeleteUserModelVersion(DeleteUserModelVersionRequest) returns (DeleteUserModelVersionResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}/versions/{version=*}"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
   ///////////////////////////////////////////////////////
@@ -251,7 +251,7 @@ service ModelPublicService {
     };
     option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -273,7 +273,7 @@ service ModelPublicService {
     };
     option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -295,7 +295,7 @@ service ModelPublicService {
     };
     option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -317,7 +317,7 @@ service ModelPublicService {
     };
     option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -335,7 +335,7 @@ service ModelPublicService {
   rpc TriggerUserModelBinaryFileUpload(stream TriggerUserModelBinaryFileUploadRequest) returns (TriggerUserModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -465,7 +465,7 @@ service ModelPublicService {
   rpc WatchOrganizationModel(WatchOrganizationModelRequest) returns (WatchOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}/watch"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
   // Watch the state of the latest model version
@@ -476,7 +476,7 @@ service ModelPublicService {
   rpc WatchOrganizationLatestModel(WatchOrganizationLatestModelRequest) returns (WatchOrganizationLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/watch"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
   // List organization model versions
@@ -486,7 +486,7 @@ service ModelPublicService {
   rpc ListOrganizationModelVersions(ListOrganizationModelVersionsRequest) returns (ListOrganizationModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
   // Delete a model version
@@ -496,7 +496,7 @@ service ModelPublicService {
   rpc DeleteOrganizationModelVersion(DeleteOrganizationModelVersionRequest) returns (DeleteOrganizationModelVersionResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
   }
 
   ///////////////////////////////////////////////////////
@@ -512,7 +512,7 @@ service ModelPublicService {
     };
     option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -534,7 +534,7 @@ service ModelPublicService {
     };
     option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -556,7 +556,7 @@ service ModelPublicService {
     };
     option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -578,7 +578,7 @@ service ModelPublicService {
     };
     option (google.api.method_signature) = "name,inputs";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -596,7 +596,7 @@ service ModelPublicService {
   rpc TriggerOrganizationModelBinaryFileUpload(stream TriggerOrganizationModelBinaryFileUploadRequest) returns (TriggerOrganizationModelBinaryFileUploadResponse) {
     option (google.api.method_signature) = "name,file";
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model";
+      tags: "Trigger";
       parameters: {
         headers: {
           name: "Instill-Requester-Uid";
@@ -614,7 +614,7 @@ service ModelPublicService {
   rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Get the details of the latest long-running operation from a user model
@@ -624,7 +624,7 @@ service ModelPublicService {
   rpc GetUserLatestModelOperation(GetUserLatestModelOperationRequest) returns (GetUserLatestModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/operation"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
   // Get the details of the latest long-running operation from a organization model
@@ -634,6 +634,6 @@ service ModelPublicService {
   rpc GetOrganizationLatestModelOperation(GetOrganizationLatestModelOperationRequest) returns (GetOrganizationLatestModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/operation"};
     option (google.api.method_signature) = "name";
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 }

--- a/model/model/v1alpha/openapi.proto.templ
+++ b/model/model/v1alpha/openapi.proto.templ
@@ -14,6 +14,18 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   tags: [
     {
       name: "Model"
+    },
+    {
+      name: "Model Definition"
+    },
+    {
+      name: "Version"
+    },
+    {
+      name: "Trigger"
+    },
+    {
+      name: "Region"
     }
   ];
 {{$conf}}

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -12,6 +12,10 @@ info:
     url: https://github.com/instill-ai/protobufs/blob/main/LICENSE
 tags:
   - name: Model
+  - name: Model Definition
+  - name: Version
+  - name: Trigger
+  - name: Region
 host: api.instill.tech
 schemes:
   - https
@@ -66,7 +70,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Model
+        - Model Definition
   /v1alpha/available-regions:
     get:
       summary: List available regions
@@ -85,7 +89,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       tags:
-        - Model
+        - Region
   /v1alpha/{model_definition_name}:
     get:
       summary: Get a model definition
@@ -125,7 +129,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Model
+        - Model Definition
   /v1alpha/models:
     get:
       summary: List models
@@ -766,7 +770,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - Model
+        - Version
   /v1alpha/{user_model_name}/watch:
     get:
       summary: Watch the state of the latest model version
@@ -798,7 +802,7 @@ paths:
           type: string
           pattern: users/[^/]+/models/[^/]+
       tags:
-        - Model
+        - Version
   /v1alpha/{user_model_name}/versions:
     get:
       summary: List user model versions
@@ -845,7 +849,7 @@ paths:
           type: integer
           format: int32
       tags:
-        - Model
+        - Version
   /v1alpha/{user_model_name}/versions/{version}:
     delete:
       summary: Delete a model version
@@ -882,7 +886,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - Model
+        - Version
   /v1alpha/{user_model_name}/versions/{version}/trigger:
     post:
       summary: Trigger model inference
@@ -929,7 +933,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Trigger
   /v1alpha/{user_model_name}/versions/{version}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -976,7 +980,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Trigger
   /v1alpha/{user_model_name}/trigger:
     post:
       summary: Trigger model inference
@@ -1017,7 +1021,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Trigger
   /v1alpha/{user_model_name}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -1058,7 +1062,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Trigger
   /v1alpha/{organization_name}/models:
     get:
       summary: List organization models
@@ -1581,7 +1585,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - Model
+        - Version
   /v1alpha/{organization_model_name}/watch:
     get:
       summary: Watch the state of the latest model version
@@ -1613,7 +1617,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/models/[^/]+
       tags:
-        - Model
+        - Version
   /v1alpha/{organization_model_name}/versions:
     get:
       summary: List organization model versions
@@ -1660,7 +1664,7 @@ paths:
           type: integer
           format: int32
       tags:
-        - Model
+        - Version
   /v1alpha/{organization_model_name}/versions/{version}:
     delete:
       summary: Delete a model version
@@ -1699,7 +1703,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - Model
+        - Version
   /v1alpha/{organization_model_name}/versions/{version}/trigger:
     post:
       summary: Trigger model inference
@@ -1746,7 +1750,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Trigger
   /v1alpha/{organization_model_name}/versions/{version}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -1793,7 +1797,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Trigger
   /v1alpha/{organization_model_name}/trigger:
     post:
       summary: Trigger model inference
@@ -1834,7 +1838,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Trigger
   /v1alpha/{organization_model_name}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -1875,7 +1879,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Trigger
   /v1alpha/{name}:
     get:
       summary: Get the details of a long-running operation
@@ -1917,7 +1921,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Model
+        - Trigger
   /v1alpha/{user_model_name}/operation:
     get:
       summary: Get the details of the latest long-running operation from a user model
@@ -1960,7 +1964,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Model
+        - Trigger
   /v1alpha/{organization_model_name}/operation:
     get:
       summary: Get the details of the latest long-running operation from a organization model
@@ -2003,7 +2007,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Model
+        - Trigger
 definitions:
   ModelPublicServicePublishOrganizationModelBody:
     type: object


### PR DESCRIPTION
Because

- VDP and Core APIs group their endpoints by subdomain via tags.

This commit

- Groups Model endpoints in subdomains
  - Model
  - Model Definition
  - Version
  - Trigger
  - Region

### Before

![CleanShot 2024-07-22 at 09 21 19](https://github.com/user-attachments/assets/3b6e0158-af95-446e-8efc-20ba949e1e7c)

### After
![CleanShot 2024-07-22 at 09 55 09](https://github.com/user-attachments/assets/035eb3fc-a54b-4563-b68a-2e94a4006bc0)
