### PR TITLE
feat(artifact): namespace endpoint

### DIFF
--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -44,7 +44,7 @@ service ArtifactPublicService {
   // Create a knowledge base
   rpc CreateKnowledgeBase(CreateKnowledgeBaseRequest) returns (CreateKnowledgeBaseResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/owners/{owner_id}/knowledge-bases"
+      post: "/v1alpha/namespaces/{owner_id}/knowledge-bases"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
@@ -52,14 +52,14 @@ service ArtifactPublicService {
 
   // Get all knowledge bases info
   rpc ListKnowledgeBases(ListKnowledgeBasesRequest) returns (ListKnowledgeBasesResponse) {
-    option (google.api.http) = {get: "/v1alpha/owners/{owner_id}/knowledge-bases"};
+    option (google.api.http) = {get: "/v1alpha/namespaces/{owner_id}/knowledge-bases"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
 
   // Update a knowledge base info
   rpc UpdateKnowledgeBase(UpdateKnowledgeBaseRequest) returns (UpdateKnowledgeBaseResponse) {
     option (google.api.http) = {
-      put: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}"
+      put: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
@@ -67,14 +67,14 @@ service ArtifactPublicService {
 
   // Delete a knowledge base
   rpc DeleteKnowledgeBase(DeleteKnowledgeBaseRequest) returns (DeleteKnowledgeBaseResponse) {
-    option (google.api.http) = {delete: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}"};
+    option (google.api.http) = {delete: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
 
   // Create a file
   rpc UploadKnowledgeBaseFile(UploadKnowledgeBaseFileRequest) returns (UploadKnowledgeBaseFileResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/files"
+      post: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/files"
       body: "file"
     };
     option (google.api.method_signature) = "owner_id,kb_id,file";
@@ -100,13 +100,13 @@ service ArtifactPublicService {
 
   // list files
   rpc ListKnowledgeBaseFiles(ListKnowledgeBaseFilesRequest) returns (ListKnowledgeBaseFilesResponse) {
-    option (google.api.http) = {get: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/files"};
+    option (google.api.http) = {get: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/files"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
   // List chunks
   rpc ListChunks(ListChunksRequest) returns (ListChunksResponse) {
     option (google.api.http) = {
-      get: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/chunks"
+      get: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/chunks"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
@@ -114,7 +114,7 @@ service ArtifactPublicService {
   // Get source file
   rpc GetSourceFile(GetSourceFileRequest) returns (GetSourceFileResponse) {
     option (google.api.http) = {
-      get: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/files/{file_uid}/source"
+      get: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/files/{file_uid}/source"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
@@ -131,7 +131,7 @@ service ArtifactPublicService {
   // Similarity chunks search
   rpc SimilarityChunksSearch(SimilarityChunksSearchRequest) returns (SimilarityChunksSearchResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/owners/{owner_id}/knowledge-bases/{kb_id}/chunks/similarity"
+      post: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/chunks/similarity"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -7,7 +7,7 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1alpha/owners/{ownerId}/knowledge-bases:
+  /v1alpha/namespaces/{ownerId}/knowledge-bases:
     get:
       summary: Get all knowledge bases info
       operationId: ArtifactPublicService_ListKnowledgeBases
@@ -53,7 +53,7 @@ paths:
             $ref: '#/definitions/ArtifactPublicServiceCreateKnowledgeBaseBody'
       tags:
         - KnowledgeBase
-  /v1alpha/owners/{ownerId}/knowledge-bases/{kbId}:
+  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}:
     delete:
       summary: Delete a knowledge base
       operationId: ArtifactPublicService_DeleteKnowledgeBase
@@ -109,7 +109,7 @@ paths:
             $ref: '#/definitions/ArtifactPublicServiceUpdateKnowledgeBaseBody'
       tags:
         - KnowledgeBase
-  /v1alpha/owners/{ownerId}/knowledge-bases/{kbId}/files:
+  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}/files:
     get:
       summary: list files
       operationId: ArtifactPublicService_ListKnowledgeBaseFiles
@@ -227,7 +227,7 @@ paths:
             $ref: '#/definitions/v1alphaProcessKnowledgeBaseFilesRequest'
       tags:
         - KnowledgeBase
-  /v1alpha/owners/{ownerId}/knowledge-bases/{kbId}/chunks:
+  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}/chunks:
     get:
       summary: List chunks
       operationId: ArtifactPublicService_ListChunks
@@ -258,7 +258,7 @@ paths:
           type: string
       tags:
         - KnowledgeBase
-  /v1alpha/owners/{ownerId}/knowledge-bases/{kbId}/files/{fileUid}/source:
+  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}/files/{fileUid}/source:
     get:
       summary: Get source file
       operationId: ArtifactPublicService_GetSourceFile
@@ -315,7 +315,7 @@ paths:
             $ref: '#/definitions/ArtifactPublicServiceUpdateChunkBody'
       tags:
         - KnowledgeBase
-  /v1alpha/owners/{ownerId}/knowledge-bases/{kbId}/chunks/similarity:
+  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}/chunks/similarity:
     post:
       summary: Similarity chunks search
       operationId: ArtifactPublicService_SimilarityChunksSearch


### PR DESCRIPTION
Because

we use namespaces for both users and orgs

This commit

change the owners to namespaces in endpoint
