### PR TITLE
feat(all): introduce new namespace endpoints

### DIFF
--- a/.github/workflows/buf-gen-openapi.yaml
+++ b/.github/workflows/buf-gen-openapi.yaml
@@ -28,17 +28,22 @@ jobs:
       - name: Generate OpenAPI definitions
         run: |
           make openapi
-
-          # Pass generated files to linter step
-          echo 'FILE_LIST<<EOF' >> $GITHUB_ENV
-          find openapiv2 -type f >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-      - name: Lint generated OpenAPI definitions
-        uses: mbowman100/swagger-validator-action@master
+      - name: Lint generated Core OpenAPI definitions
+        uses: readmeio/rdme@v8
         with:
-          # Uses the same linter than swagger-cli but spares us the
-          # installation.
-          files: ${{ env.FILE_LIST }}
+          rdme: openapi:validate openapiv2/core/service.swagger.yaml
+      - name: Lint generated VDP OpenAPI definitions
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi:validate openapiv2/vdp/service.swagger.yaml
+      - name: Lint generated Model OpenAPI definitions
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi:validate openapiv2/model/service.swagger.yaml
+      - name: Lint generated Artifact OpenAPI definitions
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi:validate openapiv2/artifact/service.swagger.yaml
       - name: Commit and push
         run: |
           if [[ `git status --porcelain` ]]; then

--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -1,6 +1,7 @@
 name: Sync docs in ReadMe 🦉
 
 on:
+  pull_request:
   push:
     branches:
       # This workflow will run every time changes in the OpenAPI docs are
@@ -14,8 +15,62 @@ on:
       - 'openapiv2/vdp/**'
 
 jobs:
-  sync-openapi-private:
+  sync-openapi-private-dev:
+    name: Keep private (dev) docs in sync with latest pull request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      old_release: ${{ steps.check-new-release.outputs.old_release }}
+      new_release: ${{ steps.check-new-release.outputs.new_release }}
+    steps:
+      - name: Check out repo 📚
+        uses: actions/checkout@v3
+        with:
+          # Needed in check-new-release to compare with the previous commit.
+          fetch-depth: 0
+
+      - name: Sync Core 🔮
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/core/service.swagger.yaml --title "🔮 Core ${{ github.ref_name }}" --key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c652d
+
+      - name: Sync Model ⚗️
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/model/service.swagger.yaml --title "⚗️ Model ${{ github.ref_name }}"--key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c652e
+
+      - name: Sync VDP 💧
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/vdp/service.swagger.yaml --title "💧 VDP ${{ github.ref_name }}"--key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c652f
+
+      - name: Sync Artifact 💾
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/artifact/service.swagger.yaml --title "💾 Artifact ${{ github.ref_name }}" --key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c6531
+
+      - name: Check new release 🔍
+        id: check-new-release
+        run: |
+          # If the version in the OpenAPI configuration has changed, extract
+          # the old and new release versions (without the "v" prefix) to
+          # variables.
+          version_file=common/openapi/v1beta/api_info.conf
+          capture_old='^-\s\+\<version:'
+          capture_new='^+\s\+\<version:'
+          extract_version='s/.*"v\(.*\)".*/\1/'
+
+          old_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_old | sed $extract_version)
+          new_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_new | sed $extract_version)
+
+          if [[ $new_version ]]; then
+            echo "new_release=$new_version" >> $GITHUB_OUTPUT
+            echo "old_release=$old_version" >> $GITHUB_OUTPUT
+          fi
+
+  sync-openapi-private-staging:
     name: Keep private (staging) docs in sync with `main`
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       old_release: ${{ steps.check-new-release.outputs.old_release }}
@@ -42,6 +97,11 @@ jobs:
         with:
           rdme: openapi openapiv2/vdp/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65bcfc78e72e300017c0b164
 
+      - name: Sync Artifact 💾
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/artifact/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=669fb97f2071e2004a8f9183
+
       - name: Check new release 🔍
         id: check-new-release
         run: |
@@ -63,7 +123,7 @@ jobs:
 
   sync-openapi-public:
     name: Sync public docs on new release
-    needs: [sync-openapi-private]
+    needs: [sync-openapi-private-staging]
     runs-on: ubuntu-latest
     if: needs.sync-openapi-private.outputs.new_release != ''
     steps:

--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -32,22 +32,22 @@ jobs:
       - name: Sync Core 🔮
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/core/service.swagger.yaml --title "🔮 Core ${{ github.ref_name }}" --key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c652d
+          rdme: openapi openapiv2/core/service.swagger.yaml --title "🔮 Core (PR ${{ github.ref_name }})" --key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c652d
 
       - name: Sync Model ⚗️
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/model/service.swagger.yaml --title "⚗️ Model ${{ github.ref_name }}"--key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c652e
+          rdme: openapi openapiv2/model/service.swagger.yaml --title "⚗️ Model (PR ${{ github.ref_name }})"--key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c652e
 
       - name: Sync VDP 💧
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/vdp/service.swagger.yaml --title "💧 VDP ${{ github.ref_name }}"--key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c652f
+          rdme: openapi openapiv2/vdp/service.swagger.yaml --title "💧 VDP (PR ${{ github.ref_name }})"--key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c652f
 
       - name: Sync Artifact 💾
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/artifact/service.swagger.yaml --title "💾 Artifact ${{ github.ref_name }}" --key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c6531
+          rdme: openapi openapiv2/artifact/service.swagger.yaml --title "💾 Artifact (PR ${{ github.ref_name }})" --key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c6531
 
       - name: Check new release 🔍
         id: check-new-release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
+        exclude: common/openapi
       - id: trailing-whitespace
   - repo: https://github.com/pinglin/conventional-pre-commit
     rev: v1.1.0
@@ -11,8 +12,23 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
   - repo: https://github.com/bufbuild/buf.git
-    rev: v1.25.0
+    rev: v1.35.0
     hooks:
       - id: buf-generate
+  - repo: local
+    hooks:
+      - id: generate-openapi
+        name: generate openapi
+        entry: make openapi
+        language: system
+  - repo: https://github.com/bufbuild/buf.git
+    rev: v1.35.0
+    hooks:
       - id: buf-format
       - id: buf-lint
+  - repo: local
+    hooks:
+      - id: validate-openapi
+        name: validate openapi
+        entry: make openapi-lint
+        language: system

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@
 # that matches the one in our CI.
 OS_NAME := $(shell uname -s | tr A-Z a-z)
 SED_IN_PLACE := sed -i
+
+# On macOS, you can install the `gsed` command via `brew install gsed` to
+# achieve the same behavior as the `sed` command on Linux.
 ifeq (${OS_NAME}, darwin)
-	SED_IN_PLACE += ''
+	SED_IN_PLACE = gsed -i
 endif
 openapi:
 	@# Inject common API configuration into each OpenAPI proto template.
@@ -25,4 +28,4 @@ openapi:
 	find openapiv2 -type f | xargs -I '{}' ${SED_IN_PLACE} '/^[[:space:]]*enum: \[\]/,+0d' {}
 openapi-lint:
 	@# Lint each file under openapiv2.
-	find openapiv2 -type f | xargs -I '{}' swagger-cli validate {}
+	find openapiv2 -type f | xargs -I '{}' rdme openapi:validate {}

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -196,7 +196,7 @@ message KnowledgeBase {
 // CreateKnowledgeBaseRequest represents a request to create a knowledge base.
 message CreateKnowledgeBaseRequest {
   // The knowledge base owner(nammespace).
-  string owner_id = 1;
+  string namespace_id = 1;
   // The knowledge base name.
   string name = 2;
   // The knowledge base description.
@@ -214,7 +214,7 @@ message CreateKnowledgeBaseResponse {
 // Request message for ListKnowledgeBases
 message ListKnowledgeBasesRequest {
   // User ID for which to list the knowledge bases
-  string owner_id = 1;
+  string namespace_id = 1;
 }
 
 // GetKnowledgeBasesResponse represents a response for getting all knowledge bases from users.
@@ -232,7 +232,7 @@ message UpdateKnowledgeBaseRequest {
   // The knowledge base tags.
   repeated string tags = 3;
   // The knowledge base owner(namespace).
-  string owner_id = 4;
+  string namespace_id = 4;
 }
 
 // UpdateKnowledgeBaseResponse represents a response for updating a knowledge base.
@@ -244,7 +244,7 @@ message UpdateKnowledgeBaseResponse {
 // DeleteKnowledgeBaseRequest represents a request to delete a knowledge base.
 message DeleteKnowledgeBaseRequest {
   // The owner's id. i.e. namespace.
-  string owner_id = 1;
+  string namespace_id = 1;
   // The knowledge base identifier.
   string kb_id = 2;
 }
@@ -325,14 +325,14 @@ message File {
   int64 size = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
   // total chunks
   int32 total_chunks = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // total tokens 
+  // total tokens
   int32 total_tokens = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // upload file request
 message UploadKnowledgeBaseFileRequest {
   // owenr uid
-  string owner_id = 1 [(google.api.field_behavior) = REQUIRED];
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // knowledge base uid
   string kb_id = 2 [(google.api.field_behavior) = REQUIRED];
   // file
@@ -379,7 +379,7 @@ message ListKnowledgeBaseFilesFilter {
 // list files request
 message ListKnowledgeBaseFilesRequest {
   // The owner uid.
-  string owner_id = 1;
+  string namespace_id = 1;
   // The knowledge base uid.
   string kb_id = 2;
   // The page size (default:10; max 100).

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package artifact.artifact.v1alpha;
 
 import "artifact/artifact/v1alpha/artifact.proto";
-import "google/api/visibility.proto";
 
 // ArtifactPrivateService exposes the private endpoints that allow clients to
 // manage artifacts.
@@ -28,6 +27,4 @@ service ArtifactPrivateService {
 
   // Delete a repository tag.
   rpc DeleteRepositoryTag(DeleteRepositoryTagRequest) returns (DeleteRepositoryTagResponse);
-
-  option (google.api.api_visibility).restriction = "INTERNAL";
 }

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -43,7 +43,7 @@ service ArtifactPublicService {
   // Create a knowledge base
   rpc CreateKnowledgeBase(CreateKnowledgeBaseRequest) returns (CreateKnowledgeBaseResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/namespaces/{owner_id}/knowledge-bases"
+      post: "/v1alpha/namespaces/{namespace_id}/knowledge-bases"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
@@ -51,14 +51,14 @@ service ArtifactPublicService {
 
   // Get all knowledge bases info
   rpc ListKnowledgeBases(ListKnowledgeBasesRequest) returns (ListKnowledgeBasesResponse) {
-    option (google.api.http) = {get: "/v1alpha/namespaces/{owner_id}/knowledge-bases"};
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/knowledge-bases"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
 
   // Update a knowledge base info
   rpc UpdateKnowledgeBase(UpdateKnowledgeBaseRequest) returns (UpdateKnowledgeBaseResponse) {
     option (google.api.http) = {
-      put: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}"
+      put: "/v1alpha/namespaces/{namespace_id}/knowledge-bases/{kb_id}"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
@@ -66,14 +66,14 @@ service ArtifactPublicService {
 
   // Delete a knowledge base
   rpc DeleteKnowledgeBase(DeleteKnowledgeBaseRequest) returns (DeleteKnowledgeBaseResponse) {
-    option (google.api.http) = {delete: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}"};
+    option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/knowledge-bases/{kb_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
 
   // Create a file
   rpc UploadKnowledgeBaseFile(UploadKnowledgeBaseFileRequest) returns (UploadKnowledgeBaseFileResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/files"
+      post: "/v1alpha/namespaces/{namespace_id}/knowledge-bases/{kb_id}/files"
       body: "file"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
@@ -96,22 +96,18 @@ service ArtifactPublicService {
 
   // list files
   rpc ListKnowledgeBaseFiles(ListKnowledgeBaseFilesRequest) returns (ListKnowledgeBaseFilesResponse) {
-    option (google.api.http) = {get: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/files"};
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/knowledge-bases/{kb_id}/files"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
   // List chunks
   rpc ListChunks(ListChunksRequest) returns (ListChunksResponse) {
-    option (google.api.http) = {
-      get: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/chunks"
-    };
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/knowledge-bases/{kb_id}/chunks"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
 
   // Get source file
   rpc GetSourceFile(GetSourceFileRequest) returns (GetSourceFileResponse) {
-    option (google.api.http) = {
-      get: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/files/{file_uid}/source"
-    };
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/knowledge-bases/{kb_id}/files/{file_uid}/source"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};
   }
 
@@ -127,7 +123,7 @@ service ArtifactPublicService {
   // Similarity chunks search
   rpc SimilarityChunksSearch(SimilarityChunksSearchRequest) returns (SimilarityChunksSearchResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/namespaces/{owner_id}/knowledge-bases/{kb_id}/chunks/similarity"
+      post: "/v1alpha/namespaces/{namespace_id}/knowledge-bases/{kb_id}/chunks/similarity"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "KnowledgeBase"};

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -7,107 +7,106 @@ import "google/protobuf/timestamp.proto";
 
 // The Chunk message represents a chunk of data in the artifact system.
 message Chunk {
-    // unique identifier of the chunk
-    string chunk_uid = 1;
-    // whether the chunk is retrievable
-    bool retrievable = 2;
-    // start position of the chunk in the source file
-    uint32 start_pos = 4;
-    // end position of the chunk in the source file
-    uint32 end_pos = 5;
-    // tokens of the chunk
-    uint32 tokens = 6;
-    // creation time of the chunk
-    google.protobuf.Timestamp create_time = 7;
-    // original file unique identifier
-    string original_file_uid = 8;
+  // unique identifier of the chunk
+  string chunk_uid = 1;
+  // whether the chunk is retrievable
+  bool retrievable = 2;
+  // start position of the chunk in the source file
+  uint32 start_pos = 4;
+  // end position of the chunk in the source file
+  uint32 end_pos = 5;
+  // tokens of the chunk
+  uint32 tokens = 6;
+  // creation time of the chunk
+  google.protobuf.Timestamp create_time = 7;
+  // original file unique identifier
+  string original_file_uid = 8;
 }
 
 // The ListChunksRequest message represents a request to list chunks in the artifact system.
 message ListChunksRequest {
-    // owner id (not uid)
-    string owner_id = 1;
-    // knowledge base name (not uid)
-    string kb_id = 2;
-    // unique identifier of the file
-    string file_uid = 3; 
+  // owner id (not uid)
+  string namespace_id = 1;
+  // knowledge base name (not uid)
+  string kb_id = 2;
+  // unique identifier of the file
+  string file_uid = 3;
 }
 
 // The ListChunksResponse message represents a response containing a list of chunks in the artifact system.
 message ListChunksResponse {
-    // repeated chunks
-    repeated Chunk chunks = 1;
+  // repeated chunks
+  repeated Chunk chunks = 1;
 }
-
 
 // The SourceFile message represents a source file in the artifact system.
 message SourceFile {
-    // original file unique identifier
-    string original_file_uid = 1;
-    // content
-    string content = 3;
-    // creation time of the source file
-    google.protobuf.Timestamp create_time = 5;
-    // update time of the source file
-    google.protobuf.Timestamp update_time = 6;
+  // original file unique identifier
+  string original_file_uid = 1;
+  // content
+  string content = 3;
+  // creation time of the source file
+  google.protobuf.Timestamp create_time = 5;
+  // update time of the source file
+  google.protobuf.Timestamp update_time = 6;
 }
 
 // get source file request
 message GetSourceFileRequest {
-    // owner id
-    string owner_id = 1;
-    // knowledge base name
-    string kb_id = 2;
-    // unique identifier of the original uploaded file
-    string file_uid = 3;
-  }
+  // owner id
+  string namespace_id = 1;
+  // knowledge base name
+  string kb_id = 2;
+  // unique identifier of the original uploaded file
+  string file_uid = 3;
+}
 
 // get source file response
 message GetSourceFileResponse {
-    // source file(either orignal file or converted file)
-    SourceFile source_file = 1;
-  }
+  // source file(either orignal file or converted file)
+  SourceFile source_file = 1;
+}
 
 // Create chunk response
 message UpdateChunkRequest {
-    // chunk uid
-    string chunk_uid = 1;
-    // whether the chunk is retrievable
-    bool retrievable = 2;
-  }
+  // chunk uid
+  string chunk_uid = 1;
+  // whether the chunk is retrievable
+  bool retrievable = 2;
+}
 
 // Updae chunk response
 message UpdateChunkResponse {
-    // chunk
-    Chunk chunk = 1;
-  }
+  // chunk
+  Chunk chunk = 1;
+}
 
 // Similar chunnk search request
 message SimilarityChunksSearchRequest {
-    // owner id
-    string owner_id = 1;
-    // knowledge base name
-    string kb_id = 2;
-    // text prompt
-    string text_prompt = 3;
-    // topk
-    uint32 topk = 4;
-  }
+  // owner id
+  string namespace_id = 1;
+  // knowledge base name
+  string kb_id = 2;
+  // text prompt
+  string text_prompt = 3;
+  // topk
+  uint32 topk = 4;
+}
 
 // Similar chunnk search response
 message SimilarityChunksSearchResponse {
-    // chunks
-    repeated SimilarityChunk similar_chunks = 1;
-  }
+  // chunks
+  repeated SimilarityChunk similar_chunks = 1;
+}
 
 // similarity chunks
 message SimilarityChunk {
-    // chunk uid
-    string chunk_uid = 1;
-    // similarity score
-    float similarity_score = 2;
-    // chunk
-    string text_content = 3;
-    // source file
-    string source_file = 4;
-  }
+  // chunk uid
+  string chunk_uid = 1;
+  // similarity score
+  float similarity_score = 2;
+  // chunk
+  string text_content = 3;
+  // source file
+  string source_file = 4;
+}

--- a/artifact/artifact/v1alpha/openapi.proto.templ
+++ b/artifact/artifact/v1alpha/openapi.proto.templ
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package artifact.artifact.v1alpha;
+
+import "protoc-gen-openapiv2/options/annotations.proto";
+
+// These options define the OpenAPI definition document information.
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "💾 Artifact "
+    description: "Artifact endpoints to manage artifact resources"
+{{$info}}
+  }
+  tags: []
+{{$conf}}
+};

--- a/buf.gen.openapi.yaml
+++ b/buf.gen.openapi.yaml
@@ -7,11 +7,12 @@ managed:
       - buf.build/googleapis/googleapis
       - buf.build/grpc-ecosystem/grpc-gateway
 plugins:
-  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.19.0
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.20.0
     out: .
     opt:
       - output_format=yaml
       - allow_merge=true,merge_file_name=service
+      - use_allof_for_refs=true # must be true so that the JSON `$ref` can work in OpenAPI parser.
       - version=true
       - omit_enum_default_value=true
       - preserve_rpc_order=true

--- a/buf.yaml
+++ b/buf.yaml
@@ -23,6 +23,3 @@ lint:
   rpc_allow_google_protobuf_empty_requests: false
   rpc_allow_google_protobuf_empty_responses: false
   service_suffix: Service
-build:
-  excludes:
-    # - bazel-grpc-gateway

--- a/common/openapi/v1beta/api_config.conf
+++ b/common/openapi/v1beta/api_config.conf
@@ -1,35 +1,35 @@
   // API config injected from common configuration.
-  host: "api.instill.tech";
+  host: "api.instill.tech"
   external_docs: {
-    url: "https://www.instill.tech/docs";
-    description: "More about Instill AI";
-  };
-  schemes: HTTPS;
-  schemes: HTTP;
-  consumes: "application/json";
-  produces: "application/json";
+    url: "https://www.instill.tech/docs"
+    description: "More about Instill AI"
+  }
+  schemes: HTTPS
+  schemes: HTTP
+  consumes: "application/json"
+  produces: "application/json"
   security_definitions: {
     security: {
-      key: "Bearer";
+      key: "Bearer"
       value: {
-        type: TYPE_API_KEY;
-        in: IN_HEADER;
-        name: "Authorization";
-        description: "Enter the token with the `Bearer ` prefix, e.g. `Bearer abcde12345`";
+        type: TYPE_API_KEY
+        in: IN_HEADER
+        name: "Authorization"
+        description: "Enter the token with the `Bearer ` prefix, e.g. `Bearer abcde12345`"
         extensions: {
-          key: "x-default";
-          value {string_value: "Bearer instill_sk_***"};
+          key: "x-default"
+          value: {string_value: "Bearer instill_sk_***"}
         }
       }
     }
   }
   security: {
     security_requirement: {
-      key: "Bearer";
-      value: {};
+      key: "Bearer"
+      value: {}
     }
   }
   responses: {
-    key: "401";
-    value: {description: "Returned when the client credentials are not valid."};
+    key: "401"
+    value: {description: "Returned when the client credentials are not valid."}
   }

--- a/common/openapi/v1beta/api_info.conf
+++ b/common/openapi/v1beta/api_info.conf
@@ -1,11 +1,11 @@
     // API info injected from common configuration.
-    version: "v0.36.0-beta";
+    version: "v0.36.0-beta"
     contact: {
-      name: "Instill AI";
-      url: "https://github.com/instill-ai";
-      email: "hello@instill.tech";
-    };
+      name: "Instill AI"
+      url: "https://github.com/instill-ai"
+      email: "hello@instill.tech"
+    }
     license: {
-      name: "Elastic License 2.0 (ELv2)";
-      url: "https://github.com/instill-ai/protobufs/blob/main/LICENSE";
-    };
+      name: "Elastic License 2.0 (ELv2)"
+      url: "https://github.com/instill-ai/protobufs/blob/main/LICENSE"
+    }

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -22,7 +22,7 @@ message LivenessRequest {
 // LivenessResponse represents a response for a service liveness status
 message LivenessResponse {
   // HealthCheckResponse message
-  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
+  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ReadinessRequest represents a request to check a service readiness status
@@ -34,7 +34,7 @@ message ReadinessRequest {
 // ReadinessResponse represents a response for a service readiness status
 message ReadinessResponse {
   // HealthCheckResponse message
-  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
+  common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // View defines how a resource is presented. It can be used as a parameter in a
@@ -62,7 +62,7 @@ enum OwnerType {
 // Permission defines how a resource can be used.
 message Permission {
   // Defines whether the resource can be modified.
-  bool can_edit = 1;
+  bool can_edit = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // MembershipState describes the state of a user membership to an organization.
@@ -164,7 +164,7 @@ message AuthenticatedUser {
   // Onboarding Status.
   OnboardingStatus onboarding_status = 17 [(google.api.field_behavior) = OPTIONAL];
   // Profile.
-  UserProfile profile = 18;
+  UserProfile profile = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Owner is a wrapper for User and Organization, used to embed owner information in other resources.
@@ -192,14 +192,14 @@ message User {
   string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // User UUID. This field is optionally set by users on creation (it will be
   // server-generated if unspecified).
-  optional string uid = 2 [(google.api.field_behavior) = IMMUTABLE];
+  optional string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Resource ID (used in `name` as the last segment). This conforms to
   // RFC-1034, which restricts to letters, numbers, and hyphen, with the first
   // character a letter, the last a letter or a number, and a 63 character
   // maximum.
   //
   // Note that the ID can be updated.
-  string id = 3 [(google.api.field_behavior) = REQUIRED];
+  string id = 3 [(google.api.field_behavior) = IMMUTABLE];
   // Creation time.
   google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Update time.
@@ -236,17 +236,12 @@ message ListUsersAdminResponse {
 
 // GetUserAdminRequest represents a request to query a user by admin
 message GetUserAdminRequest {
-  // Resource name of a user. For example:
-  // "users/local-user"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/User",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_name"}
-    }
-  ];
+  // Reserved for `user_id``
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 2;
+  // User ID
+  string user_id = 3;
 }
 
 // GetUserAdminResponse represents a response for a user resource
@@ -258,11 +253,12 @@ message GetUserAdminResponse {
 // LookUpUserAdminRequest represents a request to query a user via permalink by
 // admin
 message LookUpUserAdminRequest {
-  // Permalink of a user. For example:
-  // "users/{uid}"
-  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // Reserved for `permalink`
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 2;
+  // User UUID
+  string user_uid = 3;
 }
 
 // LookUpUserAdminResponse represents a response for a user resource by admin
@@ -276,15 +272,15 @@ message ListOrganizationsAdminRequest {
   // The maximum number of organizations to return. If this parameter is
   // unspecified, at most 10 pipelines will be returned. The cap value for this
   // parameter is 100 (i.e. any value above that will be coerced to 100).
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  optional int32 page_size = 1;
   // Page token.
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional string page_token = 2;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 3;
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  optional string filter = 4;
 }
 
 // ListOrganizationsAdminResponse represents a response for a list of organizations
@@ -299,17 +295,12 @@ message ListOrganizationsAdminResponse {
 
 // GetOrganizationAdminRequest represents a request to query a organization by admin
 message GetOrganizationAdminRequest {
-  // Resource name of a organization. For example:
-  // "organizations/local-organization"
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Organization",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  // Reserved for `name``
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 2;
+  // Organization ID
+  string organization_id = 3;
 }
 
 // GetOrganizationAdminResponse represents a response for a organization resource
@@ -321,11 +312,12 @@ message GetOrganizationAdminResponse {
 // LookUpOrganizationAdminRequest represents a request to query a organization via permalink by
 // admin
 message LookUpOrganizationAdminRequest {
-  // Permalink of a organization. For example:
-  // "organizations/{uid}"
-  string permalink = 1 [(google.api.field_behavior) = REQUIRED];
+  // Reserved for `permalink``
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional View view = 2;
+  // Organization UID
+  string organization_uid = 3;
 }
 
 // LookUpOrganizationAdminResponse represents a response for a organization resource by admin
@@ -353,32 +345,31 @@ message ListUsersRequest {
 // ListUsersResponse contains a list of users.
 message ListUsersResponse {
   // A list of user resources.
-  repeated User users = 1;
+  repeated User users = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Next page token.
-  string next_page_token = 2;
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of users.
-  int32 total_size = 3;
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetUserRequest represents a request to fetch the details of a user.
 message GetUserRequest {
-  // The resource name of the user, which allows its access by ID.
-  // - Format: `users/{user.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/User",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_name"}
-    }
-  ];
+  // Reserverd for `name`
+  reserved 1;
+
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  // User ID
+  string user_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/User"
+  ];
 }
 
 // GetUserResponse contains the requested user.
 message GetUserResponse {
   // The user resource.
-  User user = 1;
+  User user = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetAuthenticatedUserRequest represents a request to get the
@@ -388,14 +379,14 @@ message GetAuthenticatedUserRequest {}
 // GetAuthenticatedUserResponse contains the requested authenticated user.
 message GetAuthenticatedUserResponse {
   // The authenticated user resource.
-  AuthenticatedUser user = 1;
+  AuthenticatedUser user = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // PatchAuthenticatedUserRequest represents a request to update the
 // authenticated user.
 message PatchAuthenticatedUserRequest {
   // The user fields that will replace the existing ones.
-  AuthenticatedUser user = 1;
+  AuthenticatedUser user = 1 [(google.api.field_behavior) = REQUIRED];
   // The update mask specifies the subset of fields that should be modified.
   //
   // For more information about this field, see
@@ -407,7 +398,7 @@ message PatchAuthenticatedUserRequest {
 // the authenticated user resource
 message PatchAuthenticatedUserResponse {
   // The updated user resource.
-  AuthenticatedUser user = 1;
+  AuthenticatedUser user = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CheckNamespaceRequest represents a request to verify if a namespace is
@@ -470,10 +461,7 @@ message CheckNamespaceAdminResponse {
 
 // API tokens allow users to make requests to the Instill AI API.
 message ApiToken {
-  option (google.api.resource) = {
-    type: "api.instill.tech/ApiToken"
-    pattern: "tokens/{token.name}"
-  };
+  option (google.api.resource) = {type: "api.instill.tech/ApiToken"};
 
   // When users trigger a pipeline which uses an API token, the token is
   // updated with the current time. This field is used to track the last time
@@ -536,7 +524,7 @@ message CreateTokenRequest {
 // CreateTokenResponse contains the created token.
 message CreateTokenResponse {
   // The created API token resource.
-  ApiToken token = 1;
+  ApiToken token = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListTokensRequest represents a request to list the API tokens of a user.
@@ -561,33 +549,29 @@ message ListTokensResponse {
 
 // GetTokenRequest represents a request to fetch the details of an API token
 message GetTokenRequest {
-  // The resource name of the token, which allows its access by ID.
-  // - Format: `tokens/{token.id}`.
-  string name = 1 [
+  // Reserverd for `name`
+  reserved 1;
+  // Token ID
+  string token_id = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "token_name"}
-    }
+    (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"}
   ];
 }
 
 // GetTokenResponse contains the requested token.
 message GetTokenResponse {
   // The API token resource.
-  ApiToken token = 1;
+  ApiToken token = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DeleteTokenRequest represents a request to delete an API token resource.
 message DeleteTokenRequest {
-  // The resource name of the token, which allows its access by ID.
-  // - Format: `tokens/{token.id}`.
-  string name = 1 [
+  // Reserverd for `name`
+  reserved 1;
+  // Token ID
+  string token_id = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "token_name"}
-    }
+    (google.api.resource_reference) = {type: "api.instill.tech/ApiToken"}
   ];
 }
 
@@ -606,14 +590,10 @@ message ValidateTokenResponse {
 // GetRemainingCreditRequest represents a request to get the remaining credit
 // of a user or organization.
 message GetRemainingCreditRequest {
-  // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{id}`.
-  string owner = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "owner_name"}
-    }
-  ];
+  // Reserverd for `owner`
+  reserved 1;
+  // Namespace ID
+  string namespace_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetRemainingCreditResponse contains the remaining credit of a user or
@@ -623,20 +603,21 @@ message GetRemainingCreditResponse {
   // amount was returned.
   reserved 1;
   // Amount of perishable credit, i.e. credit with an expiration date.
-  float perishable = 2;
+  float perishable = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Amount of imperishable credit, e.g. purchased credit, which doesn't
   // expire.
-  float imperishable = 3;
+  float imperishable = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total remaining credit.
-  float total = 4;
+  float total = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetRemainingCreditAdminRequest represents a request to get the remaining
 // credit of a user or organization without authentication.
 message GetRemainingCreditAdminRequest {
-  // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{uid}`.
-  string owner = 1 [(google.api.field_behavior) = REQUIRED];
+  // Reserverd for `owner`
+  reserved 1;
+  // Namespace UID
+  string namespace_uid = 2;
 }
 
 // GetRemainingCreditAdminResponse contains the remaining credit of a user or
@@ -649,13 +630,14 @@ message GetRemainingCreditAdminResponse {
 // SubtractCreditAdminRequest represents a request to subtract Instill Credit from
 // an account.
 message SubtractCreditAdminRequest {
-  // The user or organization to which the credit belongs.
-  // Format: `{[users|organizations]}/{uid}`.
-  string owner = 1 [(google.api.field_behavior) = REQUIRED];
+  // Reserverd for `owner`
+  reserved 1;
   // The credit amount to subtract.
   float amount = 2;
   // The description of the entry, for traceability.
   string concept = 3;
+  // Namespace UID
+  string namespace_uid = 4;
 }
 
 // SubtractCreditResponse contains the remaining credit of an account after the
@@ -737,17 +719,11 @@ message Organization {
   option (google.api.resource) = {
     type: "api.instill.tech/Organization"
     pattern: "organizations/{organization.id}"
-    pattern: "organizations/{organization.uid}"
   };
 
   // The name of the organization, defined by its ID.
   // - Format: `organization/{organization.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Organization UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -757,7 +733,7 @@ message Organization {
   // maximum.
   //
   // Note that the ID can be updated.
-  string id = 3 [(google.api.field_behavior) = REQUIRED];
+  string id = 3 [(google.api.field_behavior) = IMMUTABLE];
   // Creation time.
   google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Update time.
@@ -765,7 +741,7 @@ message Organization {
   // The user that owns the organization.
   User owner = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Profile.
-  OrganizationProfile profile = 12;
+  OrganizationProfile profile = 12 [(google.api.field_behavior) = REQUIRED];
   // Permission
   Permission permission = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
@@ -789,11 +765,11 @@ message ListOrganizationsRequest {
 // ListOrganizationsResponse represents a response for a list of organizations
 message ListOrganizationsResponse {
   // A list of organizations
-  repeated Organization organizations = 1;
+  repeated Organization organizations = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Next page token.
-  string next_page_token = 2;
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of organizations.
-  int32 total_size = 3;
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateOrganizationRequest represents a request to create an organization.
@@ -805,58 +781,56 @@ message CreateOrganizationRequest {
 // CreateOrganizationResponse contains the created organization.
 message CreateOrganizationResponse {
   // The organization resource.
-  Organization organization = 1;
+  Organization organization = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetOrganizationRequest represents a request to fetch the details of an
 // organization.
 message GetOrganizationRequest {
-  // The resource name of the organization, which allows its access by ID.
-  // - Format: `organizations/{organization.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Organization",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  // Reserverd for `name`
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Organization ID
+  string organization_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "api.instill.tech/Organization"
+  ];
 }
 
 // GetOrganizationResponse contains the requested organization.
 message GetOrganizationResponse {
   // The organization resource.
-  Organization organization = 1;
+  Organization organization = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // UpdateOrganizationRequest represents a request to update an organization.
 message UpdateOrganizationRequest {
   // The organization fields that will replace the existing ones.
-  Organization organization = 1 [(google.api.field_behavior) = REQUIRED];
+  Organization organization = 1;
   // The update mask specifies the subset of fields that should be modified.
   //
   // For more information about this field, see
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // UpdateOrganizationResponse contains the updated organization.
 message UpdateOrganizationResponse {
   // The organization resource.
-  Organization organization = 1;
+  Organization organization = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DeleteOrganizationRequest represents a request to delete an organization.
 message DeleteOrganizationRequest {
-  // The resource name of the organization, which allows its access by ID.
-  // - Format: `organizations/{organization.id}`.
-  string name = 1 [
+  // Reserverd for `name`
+  reserved 1;
+  // Organization ID
+  string organization_id = 2 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Organization",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
+    (google.api.resource_reference).type = "api.instill.tech/Organization"
   ];
 }
 
@@ -912,43 +886,35 @@ message UserMembership {
 // ListUserMembershipsRequest represents a request to list the memberships of a
 // user.
 message ListUserMembershipsRequest {
-  // The parent resource, i.e., the user to which the memberships belong.
-  // Format: `users/{user.id}`.
-  string parent = 5 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_name"}
-    }
-  ];
+  // Reserverd for `parent`
+  reserved 5;
+
+  // User ID
+  string user_id = 6 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListUserMembershipsResponse contains a list of memberships.
 message ListUserMembershipsResponse {
   // The user memberships, i.e., the organizations the user belongs to.
-  repeated UserMembership memberships = 1;
+  repeated UserMembership memberships = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetUserMembershipRequest represents a request to query a user's membership.
 message GetUserMembershipRequest {
-  // The resource name of the membership, which allows its access by user and
-  // organization ID.
-  // - Format: `users/{user.id}/memberships/{organization.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/UserMembership"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_membership_name"}
-    }
-  ];
+  // Reserverd for `name`
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  // User ID
+  string user_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetUserMembershipResponse contains the user membership.
 message GetUserMembershipResponse {
   // The requested user membership.
-  UserMembership membership = 1;
+  UserMembership membership = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // UpdateUserMembershipRequest represents a request to update a user membership.
@@ -960,27 +926,27 @@ message UpdateUserMembershipRequest {
   // For more information about this field, see
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+  // User ID
+  string user_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // UpdateUserMembershipResponse contains the updated membership.
 message UpdateUserMembershipResponse {
   // The updated membership resource.
-  UserMembership membership = 1;
+  UserMembership membership = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DeleteUserMembershipRequest represents a request to delete a user
 // membership.
 message DeleteUserMembershipRequest {
-  // The resource name of the membership, which allows its access by user and
-  // organization ID.
-  // - Format: `users/{user.id}/memberships/{organization.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/UserMembership"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_membership_name"}
-    }
-  ];
+  // Reserved for `name`
+  reserved 1;
+  // User ID
+  string user_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteUserMembershipResponse is an empty response.
@@ -989,46 +955,38 @@ message DeleteUserMembershipResponse {}
 // ListOrganizationMembershipsRequest represents a request to list the
 // memberships of an organization.
 message ListOrganizationMembershipsRequest {
-  // The parent resource, i.e., the organization to which the memberships
-  // belong.
-  // Format: `organizations/{organization.id}`.
-  string parent = 5 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  // Reserved for `parent`
+  reserved 5;
+  // Organization ID
+  string organization_id = 6 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListOrganizationMembershipsResponse contains a list of memberships.
 message ListOrganizationMembershipsResponse {
   // The organization memberships, i.e., the users that belong to the
   // organization.
-  repeated OrganizationMembership memberships = 1;
+  repeated OrganizationMembership memberships = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetOrganizationMembershipRequest represents a request to query a user's
 // membership to an organization.
 message GetOrganizationMembershipRequest {
-  // The resource name of the membership, which allows its access by
-  // organization and user ID.
-  // - Format: `organizations/{organization.id}/memberships/{user.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/OrganizationMembership"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_membership_name"}
-    }
-  ];
+  // Reserved for `name`
+  reserved 1;
+
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Organization ID
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // User ID
+  string user_id = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetOrganizationMembershipResponse contains the organization membership.
 message GetOrganizationMembershipResponse {
   // The requested organization membership.
-  OrganizationMembership membership = 1;
+  OrganizationMembership membership = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // UpdateOrganizationMembershipRequest represents a request to update an
@@ -1041,27 +999,27 @@ message UpdateOrganizationMembershipRequest {
   // For more information about this field, see
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
   google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+  // Organization ID
+  string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // User ID
+  string user_id = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // UpdateOrganizationMembershipResponse contains the updated membership.
 message UpdateOrganizationMembershipResponse {
   // The updated membership resource.
-  OrganizationMembership membership = 1;
+  OrganizationMembership membership = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DeleteOrganizationMembershipRequest represents a request to delete an
 // organization membership.
 message DeleteOrganizationMembershipRequest {
-  // The resource name of the membership, which allows its access by
-  // organization and user ID.
-  // - Format: `organizations/{organization.id}/memberships/{user.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/OrganizationMembership"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_membership_name"}
-    }
-  ];
+  // Reserverd for `name`
+  reserved 1;
+  // Organization ID
+  string organization_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // User ID
+  string user_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteOrganizationMembershipResponse is an empty response.
@@ -1092,21 +1050,21 @@ message StripeSubscriptionDetail {
   }
 
   // Product name associated with the subscription in Stripe.
-  string product_name = 1;
+  string product_name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Unique identifier for the subscription.
-  string id = 2;
+  string id = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Identifier for the specific item within the subscription.
-  string item_id = 3;
+  string item_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Price of the subscription.
-  float price = 4;
+  float price = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Optional timestamp indicating when the subscription was canceled, if applicable.
-  optional int32 canceled_at = 5;
+  optional int32 canceled_at = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Optional timestamp indicating when the trial ended, if applicable.
-  optional int32 trial_end = 6;
+  optional int32 trial_end = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Status of the subscription.
-  Status status = 7;
+  Status status = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Description of the subscription.
-  string description = 8;
+  string description = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // UserSubscription details describe the plan (i.e., features) a user has access to.
@@ -1122,9 +1080,9 @@ message UserSubscription {
   }
 
   // Plan identifier.
-  Plan plan = 1;
+  Plan plan = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Details of the associated Stripe subscription.
-  StripeSubscriptionDetail detail = 2;
+  StripeSubscriptionDetail detail = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // OrganizationSubscription details describe the plan (i.e., features) an organization has access to.
@@ -1144,13 +1102,13 @@ message OrganizationSubscription {
   }
 
   // Plan identifier.
-  Plan plan = 1;
+  Plan plan = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Details of the associated Stripe subscription.
-  StripeSubscriptionDetail detail = 2;
+  StripeSubscriptionDetail detail = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Maximum number of seats allowed.
-  int32 max_seats = 3;
+  int32 max_seats = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Number of used seats within the organization subscription.
-  int32 used_seats = 4;
+  int32 used_seats = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetAuthenticatedUserSubscriptionRequest represents a query to fetch the subscription
@@ -1160,37 +1118,30 @@ message GetAuthenticatedUserSubscriptionRequest {}
 // GetAuthenticatedUserSubscriptionResponse contains the requested subscription.
 message GetAuthenticatedUserSubscriptionResponse {
   // The subscription resource.
-  UserSubscription subscription = 1;
+  UserSubscription subscription = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetOrganizationSubscriptionRequest represents a query to fetch the
 // subscription details of an organization.
 message GetOrganizationSubscriptionRequest {
-  // The parent resource, i.e., the organization to which the subscription
-  // refers.
-  // Format: `organizations/{organization.id}`.
-  string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_name"}
-    }
-  ];
+  // Resever for `parant`
+  reserved 1;
+  // Oragnization ID
+  string organization_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetOrganizationSubscriptionResponse contains the requested subscription.
 message GetOrganizationSubscriptionResponse {
   // The subscription resource.
-  OrganizationSubscription subscription = 1;
+  OrganizationSubscription subscription = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetUserSubscriptionAdminRequest
 message GetUserSubscriptionAdminRequest {
-  // parent
-  string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/User"}
-  ];
+  // Resever for `parant`
+  reserved 1;
+  // User ID
+  string user_id = 2;
 }
 
 // GetUserSubscriptionAdminResponse
@@ -1201,11 +1152,10 @@ message GetUserSubscriptionAdminResponse {
 
 // GetOrganizationSubscriptionAdminRequest
 message GetOrganizationSubscriptionAdminRequest {
-  // parent
-  string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {child_type: "api.instill.tech/Organization"}
-  ];
+  // Resever for `parant`
+  reserved 1;
+  // Oragnization ID
+  string organization_id = 2;
 }
 
 // GetOrganizationSubscriptionAdminResponse

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -3,57 +3,38 @@ syntax = "proto3";
 package core.mgmt.v1beta;
 
 import "core/mgmt/v1beta/mgmt.proto";
-// Google API
-import "google/api/annotations.proto";
-import "google/api/visibility.proto";
 
 // Mgmt service responds to internal access
 service MgmtPrivateService {
   // ListUsersAdmin method receives a ListUsersAdminRequest message and returns
   // a ListUsersAdminResponse message.
-  rpc ListUsersAdmin(ListUsersAdminRequest) returns (ListUsersAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/users"};
-  }
+  rpc ListUsersAdmin(ListUsersAdminRequest) returns (ListUsersAdminResponse) {}
 
   // GetUserAdmin method receives a GetUserAdminRequest message and returns
   // a GetUserAdminResponse message.
-  rpc GetUserAdmin(GetUserAdminRequest) returns (GetUserAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{name=users/*}"};
-  }
+  rpc GetUserAdmin(GetUserAdminRequest) returns (GetUserAdminResponse) {}
 
   // LookUpUserAdmin method receives a LookUpUserAdminRequest message and
   // returns a LookUpUserAdminResponse
-  rpc LookUpUserAdmin(LookUpUserAdminRequest) returns (LookUpUserAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{permalink=users/*}/lookUp"};
-  }
+  rpc LookUpUserAdmin(LookUpUserAdminRequest) returns (LookUpUserAdminResponse) {}
 
   // ListOrganizationsAdmin method receives a ListOrganizationsAdminRequest message and returns
   // a ListOrganizationsAdminResponse message.
-  rpc ListOrganizationsAdmin(ListOrganizationsAdminRequest) returns (ListOrganizationsAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/organizations"};
-  }
+  rpc ListOrganizationsAdmin(ListOrganizationsAdminRequest) returns (ListOrganizationsAdminResponse) {}
 
   // GetOrganizationAdmin method receives a GetOrganizationAdminRequest message and returns
   // a GetOrganizationAdminResponse message.
-  rpc GetOrganizationAdmin(GetOrganizationAdminRequest) returns (GetOrganizationAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{name=organizations/*}"};
-  }
+  rpc GetOrganizationAdmin(GetOrganizationAdminRequest) returns (GetOrganizationAdminResponse) {}
 
   // LookUpOrganizationAdmin method receives a LookUpOrganizationAdminRequest message and
   // returns a LookUpOrganizationAdminResponse
-  rpc LookUpOrganizationAdmin(LookUpOrganizationAdminRequest) returns (LookUpOrganizationAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{permalink=organizations/*}/lookUp"};
-  }
+  rpc LookUpOrganizationAdmin(LookUpOrganizationAdminRequest) returns (LookUpOrganizationAdminResponse) {}
 
   // GetUserSubscriptionAdmin
-  rpc GetUserSubscriptionAdmin(GetUserSubscriptionAdminRequest) returns (GetUserSubscriptionAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{parent=users/*}/subscription"};
-  }
+  rpc GetUserSubscriptionAdmin(GetUserSubscriptionAdminRequest) returns (GetUserSubscriptionAdminResponse) {}
 
   // GetOrganizationSubscriptionAdmin
-  rpc GetOrganizationSubscriptionAdmin(GetOrganizationSubscriptionAdminRequest) returns (GetOrganizationSubscriptionAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{parent=organizations/*}/subscription"};
-  }
+  rpc GetOrganizationSubscriptionAdmin(GetOrganizationSubscriptionAdminRequest) returns (GetOrganizationSubscriptionAdminResponse) {}
 
   // Subtract Instill Credit from a user or organization account.
   //
@@ -65,8 +46,7 @@ service MgmtPrivateService {
   // credit at zero. A ResourceExhausted error will be returned in this case.
   //
   // On Instill Core, this endpoint will return an Unimplemented status.
-  rpc SubtractCreditAdmin(SubtractCreditAdminRequest) returns (SubtractCreditAdminResponse) {
-  }
+  rpc SubtractCreditAdmin(SubtractCreditAdminRequest) returns (SubtractCreditAdminResponse) {}
 
   // Get the remaining Instill Credit by owner UID
   //
@@ -74,15 +54,11 @@ service MgmtPrivateService {
   // organization, referenced by UID.
   //
   // On Instill Core, this endpoint will return a 404 Not Found status.
-  rpc GetRemainingCreditAdmin(GetRemainingCreditAdminRequest) returns (GetRemainingCreditAdminResponse) {
-  }
+  rpc GetRemainingCreditAdmin(GetRemainingCreditAdminRequest) returns (GetRemainingCreditAdminResponse) {}
 
   // Check if a namespace is in use
   //
   // Returns the availability of a namespace or, alternatively, the type of
   // resource that is using it.
-  rpc CheckNamespaceAdmin(CheckNamespaceAdminRequest) returns (CheckNamespaceAdminResponse) {
-  }
-
-  option (google.api.api_visibility).restriction = "INTERNAL";
+  rpc CheckNamespaceAdmin(CheckNamespaceAdminRequest) returns (CheckNamespaceAdminResponse) {}
 }

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -5,8 +5,8 @@ package core.mgmt.v1beta;
 // Core definitions
 import "core/mgmt/v1beta/metric.proto";
 import "core/mgmt/v1beta/mgmt.proto";
-// Google API
 import "google/api/annotations.proto";
+// Google API
 import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
@@ -76,7 +76,7 @@ service MgmtPublicService {
   //
   // Returns the details of a user by their ID.
   rpc GetUser(GetUserRequest) returns (GetUserResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=users/*}"};
+    option (google.api.http) = {get: "/v1beta/users/{user_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "User"};
   }
 
@@ -103,7 +103,7 @@ service MgmtPublicService {
   //
   // Returns the organization details by its ID.
   rpc GetOrganization(GetOrganizationRequest) returns (GetOrganizationResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=organizations/*}"};
+    option (google.api.http) = {get: "/v1beta/organizations/{organization_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
@@ -115,7 +115,7 @@ service MgmtPublicService {
   // account when updating the resource.
   rpc UpdateOrganization(UpdateOrganizationRequest) returns (UpdateOrganizationResponse) {
     option (google.api.http) = {
-      patch: "/v1beta/{organization.name=organizations/*}"
+      patch: "/v1beta/organizations/{organization_id}"
       body: "organization"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
@@ -125,7 +125,7 @@ service MgmtPublicService {
   //
   // Accesses and deletes an organization by ID.
   rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=organizations/*}"};
+    option (google.api.http) = {delete: "/v1beta/organizations/{organization_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Organization"};
   }
 
@@ -133,7 +133,7 @@ service MgmtPublicService {
   //
   // Returns the memberships of a user.
   rpc ListUserMemberships(ListUserMembershipsRequest) returns (ListUserMembershipsResponse) {
-    option (google.api.http) = {get: "/v1beta/{parent=users/*}/memberships"};
+    option (google.api.http) = {get: "/v1beta/users/{user_id}/memberships"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -142,7 +142,7 @@ service MgmtPublicService {
   // Returns the details of the relationship between a user and an
   // organization. The authenticated must match the membership parent.
   rpc GetUserMembership(GetUserMembershipRequest) returns (GetUserMembershipResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=users/*/memberships/*}"};
+    option (google.api.http) = {get: "/v1beta/users/{user_id}/memberships/{organization_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -151,7 +151,7 @@ service MgmtPublicService {
   // Accesses and updates a user membership by parent and membership IDs.
   rpc UpdateUserMembership(UpdateUserMembershipRequest) returns (UpdateUserMembershipResponse) {
     option (google.api.http) = {
-      put: "/v1beta/{membership.name=users/*/memberships/*}"
+      put: "/v1beta/users/{user_id}/memberships/{organization_id}"
       body: "membership"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
@@ -161,7 +161,7 @@ service MgmtPublicService {
   //
   // Accesses and deletes a user membership by parent and membership IDs.
   rpc DeleteUserMembership(DeleteUserMembershipRequest) returns (DeleteUserMembershipResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=users/*/memberships/*}"};
+    option (google.api.http) = {delete: "/v1beta/users/{user_id}/memberships/{organization_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -169,7 +169,7 @@ service MgmtPublicService {
   //
   // Returns a paginated list of the user memberships in an organization.
   rpc ListOrganizationMemberships(ListOrganizationMembershipsRequest) returns (ListOrganizationMembershipsResponse) {
-    option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/memberships"};
+    option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/memberships"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -177,7 +177,7 @@ service MgmtPublicService {
   //
   // Returns the details of a user membership within an organization.
   rpc GetOrganizationMembership(GetOrganizationMembershipRequest) returns (GetOrganizationMembershipResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=organizations/*/memberships/*}"};
+    option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/memberships/{user_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -186,7 +186,7 @@ service MgmtPublicService {
   // Updates a user membership within an organization.
   rpc UpdateOrganizationMembership(UpdateOrganizationMembershipRequest) returns (UpdateOrganizationMembershipResponse) {
     option (google.api.http) = {
-      put: "/v1beta/{membership.name=organizations/*/memberships/*}"
+      put: "/v1beta/organizations/{organization_id}/memberships/{user_id}"
       body: "membership"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
@@ -196,7 +196,7 @@ service MgmtPublicService {
   //
   // Deletes a user membership within an organization.
   rpc DeleteOrganizationMembership(DeleteOrganizationMembershipRequest) returns (DeleteOrganizationMembershipResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=organizations/*/memberships/*}"};
+    option (google.api.http) = {delete: "/v1beta/organizations/{organization_id}/memberships/{user_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Membership"};
   }
 
@@ -208,11 +208,11 @@ service MgmtPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Subscription"};
   }
 
-  // Get an organization subscription
+  // Get the subscription of an organization
   //
   // Returns the subscription details of an organization.
   rpc GetOrganizationSubscription(GetOrganizationSubscriptionRequest) returns (GetOrganizationSubscriptionResponse) {
-    option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/subscription"};
+    option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/subscription"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Subscription"};
   }
 
@@ -239,7 +239,7 @@ service MgmtPublicService {
   //
   // Returns the details of an API token.
   rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=tokens/*}"};
+    option (google.api.http) = {get: "/v1beta/tokens/{token_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
@@ -247,11 +247,11 @@ service MgmtPublicService {
   //
   // Deletes an API token.
   rpc DeleteToken(DeleteTokenRequest) returns (DeleteTokenResponse) {
-    option (google.api.http) = {delete: "/v1beta/{name=tokens/*}"};
+    option (google.api.http) = {delete: "/v1beta/tokens/{token_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Token"};
   }
 
-  // Validate an API token.
+  // Validate an API token
   //
   // Validates an API token.
   rpc ValidateToken(ValidateTokenRequest) returns (ValidateTokenResponse) {
@@ -267,7 +267,7 @@ service MgmtPublicService {
   //
   // On Instill Core, this endpoint will return a 404 Not Found status.
   rpc GetRemainingCredit(GetRemainingCreditRequest) returns (GetRemainingCreditResponse) {
-    option (google.api.http) = {get: "/v1beta/{owner=*/*}/credit"};
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/credit"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Credit"};
   }
 
@@ -322,7 +322,7 @@ service MgmtPublicService {
   // Returns the auth token issuer details. This operation requires admin permissions.
   rpc AuthTokenIssuer(AuthTokenIssuerRequest) returns (AuthTokenIssuerResponse) {
     option (google.api.http) = {
-      post: "/v1beta/auth/token_issuer",
+      post: "/v1beta/auth/token_issuer"
       body: "*"
     };
     option (google.api.method_visibility).restriction = "INTERNAL";
@@ -349,7 +349,7 @@ service MgmtPublicService {
   // Updates the password of a user.
   rpc AuthChangePassword(AuthChangePasswordRequest) returns (AuthChangePasswordResponse) {
     option (google.api.http) = {
-      post: "/v1beta/auth/change_password",
+      post: "/v1beta/auth/change_password"
       body: "*"
     };
     option (google.api.method_visibility).restriction = "INTERNAL";

--- a/core/mgmt/v1beta/openapi.proto.templ
+++ b/core/mgmt/v1beta/openapi.proto.templ
@@ -6,35 +6,43 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
-    title: "🔮 Core";
-    description: "Core endpoints to manage user resources";
+    title: "🔮 Core"
+    description: "Core endpoints to manage user resources"
 {{$info}}
-  };
+  }
   tags: [
     {
       name: "User"
+      description: "User endpoints"
     },
     {
       name: "Organization"
+      description: "Organization endpoints"
     },
     {
       name: "Membership"
+      description: "Membership endpoints"
     },
     {
       name: "Token"
+      description: "Token endpoints"
     },
     {
       name: "Subscription"
+      description: "Subscription endpoints"
     },
     {
       name: "Credit"
+      description: "Credit endpoints"
     },
     {
       name: "Metric"
+      description: "Metric endpoints"
     },
     {
       name: "Utils"
+      description: "Util endpoints"
     }
-  ];
+  ]
 {{$conf}}
 };

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -291,6 +291,400 @@ message LookUpModelResponse {
   Model model = 1;
 }
 
+// ListNamespaceModelsRequest represents a request to list namepsace models.
+message ListNamespaceModelsRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The maximum number of models to return. If this parameter is unspecified,
+  // at most 10 models will be returned. The cap value for this parameter is
+  // 100 (i.e. any value above that will be coerced to 100).
+  optional int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+  // View allows clients to specify the desired model view in the response.
+  optional View view = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Include soft-deleted models in the result.
+  optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Limit results to pipelines with the specified visibility.
+  optional Model.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+  optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListNamespaceModelsResponse contains a list of models.
+message ListNamespaceModelsResponse {
+  // A list of model resources.
+  repeated Model models = 1;
+  // Next page token.
+  string next_page_token = 2;
+  // Total number of models.
+  int32 total_size = 3;
+}
+
+// CreateNamespaceModelRequest represents a request from a namespace to create a model.
+message CreateNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The properties of the model to be created.
+  Model model = 2;
+}
+
+// CreateNamespaceModelResponse contains the created model.
+message CreateNamespaceModelResponse {
+  // The created model resource.
+  Model model = 1;
+}
+
+// GetNamespaceModelRequest represents a request to fetch the details of a model
+// owned by a namespace.
+message GetNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // View allows clients to specify the desired model view in the response.
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetNamespaceModelResponse contains the requested model.
+message GetNamespaceModelResponse {
+  // The model resource.
+  Model model = 1;
+}
+
+// UpdateNamespaceModelRequest represents a request to update a model owned by a
+// namespace.
+message UpdateNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The model to update
+  Model model = 3 [(google.api.field_behavior) = REQUIRED];
+  // The update mask specifies the subset of fields that should be modified.
+  //
+  // For more information about this field, see
+  // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+  google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateNamespaceModelResponse contains the updated model.
+message UpdateNamespaceModelResponse {
+  // The updated model resource.
+  Model model = 1;
+}
+
+// DeleteNamespaceModelRequest represents a request to delete a model owned by a
+// namespace.
+message DeleteNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DeleteNamespaceModelResponse is an empty response.
+message DeleteNamespaceModelResponse {}
+
+// RenameNamespaceModelRequest represents a request to rename a model
+message RenameNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The new resource ID. This will transform the resource name into
+  // `namespaces/{namespace.id}/models/{new_model_id}`.
+  string new_model_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RenameNamespaceModelResponse contains a renamed model.
+message RenameNamespaceModelResponse {
+  // The renamed model resource.
+  Model model = 1;
+}
+
+// PublishNamespacehModelRequest represents a request to publish a model.
+message PublishNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// PublishNamespaceModelResponse contains a published model.
+message PublishNamespaceModelResponse {
+  // The published model resource.
+  Model model = 1;
+}
+
+// UnpublishNamespaceModelRequest represents a request to unpublish a model.
+message UnpublishNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UnpublishNamespaceModelResponse contains an unpublished model.
+message UnpublishNamespaceModelResponse {
+  // The unpublished model resource.
+  Model model = 1;
+}
+
+// GetNamespaceModelCardRequest represents a request to fetch the README card of a
+// model.
+message GetNamespaceModelCardRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetNamespaceModelCardResponse contains the model's README card.
+message GetNamespaceModelCardResponse {
+  // A model card resource.
+  ModelCard readme = 1;
+}
+
+// WatchNamespaceModelRequest represents a request to fetch current state of a model
+message WatchNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Model version tag
+  string version = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// WatchNamespaceModelResponse contains the state of a model.
+message WatchNamespaceModelResponse {
+  // State.
+  State state = 1;
+  // Deprecated field `progress`
+  reserved 2;
+  // Detail description of the state
+  string message = 3;
+}
+
+// WatchNamespaceNamespaceLatestModelRequest represents a request to fetch current state of
+// the latest model version.
+message WatchNamespaceLatestModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// WatchNamespaceLatestModelResponse contains the state of the latest model version.
+message WatchNamespaceLatestModelResponse {
+  // State.
+  State state = 1;
+  // Deprecated field `progress`
+  reserved 2;
+  // Detail description of the state
+  string message = 3;
+}
+
+// ListNamespaceModelVersionsRequest represents a request to list all the versions
+// of a model namespace of a namespace.
+message ListNamespaceModelVersionsRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The maximum number of tags to return. The default and cap values are 10
+  // and 100, respectively.
+  optional int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Page number.
+  optional int32 page = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListNamespaceModelVersionsResponse contains a list of models.
+message ListNamespaceModelVersionsResponse {
+  // A list of model resources.
+  repeated ModelVersion versions = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total number of tags.
+  int32 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The requested page size.
+  int32 page_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The requested page offset.
+  int32 page = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// DeleteNamespaceModelVersionRequest represents a request to delete a model version
+//  owned by a namespace.
+message DeleteNamespaceModelVersionRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Model version tag
+  string version = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DeleteNamespaceModelVersionResponse is an empty response.
+message DeleteNamespaceModelVersionResponse {}
+
+// TriggerNamespaceModelRequest represents a request to trigger a model inference.
+message TriggerNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Inference input parameters.
+  repeated TaskInput task_inputs = 3 [(google.api.field_behavior) = REQUIRED];
+  // Model version tag
+  string version = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerNamespaceModelResponse contains the model inference results.
+message TriggerNamespaceModelResponse {
+  // Task type.
+  common.task.v1alpha.Task task = 1;
+  // Model inference outputs.
+  repeated TaskOutput task_outputs = 2;
+}
+
+// TriggerAsyncNamespaceModelRequest represents a request to trigger a model inference
+// asynchronously.
+message TriggerAsyncNamespaceModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Inference input parameters.
+  repeated TaskInput task_inputs = 3 [(google.api.field_behavior) = REQUIRED];
+  // Model version tag
+  string version = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerAsyncNamespaceModelResponse contains the information to access the
+// status of an asynchronous model inference.
+message TriggerAsyncNamespaceModelResponse {
+  // Long-running operation information.
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TriggerNamespaceLatestModelRequest represents a request to trigger a model inference
+// with the latest uploaded version.
+message TriggerNamespaceLatestModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Inference input parameters.
+  repeated TaskInput task_inputs = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerNamespaceLatestModelResponse contains the model inference results.
+message TriggerNamespaceLatestModelResponse {
+  // Task type.
+  common.task.v1alpha.Task task = 1;
+  // Model inference outputs.
+  repeated TaskOutput task_outputs = 2;
+}
+
+// TriggerAsyncNamespaceLatestModelRequest represents a request to trigger a model inference
+// asynchronously with the latest uploaded version.
+message TriggerAsyncNamespaceLatestModelRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Inference input parameters.
+  repeated TaskInput task_inputs = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerAsyncNamespaceLatestModelResponse contains the information to access the
+// status of an asynchronous model inference.
+message TriggerAsyncNamespaceLatestModelResponse {
+  // Long-running operation information.
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TriggerNamespaceModelBinaryFileUploadRequest represents a request trigger a model
+// inference by uploading a binary file as the input.
+message TriggerNamespaceModelBinaryFileUploadRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Inference input as a binary file.
+  TaskInputStream task_input = 3 [(google.api.field_behavior) = REQUIRED];
+  // Model version tag
+  string version = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerNamespaceModelBinaryFileUploadResponse contains the model inference results.
+message TriggerNamespaceModelBinaryFileUploadResponse {
+  // Task type.
+  common.task.v1alpha.Task task = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model inference outputs.
+  repeated TaskOutput task_outputs = 2 [(google.api.field_behavior) = REQUIRED];
+  // Model version tag
+  string version = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetNamespaceLatestModelOperationRequest represents a request to fetch the latest long-running
+// operation performed on a model for a namespace.
+message GetNamespaceLatestModelOperationRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // View allows clients to specify the desired operation result in the response.
+  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetNamespaceLatestModelOperationRequest represents a request to query a long-running
+// operation.
+message GetNamespaceLatestModelOperationResponse {
+  // The long-running operation.
+  google.longrunning.Operation operation = 1;
+}
+
+// DeployNamespaceModelAdminRequest represents a request to deploy a model to online state
+message DeployNamespaceModelAdminRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Model version tag
+  string version = 3 [(google.api.field_behavior) = REQUIRED];
+  // Model image digest
+  string digest = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// DeployNamespaceModelAdminResponse represents a response for a deployed model
+message DeployNamespaceModelAdminResponse {
+  // Deprecated operation
+  reserved 1;
+}
+
+// UndeployNamespaceModelAdminRequest represents a request to undeploy a model to offline
+// state
+message UndeployNamespaceModelAdminRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Model version tag
+  string version = 3 [(google.api.field_behavior) = REQUIRED];
+  // Model image digest
+  string digest = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// UndeployNamespaceModelAdminResponse represents a response for a undeployed model
+message UndeployNamespaceModelAdminResponse {
+  // Deprecated operation
+  reserved 1;
+}
+
 // CreateUserModelRequest represents a request from a user to create a model.
 message CreateUserModelRequest {
   // The properties of the model to be created.

--- a/model/model/v1alpha/model_definition.proto
+++ b/model/model/v1alpha/model_definition.proto
@@ -8,8 +8,6 @@ import "google/api/resource.proto";
 // Protocol Buffers Well-Known Types
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-// OpenAPI
-import "protoc-gen-openapiv2/options/annotations.proto";
 
 ///////////////////////////////////////////////////////////////////
 
@@ -106,21 +104,17 @@ message ListModelDefinitionsResponse {
 // GetModelDefinitionRequest represents a request to fetch the details of a
 // model definition.
 message GetModelDefinitionRequest {
-  // The resource name of the model definition, which allows its access by ID.
-  // - Format: `model-definitions/{id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelDefinition",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "model_definition_name"}
-    }
-  ];
+  // Reserved for `name`
+  reserved 1;
   // View allows clients to specify the desired resource view in the response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The resource name of the model definition, which allows its access by ID.
+  // - Format: `model-definitions/{id}`.
+  string model_definition_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetModelDefinitionResponse contains the requested model definition.
 message GetModelDefinitionResponse {
   // The model definition resource.
-  ModelDefinition model_definition = 1;
+  ModelDefinition model_definition = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/model/model/v1alpha/model_private_service.proto
+++ b/model/model/v1alpha/model_private_service.proto
@@ -2,9 +2,6 @@ syntax = "proto3";
 
 package model.model.v1alpha;
 
-// Google API
-import "google/api/annotations.proto";
-import "google/api/visibility.proto";
 import "model/model/v1alpha/model.proto";
 
 // Model service responds to internal access
@@ -13,47 +10,27 @@ service ModelPrivateService {
 
   // ListModelsAdmin method receives a ListModelsAdminRequest message and
   // returns a ListModelsAdminResponse
-  rpc ListModelsAdmin(ListModelsAdminRequest) returns (ListModelsAdminResponse) {
-    option (google.api.http) = {get: "/v1alpha/admin/models"};
-  }
+  rpc ListModelsAdmin(ListModelsAdminRequest) returns (ListModelsAdminResponse) {}
 
   // LookUpModelAdmin method receives a LookUpModelAdminRequest message and
   // returns a LookUpModelAdminResponse
-  rpc LookUpModelAdmin(LookUpModelAdminRequest) returns (LookUpModelAdminResponse) {
-    option (google.api.http) = {get: "/v1alpha/admin/{permalink=models/*}/lookUp"};
-  }
+  rpc LookUpModelAdmin(LookUpModelAdminRequest) returns (LookUpModelAdminResponse) {}
+
+  // DeployNamespaceModelAdmin deploy a model to online state
+  rpc DeployNamespaceModelAdmin(DeployNamespaceModelAdminRequest) returns (DeployNamespaceModelAdminResponse) {}
 
   // DeployUserModelAdmin deploy a model to online state
-  rpc DeployUserModelAdmin(DeployUserModelAdminRequest) returns (DeployUserModelAdminResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/admin/{name=users/*/models/*}/{version=*}/deploy"
-      body: "*"
-    };
-  }
+  rpc DeployUserModelAdmin(DeployUserModelAdminRequest) returns (DeployUserModelAdminResponse) {}
 
   // DeployOrganizationModelAdmin deploy a model to online state
-  rpc DeployOrganizationModelAdmin(DeployOrganizationModelAdminRequest) returns (DeployOrganizationModelAdminResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/admin/{name=organizations/*/models/*}/{version=*}/deploy"
-      body: "*"
-    };
-  }
+  rpc DeployOrganizationModelAdmin(DeployOrganizationModelAdminRequest) returns (DeployOrganizationModelAdminResponse) {}
 
   // UndeployUserModelAdmin undeploy a model to offline state
-  rpc UndeployUserModelAdmin(UndeployUserModelAdminRequest) returns (UndeployUserModelAdminResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/admin/{name=users/*/models/*}/{version=*}/undeploy"
-      body: "*"
-    };
-  }
+  rpc UndeployUserModelAdmin(UndeployUserModelAdminRequest) returns (UndeployUserModelAdminResponse) {}
+
+  // UndeployNamespaceModelAdmin undeploy a model to offline state
+  rpc UndeployNamespaceModelAdmin(UndeployNamespaceModelAdminRequest) returns (UndeployNamespaceModelAdminResponse) {}
 
   // UndeployOrganizationModelAdmin undeploy a model to offline state
-  rpc UndeployOrganizationModelAdmin(UndeployOrganizationModelAdminRequest) returns (UndeployOrganizationModelAdminResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/admin/{name=organizations/*/models/*}/{version=*}/undeploy"
-      body: "*"
-    };
-  }
-
-  option (google.api.api_visibility).restriction = "INTERNAL";
+  rpc UndeployOrganizationModelAdmin(UndeployOrganizationModelAdminRequest) returns (UndeployOrganizationModelAdminResponse) {}
 }

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -62,7 +62,7 @@ service ModelPublicService {
   //
   // Returns the details of a model definition.
   rpc GetModelDefinition(GetModelDefinitionRequest) returns (GetModelDefinitionResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=model-definitions/*}"};
+    option (google.api.http) = {get: "/v1alpha/model-definitions/{model_definition_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model Definition"};
   }
 
@@ -70,7 +70,7 @@ service ModelPublicService {
   //
   // Returns a paginated list of models.
   rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
-    option (google.api.http) = {get: "/v1alpha/models"};
+    option (google.api.http) = {get: "/v1beta/models"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
@@ -80,7 +80,250 @@ service ModelPublicService {
   rpc LookUpModel(LookUpModelRequest) returns (LookUpModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{permalink=models/*}/lookUp"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
   }
+
+  // List namespace models
+  //
+  // Returns a paginated list of models.
+  rpc ListNamespaceModels(ListNamespaceModelsRequest) returns (ListNamespaceModelsResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/models"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Create a new model
+  //
+  // Creates a new model under the parenthood of a namespace. This is an
+  // asynchronous endpoint, i.e., the server will not wait for the model to be
+  // created in order to respond. Instead, it will return a response with the
+  // necessary information to access the result and status of the creation
+  // operation.
+  rpc CreateNamespaceModel(CreateNamespaceModelRequest) returns (CreateNamespaceModelResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/models"
+      body: "model"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Get a model
+  //
+  // Returns the detail of a model, accessing it by the model ID and its parent namespace.
+  rpc GetNamespaceModel(GetNamespaceModelRequest) returns (GetNamespaceModelResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Update a model
+  //
+  // Updates a model, accessing it by its resource name, which is defined by
+  // the parent namespace and the ID of the model.
+  //
+  // In REST requests, only the supplied model fields will be taken into
+  // account when updating the resource.
+  rpc UpdateNamespaceModel(UpdateNamespaceModelRequest) returns (UpdateNamespaceModelResponse) {
+    option (google.api.http) = {
+      patch: "/v1alpha/namespaces/{namespace_id}/models/{model_id}"
+      body: "model"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Delete a model
+  //
+  // Deletes a model, accesing it by its resource name, which is defined by the
+  // parent namespace and the ID of the model.
+  rpc DeleteNamespaceModel(DeleteNamespaceModelRequest) returns (DeleteNamespaceModelResponse) {
+    option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/models/{model_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Rename a model
+  //
+  // Renames a model, accesing it by its resource name, which is defined by the
+  // parent namespace and the ID of the model.
+  rpc RenameNamespaceModel(RenameNamespaceModelRequest) returns (RenameNamespaceModelResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/rename"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Publish a model
+  //
+  // Updates the visibility in a model to PUBLIC. The model is accessed by its
+  // resource name, defined by the model ID and its parent namespace.
+  rpc PublishNamespaceModel(PublishNamespaceModelRequest) returns (PublishNamespaceModelResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/publish"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Unpublish a model
+  //
+  // Updates the visibility in a model to PRIVATE. The model is accessed by its
+  // resource name, defined by the model ID and its parent namespace.
+  rpc UnpublishNamespaceModel(UnpublishNamespaceModelRequest) returns (UnpublishNamespaceModelResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/unpublish"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Get a model card
+  //
+  // Returns the README file that accompanies a model, describing it and
+  // enhancing it with metadata. The model is accessed by its resource name.
+  rpc GetNamespaceModelCard(GetNamespaceModelCardRequest) returns (GetNamespaceModelCardResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/readme"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Watch the state of a model version
+  //
+  // Returns the state of a model. The model resource allocation and scaling actions take some
+  // time, during which a model will be in various state. This endpoint
+  // allows clients to track the state.
+  rpc WatchNamespaceModel(WatchNamespaceModelRequest) returns (WatchNamespaceModelResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version}/watch"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+  }
+
+  // Watch the state of the latest model version
+  //
+  // Returns the state of the latest model version. The model resource allocation and scaling actions
+  // take some time, during which a model will be in various state. This endpoint
+  // allows clients to track the state.
+  rpc WatchNamespaceLatestModel(WatchNamespaceLatestModelRequest) returns (WatchNamespaceLatestModelResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/watch"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // List namespace model versions
+  //
+  // Returns a paginated list of version of a model namespace that belong to the specified namespace.
+  // Contains model version and digest.
+  rpc ListNamespaceModelVersions(ListNamespaceModelVersionsRequest) returns (ListNamespaceModelVersionsResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+  }
+
+  // Delete a model version
+  //
+  // Deletes a model version, accesing it by its resource name, which is defined by the
+  // parent namespace and the ID of the model, and version.
+  rpc DeleteNamespaceModelVersion(DeleteNamespaceModelVersionRequest) returns (DeleteNamespaceModelVersionResponse) {
+    option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+  }
+
+  // Trigger model inference
+  //
+  // Triggers a deployed model to infer the result of a set of task or
+  // questions.
+  rpc TriggerNamespaceModel(TriggerNamespaceModelRequest) returns (TriggerNamespaceModelResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version}/trigger"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger model inference asynchronously
+  //
+  // Triggers a deployed model to infer the result of a set of task or
+  // questions.
+  rpc TriggerAsyncNamespaceModel(TriggerAsyncNamespaceModelRequest) returns (TriggerAsyncNamespaceModelResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version}/trigger-async"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger model inference
+  //
+  // Triggers the latest deployed model version to infer the result of a set of task or
+  // questions.
+  rpc TriggerNamespaceLatestModel(TriggerNamespaceLatestModelRequest) returns (TriggerNamespaceLatestModelResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/trigger"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger model inference asynchronously
+  //
+  // Triggers the latest deployed model version to infer the result of a set of task or
+  // questions.
+  rpc TriggerAsyncNamespaceLatestModel(TriggerAsyncNamespaceLatestModelRequest) returns (TriggerAsyncNamespaceLatestModelResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/trigger-async"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Get the details of the latest long-running operation from a namespace model
+  //
+  // This method allows requesters to request the status and outcome of
+  // long-running operations in a model, such as deployment.
+  rpc GetNamespaceLatestModelOperation(GetNamespaceLatestModelOperationRequest) returns (GetNamespaceLatestModelOperationResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/operation"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // Get the details of a long-running operation
+  //
+  // This method allows requesters to request the status and outcome of
+  // long-running operations in a model, such as deployment.
+  rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
+    option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+  }
+
+  // The following endpoints are all deprecated
 
   // List user models
   //
@@ -89,7 +332,8 @@ service ModelPublicService {
   // the results will contain the models that are visible to the latter.
   rpc ListUserModels(ListUserModelsRequest) returns (ListUserModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/{parent=users/*}/models"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Create a new model
@@ -104,7 +348,8 @@ service ModelPublicService {
       post: "/v1alpha/{parent=users/*}/models"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a model
@@ -112,7 +357,8 @@ service ModelPublicService {
   // Returns the detail of a model, accessing it by the model ID and its parent user.
   rpc GetUserModel(GetUserModelRequest) returns (GetUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a model
@@ -127,7 +373,8 @@ service ModelPublicService {
       patch: "/v1alpha/{model.name=users/*/models/*}"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a model
@@ -136,7 +383,8 @@ service ModelPublicService {
   // parent user and the ID of the model.
   rpc DeleteUserModel(DeleteUserModelRequest) returns (DeleteUserModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a model
@@ -148,7 +396,8 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Publish a model
@@ -160,7 +409,8 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/publish"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Unpublish a model
@@ -172,7 +422,8 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/unpublish"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a model card
@@ -181,7 +432,8 @@ service ModelPublicService {
   // enhancing it with metadata. The model is accessed by its resource name.
   rpc GetUserModelCard(GetUserModelCardRequest) returns (GetUserModelCardResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*/readme}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Watch the state of a model version
@@ -191,7 +443,8 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchUserModel(WatchUserModelRequest) returns (WatchUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions/{version=*}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option deprecated = true;
   }
 
   // Watch the state of the latest model version
@@ -201,7 +454,8 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchUserLatestModel(WatchUserLatestModelRequest) returns (WatchUserLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option deprecated = true;
   }
 
   // List user model versions
@@ -210,7 +464,8 @@ service ModelPublicService {
   // Contains model version and digest.
   rpc ListUserModelVersions(ListUserModelVersionsRequest) returns (ListUserModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a model version
@@ -219,7 +474,8 @@ service ModelPublicService {
   // parent user and the ID of the model, and version.
   rpc DeleteUserModelVersion(DeleteUserModelVersionRequest) returns (DeleteUserModelVersionResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}/versions/{version=*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option deprecated = true;
   }
 
   ///////////////////////////////////////////////////////
@@ -234,15 +490,16 @@ service ModelPublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger model inference asynchronously
@@ -255,15 +512,16 @@ service ModelPublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger model inference
@@ -276,15 +534,16 @@ service ModelPublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger model inference asynchronously
@@ -297,15 +556,16 @@ service ModelPublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger model inference with a binary input
@@ -314,15 +574,16 @@ service ModelPublicService {
   // submitted as a binary file.
   rpc TriggerUserModelBinaryFileUpload(stream TriggerUserModelBinaryFileUploadRequest) returns (TriggerUserModelBinaryFileUploadResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // List organization models
@@ -332,7 +593,8 @@ service ModelPublicService {
   // the results will contain the models that are visible to the latter.
   rpc ListOrganizationModels(ListOrganizationModelsRequest) returns (ListOrganizationModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/{parent=organizations/*}/models"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Create a new model
@@ -347,7 +609,8 @@ service ModelPublicService {
       post: "/v1alpha/{parent=organizations/*}/models"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a model
@@ -355,7 +618,8 @@ service ModelPublicService {
   // Returns the detail of a model, accessing it by the model ID and its parent organization.
   rpc GetOrganizationModel(GetOrganizationModelRequest) returns (GetOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a model
@@ -370,7 +634,8 @@ service ModelPublicService {
       patch: "/v1alpha/{model.name=organizations/*/models/*}"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a model
@@ -379,7 +644,8 @@ service ModelPublicService {
   // parent organization and the ID of the model.
   rpc DeleteOrganizationModel(DeleteOrganizationModelRequest) returns (DeleteOrganizationModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/models/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a model
@@ -391,7 +657,8 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Publish a model
@@ -403,7 +670,8 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/publish"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Unpublish a model
@@ -415,7 +683,8 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/unpublish"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a model card
@@ -424,7 +693,8 @@ service ModelPublicService {
   // enhancing it with metadata. The model is accessed by its resource name.
   rpc GetOrganizationModelCard(GetOrganizationModelCardRequest) returns (GetOrganizationModelCardResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*/readme}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option deprecated = true;
   }
 
   // Watch the state of a model version
@@ -434,7 +704,8 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchOrganizationModel(WatchOrganizationModelRequest) returns (WatchOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option deprecated = true;
   }
 
   // Watch the state of the latest model version
@@ -444,7 +715,8 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchOrganizationLatestModel(WatchOrganizationLatestModelRequest) returns (WatchOrganizationLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option deprecated = true;
   }
 
   // List organization model versions
@@ -453,7 +725,8 @@ service ModelPublicService {
   // Contains model version and digest.
   rpc ListOrganizationModelVersions(ListOrganizationModelVersionsRequest) returns (ListOrganizationModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a model version
@@ -462,7 +735,8 @@ service ModelPublicService {
   // parent organization and the ID of the model, and version.
   rpc DeleteOrganizationModelVersion(DeleteOrganizationModelVersionRequest) returns (DeleteOrganizationModelVersionResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option deprecated = true;
   }
 
   ///////////////////////////////////////////////////////
@@ -477,15 +751,16 @@ service ModelPublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger model inference asynchronously
@@ -498,15 +773,16 @@ service ModelPublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger model inference
@@ -519,15 +795,16 @@ service ModelPublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger model inference asynchronously
@@ -540,15 +817,16 @@ service ModelPublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger model inference with a binary input
@@ -557,24 +835,16 @@ service ModelPublicService {
   // submitted as a binary file.
   rpc TriggerOrganizationModelBinaryFileUpload(stream TriggerOrganizationModelBinaryFileUploadRequest) returns (TriggerOrganizationModelBinaryFileUploadResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
-  }
-
-  // Get the details of a long-running operation
-  //
-  // This method allows requesters to request the status and outcome of
-  // long-running operations in a model, such as deployment.
-  rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option deprecated = true;
   }
 
   // Get the details of the latest long-running operation from a user model
@@ -583,7 +853,8 @@ service ModelPublicService {
   // long-running operations in a model, such as deployment.
   rpc GetUserLatestModelOperation(GetUserLatestModelOperationRequest) returns (GetUserLatestModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/operation"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get the details of the latest long-running operation from a organization model
@@ -592,6 +863,7 @@ service ModelPublicService {
   // long-running operations in a model, such as deployment.
   rpc GetOrganizationLatestModelOperation(GetOrganizationLatestModelOperationRequest) returns (GetOrganizationLatestModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/operation"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger (Deprecated)"};
+    option deprecated = true;
   }
 }

--- a/model/model/v1alpha/openapi.proto.templ
+++ b/model/model/v1alpha/openapi.proto.templ
@@ -7,26 +7,31 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 // These options define the OpenAPI definition document information.
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
-    title: "⚗️ Model";
-    description: "Endpoints to manage the AI model-related resources and features working with Instill VDP.";
+    title: "⚗️ Model"
+    description: "Endpoints to manage the AI model-related resources and features working with Instill VDP."
 {{$info}}
-  };
+  }
   tags: [
     {
-      name: "Model"
+      name: "Model Definition"
+      description: "Model definition endpoints"
     },
     {
-      name: "Model Definition"
+      name: "Model"
+      description: "Model endpoints"
     },
     {
       name: "Version"
+      description: "Model version endpoints"
     },
     {
       name: "Trigger"
+      description: "Model trigger endpoints"
     },
     {
       name: "Region"
+      description: "Model region endpoints"
     }
-  ];
+  ]
 {{$conf}}
 };

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -1,13 +1,25 @@
 swagger: "2.0"
 info:
-  title: common/healthcheck/v1beta/healthcheck.proto
-  version: version not set
+  title: "\U0001F4BE Artifact "
+  description: Artifact endpoints to manage artifact resources
+  version: v0.36.0-beta
+  contact:
+    name: Instill AI
+    url: https://github.com/instill-ai
+    email: hello@instill.tech
+  license:
+    name: Elastic License 2.0 (ELv2)
+    url: https://github.com/instill-ai/protobufs/blob/main/LICENSE
+host: api.instill.tech
+schemes:
+  - https
+  - http
 consumes:
   - application/json
 produces:
   - application/json
 paths:
-  /v1alpha/namespaces/{ownerId}/knowledge-bases:
+  /v1alpha/namespaces/{namespaceId}/knowledge-bases:
     get:
       summary: Get all knowledge bases info
       operationId: ArtifactPublicService_ListKnowledgeBases
@@ -16,12 +28,15 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaListKnowledgeBasesResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: ownerId
+        - name: namespaceId
           description: User ID for which to list the knowledge bases
           in: path
           required: true
@@ -36,12 +51,15 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaCreateKnowledgeBaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: ownerId
+        - name: namespaceId
           description: The knowledge base owner(nammespace).
           in: path
           required: true
@@ -53,7 +71,7 @@ paths:
             $ref: '#/definitions/ArtifactPublicServiceCreateKnowledgeBaseBody'
       tags:
         - KnowledgeBase
-  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}:
+  /v1alpha/namespaces/{namespaceId}/knowledge-bases/{kbId}:
     delete:
       summary: Delete a knowledge base
       operationId: ArtifactPublicService_DeleteKnowledgeBase
@@ -62,12 +80,15 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaDeleteKnowledgeBaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: ownerId
+        - name: namespaceId
           description: The owner's id. i.e. namespace.
           in: path
           required: true
@@ -87,12 +108,15 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaUpdateKnowledgeBaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: ownerId
+        - name: namespaceId
           description: The knowledge base owner(namespace).
           in: path
           required: true
@@ -109,7 +133,7 @@ paths:
             $ref: '#/definitions/ArtifactPublicServiceUpdateKnowledgeBaseBody'
       tags:
         - KnowledgeBase
-  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}/files:
+  /v1alpha/namespaces/{namespaceId}/knowledge-bases/{kbId}/files:
     get:
       summary: list files
       operationId: ArtifactPublicService_ListKnowledgeBaseFiles
@@ -118,12 +142,15 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaListKnowledgeBaseFilesResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: ownerId
+        - name: namespaceId
           description: The owner uid.
           in: path
           required: true
@@ -162,12 +189,15 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaUploadKnowledgeBaseFileResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: ownerId
+        - name: namespaceId
           description: owenr uid
           in: path
           required: true
@@ -194,6 +224,9 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaDeleteKnowledgeBaseFileResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
@@ -215,6 +248,9 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaProcessKnowledgeBaseFilesResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
@@ -227,7 +263,7 @@ paths:
             $ref: '#/definitions/v1alphaProcessKnowledgeBaseFilesRequest'
       tags:
         - KnowledgeBase
-  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}/chunks:
+  /v1alpha/namespaces/{namespaceId}/knowledge-bases/{kbId}/chunks:
     get:
       summary: List chunks
       operationId: ArtifactPublicService_ListChunks
@@ -236,12 +272,15 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaListChunksResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: ownerId
+        - name: namespaceId
           description: owner id (not uid)
           in: path
           required: true
@@ -258,7 +297,7 @@ paths:
           type: string
       tags:
         - KnowledgeBase
-  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}/files/{fileUid}/source:
+  /v1alpha/namespaces/{namespaceId}/knowledge-bases/{kbId}/files/{fileUid}/source:
     get:
       summary: Get source file
       operationId: ArtifactPublicService_GetSourceFile
@@ -267,12 +306,15 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaGetSourceFileResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: ownerId
+        - name: namespaceId
           description: owner id
           in: path
           required: true
@@ -298,6 +340,9 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaUpdateChunkResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
@@ -315,7 +360,7 @@ paths:
             $ref: '#/definitions/ArtifactPublicServiceUpdateChunkBody'
       tags:
         - KnowledgeBase
-  /v1alpha/namespaces/{ownerId}/knowledge-bases/{kbId}/chunks/similarity:
+  /v1alpha/namespaces/{namespaceId}/knowledge-bases/{kbId}/chunks/similarity:
     post:
       summary: Similarity chunks search
       operationId: ArtifactPublicService_SimilarityChunksSearch
@@ -324,12 +369,15 @@ paths:
           description: A successful response.
           schema:
             $ref: '#/definitions/v1alphaSimilarityChunksSearchResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
         default:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
-        - name: ownerId
+        - name: namespaceId
           description: owner id
           in: path
           required: true
@@ -444,15 +492,17 @@ definitions:
     type: object
     properties:
       knowledgeBase:
-        $ref: '#/definitions/v1alphaKnowledgeBase'
         description: The created knowledge base.
+        allOf:
+          - $ref: '#/definitions/v1alphaKnowledgeBase'
     description: CreateKnowledgeBaseResponse represents a response for creating a knowledge base.
   v1alphaCreateRepositoryTagResponse:
     type: object
     properties:
       tag:
-        $ref: '#/definitions/v1alphaRepositoryTag'
         description: The created tag.
+        allOf:
+          - $ref: '#/definitions/v1alphaRepositoryTag'
     description: CreateRepositoryTagResponse contains the created tag.
   v1alphaDeleteKnowledgeBaseFileResponse:
     type: object
@@ -465,8 +515,9 @@ definitions:
     type: object
     properties:
       knowledgeBase:
-        $ref: '#/definitions/v1alphaKnowledgeBase'
         description: The knowledge base identifier.
+        allOf:
+          - $ref: '#/definitions/v1alphaKnowledgeBase'
     description: DeleteKnowledgeBaseResponse represents a response for deleting a knowledge base.
   v1alphaDeleteRepositoryTagResponse:
     type: object
@@ -482,12 +533,14 @@ definitions:
         type: string
         title: file name
       type:
-        $ref: '#/definitions/v1alphaFileType'
         title: file type
+        allOf:
+          - $ref: '#/definitions/v1alphaFileType'
       processStatus:
-        $ref: '#/definitions/v1alphaFileProcessStatus'
         title: file process status
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaFileProcessStatus'
       processOutcome:
         type: string
         title: file process message
@@ -585,15 +638,17 @@ definitions:
     type: object
     properties:
       tag:
-        $ref: '#/definitions/v1alphaRepositoryTag'
         description: The created tag.
+        allOf:
+          - $ref: '#/definitions/v1alphaRepositoryTag'
     description: GetRepositoryTagResponse contains the created tag.
   v1alphaGetSourceFileResponse:
     type: object
     properties:
       sourceFile:
-        $ref: '#/definitions/v1alphaSourceFile'
         title: source file(either orignal file or converted file)
+        allOf:
+          - $ref: '#/definitions/v1alphaSourceFile'
     title: get source file response
   v1alphaKnowledgeBase:
     type: object
@@ -696,8 +751,9 @@ definitions:
         type: string
         title: next page token
       filter:
-        $ref: '#/definitions/v1alphaListKnowledgeBaseFilesFilter'
         description: The filter.
+        allOf:
+          - $ref: '#/definitions/v1alphaListKnowledgeBaseFilesFilter'
     title: list files response
   v1alphaListKnowledgeBasesResponse:
     type: object
@@ -823,20 +879,35 @@ definitions:
     type: object
     properties:
       chunk:
-        $ref: '#/definitions/v1alphaChunk'
         title: chunk
+        allOf:
+          - $ref: '#/definitions/v1alphaChunk'
     title: Updae chunk response
   v1alphaUpdateKnowledgeBaseResponse:
     type: object
     properties:
       knowledgeBase:
-        $ref: '#/definitions/v1alphaKnowledgeBase'
         description: The updated knowledge base.
+        allOf:
+          - $ref: '#/definitions/v1alphaKnowledgeBase'
     description: UpdateKnowledgeBaseResponse represents a response for updating a knowledge base.
   v1alphaUploadKnowledgeBaseFileResponse:
     type: object
     properties:
       file:
-        $ref: '#/definitions/v1alphaFile'
         title: file
+        allOf:
+          - $ref: '#/definitions/v1alphaFile'
     title: upload file response
+securityDefinitions:
+  Bearer:
+    type: apiKey
+    description: Enter the token with the `Bearer ` prefix, e.g. `Bearer abcde12345`
+    name: Authorization
+    in: header
+    x-default: Bearer instill_sk_***
+security:
+  - Bearer: []
+externalDocs:
+  description: More about Instill AI
+  url: https://www.instill.tech/docs

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -12,13 +12,21 @@ info:
     url: https://github.com/instill-ai/protobufs/blob/main/LICENSE
 tags:
   - name: User
+    description: User endpoints
   - name: Organization
+    description: Organization endpoints
   - name: Membership
+    description: Membership endpoints
   - name: Token
+    description: Token endpoints
   - name: Subscription
+    description: Subscription endpoints
   - name: Credit
+    description: Credit endpoints
   - name: Metric
+    description: Metric endpoints
   - name: Utils
+    description: Util endpoints
 host: api.instill.tech
 schemes:
   - https
@@ -74,6 +82,8 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaAuthenticatedUser'
+            required:
+              - user
       tags:
         - User
   /v1beta/users:
@@ -130,7 +140,7 @@ paths:
           type: string
       tags:
         - User
-  /v1beta/{user_name}:
+  /v1beta/users/{userId}:
     get:
       summary: Get a user
       description: Returns the details of a user by their ID.
@@ -148,14 +158,11 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_name
-          description: |-
-            The resource name of the user, which allows its access by ID.
-            - Format: `users/{user.id}`.
+        - name: userId
+          description: User ID
           in: path
           required: true
           type: string
-          pattern: users/[^/]+
         - name: view
           description: |-
             View allows clients to specify the desired resource view in the response.
@@ -249,7 +256,7 @@ paths:
             $ref: '#/definitions/v1betaOrganization'
       tags:
         - Organization
-  /v1beta/{organization_name}:
+  /v1beta/organizations/{organizationId}:
     get:
       summary: Get an organization
       description: Returns the organization details by its ID.
@@ -267,14 +274,11 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_name
-          description: |-
-            The resource name of the organization, which allows its access by ID.
-            - Format: `organizations/{organization.id}`.
+        - name: organizationId
+          description: Organization ID
           in: path
           required: true
           type: string
-          pattern: organizations/[^/]+
         - name: view
           description: |-
             View allows clients to specify the desired resource view in the response.
@@ -306,14 +310,11 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_name
-          description: |-
-            The resource name of the organization, which allows its access by ID.
-            - Format: `organizations/{organization.id}`.
+        - name: organizationId
+          description: Organization ID
           in: path
           required: true
           type: string
-          pattern: organizations/[^/]+
       tags:
         - Organization
     patch:
@@ -337,61 +338,20 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_name
-          description: |-
-            The name of the organization, defined by its ID.
-            - Format: `organization/{organization.id}`.
+        - name: organizationId
+          description: Organization ID
           in: path
           required: true
           type: string
-          pattern: organizations/[^/]+
         - name: organization
           description: The organization fields that will replace the existing ones.
           in: body
           required: true
           schema:
-            type: object
-            properties:
-              uid:
-                type: string
-                description: Organization UUID.
-                readOnly: true
-              id:
-                type: string
-                description: |-
-                  Resource ID (used in `name` as the last segment). This conforms to
-                  RFC-1034, which restricts to letters, numbers, and hyphen, with the first
-                  character a letter, the last a letter or a number, and a 63 character
-                  maximum.
-
-                  Note that the ID can be updated.
-              createTime:
-                type: string
-                format: date-time
-                description: Creation time.
-                readOnly: true
-              updateTime:
-                type: string
-                format: date-time
-                description: Update time.
-                readOnly: true
-              owner:
-                $ref: '#/definitions/v1betaUser'
-                description: The user that owns the organization.
-                readOnly: true
-              profile:
-                $ref: '#/definitions/v1betaOrganizationProfile'
-                description: Profile.
-              permission:
-                $ref: '#/definitions/v1betaPermission'
-                title: Permission
-                readOnly: true
-            title: The organization fields that will replace the existing ones.
-            required:
-              - id
+            $ref: '#/definitions/v1betaOrganization'
       tags:
         - Organization
-  /v1beta/{user_name}/memberships:
+  /v1beta/users/{userId}/memberships:
     get:
       summary: List user memberships
       description: Returns the memberships of a user.
@@ -409,17 +369,14 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_name
-          description: |-
-            The parent resource, i.e., the user to which the memberships belong.
-            Format: `users/{user.id}`.
+        - name: userId
+          description: User ID
           in: path
           required: true
           type: string
-          pattern: users/[^/]+
       tags:
         - Membership
-  /v1beta/{user_membership_name}:
+  /v1beta/users/{userId}/memberships/{organizationId}:
     get:
       summary: Get a user membership
       description: |-
@@ -439,15 +396,16 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by user and
-            organization ID.
-            - Format: `users/{user.id}/memberships/{organization.id}`.
+        - name: userId
+          description: User ID
           in: path
           required: true
           type: string
-          pattern: users/[^/]+/memberships/[^/]+
+        - name: organizationId
+          description: Organization ID
+          in: path
+          required: true
+          type: string
         - name: view
           description: |-
             View allows clients to specify the desired resource view in the response.
@@ -479,15 +437,16 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by user and
-            organization ID.
-            - Format: `users/{user.id}/memberships/{organization.id}`.
+        - name: userId
+          description: User ID
           in: path
           required: true
           type: string
-          pattern: users/[^/]+/memberships/[^/]+
+        - name: organizationId
+          description: Organization ID
+          in: path
+          required: true
+          type: string
       tags:
         - Membership
     put:
@@ -507,40 +466,24 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: user_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by user and
-            organization ID.
-            - Format: `users/{user.id}/memberships/{organization.id}`.
+        - name: userId
+          description: User ID
           in: path
           required: true
           type: string
-          pattern: users/[^/]+/memberships/[^/]+
+        - name: organizationId
+          description: Organization ID
+          in: path
+          required: true
+          type: string
         - name: membership
           description: The membership fields to update.
           in: body
           required: true
           schema:
-            type: object
-            properties:
-              role:
-                type: string
-                description: Role of the user in the organization.
-                readOnly: true
-              state:
-                $ref: '#/definitions/v1betaMembershipState'
-                description: State of the membership.
-              user:
-                $ref: '#/definitions/v1betaUser'
-                description: User information.
-                readOnly: true
-              organization:
-                $ref: '#/definitions/v1betaOrganization'
-                description: Organization information.
-                readOnly: true
-            title: The membership fields to update.
+            $ref: '#/definitions/v1betaUserMembership'
             required:
-              - state
+              - membership
         - name: updateMask
           description: |-
             The update mask specifies the subset of fields that should be modified.
@@ -552,7 +495,7 @@ paths:
           type: string
       tags:
         - Membership
-  /v1beta/{organization_name}/memberships:
+  /v1beta/organizations/{organizationId}/memberships:
     get:
       summary: List organization memberships
       description: Returns a paginated list of the user memberships in an organization.
@@ -570,18 +513,14 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_name
-          description: |-
-            The parent resource, i.e., the organization to which the memberships
-            belong.
-            Format: `organizations/{organization.id}`.
+        - name: organizationId
+          description: Organization ID
           in: path
           required: true
           type: string
-          pattern: organizations/[^/]+
       tags:
         - Membership
-  /v1beta/{organization_membership_name}:
+  /v1beta/organizations/{organizationId}/memberships/{userId}:
     get:
       summary: Get a an organization membership
       description: Returns the details of a user membership within an organization.
@@ -599,15 +538,16 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by
-            organization and user ID.
-            - Format: `organizations/{organization.id}/memberships/{user.id}`.
+        - name: organizationId
+          description: Organization ID
           in: path
           required: true
           type: string
-          pattern: organizations/[^/]+/memberships/[^/]+
+        - name: userId
+          description: User ID
+          in: path
+          required: true
+          type: string
         - name: view
           description: |-
             View allows clients to specify the desired resource view in the response.
@@ -639,15 +579,16 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by
-            organization and user ID.
-            - Format: `organizations/{organization.id}/memberships/{user.id}`.
+        - name: organizationId
+          description: Organization ID
           in: path
           required: true
           type: string
-          pattern: organizations/[^/]+/memberships/[^/]+
+        - name: userId
+          description: User ID
+          in: path
+          required: true
+          type: string
       tags:
         - Membership
     put:
@@ -667,40 +608,24 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_membership_name
-          description: |-
-            The resource name of the membership, which allows its access by
-            organization and user ID.
-            - Format: `organizations/{organization.id}/memberships/{user.id}`.
+        - name: organizationId
+          description: Organization ID
           in: path
           required: true
           type: string
-          pattern: organizations/[^/]+/memberships/[^/]+
+        - name: userId
+          description: User ID
+          in: path
+          required: true
+          type: string
         - name: membership
           description: The membership fields to update.
           in: body
           required: true
           schema:
-            type: object
-            properties:
-              role:
-                type: string
-                description: Role of the user in the organization.
-              state:
-                $ref: '#/definitions/v1betaMembershipState'
-                description: State of the membership.
-                readOnly: true
-              user:
-                $ref: '#/definitions/v1betaUser'
-                description: User information.
-                readOnly: true
-              organization:
-                $ref: '#/definitions/v1betaOrganization'
-                description: Organization information.
-                readOnly: true
-            title: The membership fields to update.
+            $ref: '#/definitions/v1betaOrganizationMembership'
             required:
-              - role
+              - membership
         - name: updateMask
           description: |-
             The update mask specifies the subset of fields that should be modified.
@@ -731,9 +656,9 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       tags:
         - Subscription
-  /v1beta/{organization_name}/subscription:
+  /v1beta/organizations/{organizationId}/subscription:
     get:
-      summary: Get an organization subscription
+      summary: Get the subscription of an organization
       description: Returns the subscription details of an organization.
       operationId: MgmtPublicService_GetOrganizationSubscription
       responses:
@@ -749,15 +674,11 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: organization_name
-          description: |-
-            The parent resource, i.e., the organization to which the subscription
-            refers.
-            Format: `organizations/{organization.id}`.
+        - name: organizationId
+          description: Oragnization ID
           in: path
           required: true
           type: string
-          pattern: organizations/[^/]+
       tags:
         - Subscription
   /v1beta/tokens:
@@ -819,7 +740,7 @@ paths:
             $ref: '#/definitions/v1betaApiToken'
       tags:
         - Token
-  /v1beta/{token_name}:
+  /v1beta/tokens/{tokenId}:
     get:
       summary: Get an API token
       description: Returns the details of an API token.
@@ -837,14 +758,11 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: token_name
-          description: |-
-            The resource name of the token, which allows its access by ID.
-            - Format: `tokens/{token.id}`.
+        - name: tokenId
+          description: Token ID
           in: path
           required: true
           type: string
-          pattern: tokens/[^/]+
       tags:
         - Token
     delete:
@@ -864,19 +782,16 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: token_name
-          description: |-
-            The resource name of the token, which allows its access by ID.
-            - Format: `tokens/{token.id}`.
+        - name: tokenId
+          description: Token ID
           in: path
           required: true
           type: string
-          pattern: tokens/[^/]+
       tags:
         - Token
   /v1beta/validate_token:
     post:
-      summary: Validate an API token.
+      summary: Validate an API token
       description: Validates an API token.
       operationId: MgmtPublicService_ValidateToken
       responses:
@@ -893,7 +808,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       tags:
         - Token
-  /v1beta/{owner_name}/credit:
+  /v1beta/namespaces/{namespaceId}/credit:
     get:
       summary: Get the remaining Instill Credit
       description: |-
@@ -916,14 +831,11 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: owner_name
-          description: |-
-            The user or organization to which the credit belongs.
-            Format: `{[users|organizations]}/{id}`.
+        - name: namespaceId
+          description: Namespace ID
           in: path
           required: true
           type: string
-          pattern: '[^/]+/[^/]+'
       tags:
         - Credit
   /v1beta/check-namespace:
@@ -1134,162 +1046,6 @@ definitions:
        - STATE_INACTIVE: Inactive.
        - STATE_ACTIVE: Active.
        - STATE_EXPIRED: Expired.
-  HealthCheckResponseServingStatus:
-    type: string
-    enum:
-      - SERVING_STATUS_SERVING
-      - SERVING_STATUS_NOT_SERVING
-    description: |-
-      - SERVING_STATUS_SERVING: Serving status: SERVING
-       - SERVING_STATUS_NOT_SERVING: Serving status: NOT SERVING
-    title: ServingStatus enumerates the status of a queried service
-  SessionService:
-    type: string
-    enum:
-      - SERVICE_MGMT
-      - SERVICE_CONNECTOR
-      - SERVICE_MODEL
-      - SERVICE_PIPELINE
-      - SERVICE_ARTIFACT
-    description: |-
-      - SERVICE_MGMT: Service: MGMT
-       - SERVICE_CONNECTOR: Service: CONNECTOR
-       - SERVICE_MODEL: Service: MODEL
-       - SERVICE_PIPELINE: Service: PIPELINE
-       - SERVICE_ARTIFACT: Service: ARTIFACT
-    title: Service enumerates the services to collect data from
-  UserUsageDataConnectorExecuteData:
-    type: object
-    properties:
-      connectorUid:
-        type: string
-        title: UID for the executed connector
-      executeUid:
-        type: string
-        title: UID for the execute log
-      executeTime:
-        type: string
-        format: date-time
-        title: Timestamp for the execution
-      connectorDefinitionUid:
-        type: string
-        title: Definition UID of the connector
-      status:
-        $ref: '#/definitions/mgmtv1betaStatus'
-        title: Final status of the execution
-      userUid:
-        type: string
-        title: UUID of the user who execute the connector
-      userType:
-        $ref: '#/definitions/v1betaOwnerType'
-        title: Type of the user who execute the connector
-    title: Per execute usage metadata
-    required:
-      - connectorUid
-      - executeUid
-      - executeTime
-      - connectorDefinitionUid
-      - status
-      - userUid
-      - userType
-  UserUsageDataModelTriggerData:
-    type: object
-    properties:
-      modelUid:
-        type: string
-        title: UID for the trigged model
-      triggerUid:
-        type: string
-        title: UID for the trigger log
-      triggerTime:
-        type: string
-        format: date-time
-        title: Timestamp for the trigger
-      modelDefinitionUid:
-        type: string
-        title: Definition UID of the model
-      modelTask:
-        $ref: '#/definitions/v1alphaTask'
-        title: Task of the model
-      status:
-        $ref: '#/definitions/mgmtv1betaStatus'
-        title: Final status of the execution
-      userUid:
-        type: string
-        title: UUID of the user who trigger the model
-      userType:
-        $ref: '#/definitions/v1betaOwnerType'
-        title: Type of the user who trigger the model
-    title: Per trigger usage metadata
-    required:
-      - modelUid
-      - triggerUid
-      - triggerTime
-      - modelDefinitionUid
-      - modelTask
-      - status
-      - userUid
-      - userType
-  UserUsageDataPipelineTriggerData:
-    type: object
-    properties:
-      pipelineUid:
-        type: string
-        title: UID for the triggered pipeline
-      triggerUid:
-        type: string
-        title: UID for the trigger log
-      triggerTime:
-        type: string
-        format: date-time
-        title: Timestamp for the trigger
-      triggerMode:
-        $ref: '#/definitions/v1betaMode'
-        title: Trigger mode
-      status:
-        $ref: '#/definitions/mgmtv1betaStatus'
-        title: Final status of the execution
-      pipelineReleaseId:
-        type: string
-        title: Version for the triggered release pipeline, empty string if not release
-      pipelineReleaseUid:
-        type: string
-        title: UID for the triggered release pipeline, empty string if not release
-      userUid:
-        type: string
-        title: UUID of the user who trigger the pipeline
-      userType:
-        $ref: '#/definitions/v1betaOwnerType'
-        title: Type of the user who trigger the pipeline
-      pipelineId:
-        type: string
-        title: ID for the triggered pipeline
-    title: Per trigger usage metadata
-    required:
-      - pipelineUid
-      - triggerUid
-      - triggerTime
-      - triggerMode
-      - status
-      - pipelineReleaseId
-      - pipelineReleaseUid
-      - userUid
-      - userType
-      - pipelineId
-  coreusagev1betaLivenessResponse:
-    type: object
-    properties:
-      healthCheckResponse:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
-        title: HealthCheckResponse message
-    title: LivenessResponse represents a response for a service liveness status
-  coreusagev1betaReadinessResponse:
-    type: object
-    properties:
-      healthCheckResponse:
-        $ref: '#/definitions/v1betaHealthCheckResponse'
-        title: HealthCheckResponse message
-    title: ReadinessResponse represents a response for a service readiness status
   googlerpcStatus:
     type: object
     properties:
@@ -1319,38 +1075,6 @@ definitions:
       '@type':
         type: string
     additionalProperties: {}
-  v1alphaTask:
-    type: string
-    enum:
-      - TASK_CLASSIFICATION
-      - TASK_DETECTION
-      - TASK_KEYPOINT
-      - TASK_OCR
-      - TASK_INSTANCE_SEGMENTATION
-      - TASK_SEMANTIC_SEGMENTATION
-      - TASK_TEXT_TO_IMAGE
-      - TASK_TEXT_GENERATION
-      - TASK_TEXT_GENERATION_CHAT
-      - TASK_VISUAL_QUESTION_ANSWERING
-      - TASK_IMAGE_TO_IMAGE
-      - TASK_TEXT_EMBEDDINGS
-      - TASK_SPEECH_RECOGNITION
-    description: |-
-      Task enumerates the AI task that a model is designed to solve.
-
-       - TASK_CLASSIFICATION: Image Classification - classify images into predefined categories.
-       - TASK_DETECTION: Object Detection - detect and localize multiple objects in images.
-       - TASK_KEYPOINT: Keypoint Detection - detect and localize multiple keypoints of objects in images.
-       - TASK_OCR: OCR (Optical Character Recognition) - detect and recognize text in images.
-       - TASK_INSTANCE_SEGMENTATION: Instance Segmentation - detect, localize and delineate multiple objects in images.
-       - TASK_SEMANTIC_SEGMENTATION: Semantic Segmentation - classify image pixels into predefined categories.
-       - TASK_TEXT_TO_IMAGE: Text to Image - generate images from input text prompts.
-       - TASK_TEXT_GENERATION: Text Generation - generate texts from input text prompts.
-       - TASK_TEXT_GENERATION_CHAT: Conversational Text Generation - generate text as responses to a dialog input.
-       - TASK_VISUAL_QUESTION_ANSWERING: Visual Question Answering - generate text as a response to a visual prompt.
-       - TASK_IMAGE_TO_IMAGE: Image to Image - generate an image from another image.
-       - TASK_TEXT_EMBEDDINGS: Text Embeddings - generate an embedding (a representation as coordinates) from a text input.
-       - TASK_SPEECH_RECOGNITION: Speech Recognition - transcribe the words in an audio input.
   v1betaApiToken:
     type: object
     properties:
@@ -1399,9 +1123,10 @@ definitions:
           that issued the token.
         readOnly: true
       state:
-        $ref: '#/definitions/ApiTokenState'
         description: State.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/ApiTokenState'
       tokenType:
         type: string
         description: Token type. Value is fixed to "Bearer".
@@ -1415,29 +1140,6 @@ definitions:
         format: date-time
         description: Expiration time.
     description: API tokens allow users to make requests to the Instill AI API.
-  v1betaArtifactUsageData:
-    type: object
-    properties:
-      usages:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaArtifactUsageDataUserUsageData'
-        title: Usage data of all users in the artifact service
-    title: Artifact service usage data
-  v1betaArtifactUsageDataUserUsageData:
-    type: object
-    properties:
-      ownerUid:
-        type: string
-        title: Owner UUID
-      ownerType:
-        $ref: '#/definitions/v1betaOwnerType'
-        title: Owner type
-    title: Per user usage data in the artifact service
-    required:
-      - ownerUid
-      - ownerType
   v1betaAuthenticatedUser:
     type: object
     properties:
@@ -1498,11 +1200,14 @@ definitions:
         type: string
         description: Console cookie token.
       onboardingStatus:
-        $ref: '#/definitions/v1betaOnboardingStatus'
         description: Onboarding Status.
+        allOf:
+          - $ref: '#/definitions/v1betaOnboardingStatus'
       profile:
-        $ref: '#/definitions/v1betaUserProfile'
         description: Profile.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUserProfile'
     description: |-
       AuthenticatedUser contains the information of an authenticated user, i.e.,
       the public user information plus some fields that should only be accessed by
@@ -1515,8 +1220,9 @@ definitions:
     type: object
     properties:
       type:
-        $ref: '#/definitions/v1betaCheckNamespaceAdminResponseNamespace'
         description: Namespace type.
+        allOf:
+          - $ref: '#/definitions/v1betaCheckNamespaceAdminResponseNamespace'
       uid:
         type: string
         description: Namespace UID.
@@ -1552,8 +1258,9 @@ definitions:
     type: object
     properties:
       type:
-        $ref: '#/definitions/v1betaCheckNamespaceResponseNamespace'
         description: Namespace type.
+        allOf:
+          - $ref: '#/definitions/v1betaCheckNamespaceResponseNamespace'
     description: |-
       CheckNamespaceResponse contains the availability of a namespace or the type
       of resource that's using it.
@@ -1571,56 +1278,23 @@ definitions:
        - NAMESPACE_USER: Namespace belongs to a user.
        - NAMESPACE_ORGANIZATION: Namespace belongs to an organization.
        - NAMESPACE_RESERVED: Reserved.
-  v1betaConnectorUsageData:
-    type: object
-    properties:
-      usages:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaConnectorUsageDataUserUsageData'
-        title: Usage data of all users in the connector service
-    title: Connector service usage data
-  v1betaConnectorUsageDataUserUsageData:
-    type: object
-    properties:
-      ownerUid:
-        type: string
-        title: Owner UUID
-      connectorExecuteData:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/UserUsageDataConnectorExecuteData'
-        title: Execution data for each user
-      ownerType:
-        $ref: '#/definitions/v1betaOwnerType'
-        title: Owner type
-    title: Per user usage data in the connector service
-    required:
-      - ownerUid
-      - connectorExecuteData
-      - ownerType
   v1betaCreateOrganizationResponse:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
         description: The organization resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     description: CreateOrganizationResponse contains the created organization.
-  v1betaCreateSessionResponse:
-    type: object
-    properties:
-      session:
-        $ref: '#/definitions/v1betaSession'
-        title: A session resource
-    title: CreateSessionResponse represents a response for a session response
   v1betaCreateTokenResponse:
     type: object
     properties:
       token:
-        $ref: '#/definitions/v1betaApiToken'
         description: The created API token resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaApiToken'
     description: CreateTokenResponse contains the created token.
   v1betaCreditConsumptionChartRecord:
     type: object
@@ -1667,333 +1341,62 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaAuthenticatedUser'
         description: The authenticated user resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaAuthenticatedUser'
     description: GetAuthenticatedUserResponse contains the requested authenticated user.
   v1betaGetAuthenticatedUserSubscriptionResponse:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaUserSubscription'
         description: The subscription resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUserSubscription'
     description: GetAuthenticatedUserSubscriptionResponse contains the requested subscription.
-  v1betaGetBulkCumulativeModelOnlineRecordsResponse:
-    type: object
-    properties:
-      bulkCumulativeRecords:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaGetCumulativeModelOnlineRecordsResponse'
-        title: A list of cumulative model online record lists
-    title: |-
-      GetBulkCumulativeModelOnlineRecordsResponse represents a response to
-      GetBulkCumulativeModelOnlineRecordsRequest
-    required:
-      - bulkCumulativeRecords
-  v1betaGetBulkCumulativePipelineTriggerRecordsResponse:
-    type: object
-    properties:
-      bulkCumulativeRecords:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaGetCumulativePipelineTriggerRecordsResponse'
-        title: A list of cumulative pipeline trigger record lists
-    title: |-
-      GetBulkCumulativePipelineTriggerRecordsResponse represents a response to
-      GetBulkCumulativePipelineTriggerRecordsRequest
-    required:
-      - bulkCumulativeRecords
-  v1betaGetBulkModelOnlinePriceResponse:
-    type: object
-    properties:
-      bulkPrices:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaGetModelOnlinePriceResponse'
-        title: A list of model online price lists
-    title: |-
-      GetBulkModelOnlinePriceResponse represents a response to
-      GetBulkModelOnlinePriceRequest
-    required:
-      - bulkPrices
-  v1betaGetBulkModelOnlineRecordsResponse:
-    type: object
-    properties:
-      bulkRecords:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaGetModelOnlineRecordsResponse'
-        title: A list of model online record lists
-    title: |-
-      GetBulkModelOnlineRecordsResponse represents a response to
-      GetBulkModelOnlineRecordsRequest
-    required:
-      - bulkRecords
-  v1betaGetBulkModelOnlineSummaryResponse:
-    type: object
-    properties:
-      bulkSummaries:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaGetModelOnlineSummaryResponse'
-        title: A list of model online usage summaries
-    title: |-
-      GetBulkModelOnlineSummaryResponse represents a response to
-      GetBulkModelOnlineSummaryRequest
-    required:
-      - bulkSummaries
-  v1betaGetBulkPipelineTriggerPriceResponse:
-    type: object
-    properties:
-      bulkPrices:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaGetPipelineTriggerPriceResponse'
-        title: A list of pipeline trigger price lists
-    title: |-
-      GetBulkPipelineTriggerPriceResponse represents a response to
-      GetBulkPipelineTriggerPriceRequest
-    required:
-      - bulkPrices
-  v1betaGetBulkPipelineTriggerRecordsResponse:
-    type: object
-    properties:
-      bulkRecords:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaGetPipelineTriggerRecordsResponse'
-        title: A list of pipeline trigger record lists
-    title: |-
-      GetBulkPipelineTriggerRecordsResponse represents a response to
-      GetBulkPipelineTriggerRecordsRequest
-    required:
-      - bulkRecords
-  v1betaGetBulkPipelineTriggerSummariesResponse:
-    type: object
-    properties:
-      bulkSummaries:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaGetPipelineTriggerSummaryResponse'
-        title: A list of pipeline trigger usage summaries
-    title: |-
-      GetBulkPipelineTriggerSummariesResponse represents a response to
-      GetBulkPipelineTriggerSummariesRequest
-    required:
-      - bulkSummaries
-  v1betaGetCumulativeModelOnlineRecordsRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      model:
-        $ref: '#/definitions/v1betaModelData'
-        title: Model information
-      timeInterval:
-        $ref: '#/definitions/v1betaTimeInterval'
-        title: Time interval
-    title: |-
-      GetCumulativeModelOnlineRecordsRequest represents a query for cumulative
-      model online records
-    required:
-      - user
-      - model
-      - timeInterval
-  v1betaGetCumulativeModelOnlineRecordsResponse:
-    type: object
-    properties:
-      cumulativeRecords:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaModelUsageRecord'
-        title: A list of model online records in cumulative format
-    title: |-
-      GetCumulativeModelOnlineRecordsResponse represents a response to
-      GetCumulativeModelOnlineRecordsRequest
-    required:
-      - cumulativeRecords
-  v1betaGetCumulativePipelineTriggerRecordsRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
-        title: Pipeline information
-      timeInterval:
-        $ref: '#/definitions/v1betaTimeInterval'
-        title: Time interval
-    title: |-
-      GetCumulativePipelineTriggerRecordsRequest represents a query for cumulative
-      pipeline trigger records
-    required:
-      - user
-      - pipeline
-  v1betaGetCumulativePipelineTriggerRecordsResponse:
-    type: object
-    properties:
-      cumulativeRecords:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaPipelineUsageRecord'
-        title: Pipeline trigger records where values are in cumulative formats
-    title: |-
-      GetCumulativePipelineTriggerRecordsResponse represents a response to
-      GetCumulativePipelineTriggerRecordsRequest
-    required:
-      - cumulativeRecords
-  v1betaGetModelOnlinePriceRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      model:
-        $ref: '#/definitions/v1betaModelData'
-        title: Pipeline information
-      timeInterval:
-        $ref: '#/definitions/v1betaTimeInterval'
-        title: Time interval
-    title: |-
-      GetPipelineTriggerPriceRequest represents a query for price data of the
-      billing periods covered by the time interval
-    required:
-      - user
-      - model
-      - timeInterval
-  v1betaGetModelOnlinePriceResponse:
-    type: object
-    properties:
-      price:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaPriceData'
-        title: |-
-          A list of model online prices given the billing periods covered by the time
-          interval
-    title: |-
-      GetModelOnlinePriceResponse represents a response to
-      GetModelOnlinePriceRequest
-    required:
-      - price
-  v1betaGetModelOnlineRecordsRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      model:
-        $ref: '#/definitions/v1betaModelData'
-        title: Model information
-      timeInterval:
-        $ref: '#/definitions/v1betaTimeInterval'
-        title: Time interval
-    title: GetModelOnlineRecordsRequest represent a query for model online records
-    required:
-      - user
-      - model
-      - timeInterval
-  v1betaGetModelOnlineRecordsResponse:
-    type: object
-    properties:
-      records:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaModelUsageRecord'
-        title: A list of model trigger records
-    title: |-
-      GetModelOnlineRecordsResponse represents a response to
-      GetModelOnlineRecordsRequest
-    required:
-      - records
-  v1betaGetModelOnlineSummaryRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      model:
-        $ref: '#/definitions/v1betaModelData'
-        title: Pipeline information
-      timeInterval:
-        $ref: '#/definitions/v1betaTimeInterval'
-        title: Time interval
-    title: GetModelOnlineSummaryRequest represents a query for model online summary
-    required:
-      - user
-      - model
-      - timeInterval
-  v1betaGetModelOnlineSummaryResponse:
-    type: object
-    properties:
-      summary:
-        $ref: '#/definitions/v1betaUsageSummary'
-        title: The total model online usage in the time interval
-    title: |-
-      GetModelOnlineSummaryResponse represents a response to
-      GetModelOnlineSummaryRequest
-    required:
-      - summary
-  v1betaGetModelsResponse:
-    type: object
-    properties:
-      models:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaModelData'
-        title: A list of model informations
-    title: GetPipelinesResponse represents a respond to GetModelsRequest
-    required:
-      - models
   v1betaGetOrganizationAdminResponse:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
         title: A organization resource
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     title: GetOrganizationAdminResponse represents a response for a organization resource
   v1betaGetOrganizationMembershipResponse:
     type: object
     properties:
       membership:
-        $ref: '#/definitions/v1betaOrganizationMembership'
         description: The requested organization membership.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganizationMembership'
     description: GetOrganizationMembershipResponse contains the organization membership.
   v1betaGetOrganizationResponse:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
         description: The organization resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     description: GetOrganizationResponse contains the requested organization.
   v1betaGetOrganizationSubscriptionAdminResponse:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaOrganizationSubscription'
         title: Subscription
+        allOf:
+          - $ref: '#/definitions/v1betaOrganizationSubscription'
     title: GetOrganizationSubscriptionAdminResponse
   v1betaGetOrganizationSubscriptionResponse:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaOrganizationSubscription'
         description: The subscription resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganizationSubscription'
     description: GetOrganizationSubscriptionResponse contains the requested subscription.
   v1betaGetPipelineTriggerCountResponse:
     type: object
@@ -2007,114 +1410,6 @@ definitions:
     description: |-
       GetPipelineTriggerCountResponse contains the trigger count, grouped by
       trigger status.
-  v1betaGetPipelineTriggerPriceRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
-        title: Pipeline information
-      timeInterval:
-        $ref: '#/definitions/v1betaTimeInterval'
-        title: Time interval
-    title: |-
-      GetPipelineTriggerPriceRequest represents a query for pipeline trigger prices
-      given the billing periods covered by the time interval
-    required:
-      - user
-      - pipeline
-      - timeInterval
-  v1betaGetPipelineTriggerPriceResponse:
-    type: object
-    properties:
-      price:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaPriceData'
-        title: |-
-          A list of pipeline trigger prices given the billing periods covered by the
-          time interval
-    title: |-
-      GetPipelineTriggerPriceResponse represents a response to
-      GetPipelineTriggerPriceRequest
-    required:
-      - price
-  v1betaGetPipelineTriggerRecordsRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
-        title: Pipeline information
-      timeInterval:
-        $ref: '#/definitions/v1betaTimeInterval'
-        title: Time interval
-    title: |-
-      GetPipelineTriggerRecordsRequest represents a query for pipeline trigger
-      records
-    required:
-      - user
-      - pipeline
-  v1betaGetPipelineTriggerRecordsResponse:
-    type: object
-    properties:
-      records:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaPipelineUsageRecord'
-        title: A list of pipeline trigger records
-    title: |-
-      GetPipelineTriggerRecordsResponse represents a response to
-      GetPipelineTriggerRecordsRequest
-    required:
-      - records
-  v1betaGetPipelineTriggerSummaryRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
-        title: Pipeline information
-      timeInterval:
-        $ref: '#/definitions/v1betaTimeInterval'
-        title: Time interval
-    title: |-
-      GetPipelineTriggerSummaryRequest represents a query for pipeline trigger
-      summary
-    required:
-      - user
-      - pipeline
-  v1betaGetPipelineTriggerSummaryResponse:
-    type: object
-    properties:
-      summaries:
-        $ref: '#/definitions/v1betaUsageSummary'
-        title: The total pipeline trigger usage in the time interval
-    title: |-
-      GetPipelineTriggerSummaryResponse represents a response to
-      GetPipelineTriggerSummaryRequest
-    required:
-      - summaries
-  v1betaGetPipelinesResponse:
-    type: object
-    properties:
-      pipelines:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaPipelineData'
-        title: A list of pipeline informations
-    title: GetPipelinesResponse represents a respond to GetPipelineRequest
-    required:
-      - pipelines
   v1betaGetRemainingCreditAdminResponse:
     type: object
     properties:
@@ -2132,16 +1427,19 @@ definitions:
         type: number
         format: float
         description: Amount of perishable credit, i.e. credit with an expiration date.
+        readOnly: true
       imperishable:
         type: number
         format: float
         description: |-
           Amount of imperishable credit, e.g. purchased credit, which doesn't
           expire.
+        readOnly: true
       total:
         type: number
         format: float
         description: Total remaining credit.
+        readOnly: true
     description: |-
       GetRemainingCreditResponse contains the remaining credit of a user or
       organization.
@@ -2149,51 +1447,45 @@ definitions:
     type: object
     properties:
       token:
-        $ref: '#/definitions/v1betaApiToken'
         description: The API token resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaApiToken'
     description: GetTokenResponse contains the requested token.
   v1betaGetUserAdminResponse:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUser'
         title: A user resource
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
     title: GetUserAdminResponse represents a response for a user resource
   v1betaGetUserMembershipResponse:
     type: object
     properties:
       membership:
-        $ref: '#/definitions/v1betaUserMembership'
         description: The requested user membership.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUserMembership'
     description: GetUserMembershipResponse contains the user membership.
   v1betaGetUserResponse:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUser'
         description: The user resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
     description: GetUserResponse contains the requested user.
   v1betaGetUserSubscriptionAdminResponse:
     type: object
     properties:
       subscription:
-        $ref: '#/definitions/v1betaUserSubscription'
         title: Subscription
+        allOf:
+          - $ref: '#/definitions/v1betaUserSubscription'
     title: GetUserSubscriptionAdminResponse
-  v1betaHealthCheckRequest:
-    type: object
-    properties:
-      service:
-        type: string
-        title: Service name to check for its readiness status
-    title: HealthCheckRequest represents a request to health check a service
-  v1betaHealthCheckResponse:
-    type: object
-    properties:
-      status:
-        $ref: '#/definitions/HealthCheckResponseServingStatus'
-        title: Status is the instance of the enum type ServingStatus
-    title: HealthCheckResponse represents a response for a service heath status
   v1betaListCreditConsumptionChartRecordsResponse:
     type: object
     properties:
@@ -2217,6 +1509,7 @@ definitions:
         description: |-
           The organization memberships, i.e., the users that belong to the
           organization.
+        readOnly: true
     description: ListOrganizationMembershipsResponse contains a list of memberships.
   v1betaListOrganizationsAdminResponse:
     type: object
@@ -2244,13 +1537,16 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaOrganization'
         title: A list of organizations
+        readOnly: true
       nextPageToken:
         type: string
         description: Next page token.
+        readOnly: true
       totalSize:
         type: integer
         format: int32
         description: Total number of organizations.
+        readOnly: true
     title: ListOrganizationsResponse represents a response for a list of organizations
   v1betaListPipelineTriggerChartRecordsResponse:
     type: object
@@ -2294,6 +1590,7 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaUserMembership'
         description: The user memberships, i.e., the organizations the user belongs to.
+        readOnly: true
     description: ListUserMembershipsResponse contains a list of memberships.
   v1betaListUsersAdminResponse:
     type: object
@@ -2321,27 +1618,32 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaUser'
         description: A list of user resources.
+        readOnly: true
       nextPageToken:
         type: string
         description: Next page token.
+        readOnly: true
       totalSize:
         type: integer
         format: int32
         description: Total number of users.
+        readOnly: true
     description: ListUsersResponse contains a list of users.
   v1betaLookUpOrganizationAdminResponse:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
         title: A organization resource
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     title: LookUpOrganizationAdminResponse represents a response for a organization resource by admin
   v1betaLookUpUserAdminResponse:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUser'
         title: A user resource
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
     title: LookUpUserAdminResponse represents a response for a user resource by admin
   v1betaMembershipState:
     type: string
@@ -2354,109 +1656,6 @@ definitions:
        - MEMBERSHIP_STATE_ACTIVE: Active.
        - MEMBERSHIP_STATE_PENDING: Pending, i.e., a request has been sent to the user to join an
       organization.
-  v1betaMgmtUsageData:
-    type: object
-    properties:
-      userUsages:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaAuthenticatedUser'
-        title: Repeated user usage data
-      orgUsages:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaOrganization'
-        title: Repeated org usage data
-    title: Management service usage data
-  v1betaMode:
-    type: string
-    enum:
-      - MODE_SYNC
-      - MODE_ASYNC
-    description: |-
-      Mode describes the execution mode of the pipeline (sync or async).
-
-       - MODE_SYNC: Synchronous (result is returned in the response).
-       - MODE_ASYNC: Asynchronous (response only contains acknowledgement).
-  v1betaModelData:
-    type: object
-    properties:
-      uid:
-        type: string
-        title: Model unique id that is auto generated
-      id:
-        type: string
-        title: Model id that is given by the users
-      instanceId:
-        type: string
-        title: The id of the model instance that is deployed
-      task:
-        type: string
-        title: The AI task supported by this model
-    title: Pipeline records definition
-    required:
-      - uid
-      - id
-      - instanceId
-      - task
-  v1betaModelUsageData:
-    type: object
-    properties:
-      usages:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaModelUsageDataUserUsageData'
-        title: Usage data of all users in the model service
-    title: Model service usage data
-  v1betaModelUsageDataUserUsageData:
-    type: object
-    properties:
-      ownerUid:
-        type: string
-        title: Owner UUID
-      modelTriggerData:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/UserUsageDataModelTriggerData'
-        title: Trigger data for each user
-      ownerType:
-        $ref: '#/definitions/v1betaOwnerType'
-        title: Owner type
-    title: Per user usage data in the model service
-    required:
-      - ownerUid
-      - modelTriggerData
-      - ownerType
-  v1betaModelUsageRecord:
-    type: object
-    properties:
-      deployTime:
-        type: string
-        format: date-time
-        title: Time when the model is ONLINE
-      recordTime:
-        type: string
-        format: date-time
-        title: Time when model online usage is recorded
-      value:
-        type: integer
-        format: int32
-        title: |-
-          The model online usage record that is logged in cumulative manner. This
-          value records the cumulative usage since model is online in the current
-          billing period
-    title: Model online usage record definition
-    required:
-      - deployTime
-      - recordTime
-      - value
-  v1betaNullMessage:
-    type: object
-    title: Nul Message for gRPC REQ/RES
   v1betaOnboardingStatus:
     type: string
     enum:
@@ -2501,21 +1700,24 @@ definitions:
         description: Update time.
         readOnly: true
       owner:
-        $ref: '#/definitions/v1betaUser'
         description: The user that owns the organization.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
       profile:
-        $ref: '#/definitions/v1betaOrganizationProfile'
         description: Profile.
+        allOf:
+          - $ref: '#/definitions/v1betaOrganizationProfile'
       permission:
-        $ref: '#/definitions/v1betaPermission'
         title: Permission
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaPermission'
     description: |-
       Organizations group several users. As entities, they can own resources such
       as pipelines or releases.
     required:
-      - id
+      - profile
   v1betaOrganizationMembership:
     type: object
     properties:
@@ -2530,17 +1732,20 @@ definitions:
         type: string
         description: Role of the user in the organization.
       state:
-        $ref: '#/definitions/v1betaMembershipState'
         description: State of the membership.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaMembershipState'
       user:
-        $ref: '#/definitions/v1betaUser'
         description: User information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
       organization:
-        $ref: '#/definitions/v1betaOrganization'
         description: Organization information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     description: |-
       An organization membership defines the relationship between an organization
       and a user that is attached to it.
@@ -2573,19 +1778,25 @@ definitions:
     type: object
     properties:
       plan:
-        $ref: '#/definitions/v1betaOrganizationSubscriptionPlan'
         description: Plan identifier.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganizationSubscriptionPlan'
       detail:
-        $ref: '#/definitions/v1betaStripeSubscriptionDetail'
         description: Details of the associated Stripe subscription.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaStripeSubscriptionDetail'
       maxSeats:
         type: integer
         format: int32
         description: Maximum number of seats allowed.
+        readOnly: true
       usedSeats:
         type: integer
         format: int32
         description: Number of used seats within the organization subscription.
+        readOnly: true
     description: OrganizationSubscription details describe the plan (i.e., features) an organization has access to.
   v1betaOrganizationSubscriptionPlan:
     type: string
@@ -2601,21 +1812,14 @@ definitions:
        - PLAN_TEAM: Team plan.
        - PLAN_ENTERPRISE: Enterprise plan.
        - PLAN_TEAM_PRO: Team pro plan.
-  v1betaOwnerType:
-    type: string
-    enum:
-      - OWNER_TYPE_USER
-      - OWNER_TYPE_ORGANIZATION
-    description: |-
-      - OWNER_TYPE_USER: OwnerType: USER
-       - OWNER_TYPE_ORGANIZATION: OwnerType: ORGANIZATION
-    title: OwnerType enumerates the owner type of any resource
   v1betaPatchAuthenticatedUserResponse:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaAuthenticatedUser'
         description: The updated user resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaAuthenticatedUser'
     title: |-
       PatchAuthenticatedUserResponse contains the updated user.
       the authenticated user resource
@@ -2625,24 +1829,8 @@ definitions:
       canEdit:
         type: boolean
         description: Defines whether the resource can be modified.
+        readOnly: true
     description: Permission defines how a resource can be used.
-  v1betaPipelineData:
-    type: object
-    properties:
-      uid:
-        type: string
-        title: Pipeline unique id that is auto generated
-      id:
-        type: string
-        title: Pipeline id assigned by users
-      task:
-        type: string
-        title: Pipeline task indicate the AI task this pipeline supports
-    title: Pipeline records definition
-    required:
-      - uid
-      - id
-      - task
   v1betaPipelineTriggerChartRecord:
     type: object
     properties:
@@ -2682,305 +1870,52 @@ definitions:
         title: Number og triggers
         readOnly: true
       status:
-        $ref: '#/definitions/mgmtv1betaStatus'
         title: This field will be present when results are grouped by trigger status;
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/mgmtv1betaStatus'
     description: |-
       PipelineTriggerCount represents a pipeline execution count with some
       aggregation params (e.g. trigger status).
-  v1betaPipelineUsageData:
-    type: object
-    properties:
-      usages:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaPipelineUsageDataUserUsageData'
-        title: Usage data of all users in the pipeline service
-    title: Pipeline service usage data
-  v1betaPipelineUsageDataUserUsageData:
-    type: object
-    properties:
-      ownerUid:
-        type: string
-        title: Owner UUID
-      pipelineTriggerData:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/UserUsageDataPipelineTriggerData'
-        title: Trigger data for each user
-      ownerType:
-        $ref: '#/definitions/v1betaOwnerType'
-        title: Owner type
-    title: Per user usage data in the pipeline service
-    required:
-      - ownerUid
-      - pipelineTriggerData
-      - ownerType
-  v1betaPipelineUsageRecord:
-    type: object
-    properties:
-      requestId:
-        type: string
-        description: A unique request id given by vdp when trigger the pipeline.
-      operationId:
-        type: string
-        title: A unique operation id given by vdp
-      status:
-        type: string
-        title: The HTTP status received when user trigger the pipeline
-      triggerTime:
-        type: string
-        format: date-time
-        title: Time when the pipeline is triggered
-      recordTime:
-        type: string
-        format: date-time
-        title: Time when the pipeline trigger usage is recorded
-      value:
-        type: integer
-        format: int32
-        title: |-
-          The pipeline trigger usage record. The unit of the usage should be
-          consistent with Stripe
-    title: Pipeline trigger usage record definition
-    required:
-      - requestId
-      - operationId
-      - status
-      - triggerTime
-      - recordTime
-      - value
-  v1betaPriceData:
-    type: object
-    properties:
-      time:
-        $ref: '#/definitions/v1betaTimeInterval'
-        title: Time when the price record is generated
-      currency:
-        type: string
-        title: The currency of the price
-        readOnly: true
-      amount:
-        type: number
-        format: float
-        title: The price of the query usage in the current billing period
-        readOnly: true
-    title: Pricing information
-    required:
-      - time
-  v1betaReportModelOnlineRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      model:
-        $ref: '#/definitions/v1betaModelData'
-        title: Model information
-      cumUsageRecord:
-        $ref: '#/definitions/v1betaModelUsageRecord'
-        title: Model online record
-    title: |-
-      ReportModelOnlineRequest represents a request for reporting a model-online
-      record
-    required:
-      - user
-      - model
-      - cumUsageRecord
-  v1betaReportModelOnlineResponse:
-    type: object
-    properties:
-      "null":
-        $ref: '#/definitions/v1betaNullMessage'
-        title: Null message for empty response
-    title: |-
-      ReportModelOnlineResponse represents a respond to a model-online-record
-      report request
-  v1betaReportModelOnlinesResponse:
-    type: object
-    properties:
-      "null":
-        $ref: '#/definitions/v1betaNullMessage'
-        title: Null message for empty response
-    title: |-
-      ReportModelOnlinesResponse represents a respond to a model-online-records
-      reporting bulk request
-  v1betaReportPipelineTriggerRequest:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/v1betaUserData'
-        title: User information
-      pipeline:
-        $ref: '#/definitions/v1betaPipelineData'
-        title: Pipeline information
-      usageRecord:
-        $ref: '#/definitions/v1betaPipelineUsageRecord'
-        title: Pipeline trigger record
-    title: |-
-      ReportPipelineTriggerRequest represents a request for reporting a
-      pipeline-trigger record
-    required:
-      - user
-      - pipeline
-      - usageRecord
-  v1betaReportPipelineTriggerResponse:
-    type: object
-    properties:
-      "null":
-        $ref: '#/definitions/v1betaNullMessage'
-        title: Null message for empty response
-    title: |-
-      ReportPipelineTriggerResponse represents a respond to a
-      pipeline-trigger-record report request
-  v1betaReportPipelineTriggersResponse:
-    type: object
-    properties:
-      "null":
-        $ref: '#/definitions/v1betaNullMessage'
-        title: Null message for empty response
-    title: |-
-      ReportPipelineTriggersResponse represents a respond to a
-      pipeline-trigger-records reporting bulk request
-  v1betaSendSessionReportResponse:
-    type: object
-    title: SendReportResponse represents an empty response
-  v1betaSession:
-    type: object
-    properties:
-      name:
-        type: string
-        title: Resource name in the format of 'sessions/uid'
-        readOnly: true
-      uid:
-        type: string
-        title: Resource UUID
-        readOnly: true
-      service:
-        $ref: '#/definitions/SessionService'
-        title: name of the service to collect data from
-      edition:
-        type: string
-        title: 'Session edition, allowed values include: ''local-ce'' and ''local-ce:dev'''
-      version:
-        type: string
-        title: Version of the service
-      arch:
-        type: string
-        title: Architecture of the system
-      os:
-        type: string
-        title: Operating system
-      uptime:
-        type: string
-        format: int64
-        title: Session service uptime
-      reportTime:
-        type: string
-        format: date-time
-        title: Report time
-      token:
-        type: string
-        description: |-
-          Token to send report. The token is generated by the server and sent to
-          the client. Client needs to use the token to send report to the server.
-        readOnly: true
-      createTime:
-        type: string
-        format: date-time
-        title: Session creation time
-        readOnly: true
-      updateTime:
-        type: string
-        format: date-time
-        title: Session update time
-        readOnly: true
-      ownerUid:
-        type: string
-        title: Owner UUID of the instance, can also be considered as instance UUID
-    title: |-
-      Session represents a unique session whenever a new instance of VDP service
-      gets started. The usage server returns a token that should be used as part of
-      the challenge when sending a report with data collected from this session
-    required:
-      - service
-      - edition
-      - version
-      - arch
-      - os
-      - uptime
-      - reportTime
-      - ownerUid
-  v1betaSessionReport:
-    type: object
-    properties:
-      sessionUid:
-        type: string
-        title: Session uid
-      token:
-        type: string
-        title: Session token
-      pow:
-        type: string
-        title: Proof-of-work See https://en.wikipedia.org/wiki/Proof_of_work
-      session:
-        $ref: '#/definitions/v1betaSession'
-        title: Session
-      mgmtUsageData:
-        $ref: '#/definitions/v1betaMgmtUsageData'
-        title: Management service usage data
-      connectorUsageData:
-        $ref: '#/definitions/v1betaConnectorUsageData'
-        title: Connector service usage data
-      modelUsageData:
-        $ref: '#/definitions/v1betaModelUsageData'
-        title: Model service usage data
-      pipelineUsageData:
-        $ref: '#/definitions/v1betaPipelineUsageData'
-        title: Pipeline service usage data
-      artifactUsageData:
-        $ref: '#/definitions/v1betaArtifactUsageData'
-        title: Artifact service usage data
-    title: |-
-      SessionReport represents a report to be sent to the server that includes the
-      usage data of a session
-    required:
-      - sessionUid
-      - token
-      - pow
-      - session
   v1betaStripeSubscriptionDetail:
     type: object
     properties:
       productName:
         type: string
         description: Product name associated with the subscription in Stripe.
+        readOnly: true
       id:
         type: string
         description: Unique identifier for the subscription.
+        readOnly: true
       itemId:
         type: string
         description: Identifier for the specific item within the subscription.
+        readOnly: true
       price:
         type: number
         format: float
         description: Price of the subscription.
+        readOnly: true
       canceledAt:
         type: integer
         format: int32
         description: Optional timestamp indicating when the subscription was canceled, if applicable.
+        readOnly: true
       trialEnd:
         type: integer
         format: int32
         description: Optional timestamp indicating when the trial ended, if applicable.
+        readOnly: true
       status:
-        $ref: '#/definitions/v1betaStripeSubscriptionDetailStatus'
         description: Status of the subscription.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaStripeSubscriptionDetailStatus'
       description:
         type: string
         description: Description of the subscription.
+        readOnly: true
     description: StripeSubscriptionDetail describes the details of a subscription in Stripe.
   v1betaStripeSubscriptionDetailStatus:
     type: string
@@ -3014,57 +1949,33 @@ definitions:
     description: |-
       SubtractCreditResponse contains the remaining credit of an account after the
       subtraction.
-  v1betaTimeInterval:
-    type: object
-    properties:
-      startTime:
-        type: string
-        format: date-time
-        title: Start time of the interval
-      endTime:
-        type: string
-        format: date-time
-        title: End time of the interval
-    title: Time interval
-    required:
-      - startTime
-      - endTime
   v1betaUpdateOrganizationMembershipResponse:
     type: object
     properties:
       membership:
-        $ref: '#/definitions/v1betaOrganizationMembership'
         description: The updated membership resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganizationMembership'
     description: UpdateOrganizationMembershipResponse contains the updated membership.
   v1betaUpdateOrganizationResponse:
     type: object
     properties:
       organization:
-        $ref: '#/definitions/v1betaOrganization'
         description: The organization resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     description: UpdateOrganizationResponse contains the updated organization.
   v1betaUpdateUserMembershipResponse:
     type: object
     properties:
       membership:
-        $ref: '#/definitions/v1betaUserMembership'
         description: The updated membership resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUserMembership'
     description: UpdateUserMembershipResponse contains the updated membership.
-  v1betaUsageSummary:
-    type: object
-    properties:
-      time:
-        type: string
-        format: date-time
-        title: Time when the summary is generated
-      value:
-        type: integer
-        format: int32
-        title: The total usage since the beginning of the current billing period
-    title: Usage summary definition
-    required:
-      - time
-      - value
   v1betaUser:
     type: object
     properties:
@@ -3079,6 +1990,7 @@ definitions:
         description: |-
           User UUID. This field is optionally set by users on creation (it will be
           server-generated if unspecified).
+        readOnly: true
       id:
         type: string
         description: |-
@@ -3099,25 +2011,12 @@ definitions:
         description: Update time.
         readOnly: true
       profile:
-        $ref: '#/definitions/v1betaUserProfile'
         description: Profile.
+        allOf:
+          - $ref: '#/definitions/v1betaUserProfile'
     description: |-
       User describes an individual that interacts with Instill AI. It doesn't
       contain any private information about the user.
-    required:
-      - id
-  v1betaUserData:
-    type: object
-    properties:
-      uid:
-        type: string
-        title: User unique id
-      name:
-        type: string
-        title: User name, which is not necessary for service queries
-    title: User records definition
-    required:
-      - uid
   v1betaUserMembership:
     type: object
     properties:
@@ -3133,16 +2032,19 @@ definitions:
         description: Role of the user in the organization.
         readOnly: true
       state:
-        $ref: '#/definitions/v1betaMembershipState'
         description: State of the membership.
+        allOf:
+          - $ref: '#/definitions/v1betaMembershipState'
       user:
-        $ref: '#/definitions/v1betaUser'
         description: User information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
       organization:
-        $ref: '#/definitions/v1betaOrganization'
         description: Organization information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     description: |-
       A user membership defines the relationship between a user and an
       organization they belong to.
@@ -3178,11 +2080,15 @@ definitions:
     type: object
     properties:
       plan:
-        $ref: '#/definitions/v1betaUserSubscriptionPlan'
         description: Plan identifier.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUserSubscriptionPlan'
       detail:
-        $ref: '#/definitions/v1betaStripeSubscriptionDetail'
         description: Details of the associated Stripe subscription.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaStripeSubscriptionDetail'
     description: UserSubscription details describe the plan (i.e., features) a user has access to.
   v1betaUserSubscriptionPlan:
     type: string

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -11,11 +11,16 @@ info:
     name: Elastic License 2.0 (ELv2)
     url: https://github.com/instill-ai/protobufs/blob/main/LICENSE
 tags:
-  - name: Model
   - name: Model Definition
+    description: Model definition endpoints
+  - name: Model
+    description: Model endpoints
   - name: Version
+    description: Model version endpoints
   - name: Trigger
+    description: Model trigger endpoints
   - name: Region
+    description: Model region endpoints
 host: api.instill.tech
 schemes:
   - https
@@ -90,7 +95,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       tags:
         - Region
-  /v1alpha/{model_definition_name}:
+  /v1alpha/model-definitions/{modelDefinitionId}:
     get:
       summary: Get a model definition
       description: Returns the details of a model definition.
@@ -108,14 +113,13 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: model_definition_name
+        - name: modelDefinitionId
           description: |-
             The resource name of the model definition, which allows its access by ID.
             - Format: `model-definitions/{id}`.
           in: path
           required: true
           type: string
-          pattern: model-definitions/[^/]+
         - name: view
           description: |-
             View allows clients to specify the desired resource view in the response.
@@ -130,7 +134,7 @@ paths:
             - VIEW_FULL
       tags:
         - Model Definition
-  /v1alpha/models:
+  /v1beta/models:
     get:
       summary: List models
       description: Returns a paginated list of models.
@@ -208,16 +212,16 @@ paths:
           type: string
       tags:
         - Model
-  /v1alpha/{permalink}/lookUp:
+  /v1beta/namespaces/{namespaceId}/models:
     get:
-      summary: Get a model by UID
-      description: Returns the details of a model by a permalink defined by the resource UID.
-      operationId: ModelPublicService_LookUpModel
+      summary: List namespace models
+      description: Returns a paginated list of models.
+      operationId: ModelPublicService_ListNamespaceModels
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaLookUpModelResponse'
+            $ref: '#/definitions/v1alphaListNamespaceModelsResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -226,14 +230,769 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: permalink
-          description: |-
-            The permalink of the model, which allows its access by UID.
-            - Format: `models/{model.uid}`.
+        - name: namespaceId
+          description: Namespace ID
           in: path
           required: true
           type: string
-          pattern: models/[^/]+
+        - name: pageSize
+          description: |-
+            The maximum number of models to return. If this parameter is unspecified,
+            at most 10 models will be returned. The cap value for this parameter is
+            100 (i.e. any value above that will be coerced to 100).
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageToken
+          description: Page token.
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View allows clients to specify the desired model view in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+        - name: showDeleted
+          description: Include soft-deleted models in the result.
+          in: query
+          required: false
+          type: boolean
+        - name: filter
+          description: |-
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression.
+            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+          in: query
+          required: false
+          type: string
+        - name: visibility
+          description: |-
+            Limit results to pipelines with the specified visibility.
+
+             - VISIBILITY_PRIVATE: Only the owner can see the model.
+             - VISIBILITY_PUBLIC: Other users can see the model.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VISIBILITY_PRIVATE
+            - VISIBILITY_PUBLIC
+        - name: orderBy
+          description: |-
+            Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+            Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+          in: query
+          required: false
+          type: string
+      tags:
+        - Model
+  /v1alpha/namespaces/{namespaceId}/models:
+    post:
+      summary: Create a new model
+      description: |-
+        Creates a new model under the parenthood of a namespace. This is an
+        asynchronous endpoint, i.e., the server will not wait for the model to be
+        created in order to respond. Instead, it will return a response with the
+        necessary information to access the result and status of the creation
+        operation.
+      operationId: ModelPublicService_CreateNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaCreateNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: model
+          description: The properties of the model to be created.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaModel'
+      tags:
+        - Model
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}:
+    get:
+      summary: Get a model
+      description: Returns the detail of a model, accessing it by the model ID and its parent namespace.
+      operationId: ModelPublicService_GetNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: view
+          description: |-
+            View allows clients to specify the desired model view in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+      tags:
+        - Model
+    delete:
+      summary: Delete a model
+      description: |-
+        Deletes a model, accesing it by its resource name, which is defined by the
+        parent namespace and the ID of the model.
+      operationId: ModelPublicService_DeleteNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+      tags:
+        - Model
+    patch:
+      summary: Update a model
+      description: |-
+        Updates a model, accessing it by its resource name, which is defined by
+        the parent namespace and the ID of the model.
+
+        In REST requests, only the supplied model fields will be taken into
+        account when updating the resource.
+      operationId: ModelPublicService_UpdateNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUpdateNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: model
+          description: The model to update
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1alphaModel'
+            required:
+              - model
+      tags:
+        - Model
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/rename:
+    post:
+      summary: Rename a model
+      description: |-
+        Renames a model, accesing it by its resource name, which is defined by the
+        parent namespace and the ID of the model.
+      operationId: ModelPublicService_RenameNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaRenameNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ModelPublicServiceRenameNamespaceModelBody'
+      tags:
+        - Model
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/publish:
+    post:
+      summary: Publish a model
+      description: |-
+        Updates the visibility in a model to PUBLIC. The model is accessed by its
+        resource name, defined by the model ID and its parent namespace.
+      operationId: ModelPublicService_PublishNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaPublishNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ModelPublicServicePublishNamespaceModelBody'
+      tags:
+        - Model
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/unpublish:
+    post:
+      summary: Unpublish a model
+      description: |-
+        Updates the visibility in a model to PRIVATE. The model is accessed by its
+        resource name, defined by the model ID and its parent namespace.
+      operationId: ModelPublicService_UnpublishNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaUnpublishNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ModelPublicServiceUnpublishNamespaceModelBody'
+      tags:
+        - Model
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/readme:
+    get:
+      summary: Get a model card
+      description: |-
+        Returns the README file that accompanies a model, describing it and
+        enhancing it with metadata. The model is accessed by its resource name.
+      operationId: ModelPublicService_GetNamespaceModelCard
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetNamespaceModelCardResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+      tags:
+        - Model
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}/watch:
+    get:
+      summary: Watch the state of a model version
+      description: |-
+        Returns the state of a model. The model resource allocation and scaling actions take some
+        time, during which a model will be in various state. This endpoint
+        allows clients to track the state.
+      operationId: ModelPublicService_WatchNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: version
+          description: Model version tag
+          in: path
+          required: true
+          type: string
+      tags:
+        - Version
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/watch:
+    get:
+      summary: Watch the state of the latest model version
+      description: |-
+        Returns the state of the latest model version. The model resource allocation and scaling actions
+        take some time, during which a model will be in various state. This endpoint
+        allows clients to track the state.
+      operationId: ModelPublicService_WatchNamespaceLatestModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaWatchNamespaceLatestModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+      tags:
+        - Model
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions:
+    get:
+      summary: List namespace model versions
+      description: |-
+        Returns a paginated list of version of a model namespace that belong to the specified namespace.
+        Contains model version and digest.
+      operationId: ModelPublicService_ListNamespaceModelVersions
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListNamespaceModelVersionsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: pageSize
+          description: |-
+            The maximum number of tags to return. The default and cap values are 10
+            and 100, respectively.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: page
+          description: Page number.
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - Version
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}:
+    delete:
+      summary: Delete a model version
+      description: |-
+        Deletes a model version, accesing it by its resource name, which is defined by the
+        parent namespace and the ID of the model, and version.
+      operationId: ModelPublicService_DeleteNamespaceModelVersion
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaDeleteNamespaceModelVersionResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: version
+          description: Model version tag
+          in: path
+          required: true
+          type: string
+      tags:
+        - Version
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}/trigger:
+    post:
+      summary: Trigger model inference
+      description: |-
+        Triggers a deployed model to infer the result of a set of task or
+        questions.
+      operationId: ModelPublicService_TriggerNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: version
+          description: Model version tag
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ModelPublicServiceTriggerNamespaceModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}/trigger-async:
+    post:
+      summary: Trigger model inference asynchronously
+      description: |-
+        Triggers a deployed model to infer the result of a set of task or
+        questions.
+      operationId: ModelPublicService_TriggerAsyncNamespaceModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerAsyncNamespaceModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: version
+          description: Model version tag
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ModelPublicServiceTriggerAsyncNamespaceModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/trigger:
+    post:
+      summary: Trigger model inference
+      description: |-
+        Triggers the latest deployed model version to infer the result of a set of task or
+        questions.
+      operationId: ModelPublicService_TriggerNamespaceLatestModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerNamespaceLatestModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ModelPublicServiceTriggerNamespaceLatestModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/trigger-async:
+    post:
+      summary: Trigger model inference asynchronously
+      description: |-
+        Triggers the latest deployed model version to infer the result of a set of task or
+        questions.
+      operationId: ModelPublicService_TriggerAsyncNamespaceLatestModel
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaTriggerAsyncNamespaceLatestModelResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ModelPublicServiceTriggerAsyncNamespaceLatestModelBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/operation:
+    get:
+      summary: Get the details of the latest long-running operation from a namespace model
+      description: |-
+        This method allows requesters to request the status and outcome of
+        long-running operations in a model, such as deployment.
+      operationId: ModelPublicService_GetNamespaceLatestModelOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetNamespaceLatestModelOperationResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: modelId
+          description: Model ID
+          in: path
+          required: true
+          type: string
+        - name: view
+          description: |-
+            View allows clients to specify the desired operation result in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+      tags:
+        - Model
+  /v1alpha/{name}:
+    get:
+      summary: Get the details of a long-running operation
+      description: |-
+        This method allows requesters to request the status and outcome of
+        long-running operations in a model, such as deployment.
+      operationId: ModelPublicService_GetModelOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetModelOperationResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            The resource name of the model, which allows its access ID.
+            - Format: `operations/{operation.id}`.
+          in: path
+          required: true
+          type: string
+          pattern: operations/[^/]+
         - name: view
           description: |-
             View allows clients to specify the desired model view in the response.
@@ -336,7 +1095,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Model (Deprecated)
     post:
       summary: Create a new model
       description: |-
@@ -374,7 +1133,7 @@ paths:
           schema:
             $ref: '#/definitions/v1alphaModel'
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{user_model_name}:
     get:
       summary: Get a model
@@ -415,7 +1174,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Model
+        - Model (Deprecated)
     delete:
       summary: Delete a model
       description: |-
@@ -445,7 +1204,7 @@ paths:
           type: string
           pattern: users/[^/]+/models/[^/]+
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{model_name}:
     patch:
       summary: Update a model
@@ -508,11 +1267,13 @@ paths:
                   specification in the model definition (i.e. the `model_spec` field in the
                   model definition).
               task:
-                $ref: '#/definitions/v1alphaTask'
                 description: Model task.
+                allOf:
+                  - $ref: '#/definitions/v1alphaTask'
               visibility:
-                $ref: '#/definitions/v1alphaModelVisibility'
                 description: Model visibility.
+                allOf:
+                  - $ref: '#/definitions/v1alphaModelVisibility'
               createTime:
                 type: string
                 format: date-time
@@ -533,9 +1294,10 @@ paths:
                 description: Resource name of the owner.
                 readOnly: true
               owner:
-                $ref: '#/definitions/v1betaOwner'
                 description: Model owner.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaOwner'
               region:
                 type: string
                 description: Region of choice for the particular provider to host the model.
@@ -555,20 +1317,23 @@ paths:
                 type: string
                 description: License under which the model is distributed.
               sampleInput:
-                $ref: '#/definitions/v1alphaTaskInput'
                 title: Sample input for this model
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1alphaTaskInput'
               sampleOutput:
-                $ref: '#/definitions/v1alphaTaskOutput'
                 title: Sample output for this model
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1alphaTaskOutput'
               profileImage:
                 type: string
                 description: Model profile image in base64 format.
               permission:
-                $ref: '#/definitions/modelv1alphaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/modelv1alphaPermission'
               inputSchema:
                 type: object
                 title: Input schema for the model
@@ -593,7 +1358,7 @@ paths:
               - region
               - hardware
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{user_model_name}/rename:
     post:
       summary: Rename a model
@@ -629,7 +1394,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceRenameUserModelBody'
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{user_model_name}/publish:
     post:
       summary: Publish a model
@@ -665,7 +1430,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServicePublishUserModelBody'
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{user_model_name}/unpublish:
     post:
       summary: Unpublish a model
@@ -701,7 +1466,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceUnpublishUserModelBody'
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{user_model_card_name}:
     get:
       summary: Get a model card
@@ -732,7 +1497,7 @@ paths:
           type: string
           pattern: users/[^/]+/models/[^/]+/readme
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{user_model_name}/versions/{version}/watch:
     get:
       summary: Watch the state of a model version
@@ -770,7 +1535,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - Version
+        - Version (Deprecated)
   /v1alpha/{user_model_name}/watch:
     get:
       summary: Watch the state of the latest model version
@@ -802,7 +1567,7 @@ paths:
           type: string
           pattern: users/[^/]+/models/[^/]+
       tags:
-        - Version
+        - Version (Deprecated)
   /v1alpha/{user_model_name}/versions:
     get:
       summary: List user model versions
@@ -849,7 +1614,7 @@ paths:
           type: integer
           format: int32
       tags:
-        - Version
+        - Version (Deprecated)
   /v1alpha/{user_model_name}/versions/{version}:
     delete:
       summary: Delete a model version
@@ -886,7 +1651,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - Version
+        - Version (Deprecated)
   /v1alpha/{user_model_name}/versions/{version}/trigger:
     post:
       summary: Trigger model inference
@@ -933,7 +1698,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1alpha/{user_model_name}/versions/{version}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -980,7 +1745,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1alpha/{user_model_name}/trigger:
     post:
       summary: Trigger model inference
@@ -1021,7 +1786,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1alpha/{user_model_name}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -1062,7 +1827,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1alpha/{organization_name}/models:
     get:
       summary: List organization models
@@ -1151,7 +1916,7 @@ paths:
           required: false
           type: string
       tags:
-        - Model
+        - Model (Deprecated)
     post:
       summary: Create a new model
       description: |-
@@ -1189,7 +1954,7 @@ paths:
           schema:
             $ref: '#/definitions/v1alphaModel'
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{organization_model_name}:
     get:
       summary: Get a model
@@ -1230,7 +1995,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Model
+        - Model (Deprecated)
     delete:
       summary: Delete a model
       description: |-
@@ -1260,7 +2025,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/models/[^/]+
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{model_name_1}:
     patch:
       summary: Update a model
@@ -1323,11 +2088,13 @@ paths:
                   specification in the model definition (i.e. the `model_spec` field in the
                   model definition).
               task:
-                $ref: '#/definitions/v1alphaTask'
                 description: Model task.
+                allOf:
+                  - $ref: '#/definitions/v1alphaTask'
               visibility:
-                $ref: '#/definitions/v1alphaModelVisibility'
                 description: Model visibility.
+                allOf:
+                  - $ref: '#/definitions/v1alphaModelVisibility'
               createTime:
                 type: string
                 format: date-time
@@ -1348,9 +2115,10 @@ paths:
                 description: Resource name of the owner.
                 readOnly: true
               owner:
-                $ref: '#/definitions/v1betaOwner'
                 description: Model owner.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaOwner'
               region:
                 type: string
                 description: Region of choice for the particular provider to host the model.
@@ -1370,20 +2138,23 @@ paths:
                 type: string
                 description: License under which the model is distributed.
               sampleInput:
-                $ref: '#/definitions/v1alphaTaskInput'
                 title: Sample input for this model
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1alphaTaskInput'
               sampleOutput:
-                $ref: '#/definitions/v1alphaTaskOutput'
                 title: Sample output for this model
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1alphaTaskOutput'
               profileImage:
                 type: string
                 description: Model profile image in base64 format.
               permission:
-                $ref: '#/definitions/modelv1alphaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/modelv1alphaPermission'
               inputSchema:
                 type: object
                 title: Input schema for the model
@@ -1408,7 +2179,7 @@ paths:
               - region
               - hardware
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{organization_model_name}/rename:
     post:
       summary: Rename a model
@@ -1444,7 +2215,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceRenameOrganizationModelBody'
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{organization_model_name}/publish:
     post:
       summary: Publish a model
@@ -1480,7 +2251,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServicePublishOrganizationModelBody'
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{organization_model_name}/unpublish:
     post:
       summary: Unpublish a model
@@ -1516,7 +2287,7 @@ paths:
           schema:
             $ref: '#/definitions/ModelPublicServiceUnpublishOrganizationModelBody'
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{organization_model_card_name}:
     get:
       summary: Get a model card
@@ -1547,7 +2318,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/models/[^/]+/readme
       tags:
-        - Model
+        - Model (Deprecated)
   /v1alpha/{organization_model_name}/versions/{version}/watch:
     get:
       summary: Watch the state of a model version
@@ -1585,7 +2356,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - Version
+        - Version (Deprecated)
   /v1alpha/{organization_model_name}/watch:
     get:
       summary: Watch the state of the latest model version
@@ -1617,7 +2388,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/models/[^/]+
       tags:
-        - Version
+        - Version (Deprecated)
   /v1alpha/{organization_model_name}/versions:
     get:
       summary: List organization model versions
@@ -1664,7 +2435,7 @@ paths:
           type: integer
           format: int32
       tags:
-        - Version
+        - Version (Deprecated)
   /v1alpha/{organization_model_name}/versions/{version}:
     delete:
       summary: Delete a model version
@@ -1703,7 +2474,7 @@ paths:
           type: string
           pattern: '[^/]+'
       tags:
-        - Version
+        - Version (Deprecated)
   /v1alpha/{organization_model_name}/versions/{version}/trigger:
     post:
       summary: Trigger model inference
@@ -1750,7 +2521,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1alpha/{organization_model_name}/versions/{version}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -1797,7 +2568,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1alpha/{organization_model_name}/trigger:
     post:
       summary: Trigger model inference
@@ -1838,7 +2609,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1alpha/{organization_model_name}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -1879,49 +2650,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
-  /v1alpha/{name}:
-    get:
-      summary: Get the details of a long-running operation
-      description: |-
-        This method allows requesters to request the status and outcome of
-        long-running operations in a model, such as deployment.
-      operationId: ModelPublicService_GetModelOperation
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetModelOperationResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: name
-          description: |-
-            The resource name of the model, which allows its access ID.
-            - Format: `operations/{operation.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: operations/[^/]+
-        - name: view
-          description: |-
-            View allows clients to specify the desired model view in the response.
-
-             - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
-             - VIEW_FULL: Full representation.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-      tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1alpha/{user_model_name}/operation:
     get:
       summary: Get the details of the latest long-running operation from a user model
@@ -1964,7 +2693,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1alpha/{organization_model_name}/operation:
     get:
       summary: Get the details of the latest long-running operation from a organization model
@@ -2007,14 +2736,28 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Trigger
+        - Trigger (Deprecated)
 definitions:
+  ModelPublicServicePublishNamespaceModelBody:
+    type: object
+    description: PublishNamespacehModelRequest represents a request to publish a model.
   ModelPublicServicePublishOrganizationModelBody:
     type: object
     description: PublisOrganizationhModelRequest represents a request to publish a model.
   ModelPublicServicePublishUserModelBody:
     type: object
     description: PublisUserhModelRequest represents a request to publish a model.
+  ModelPublicServiceRenameNamespaceModelBody:
+    type: object
+    properties:
+      newModelId:
+        type: string
+        description: |-
+          The new resource ID. This will transform the resource name into
+          `namespaces/{namespace.id}/models/{new_model_id}`.
+    title: RenameNamespaceModelRequest represents a request to rename a model
+    required:
+      - newModelId
   ModelPublicServiceRenameOrganizationModelBody:
     type: object
     properties:
@@ -2037,6 +2780,34 @@ definitions:
     title: RenameUserModelRequest represents a request to rename a model
     required:
       - newModelId
+  ModelPublicServiceTriggerAsyncNamespaceLatestModelBody:
+    type: object
+    properties:
+      taskInputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskInput'
+        description: Inference input parameters.
+    description: |-
+      TriggerAsyncNamespaceLatestModelRequest represents a request to trigger a model inference
+      asynchronously with the latest uploaded version.
+    required:
+      - taskInputs
+  ModelPublicServiceTriggerAsyncNamespaceModelBody:
+    type: object
+    properties:
+      taskInputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskInput'
+        description: Inference input parameters.
+    description: |-
+      TriggerAsyncNamespaceModelRequest represents a request to trigger a model inference
+      asynchronously.
+    required:
+      - taskInputs
   ModelPublicServiceTriggerAsyncOrganizationLatestModelBody:
     type: object
     properties:
@@ -2093,6 +2864,32 @@ definitions:
       asynchronously.
     required:
       - taskInputs
+  ModelPublicServiceTriggerNamespaceLatestModelBody:
+    type: object
+    properties:
+      taskInputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskInput'
+        description: Inference input parameters.
+    description: |-
+      TriggerNamespaceLatestModelRequest represents a request to trigger a model inference
+      with the latest uploaded version.
+    required:
+      - taskInputs
+  ModelPublicServiceTriggerNamespaceModelBody:
+    type: object
+    properties:
+      taskInputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskInput'
+        description: Inference input parameters.
+    description: TriggerNamespaceModelRequest represents a request to trigger a model inference.
+    required:
+      - taskInputs
   ModelPublicServiceTriggerOrganizationLatestModelBody:
     type: object
     properties:
@@ -2143,6 +2940,9 @@ definitions:
     description: TriggerUserModelRequest represents a request to trigger a model inference.
     required:
       - taskInputs
+  ModelPublicServiceUnpublishNamespaceModelBody:
+    type: object
+    description: UnpublishNamespaceModelRequest represents a request to unpublish a model.
   ModelPublicServiceUnpublishOrganizationModelBody:
     type: object
     description: UnpublishOrganizationModelRequest represents a request to unpublish a model.
@@ -2159,12 +2959,13 @@ definitions:
           originally returns it. If you use the default HTTP mapping, the
           `name` should be a resource name ending with `operations/{unique_id}`.
       metadata:
-        $ref: '#/definitions/protobufAny'
         description: |-
           Service-specific metadata associated with the operation.  It typically
           contains progress information and common metadata such as create time.
           Some services might not provide such metadata.  Any method that returns a
           long-running operation should document the metadata type, if any.
+        allOf:
+          - $ref: '#/definitions/protobufAny'
       done:
         type: boolean
         description: |-
@@ -2172,10 +2973,10 @@ definitions:
           If `true`, the operation is completed, and either `error` or `response` is
           available.
       error:
-        $ref: '#/definitions/googlerpcStatus'
         description: The error result of the operation in case of failure or cancellation.
+        allOf:
+          - $ref: '#/definitions/googlerpcStatus'
       response:
-        $ref: '#/definitions/protobufAny'
         description: |-
           The normal response of the operation in case of success.  If the original
           method returns no data on success, such as `Delete`, the response is
@@ -2185,6 +2986,8 @@ definitions:
           is the original method name.  For example, if the original method name
           is `TakeSnapshot()`, the inferred response type is
           `TakeSnapshotResponse`.
+        allOf:
+          - $ref: '#/definitions/protobufAny'
     description: |-
       This resource represents a long-running operation that is the result of a
       network API call.
@@ -2226,6 +3029,7 @@ definitions:
       canEdit:
         type: boolean
         description: Defines whether the resource can be modified.
+        readOnly: true
     description: Permission defines how a resource can be used.
   modelv1alphaPermission:
     type: object
@@ -2464,20 +3268,36 @@ definitions:
         description: Score.
         readOnly: true
     description: ClassificationOutput contains the result of an image classification task.
+  v1alphaCreateNamespaceModelResponse:
+    type: object
+    properties:
+      model:
+        description: The created model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
+    description: CreateNamespaceModelResponse contains the created model.
   v1alphaCreateOrganizationModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The created model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: CreateOrganizationModelResponse contains the created model.
   v1alphaCreateUserModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The created model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: CreateUserModelResponse contains the created model.
+  v1alphaDeleteNamespaceModelResponse:
+    type: object
+    description: DeleteNamespaceModelResponse is an empty response.
+  v1alphaDeleteNamespaceModelVersionResponse:
+    type: object
+    description: DeleteNamespaceModelVersionResponse is an empty response.
   v1alphaDeleteOrganizationModelResponse:
     type: object
     description: DeleteOrganizationModelResponse is an empty response.
@@ -2490,6 +3310,9 @@ definitions:
   v1alphaDeleteUserModelVersionResponse:
     type: object
     description: DeleteUserModelVersionResponse is an empty response.
+  v1alphaDeployNamespaceModelAdminResponse:
+    type: object
+    title: DeployNamespaceModelAdminResponse represents a response for a deployed model
   v1alphaDeployOrganizationModelAdminResponse:
     type: object
     title: DeployOrganizationModelAdminResponse represents a response for a deployed model
@@ -2538,9 +3361,10 @@ definitions:
         description: Score.
         readOnly: true
       boundingBox:
-        $ref: '#/definitions/v1alphaBoundingBox'
         description: Bounding box.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaBoundingBox'
     description: DetectionObject represents an identified object in an image.
   v1alphaDetectionOutput:
     type: object
@@ -2557,24 +3381,54 @@ definitions:
     type: object
     properties:
       modelDefinition:
-        $ref: '#/definitions/v1alphaModelDefinition'
         description: The model definition resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaModelDefinition'
     description: GetModelDefinitionResponse contains the requested model definition.
   v1alphaGetModelOperationResponse:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: The long-running operation.
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       GetModelOperationRequest represents a request to query a long-running
       operation.
+  v1alphaGetNamespaceLatestModelOperationResponse:
+    type: object
+    properties:
+      operation:
+        description: The long-running operation.
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
+    description: |-
+      GetNamespaceLatestModelOperationRequest represents a request to query a long-running
+      operation.
+  v1alphaGetNamespaceModelCardResponse:
+    type: object
+    properties:
+      readme:
+        description: A model card resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModelCard'
+    description: GetNamespaceModelCardResponse contains the model's README card.
+  v1alphaGetNamespaceModelResponse:
+    type: object
+    properties:
+      model:
+        description: The model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
+    description: GetNamespaceModelResponse contains the requested model.
   v1alphaGetOrganizationLatestModelOperationResponse:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: The long-running operation.
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       GetOrganizationLatestModelOperationRequest represents a request to query a long-running
       operation.
@@ -2582,22 +3436,25 @@ definitions:
     type: object
     properties:
       readme:
-        $ref: '#/definitions/v1alphaModelCard'
         description: A model card resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModelCard'
     description: GetOrganizationModelCardResponse contains the model's README card.
   v1alphaGetOrganizationModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: GetOrganizationModelResponse contains the requested model.
   v1alphaGetUserLatestModelOperationResponse:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: The long-running operation.
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       GetUserLatestModelOperationRequest represents a request to query a long-running
       operation.
@@ -2605,26 +3462,29 @@ definitions:
     type: object
     properties:
       readme:
-        $ref: '#/definitions/v1alphaModelCard'
         description: A model card resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModelCard'
     description: GetUserModelCardResponse contains the model's README card.
   v1alphaGetUserModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: GetUserModelResponse contains the requested model.
   v1alphaImageContent:
     type: object
     properties:
       imageUrl:
-        $ref: '#/definitions/v1alphaPromptImage'
         description: |-
           Image as URL or base64 code.
 
           NOTE: the `image_url` name comes from a convention from OpenAI, it doesn't
           determine the format of the image.
+        allOf:
+          - $ref: '#/definitions/v1alphaPromptImage'
       detail:
         type: string
         description: Additional information.
@@ -2721,9 +3581,10 @@ definitions:
         description: Score.
         readOnly: true
       boundingBox:
-        $ref: '#/definitions/v1alphaBoundingBox'
         description: Bounding box.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaBoundingBox'
     description: |-
       InstanceSegmentationObject is an object in an image, localized and
       delineated.
@@ -2804,9 +3665,10 @@ definitions:
         description: Score.
         readOnly: true
       boundingBox:
-        $ref: '#/definitions/v1alphaBoundingBox'
         description: Bounding box.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaBoundingBox'
     description: |-
       KeypointObject is a detected object with its keypoints, e.g. a detected
       human shape with its legs, arms, core, etc.
@@ -2884,6 +3746,49 @@ definitions:
         format: int32
         description: Total number of models.
     description: ListModelsResponse contains a list of models.
+  v1alphaListNamespaceModelVersionsResponse:
+    type: object
+    properties:
+      versions:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaModelVersion'
+        description: A list of model resources.
+        readOnly: true
+      totalSize:
+        type: integer
+        format: int32
+        description: Total number of tags.
+        readOnly: true
+      pageSize:
+        type: integer
+        format: int32
+        description: The requested page size.
+        readOnly: true
+      page:
+        type: integer
+        format: int32
+        description: The requested page offset.
+        readOnly: true
+    description: ListNamespaceModelVersionsResponse contains a list of models.
+  v1alphaListNamespaceModelsResponse:
+    type: object
+    properties:
+      models:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaModel'
+        description: A list of model resources.
+      nextPageToken:
+        type: string
+        description: Next page token.
+      totalSize:
+        type: integer
+        format: int32
+        description: Total number of models.
+    description: ListNamespaceModelsResponse contains a list of models.
   v1alphaListOrganizationModelVersionsResponse:
     type: object
     properties:
@@ -2966,16 +3871,10 @@ definitions:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         title: A model resource
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     title: LookUpModelResponse represents a response for a model
-  v1alphaLookUpModelResponse:
-    type: object
-    properties:
-      model:
-        $ref: '#/definitions/v1alphaModel'
-        description: The requested model.
-    description: LookUpModelResponse contains the requested model.
   v1alphaMessage:
     type: object
     properties:
@@ -2996,12 +3895,13 @@ definitions:
         type: string
         description: Content type.
       imageUrl:
-        $ref: '#/definitions/v1alphaImageContent'
         description: |-
           Image content.
 
           NOTE: the `image_url` name comes from a convention from OpenAI, it doesn't
           determine the format of the image.
+        allOf:
+          - $ref: '#/definitions/v1alphaImageContent'
       text:
         type: string
         description: Text content.
@@ -3041,11 +3941,13 @@ definitions:
           specification in the model definition (i.e. the `model_spec` field in the
           model definition).
       task:
-        $ref: '#/definitions/v1alphaTask'
         description: Model task.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
       visibility:
-        $ref: '#/definitions/v1alphaModelVisibility'
         description: Model visibility.
+        allOf:
+          - $ref: '#/definitions/v1alphaModelVisibility'
       createTime:
         type: string
         format: date-time
@@ -3066,9 +3968,10 @@ definitions:
         description: Resource name of the owner.
         readOnly: true
       owner:
-        $ref: '#/definitions/v1betaOwner'
         description: Model owner.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOwner'
       region:
         type: string
         description: Region of choice for the particular provider to host the model.
@@ -3088,20 +3991,23 @@ definitions:
         type: string
         description: License under which the model is distributed.
       sampleInput:
-        $ref: '#/definitions/v1alphaTaskInput'
         title: Sample input for this model
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaTaskInput'
       sampleOutput:
-        $ref: '#/definitions/v1alphaTaskOutput'
         title: Sample output for this model
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaTaskOutput'
       profileImage:
         type: string
         description: Model profile image in base64 format.
       permission:
-        $ref: '#/definitions/modelv1alphaPermission'
         description: Permission defines how a pipeline can be used.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/modelv1alphaPermission'
       inputSchema:
         type: object
         title: Input schema for the model
@@ -3196,9 +4102,10 @@ definitions:
         description: Display icon.
         readOnly: true
       releaseStage:
-        $ref: '#/definitions/v1alphaReleaseStage'
         description: Release stage.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaReleaseStage'
       modelSpec:
         type: object
         description: |-
@@ -3239,9 +4146,10 @@ definitions:
         type: string
         description: Unique identifier, computed from the manifest the tag refers to.
       state:
-        $ref: '#/definitions/modelv1alphaState'
         description: Current state of this model version.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/modelv1alphaState'
       updateTime:
         type: string
         format: date-time
@@ -3300,9 +4208,10 @@ definitions:
         description: Score.
         readOnly: true
       boundingBox:
-        $ref: '#/definitions/v1alphaBoundingBox'
         description: Bounding box.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaBoundingBox'
     description: |-
       OcrObject is a text object within an image. OCR stands for Optical Character
       Recognition.
@@ -3327,19 +4236,29 @@ definitions:
         type: string
         description: Base64-encoded image.
     description: PromptImage is an image input for model inference.
+  v1alphaPublishNamespaceModelResponse:
+    type: object
+    properties:
+      model:
+        description: The published model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
+    description: PublishNamespaceModelResponse contains a published model.
   v1alphaPublishOrganizationModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The published model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: PublishOrganizationModelResponse contains a published model.
   v1alphaPublishUserModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The published model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: PublishUserModelResponse contains a published model.
   v1alphaRegion:
     type: object
@@ -3369,19 +4288,29 @@ definitions:
        - RELEASE_STAGE_BETA: Beta.
        - RELEASE_STAGE_GENERALLY_AVAILABLE: Generally available.
        - RELEASE_STAGE_CUSTOM: Custom.
+  v1alphaRenameNamespaceModelResponse:
+    type: object
+    properties:
+      model:
+        description: The renamed model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
+    description: RenameNamespaceModelResponse contains a renamed model.
   v1alphaRenameOrganizationModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The renamed model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: RenameOrganizationModelResponse contains a renamed model.
   v1alphaRenameUserModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The renamed model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: RenameUserModelResponse contains a renamed model.
   v1alphaSemanticSegmentationInput:
     type: object
@@ -3477,133 +4406,169 @@ definitions:
     type: object
     properties:
       classification:
-        $ref: '#/definitions/v1alphaClassificationInput'
         description: Image classification input.
+        allOf:
+          - $ref: '#/definitions/v1alphaClassificationInput'
       detection:
-        $ref: '#/definitions/v1alphaDetectionInput'
         description: Object detection input.
+        allOf:
+          - $ref: '#/definitions/v1alphaDetectionInput'
       keypoint:
-        $ref: '#/definitions/v1alphaKeypointInput'
         description: Keypoint detection input.
+        allOf:
+          - $ref: '#/definitions/v1alphaKeypointInput'
       ocr:
-        $ref: '#/definitions/v1alphaOcrInput'
         description: Optical Character Recognition input.
+        allOf:
+          - $ref: '#/definitions/v1alphaOcrInput'
       instanceSegmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationInput'
         description: Instance segmentation input.
+        allOf:
+          - $ref: '#/definitions/v1alphaInstanceSegmentationInput'
       semanticSegmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationInput'
         description: Semantic segmentation input.
+        allOf:
+          - $ref: '#/definitions/v1alphaSemanticSegmentationInput'
       textToImage:
-        $ref: '#/definitions/v1alphaTextToImageInput'
         description: Text to image input.
+        allOf:
+          - $ref: '#/definitions/v1alphaTextToImageInput'
       imageToImage:
-        $ref: '#/definitions/v1alphaImageToImageInput'
         description: Image to image input.
+        allOf:
+          - $ref: '#/definitions/v1alphaImageToImageInput'
       textGeneration:
-        $ref: '#/definitions/v1alphaTextGenerationInput'
         description: Text generation input.
+        allOf:
+          - $ref: '#/definitions/v1alphaTextGenerationInput'
       textGenerationChat:
-        $ref: '#/definitions/v1alphaTextGenerationChatInput'
         description: Conversational text generation input.
+        allOf:
+          - $ref: '#/definitions/v1alphaTextGenerationChatInput'
       visualQuestionAnswering:
-        $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
         description: Visual question answering input.
+        allOf:
+          - $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
       unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedInput'
         description: Unspecified task input.
+        allOf:
+          - $ref: '#/definitions/v1alphaUnspecifiedInput'
     description: TaskInput represents a question or task for an AI model.
   v1alphaTaskInputStream:
     type: object
     properties:
       classification:
-        $ref: '#/definitions/v1alphaClassificationInputStream'
         title: The classification input
+        allOf:
+          - $ref: '#/definitions/v1alphaClassificationInputStream'
       detection:
-        $ref: '#/definitions/v1alphaDetectionInputStream'
         title: The detection input
+        allOf:
+          - $ref: '#/definitions/v1alphaDetectionInputStream'
       keypoint:
-        $ref: '#/definitions/v1alphaKeypointInputStream'
         title: The keypoint input
+        allOf:
+          - $ref: '#/definitions/v1alphaKeypointInputStream'
       ocr:
-        $ref: '#/definitions/v1alphaOcrInputStream'
         title: The ocr input
+        allOf:
+          - $ref: '#/definitions/v1alphaOcrInputStream'
       instanceSegmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationInputStream'
         title: The instance segmentation input
+        allOf:
+          - $ref: '#/definitions/v1alphaInstanceSegmentationInputStream'
       semanticSegmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationInputStream'
         title: The semantic segmentation input
+        allOf:
+          - $ref: '#/definitions/v1alphaSemanticSegmentationInputStream'
       textToImage:
-        $ref: '#/definitions/v1alphaTextToImageInput'
         title: The text to image input
+        allOf:
+          - $ref: '#/definitions/v1alphaTextToImageInput'
       imageToImage:
-        $ref: '#/definitions/v1alphaImageToImageInput'
         title: The image to image input
+        allOf:
+          - $ref: '#/definitions/v1alphaImageToImageInput'
       textGeneration:
-        $ref: '#/definitions/v1alphaTextGenerationInput'
         title: The text generation input
+        allOf:
+          - $ref: '#/definitions/v1alphaTextGenerationInput'
       textGenerationChat:
-        $ref: '#/definitions/v1alphaTextGenerationChatInput'
         title: The text generation chat input
+        allOf:
+          - $ref: '#/definitions/v1alphaTextGenerationChatInput'
       visualQuestionAnswering:
-        $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
         title: The visual question answering input
+        allOf:
+          - $ref: '#/definitions/v1alphaVisualQuestionAnsweringInput'
       unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedInput'
         title: The unspecified task input
+        allOf:
+          - $ref: '#/definitions/v1alphaUnspecifiedInput'
     title: TaskInputStream represents the input to trigger a model with stream method
   v1alphaTaskOutput:
     type: object
     properties:
       classification:
-        $ref: '#/definitions/v1alphaClassificationOutput'
         description: Image classification output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaClassificationOutput'
       detection:
-        $ref: '#/definitions/v1alphaDetectionOutput'
         description: Object detection output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaDetectionOutput'
       keypoint:
-        $ref: '#/definitions/v1alphaKeypointOutput'
         description: Keypoint detection output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaKeypointOutput'
       ocr:
-        $ref: '#/definitions/v1alphaOcrOutput'
         description: Optical Character Recognition output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaOcrOutput'
       instanceSegmentation:
-        $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
         description: Instance segmentation output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaInstanceSegmentationOutput'
       semanticSegmentation:
-        $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
         description: Semantic segmentation output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaSemanticSegmentationOutput'
       textToImage:
-        $ref: '#/definitions/v1alphaTextToImageOutput'
         description: Text to image output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaTextToImageOutput'
       imageToImage:
-        $ref: '#/definitions/v1alphaImageToImageOutput'
         description: Image to image output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaImageToImageOutput'
       textGeneration:
-        $ref: '#/definitions/v1alphaTextGenerationOutput'
         description: Text generation output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaTextGenerationOutput'
       textGenerationChat:
-        $ref: '#/definitions/v1alphaTextGenerationChatOutput'
         description: Conversational text generation output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaTextGenerationChatOutput'
       visualQuestionAnswering:
-        $ref: '#/definitions/v1alphaVisualQuestionAnsweringOutput'
         description: Visual question answering output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaVisualQuestionAnsweringOutput'
       unspecified:
-        $ref: '#/definitions/v1alphaUnspecifiedOutput'
         description: Unspecified task output.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaUnspecifiedOutput'
     description: TaskOutput represents the result of an AI task performed by a model.
   v1alphaTextGenerationChatInput:
     type: object
@@ -3755,13 +4720,36 @@ definitions:
         description: A list of generated images, encoded in base64.
         readOnly: true
     description: TextToImageOutput contains the result of a text-to-image task.
+  v1alphaTriggerAsyncNamespaceLatestModelResponse:
+    type: object
+    properties:
+      operation:
+        description: Long-running operation information.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
+    description: |-
+      TriggerAsyncNamespaceLatestModelResponse contains the information to access the
+      status of an asynchronous model inference.
+  v1alphaTriggerAsyncNamespaceModelResponse:
+    type: object
+    properties:
+      operation:
+        description: Long-running operation information.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
+    description: |-
+      TriggerAsyncNamespaceModelResponse contains the information to access the
+      status of an asynchronous model inference.
   v1alphaTriggerAsyncOrganizationLatestModelResponse:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: Long-running operation information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       TriggerAsyncOrganizationLatestModelResponse contains the information to access the
       status of an asynchronous model inference.
@@ -3769,9 +4757,10 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: Long-running operation information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       TriggerAsyncOrganizationModelResponse contains the information to access the
       status of an asynchronous model inference.
@@ -3779,9 +4768,10 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: Long-running operation information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       TriggerAsyncUserLatestModelResponse contains the information to access the
       status of an asynchronous model inference.
@@ -3789,18 +4779,48 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: Long-running operation information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       TriggerAsyncUserModelResponse contains the information to access the
       status of an asynchronous model inference.
+  v1alphaTriggerNamespaceLatestModelResponse:
+    type: object
+    properties:
+      task:
+        description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
+      taskOutputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskOutput'
+        description: Model inference outputs.
+    description: TriggerNamespaceLatestModelResponse contains the model inference results.
+  v1alphaTriggerNamespaceModelResponse:
+    type: object
+    properties:
+      task:
+        description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
+      taskOutputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskOutput'
+        description: Model inference outputs.
+    description: TriggerNamespaceModelResponse contains the model inference results.
   v1alphaTriggerOrganizationLatestModelResponse:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
         description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
       taskOutputs:
         type: array
         items:
@@ -3812,8 +4832,9 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
         description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
       taskOutputs:
         type: array
         items:
@@ -3828,8 +4849,9 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
         description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
       taskOutputs:
         type: array
         items:
@@ -3841,8 +4863,9 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
         description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
       taskOutputs:
         type: array
         items:
@@ -3854,8 +4877,9 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
         description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
       taskOutputs:
         type: array
         items:
@@ -3874,8 +4898,9 @@ definitions:
     type: object
     properties:
       task:
-        $ref: '#/definitions/v1alphaTask'
         description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
       taskOutputs:
         type: array
         items:
@@ -3883,25 +4908,38 @@ definitions:
           $ref: '#/definitions/v1alphaTaskOutput'
         description: Model inference outputs.
     description: TriggerUserModelResponse contains the model inference results.
+  v1alphaUndeployNamespaceModelAdminResponse:
+    type: object
+    title: UndeployNamespaceModelAdminResponse represents a response for a undeployed model
   v1alphaUndeployOrganizationModelAdminResponse:
     type: object
     title: UndeployOrganizationModelAdminResponse represents a response for a undeployed model
   v1alphaUndeployUserModelAdminResponse:
     type: object
     title: UndeployUserModelAdminResponse represents a response for a undeployed model
+  v1alphaUnpublishNamespaceModelResponse:
+    type: object
+    properties:
+      model:
+        description: The unpublished model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
+    description: UnpublishNamespaceModelResponse contains an unpublished model.
   v1alphaUnpublishOrganizationModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The unpublished model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: UnpublishOrganizationModelResponse contains an unpublished model.
   v1alphaUnpublishUserModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The unpublished model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: UnpublishUserModelResponse contains an unpublished model.
   v1alphaUnspecifiedInput:
     type: object
@@ -3922,19 +4960,29 @@ definitions:
         description: The task outputs.
         readOnly: true
     description: UnspecifiedOutput contains the result of an unspecified task.
+  v1alphaUpdateNamespaceModelResponse:
+    type: object
+    properties:
+      model:
+        description: The updated model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
+    description: UpdateNamespaceModelResponse contains the updated model.
   v1alphaUpdateOrganizationModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The updated model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: UpdateOrganizationModelResponse contains the updated model.
   v1alphaUpdateUserModelResponse:
     type: object
     properties:
       model:
-        $ref: '#/definitions/v1alphaModel'
         description: The updated model resource.
+        allOf:
+          - $ref: '#/definitions/v1alphaModel'
     description: UpdateUserModelResponse contains the updated model.
   v1alphaVisualQuestionAnsweringInput:
     type: object
@@ -3993,12 +5041,35 @@ definitions:
     description: |-
       VisualQuestionAnsweringOutput contains the result of a visual
       question-answering task.
+  v1alphaWatchNamespaceLatestModelResponse:
+    type: object
+    properties:
+      state:
+        description: State.
+        allOf:
+          - $ref: '#/definitions/modelv1alphaState'
+      message:
+        type: string
+        title: Detail description of the state
+    description: WatchNamespaceLatestModelResponse contains the state of the latest model version.
+  v1alphaWatchNamespaceModelResponse:
+    type: object
+    properties:
+      state:
+        description: State.
+        allOf:
+          - $ref: '#/definitions/modelv1alphaState'
+      message:
+        type: string
+        title: Detail description of the state
+    description: WatchNamespaceModelResponse contains the state of a model.
   v1alphaWatchOrganizationLatestModelResponse:
     type: object
     properties:
       state:
-        $ref: '#/definitions/modelv1alphaState'
         description: State.
+        allOf:
+          - $ref: '#/definitions/modelv1alphaState'
       message:
         type: string
         title: Detail description of the state
@@ -4007,8 +5078,9 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/modelv1alphaState'
         description: State.
+        allOf:
+          - $ref: '#/definitions/modelv1alphaState'
       message:
         type: string
         title: Detail description of the state
@@ -4017,8 +5089,9 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/modelv1alphaState'
         description: State.
+        allOf:
+          - $ref: '#/definitions/modelv1alphaState'
       message:
         type: string
         title: Detail description of the state
@@ -4027,8 +5100,9 @@ definitions:
     type: object
     properties:
       state:
-        $ref: '#/definitions/modelv1alphaState'
         description: State.
+        allOf:
+          - $ref: '#/definitions/modelv1alphaState'
       message:
         type: string
         title: Detail description of the state
@@ -4066,21 +5140,24 @@ definitions:
         description: Update time.
         readOnly: true
       owner:
-        $ref: '#/definitions/v1betaUser'
         description: The user that owns the organization.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
       profile:
-        $ref: '#/definitions/v1betaOrganizationProfile'
         description: Profile.
+        allOf:
+          - $ref: '#/definitions/v1betaOrganizationProfile'
       permission:
-        $ref: '#/definitions/mgmtv1betaPermission'
         title: Permission
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/mgmtv1betaPermission'
     description: |-
       Organizations group several users. As entities, they can own resources such
       as pipelines or releases.
     required:
-      - id
+      - profile
   v1betaOrganizationProfile:
     type: object
     properties:
@@ -4108,13 +5185,15 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/v1betaUser'
         description: User.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
       organization:
-        $ref: '#/definitions/v1betaOrganization'
         description: Organization.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     description: Owner is a wrapper for User and Organization, used to embed owner information in other resources.
   v1betaUser:
     type: object
@@ -4130,6 +5209,7 @@ definitions:
         description: |-
           User UUID. This field is optionally set by users on creation (it will be
           server-generated if unspecified).
+        readOnly: true
       id:
         type: string
         description: |-
@@ -4150,13 +5230,12 @@ definitions:
         description: Update time.
         readOnly: true
       profile:
-        $ref: '#/definitions/v1betaUserProfile'
         description: Profile.
+        allOf:
+          - $ref: '#/definitions/v1betaUserProfile'
     description: |-
       User describes an individual that interacts with Instill AI. It doesn't
       contain any private information about the user.
-    required:
-      - id
   v1betaUserProfile:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -12,11 +12,17 @@ info:
     url: https://github.com/instill-ai/protobufs/blob/main/LICENSE
 tags:
   - name: Component
+    description: Component endpoints
   - name: Pipeline
+    description: Pipeline endpoints
   - name: Release
+    description: Pipeline Release endpoints
   - name: Trigger
+    description: Pipeline Trigger endpoints
   - name: Secret
+    description: Namespace Secret endpoints
   - name: Utils
+    description: Utils endpoints
 host: api.instill.tech
 schemes:
   - https
@@ -26,25 +32,6 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1beta/hub-stats:
-    get:
-      summary: Get hub status
-      description: Return the stats of the hub
-      operationId: PipelinePublicService_GetHubStats
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetHubStatsResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      tags:
-        - Pipeline
   /v1beta/pipelines:
     get:
       summary: List accessible pipelines
@@ -127,18 +114,16 @@ paths:
           type: string
       tags:
         - Pipeline
-  /v1beta/{permalink}/lookUp:
+  /v1beta/namespaces/{namespaceId}/pipelines:
     get:
-      summary: Get a pipeline by UID
-      description: |-
-        Returns the details of a pipeline by a permalink defined by the resource
-        UID.
-      operationId: PipelinePublicService_LookUpPipeline
+      summary: List namespace pipelines
+      description: Returns a paginated list of pipelines of a namespace
+      operationId: PipelinePublicService_ListNamespacePipelines
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaLookUpPipelineResponse'
+            $ref: '#/definitions/v1betaListNamespacePipelinesResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -147,14 +132,133 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: permalink
-          description: |-
-            The permalink of the pipeline, which allows its access by UID.
-            - Format: `pipelines/{pipeline.uid}`.
+        - name: namespaceId
+          description: Namespace ID
           in: path
           required: true
           type: string
-          pattern: pipelines/[^/]+
+        - name: pageSize
+          description: |-
+            The maximum number of pipelines to return. If this parameter is
+            unspecified, at most 10 pipelines will be returned. The cap value for this
+            parameter is 100 (i.e. any value above that will be coerced to 100).
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageToken
+          description: Page token.
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View allows clients to specify the desired pipeline view in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+             - VIEW_RECIPE: Contains the recipe of the resource.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_RECIPE
+        - name: filter
+          description: |-
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression.
+            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+            - Example:
+            `recipe.components.definition_name:"operator-definitions/2ac8be70-0f7a-4b61-a33d-098b8acfa6f3"`.
+          in: query
+          required: false
+          type: string
+        - name: showDeleted
+          description: Include soft-deleted pipelines in the result.
+          in: query
+          required: false
+          type: boolean
+        - name: visibility
+          description: |-
+            Limit results to pipelines with the specified visibility.
+
+             - VISIBILITY_PRIVATE: Only the user can see the pipeline.
+             - VISIBILITY_PUBLIC: Other users can see the pipeline.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VISIBILITY_PRIVATE
+            - VISIBILITY_PUBLIC
+        - name: orderBy
+          description: |-
+            Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+            Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+          in: query
+          required: false
+          type: string
+      tags:
+        - Pipeline
+    post:
+      summary: Create a new pipeline
+      description: Creates a new pipeline under a namespace.
+      operationId: PipelinePublicService_CreateNamespacePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCreateNamespacePipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: The namespace that creates the pipeline.
+          in: path
+          required: true
+          type: string
+        - name: pipeline
+          description: The properties of the pipeline to be created.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1betaPipeline'
+      tags:
+        - Pipeline
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}:
+    get:
+      summary: Get a pipeline
+      description: Returns the details of a pipeline.
+      operationId: PipelinePublicService_GetNamespacePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetNamespacePipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
         - name: view
           description: |-
             View allows clients to specify the desired pipeline view in the response.
@@ -171,6 +275,1017 @@ paths:
             - VIEW_RECIPE
       tags:
         - Pipeline
+    delete:
+      summary: Delete a pipeline
+      description: |-
+        Deletes a pipeline, accesing it by its resource name, which is defined by
+        the parent namespace and the ID of the pipeline. The authenticated namespace must be
+        the parent of the pipeline in order to delete it.
+      operationId: PipelinePublicService_DeleteNamespacePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDeleteNamespacePipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+      tags:
+        - Pipeline
+    patch:
+      summary: Update a pipeline
+      description: |-
+        Udpates a pipeline, accessing it by its resource name, which is defined by
+        the parent namespace and the ID of the pipeline. The authenticated namespace must be
+        the parent of the pipeline in order to modify it.
+
+        In REST requests, only the supplied pipeline fields will be taken into
+        account when updating the resource.
+      operationId: PipelinePublicService_UpdateNamespacePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaUpdateNamespacePipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: pipeline
+          description: The pipeline fields that will replace the existing ones.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1betaPipeline'
+      tags:
+        - Pipeline
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/validate:
+    post:
+      summary: Validate a pipeline
+      description: |-
+        Validates a pipeline by its resource name, which is defined by the parent
+        namespace and the ID of the pipeline.
+
+        Validation checks the recipe of the pipeline and the status of its components.
+      operationId: PipelinePublicService_ValidateNamespacePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaValidateNamespacePipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceValidateNamespacePipelineBody'
+      tags:
+        - Pipeline
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/rename:
+    post:
+      summary: Rename a pipeline
+      description: |-
+        Updates the ID of a pipeline. Since this is an output-only field, a custom
+        method is required to modify it.
+
+        The pipeline name will be updated accordingly, as it is  composed by the
+        parent namespace and ID of the pipeline (e.g.
+        `namespaces/luigi/pipelines/pizza-recipe-generator`).
+
+        The authenticated namespace must be the parent of the pipeline in order to
+        perform this action.
+      operationId: PipelinePublicService_RenameNamespacePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaRenameNamespacePipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceRenameNamespacePipelineBody'
+      tags:
+        - Pipeline
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/clone:
+    post:
+      summary: Clone a pipeline
+      description: |-
+        Clones a pipeline owned by a namespace. The new pipeline may have a different
+        parent, and this can be either a namespace or an organization.
+      operationId: PipelinePublicService_CloneNamespacePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCloneNamespacePipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceCloneNamespacePipelineBody'
+      tags:
+        - Pipeline
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/trigger:
+    post:
+      summary: Trigger a pipeline
+      description: |-
+        Triggers the execution of a pipeline synchronously, i.e., the result is
+        sent back to the namespace right after the data is processed. This method is
+        intended for real-time inference when low latency is of concern.
+
+        The pipeline is identified by its resource name, formed by the parent namespace
+        and ID of the pipeline.
+
+        For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+      operationId: PipelinePublicService_TriggerNamespacePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaTriggerNamespacePipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceTriggerNamespacePipelineBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/trigger-stream:
+    post:
+      summary: Trigger a pipeline via streaming
+      description: |-
+        Triggers the execution of a pipeline asynchronously and streams back the response.
+        This method is intended for real-time inference when low latency is of concern
+        and the response needs to be processed incrementally.
+
+        The pipeline is identified by its resource name, formed by the parent namespace
+        and ID of the pipeline.
+      operationId: PipelinePublicService_TriggerNamespacePipelineWithStream
+      responses:
+        "200":
+          description: A successful response.(streaming responses)
+          schema:
+            type: object
+            properties:
+              result:
+                $ref: '#/definitions/v1betaTriggerNamespacePipelineWithStreamResponse'
+              error:
+                $ref: '#/definitions/googlerpcStatus'
+            title: Stream result of v1betaTriggerNamespacePipelineWithStreamResponse
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceTriggerNamespacePipelineWithStreamBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/trigger-async:
+    post:
+      summary: Trigger a pipeline asynchronously
+      description: |-
+        Triggers the execution of a pipeline asynchronously, i.e., the result
+        contains the necessary information to access the result and status of the
+        operation. This method is intended for cases that require long-running
+        workloads.
+
+        The pipeline is identified by its resource name, formed by the parent namespace
+        and ID of the pipeline.
+
+        For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+      operationId: PipelinePublicService_TriggerAsyncNamespacePipeline
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaTriggerAsyncNamespacePipelineResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceTriggerAsyncNamespacePipelineBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases:
+    get:
+      summary: List the releases in a pipeline
+      description: |-
+        Lists the commited versions of a pipeline, identified by its resource
+        name, which is formed by the parent namespace and ID of the pipeline.
+      operationId: PipelinePublicService_ListNamespacePipelineReleases
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaListNamespacePipelineReleasesResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: pageSize
+          description: |-
+            The maximum number of releases to return. If this parameter is
+            unspecified, at most 10 pipelines will be returned. The cap value for this
+            parameter is 100 (i.e. any value above that will be coerced to 100).
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageToken
+          description: Page token.
+          in: query
+          required: false
+          type: string
+        - name: view
+          description: |-
+            View allows clients to specify the desired pipeline view in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+             - VIEW_RECIPE: Contains the recipe of the resource.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_RECIPE
+        - name: filter
+          description: |-
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression.
+            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+          in: query
+          required: false
+          type: string
+        - name: showDeleted
+          description: Include soft-deleted pipelines in the result.
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Release
+    post:
+      summary: Create a pipeline release
+      description: |-
+        Commits the version of a pipeline, identified by its resource name, which
+        is formed by the parent namespace and ID of the pipeline.
+
+        The authenticated namespace must be the parent of the pipeline in order to
+        perform this action.
+      operationId: PipelinePublicService_CreateNamespacePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCreateNamespacePipelineReleaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: release
+          description: The release information.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1betaPipelineRelease'
+      tags:
+        - Release
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}:
+    get:
+      summary: Get a pipeline release
+      description: |-
+        Gets the details of a pipeline release, where the pipeline is identified
+        by its resource name, formed by its parent namespace and ID.
+      operationId: PipelinePublicService_GetNamespacePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetNamespacePipelineReleaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: releaseId
+          description: Release ID
+          in: path
+          required: true
+          type: string
+        - name: view
+          description: |-
+            View allows clients to specify the desired pipeline view in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+             - VIEW_RECIPE: Contains the recipe of the resource.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_RECIPE
+      tags:
+        - Release
+    delete:
+      summary: Delete a pipeline release
+      description: |-
+        Deletes a pipeline release, where the pipeline is identified by its
+        resource name, formed by its parent namespace and ID.
+
+        The authenticated namespace must be the parent of the pipeline in order to
+        perform this action.
+      operationId: PipelinePublicService_DeleteNamespacePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDeleteNamespacePipelineReleaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: releaseId
+          description: Release ID
+          in: path
+          required: true
+          type: string
+      tags:
+        - Release
+    patch:
+      summary: Update a pipeline release
+      description: |-
+        Updates the details of a pipeline release, where the pipeline is
+        identified by its resource name, formed by its parent namespace and ID.
+
+        The authenticated namespace must be the parent of the pipeline in order to
+        perform this action.
+      operationId: PipelinePublicService_UpdateNamespacePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaUpdateNamespacePipelineReleaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: releaseId
+          description: Release ID
+          in: path
+          required: true
+          type: string
+        - name: release
+          description: |-
+            The pipeline release fields that will replace the existing ones.
+            A pipeline release resource to update
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1betaPipelineRelease'
+      tags:
+        - Release
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}/clone:
+    post:
+      summary: Clone a pipeline release
+      description: |-
+        Clones a pipeline release owned by a namespace. The new pipeline may have a different
+        parent, and this can be either a namespace or an organization.
+      operationId: PipelinePublicService_CloneNamespacePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCloneNamespacePipelineReleaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: releaseId
+          description: Release ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceCloneNamespacePipelineReleaseBody'
+      tags:
+        - Release
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}/trigger:
+    post:
+      summary: Trigger a pipeline release
+      description: |-
+        Triggers the synchronous execution of of a pipeline. While the trigger
+        endpoint (where the release version isn't specified) triggers the pipeline
+        at its latest release, this method allows the client to specified any
+        committed release.
+
+        The pipeline is identified by its resource name, formed by its parent namespace
+        and ID.
+      operationId: PipelinePublicService_TriggerNamespacePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaTriggerNamespacePipelineReleaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: releaseId
+          description: Release ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceTriggerNamespacePipelineReleaseBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}/trigger-async:
+    post:
+      summary: Trigger a pipeline release asynchronously
+      description: |-
+        Triggers the asynchronous execution of of a pipeline. While the trigger
+        endpoint (where the release version isn't specified) triggers the pipeline
+        at its latest release, this method allows the client to specified any
+        committed release.
+
+        The pipeline is identified by its resource name, formed by its parent namespace
+        and ID.
+      operationId: PipelinePublicService_TriggerAsyncNamespacePipelineRelease
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaTriggerAsyncNamespacePipelineReleaseResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pipelineId
+          description: Pipeline ID
+          in: path
+          required: true
+          type: string
+        - name: releaseId
+          description: Release ID
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/PipelinePublicServiceTriggerAsyncNamespacePipelineReleaseBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1beta/namespaces/{namespaceId}/secrets:
+    get:
+      summary: List secrets
+      description: |-
+        Returns a paginated list of secrets that belong to the specified
+        namespace.
+      operationId: PipelinePublicService_ListSecrets
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaListSecretsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: pageSize
+          description: |-
+            The maximum number of secrets to return. If this parameter is unspecified,
+            at most 10 pipelines will be returned. The cap value for this parameter is
+            100 (i.e. any value above that will be coerced to 100).
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageToken
+          description: Page secret.
+          in: query
+          required: false
+          type: string
+      tags:
+        - Secret
+    post:
+      summary: Create a secret
+      description: Creates a new secret under the parenthood of an namespace.
+      operationId: PipelinePublicService_CreateSecret
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaCreateSecretResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: secret
+          description: The properties of the secret to be created.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1betaSecret'
+        - name: secretId
+          description: Secret ID
+          in: query
+          required: true
+          type: string
+      tags:
+        - Secret
+  /v1beta/namespaces/{namespaceId}/secrets/{secretId}:
+    get:
+      summary: Get a secret
+      description: |-
+        Returns the details of an namespace-owned secret by its resource name,
+        which is defined by the parent namespace and the ID of the secret.
+      operationId: PipelinePublicService_GetSecret
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetSecretResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: secretId
+          description: Secret ID
+          in: path
+          required: true
+          type: string
+      tags:
+        - Secret
+    delete:
+      summary: Delete a secret
+      description: |-
+        Deletes a secret, accesing it by its resource name, which is defined by
+        the parent namespace and the ID of the secret.
+      operationId: PipelinePublicService_DeleteSecret
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaDeleteSecretResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: secretId
+          description: Secret ID
+          in: path
+          required: true
+          type: string
+      tags:
+        - Secret
+    patch:
+      summary: Update a secret
+      description: |-
+        Udpates a secret, accessing it by its resource name, which is defined by
+
+        In REST requests, only the supplied secret fields will be taken into
+        account when updating the resource.
+      operationId: PipelinePublicService_UpdateSecret
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaUpdateSecretResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespaceId
+          description: Namespace ID
+          in: path
+          required: true
+          type: string
+        - name: secretId
+          description: Secret ID
+          in: path
+          required: true
+          type: string
+        - name: secret
+          description: The secret fields to update.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1betaSecret'
+      tags:
+        - Secret
+  /v1beta/component-definitions:
+    get:
+      summary: List component definitions
+      description: |-
+        Returns a paginated list of component definitions, regardless their type.
+        This offers a single source of truth, with pagination and filter
+        capabilities, for the components that might be used in a VDP pipeline.
+      operationId: PipelinePublicService_ListComponentDefinitions
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaListComponentDefinitionsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pageSize
+          description: |-
+            The maximum number of component definitions to return. If this parameter
+            is unspecified, at most 10 definitions will be returned. The cap value for
+            this parameter is 100 (i.e. any value above that will be coerced to 100).
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: view
+          description: |-
+            View allows clients to specify the desired resource view in the response.
+
+             - VIEW_BASIC: Default view, only includes basic information (removes the `spec`
+            field).
+             - VIEW_FULL: Full representation.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+        - name: filter
+          description: |-
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression.
+            - Example: `component_type="COMPONENT_TYPE_AI"`.
+            - Example: `tasks:"TASK_TEXT_GENERATION"`.
+          in: query
+          required: false
+          type: string
+        - name: page
+          description: Page number.
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - Component
+  /v1beta/{name}:
+    get:
+      summary: Get the details of a long-running operation
+      description: |-
+        This method allows requesters to request the status and outcome of
+        long-running operations such as asynchronous pipeline triggers.
+      operationId: PipelinePublicService_GetOperation
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaGetOperationResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: name
+          description: |-
+            The name of the operation resource. Asynchronous methods will contain this
+            information in their response.
+          in: path
+          required: true
+          type: string
+          pattern: operations/[^/]+
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
   /v1beta/{user_name}/pipelines:
     get:
       summary: List user pipelines
@@ -264,7 +1379,7 @@ paths:
           required: false
           type: string
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
     post:
       summary: Create a new user pipeline
       description: |-
@@ -300,7 +1415,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaPipeline'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{user_pipeline_name}:
     get:
       summary: Get a pipeline owned by a user
@@ -345,7 +1460,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
     delete:
       summary: Delete a pipeline owned by a user
       description: |-
@@ -376,8 +1491,8 @@ paths:
           type: string
           pattern: users/[^/]+/pipelines/[^/]+
       tags:
-        - Pipeline
-  /v1beta/{pipeline_name}:
+        - Pipeline (Deprecated)
+  /v1beta/{pipeline.name}:
     patch:
       summary: Update a pipeline owned by a user
       description: |-
@@ -401,7 +1516,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: pipeline_name
+        - name: pipeline.name
           description: |-
             The name of the pipeline, defined by its parent and ID.
             - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
@@ -449,8 +1564,9 @@ paths:
                 description: Pipeline delete time.
                 readOnly: true
               sharing:
-                $ref: '#/definitions/v1betaSharing'
                 description: Pipeline sharing information.
+                allOf:
+                  - $ref: '#/definitions/v1betaSharing'
               metadata:
                 type: object
                 description: Metadata holds console-related data such as the pipeline builder layout.
@@ -469,30 +1585,35 @@ paths:
                 type: string
                 description: README holds the pipeline documentation.
               permission:
-                $ref: '#/definitions/vdppipelinev1betaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/vdppipelinev1betaPermission'
               visibility:
-                $ref: '#/definitions/v1betaPipelineVisibility'
                 description: Pipeline visibility.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaPipelineVisibility'
               owner:
-                $ref: '#/definitions/v1betaOwner'
                 description: Pipeline owner.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaOwner'
               dataSpecification:
-                $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaDataSpecification'
               tags:
                 type: array
                 items:
                   type: string
                 description: Tags.
               stats:
-                $ref: '#/definitions/PipelineStats'
                 description: Statistic data.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/PipelineStats'
               rawRecipe:
                 type: string
                 description: |-
@@ -511,8 +1632,10 @@ paths:
                 type: string
                 description: Pipeline profile image in base64 format.
             title: The pipeline fields that will replace the existing ones.
+            required:
+              - recipe
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{user_pipeline_name}/validate:
     post:
       summary: Validate a pipeline a pipeline owned by a user
@@ -550,7 +1673,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceValidateUserPipelineBody'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{user_pipeline_name}/rename:
     post:
       summary: Rename a pipeline owned by a user
@@ -593,7 +1716,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceRenameUserPipelineBody'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{user_pipeline_name}/clone:
     post:
       summary: Clone a pipeline owned by a user
@@ -629,7 +1752,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceCloneUserPipelineBody'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{user_pipeline_release_name}/clone:
     post:
       summary: Clone a pipeline release owned by a user
@@ -664,7 +1787,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceCloneUserPipelineReleaseBody'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{user_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by a user
@@ -676,8 +1799,7 @@ paths:
         The pipeline is identified by its resource name, formed by the parent user
         and ID of the pipeline.
 
-        For more information, see [Trigger
-        Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+        For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
       operationId: PipelinePublicService_TriggerUserPipeline
       responses:
         "200":
@@ -712,7 +1834,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/{user_pipeline_name}/trigger-stream:
     post:
       summary: Trigger a pipeline owned by a user and stream back the response
@@ -763,7 +1885,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/{user_pipeline_name}/triggerAsync:
     post:
       summary: Trigger a pipeline owned by a user asynchronously
@@ -776,8 +1898,7 @@ paths:
         The pipeline is identified by its resource name, formed by the parent user
         and ID of the pipeline.
 
-        For more information, see [Trigger
-        Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+        For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
       operationId: PipelinePublicService_TriggerAsyncUserPipeline
       responses:
         "200":
@@ -812,7 +1933,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/{user_name}/releases:
     get:
       summary: List the releases in a pipeline owned by a user
@@ -883,7 +2004,7 @@ paths:
           required: false
           type: boolean
       tags:
-        - Release
+        - Release (Deprecated)
     post:
       summary: Release a version of a pipeline owned by a user
       description: |-
@@ -921,7 +2042,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaPipelineRelease'
       tags:
-        - Release
+        - Release (Deprecated)
   /v1beta/{user_pipeline_release_name}:
     get:
       summary: Get a release in a pipeline owned by a user
@@ -966,7 +2087,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - Release
+        - Release (Deprecated)
     delete:
       summary: Delete a release in a pipeline owned by a user
       description: |-
@@ -999,8 +2120,8 @@ paths:
           type: string
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
-        - Release
-  /v1beta/{pipeline_release_name}:
+        - Release (Deprecated)
+  /v1beta/{release.name}:
     patch:
       summary: Update a release in a pipeline owned by a user
       description: |-
@@ -1023,7 +2144,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: pipeline_release_name
+        - name: release.name
           description: |-
             The name of the release, defined by its parent and ID.
             - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}`.
@@ -1084,9 +2205,10 @@ paths:
                 type: string
                 description: README.
               dataSpecification:
-                $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaDataSpecification'
               rawRecipe:
                 type: string
                 description: |-
@@ -1096,7 +2218,7 @@ paths:
               The pipeline release fields that will replace the existing ones.
               A pipeline release resource to update
       tags:
-        - Release
+        - Release (Deprecated)
   /v1beta/{user_pipeline_release_name}/restore:
     post:
       summary: Set the version of a pipeline owned by a user to a pinned release
@@ -1132,7 +2254,7 @@ paths:
           type: string
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
-        - Release
+        - Release (Deprecated)
   /v1beta/{user_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by a user
@@ -1176,7 +2298,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceRenameUserPipelineReleaseBody'
       tags:
-        - Release
+        - Release (Deprecated)
   /v1beta/{user_pipeline_release_name}/trigger:
     post:
       summary: Trigger a version of a pipeline owned by a user
@@ -1222,7 +2344,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/{user_pipeline_release_name}/triggerAsync:
     post:
       summary: Trigger a version of a pipeline owned by a user asynchronously
@@ -1268,7 +2390,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/{organization_name}/pipelines:
     get:
       summary: List organization pipelines
@@ -1360,7 +2482,7 @@ paths:
           required: false
           type: string
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
     post:
       summary: Create a new organization pipeline
       description: Creates a new pipeline under the parenthood of an organization.
@@ -1393,7 +2515,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaPipeline'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{organization_pipeline_name}:
     get:
       summary: Get a pipeline owned by an organization
@@ -1438,7 +2560,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
     delete:
       summary: Delete a pipeline owned by an organization
       description: |-
@@ -1468,8 +2590,8 @@ paths:
           type: string
           pattern: organizations/[^/]+/pipelines/[^/]+
       tags:
-        - Pipeline
-  /v1beta/{pipeline_name_1}:
+        - Pipeline (Deprecated)
+  /v1beta/{pipeline.name_1}:
     patch:
       summary: Update a pipeline owned by an organization
       description: |-
@@ -1491,7 +2613,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: pipeline_name_1
+        - name: pipeline.name_1
           description: |-
             The name of the pipeline, defined by its parent and ID.
             - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
@@ -1539,8 +2661,9 @@ paths:
                 description: Pipeline delete time.
                 readOnly: true
               sharing:
-                $ref: '#/definitions/v1betaSharing'
                 description: Pipeline sharing information.
+                allOf:
+                  - $ref: '#/definitions/v1betaSharing'
               metadata:
                 type: object
                 description: Metadata holds console-related data such as the pipeline builder layout.
@@ -1559,30 +2682,35 @@ paths:
                 type: string
                 description: README holds the pipeline documentation.
               permission:
-                $ref: '#/definitions/vdppipelinev1betaPermission'
                 description: Permission defines how a pipeline can be used.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/vdppipelinev1betaPermission'
               visibility:
-                $ref: '#/definitions/v1betaPipelineVisibility'
                 description: Pipeline visibility.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaPipelineVisibility'
               owner:
-                $ref: '#/definitions/v1betaOwner'
                 description: Pipeline owner.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaOwner'
               dataSpecification:
-                $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaDataSpecification'
               tags:
                 type: array
                 items:
                   type: string
                 description: Tags.
               stats:
-                $ref: '#/definitions/PipelineStats'
                 description: Statistic data.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/PipelineStats'
               rawRecipe:
                 type: string
                 description: |-
@@ -1601,8 +2729,10 @@ paths:
                 type: string
                 description: Pipeline profile image in base64 format.
             title: The pipeline fields that will replace the existing ones.
+            required:
+              - recipe
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{organization_pipeline_name}/validate:
     post:
       summary: Validate a pipeline a pipeline owned by an organization
@@ -1641,7 +2771,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceValidateOrganizationPipelineBody'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{organization_pipeline_name}/rename:
     post:
       summary: Rename a pipeline owned by an organization
@@ -1681,7 +2811,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceRenameOrganizationPipelineBody'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{org_pipeline_name}/clone:
     post:
       summary: Clone a pipeline owned by an organization
@@ -1717,7 +2847,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineBody'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{org_pipeline_release_name}/clone:
     post:
       summary: Clone a pipeline release owned by an organization
@@ -1752,7 +2882,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineReleaseBody'
       tags:
-        - Pipeline
+        - Pipeline (Deprecated)
   /v1beta/{organization_pipeline_name}/trigger-stream:
     post:
       summary: Trigger a pipeline owned by an organization
@@ -1764,8 +2894,7 @@ paths:
         The pipeline is identified by its resource name, formed by the parent
         organization and ID of the pipeline.
 
-        For more information, see [Trigger
-        Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+        For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
       operationId: PipelinePublicService_TriggerOrganizationPipelineStream
       responses:
         "200":
@@ -1806,7 +2935,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/{organization_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by an organization
@@ -1818,8 +2947,7 @@ paths:
         The pipeline is identified by its resource name, formed by the parent
         organization and ID of the pipeline.
 
-        For more information, see [Trigger
-        Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+        For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
       operationId: PipelinePublicService_TriggerOrganizationPipeline
       responses:
         "200":
@@ -1854,7 +2982,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/{organization_pipeline_name}/triggerAsync:
     post:
       summary: Trigger a pipeline owned by an organization asynchronously
@@ -1867,8 +2995,7 @@ paths:
         The pipeline is identified by its resource name, formed by the parent
         organization and ID of the pipeline.
 
-        For more information, see [Trigger
-        Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+        For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
       operationId: PipelinePublicService_TriggerAsyncOrganizationPipeline
       responses:
         "200":
@@ -1903,7 +3030,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/{organization_name}/releases:
     get:
       summary: List the releases in a pipeline owned by an organization
@@ -1974,7 +3101,7 @@ paths:
           required: false
           type: boolean
       tags:
-        - Release
+        - Release (Deprecated)
     post:
       summary: Release a version of a pipeline owned by an organization
       description: |-
@@ -2009,7 +3136,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaPipelineRelease'
       tags:
-        - Release
+        - Release (Deprecated)
   /v1beta/{organization_pipeline_release_name}:
     get:
       summary: Get a release in a pipeline owned by an organization
@@ -2055,7 +3182,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - Release
+        - Release (Deprecated)
     delete:
       summary: Delete a release in a pipeline owned by an organization
       description: |-
@@ -2086,8 +3213,8 @@ paths:
           type: string
           pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
-        - Release
-  /v1beta/{pipeline_release_name_1}:
+        - Release (Deprecated)
+  /v1beta/{release.name_1}:
     patch:
       summary: Update a release in a pipeline owned by an organization
       description: |-
@@ -2107,7 +3234,7 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: pipeline_release_name_1
+        - name: release.name_1
           description: |-
             The name of the release, defined by its parent and ID.
             - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}`.
@@ -2168,9 +3295,10 @@ paths:
                 type: string
                 description: README.
               dataSpecification:
-                $ref: '#/definitions/v1betaDataSpecification'
                 description: Data specifications.
                 readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaDataSpecification'
               rawRecipe:
                 type: string
                 description: |-
@@ -2180,7 +3308,7 @@ paths:
               The pipeline release fields that will replace the existing ones.
               A pipeline release resource to update
       tags:
-        - Release
+        - Release (Deprecated)
   /v1beta/{organization_pipeline_release_name}/restore:
     post:
       summary: Set the version of a pipeline owned by an organization to a pinned release
@@ -2214,7 +3342,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
-        - Release
+        - Release (Deprecated)
   /v1beta/{organization_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by an organization
@@ -2256,7 +3384,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelinePublicServiceRenameOrganizationPipelineReleaseBody'
       tags:
-        - Release
+        - Release (Deprecated)
   /v1beta/{organization_pipeline_release_name}/trigger:
     post:
       summary: Trigger a version of a pipeline owned by an organization
@@ -2303,7 +3431,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/{organization_pipeline_release_name}/triggerAsync:
     post:
       summary: Trigger a version of a pipeline owned by an organization asynchronously
@@ -2350,42 +3478,7 @@ paths:
           required: false
           type: string
       tags:
-        - Trigger
-  /v1beta/{name}:
-    get:
-      summary: Get the details of a long-running operation
-      description: |-
-        This method allows requesters to request the status and outcome of
-        long-running operations such as asynchronous pipeline triggers.
-      operationId: PipelinePublicService_GetOperation
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaGetOperationResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: name
-          description: |-
-            The name of the operation resource. Asynchronous methods will contain this
-            information in their response.
-          in: path
-          required: true
-          type: string
-          pattern: operations/[^/]+
-        - name: Instill-Requester-Uid
-          description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
-          in: header
-          required: false
-          type: string
-      tags:
-        - Trigger
+        - Trigger (Deprecated)
   /v1beta/connector-definitions:
     get:
       summary: List connector definitions
@@ -2440,7 +3533,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Component
+        - Component (Deprecated)
   /v1beta/{connector_definition_name}:
     get:
       summary: Get connector definition
@@ -2481,7 +3574,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Component
+        - Component (Deprecated)
   /v1beta/operator-definitions:
     get:
       summary: List operator definitions
@@ -2537,67 +3630,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Component
-  /v1beta/component-definitions:
-    get:
-      summary: List component definitions
-      description: |-
-        Returns a paginated list of component definitions, regardless their type.
-        This offers a single source of truth, with pagination and filter
-        capabilities, for the components that might be used in a VDP pipeline.
-      operationId: PipelinePublicService_ListComponentDefinitions
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1betaListComponentDefinitionsResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: pageSize
-          description: |-
-            The maximum number of component definitions to return. If this parameter
-            is unspecified, at most 10 definitions will be returned. The cap value for
-            this parameter is 100 (i.e. any value above that will be coerced to 100).
-          in: query
-          required: false
-          type: integer
-          format: int32
-        - name: view
-          description: |-
-            View allows clients to specify the desired resource view in the response.
-
-             - VIEW_BASIC: Default view, only includes basic information (removes the `spec`
-            field).
-             - VIEW_FULL: Full representation.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-        - name: filter
-          description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
-            - Example: `component_type="COMPONENT_TYPE_AI"`.
-            - Example: `tasks:"TASK_TEXT_GENERATION"`.
-          in: query
-          required: false
-          type: string
-        - name: page
-          description: Page number.
-          in: query
-          required: false
-          type: integer
-          format: int32
-      tags:
-        - Component
+        - Component (Deprecated)
   /v1beta/{operator_definition_name}:
     get:
       summary: Get operator definition
@@ -2638,7 +3671,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - Component
+        - Component (Deprecated)
   /v1beta/check-name:
     post:
       summary: Check the availibity of a resource name
@@ -2668,7 +3701,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaCheckNameRequest'
       tags:
-        - Utils
+        - Utils (Deprecated)
   /v1beta/{user_name}/secrets:
     get:
       summary: List user secrets
@@ -2712,7 +3745,7 @@ paths:
           required: false
           type: string
       tags:
-        - Secret
+        - Secret (Deprecated)
     post:
       summary: Create a new user secret
       description: Creates a new secret under the parenthood of an user.
@@ -2745,7 +3778,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaSecret'
       tags:
-        - Secret
+        - Secret (Deprecated)
   /v1beta/{user_secret_name}:
     get:
       summary: Get a secret owned by an user
@@ -2775,7 +3808,7 @@ paths:
           type: string
           pattern: users/[^/]+/secrets/[^/]+
       tags:
-        - Secret
+        - Secret (Deprecated)
     delete:
       summary: Delete a secret owned by an user
       description: |-
@@ -2804,7 +3837,7 @@ paths:
           type: string
           pattern: users/[^/]+/secrets/[^/]+
       tags:
-        - Secret
+        - Secret (Deprecated)
   /v1beta/{secret.name}:
     patch:
       summary: Update a secret owned by an user
@@ -2871,7 +3904,7 @@ paths:
                 title: Description
             title: The secret fields to update.
       tags:
-        - Secret
+        - Secret (Deprecated)
   /v1beta/{organization_name}/secrets:
     get:
       summary: List organization secrets
@@ -2915,7 +3948,7 @@ paths:
           required: false
           type: string
       tags:
-        - Secret
+        - Secret (Deprecated)
     post:
       summary: Create a new organization secret
       description: Creates a new secret under the parenthood of an organization.
@@ -2948,7 +3981,7 @@ paths:
           schema:
             $ref: '#/definitions/v1betaSecret'
       tags:
-        - Secret
+        - Secret (Deprecated)
   /v1beta/{organization_secret_name}:
     get:
       summary: Get a secret owned by an organization
@@ -2978,7 +4011,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/secrets/[^/]+
       tags:
-        - Secret
+        - Secret (Deprecated)
     delete:
       summary: Delete a secret owned by an organization
       description: |-
@@ -3007,7 +4040,7 @@ paths:
           type: string
           pattern: organizations/[^/]+/secrets/[^/]+
       tags:
-        - Secret
+        - Secret (Deprecated)
   /v1beta/{secret.name_1}:
     patch:
       summary: Update a secret owned by an organization
@@ -3074,7 +4107,7 @@ paths:
                 title: Description
             title: The secret fields to update.
       tags:
-        - Secret
+        - Secret (Deprecated)
 definitions:
   CheckNameResponseName:
     type: string
@@ -3144,6 +4177,50 @@ definitions:
     required:
       - componentSpecification
       - dataSpecifications
+  PipelinePublicServiceCloneNamespacePipelineBody:
+    type: object
+    properties:
+      target:
+        type: string
+        title: |-
+          The target pipeline. It can be under a user or an organization
+          namespace, so the following formats are accepted:
+          - `{user.id}/{pipeline.id}`
+          - `{organization.id}/{pipeline.id}`
+      description:
+        type: string
+        description: Pipeline description.
+      sharing:
+        description: Pipeline sharing information.
+        allOf:
+          - $ref: '#/definitions/v1betaSharing'
+    description: |-
+      CloneNamespacePipelineRequest represents a request to clone a pipeline owned by a
+      user.
+    required:
+      - target
+  PipelinePublicServiceCloneNamespacePipelineReleaseBody:
+    type: object
+    properties:
+      target:
+        type: string
+        title: |-
+          The target pipeline. It can be under a user or an organization
+          namespace, so the following formats are accepted:
+          - `{user.id}/{pipeline.id}`
+          - `{organization.id}/{pipeline.id}`
+      description:
+        type: string
+        description: Pipeline description.
+      sharing:
+        description: Pipeline sharing information.
+        allOf:
+          - $ref: '#/definitions/v1betaSharing'
+    description: |-
+      CloneNamespacePipelineReleaseRequest represents a request to clone a pipeline
+      release owned by a user.
+    required:
+      - target
   PipelinePublicServiceCloneOrganizationPipelineBody:
     type: object
     properties:
@@ -3158,8 +4235,9 @@ definitions:
         type: string
         description: Pipeline description.
       sharing:
-        $ref: '#/definitions/v1betaSharing'
         description: Pipeline sharing information.
+        allOf:
+          - $ref: '#/definitions/v1betaSharing'
     description: |-
       CloneOrganizationPipelineRequest represents a request to clone a pipeline
       owned by an organization.
@@ -3179,8 +4257,9 @@ definitions:
         type: string
         description: Pipeline description.
       sharing:
-        $ref: '#/definitions/v1betaSharing'
         description: Pipeline sharing information.
+        allOf:
+          - $ref: '#/definitions/v1betaSharing'
     description: |-
       CloneOrganizationPipelineReleaseRequest represents a request to clone a pipeline
       release owned by an organization.
@@ -3200,8 +4279,9 @@ definitions:
         type: string
         description: Pipeline description.
       sharing:
-        $ref: '#/definitions/v1betaSharing'
         description: Pipeline sharing information.
+        allOf:
+          - $ref: '#/definitions/v1betaSharing'
     description: |-
       CloneUserPipelineRequest represents a request to clone a pipeline owned by a
       user.
@@ -3221,13 +4301,27 @@ definitions:
         type: string
         description: Pipeline description.
       sharing:
-        $ref: '#/definitions/v1betaSharing'
         description: Pipeline sharing information.
+        allOf:
+          - $ref: '#/definitions/v1betaSharing'
     description: |-
       CloneUserPipelineReleaseRequest represents a request to clone a pipeline
       release owned by a user.
     required:
       - target
+  PipelinePublicServiceRenameNamespacePipelineBody:
+    type: object
+    properties:
+      newPipelineId:
+        type: string
+        description: |-
+          The new resource ID. This will transform the resource name into
+          `namespaces/{namespace.id}/pipelines/{new_pipeline_id}`.
+    description: |-
+      RenameNamespacePipelineRequest represents a request to rename the name of a
+      pipeline owned by a namespace.
+    required:
+      - newPipelineId
   PipelinePublicServiceRenameOrganizationPipelineBody:
     type: object
     properties:
@@ -3280,6 +4374,40 @@ definitions:
       a user-owned pipeline.
     required:
       - newPipelineReleaseId
+  PipelinePublicServiceTriggerAsyncNamespacePipelineBody:
+    type: object
+    properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
+      data:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
+    description: |-
+      TriggerNamespacePipelineRequest represents a request to trigger a user-owned
+      pipeline synchronously.
+  PipelinePublicServiceTriggerAsyncNamespacePipelineReleaseBody:
+    type: object
+    properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
+      data:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
+    description: |-
+      TriggerNamespacePipelineReleaseRequest represents a request to trigger a pinned
+      release of a user-owned pipeline asynchronously.
   PipelinePublicServiceTriggerAsyncOrganizationPipelineBody:
     type: object
     properties:
@@ -3348,6 +4476,60 @@ definitions:
     description: |-
       TriggerUserPipelineReleaseRequest represents a request to trigger a pinned
       release of a user-owned pipeline asynchronously.
+  PipelinePublicServiceTriggerNamespacePipelineBody:
+    type: object
+    properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
+      data:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
+    description: |-
+      TriggerNamespacePipelineRequest represents a request to trigger a user-owned
+      pipeline synchronously.
+    required:
+      - inputs
+      - data
+  PipelinePublicServiceTriggerNamespacePipelineReleaseBody:
+    type: object
+    properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
+      data:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
+    description: |-
+      TriggerNamespacePipelineReleaseRequest represents a request to trigger a pinned
+      release of a user-owned pipeline.
+  PipelinePublicServiceTriggerNamespacePipelineWithStreamBody:
+    type: object
+    properties:
+      inputs:
+        type: array
+        items:
+          type: object
+        description: Pipeline input parameters, it will be deprecated soon.
+      data:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaTriggerData'
+        title: Data
+    description: |-
+      TriggerNamespacePipelineWithStreamRequest represents a request to trigger a user-owned
+      pipeline synchronously and streams back the results.
   PipelinePublicServiceTriggerOrganizationPipelineBody:
     type: object
     properties:
@@ -3450,6 +4632,11 @@ definitions:
     description: |-
       TriggerUserPipelineWithStreamRequest represents a request to trigger a user-owned
       pipeline synchronously and streams back the results.
+  PipelinePublicServiceValidateNamespacePipelineBody:
+    type: object
+    description: |-
+      ValidateNamespacePipelineRequest represents a request to validate a pipeline
+      owned by a user.
   PipelinePublicServiceValidateOrganizationPipelineBody:
     type: object
     description: |-
@@ -3467,14 +4654,17 @@ definitions:
         type: integer
         format: int32
         description: Number of pipeline runs.
+        readOnly: true
       lastRunTime:
         type: string
         format: date-time
         description: Last run time.
+        readOnly: true
       numberOfClones:
         type: integer
         format: int32
         description: Number of times this pipeline has been cloned.
+        readOnly: true
     title: Statistic data
   SharingShareCode:
     type: object
@@ -3493,8 +4683,9 @@ definitions:
         type: boolean
         description: Defines whether the sharing option via link is enabled.
       role:
-        $ref: '#/definitions/v1betaRole'
         description: Defines the role users will have over the resource.
+        allOf:
+          - $ref: '#/definitions/v1betaRole'
     description: ShareCode describes a sharing configuration through a link.
   coremgmtv1betaPermission:
     type: object
@@ -3502,6 +4693,7 @@ definitions:
       canEdit:
         type: boolean
         description: Defines whether the resource can be modified.
+        readOnly: true
     description: Permission defines how a resource can be used.
   googlelongrunningOperation:
     type: object
@@ -3513,12 +4705,13 @@ definitions:
           originally returns it. If you use the default HTTP mapping, the
           `name` should be a resource name ending with `operations/{unique_id}`.
       metadata:
-        $ref: '#/definitions/protobufAny'
         description: |-
           Service-specific metadata associated with the operation.  It typically
           contains progress information and common metadata such as create time.
           Some services might not provide such metadata.  Any method that returns a
           long-running operation should document the metadata type, if any.
+        allOf:
+          - $ref: '#/definitions/protobufAny'
       done:
         type: boolean
         description: |-
@@ -3526,10 +4719,10 @@ definitions:
           If `true`, the operation is completed, and either `error` or `response` is
           available.
       error:
-        $ref: '#/definitions/googlerpcStatus'
         description: The error result of the operation in case of failure or cancellation.
+        allOf:
+          - $ref: '#/definitions/googlerpcStatus'
       response:
-        $ref: '#/definitions/protobufAny'
         description: |-
           The normal response of the operation in case of success.  If the original
           method returns no data on success, such as `Delete`, the response is
@@ -3539,6 +4732,8 @@ definitions:
           is the original method name.  For example, if the original method name
           is `TakeSnapshot()`, the inferred response type is
           `TakeSnapshotResponse`.
+        allOf:
+          - $ref: '#/definitions/protobufAny'
     description: |-
       This resource represents a long-running operation that is the result of a
       network API call.
@@ -3588,6 +4783,7 @@ definitions:
         description: |-
           User UUID. This field is optionally set by users on creation (it will be
           server-generated if unspecified).
+        readOnly: true
       id:
         type: string
         description: |-
@@ -3608,13 +4804,12 @@ definitions:
         description: Update time.
         readOnly: true
       profile:
-        $ref: '#/definitions/v1betaUserProfile'
         description: Profile.
+        allOf:
+          - $ref: '#/definitions/v1betaUserProfile'
     description: |-
       User describes an individual that interacts with Instill AI. It doesn't
       contain any private information about the user.
-    required:
-      - id
   protobufAny:
     type: object
     properties:
@@ -3764,9 +4959,16 @@ definitions:
     type: object
     properties:
       availability:
-        $ref: '#/definitions/CheckNameResponseName'
         description: The availability of the requested name.
+        allOf:
+          - $ref: '#/definitions/CheckNameResponseName'
     description: CheckNameResponse contains the availability of a resource name.
+  v1betaCloneNamespacePipelineReleaseResponse:
+    type: object
+    description: CloneNamespacePipelineReleaseResponse contains a cloned pipeline.
+  v1betaCloneNamespacePipelineResponse:
+    type: object
+    description: CloneNamespacePipelineResponse contains a cloned pipeline.
   v1betaCloneOrganizationPipelineReleaseResponse:
     type: object
     description: CloneOrganizationPipelineReleaseResponse contains a cloned pipeline.
@@ -3815,13 +5017,15 @@ definitions:
           frontend applications to pull and locate the icons.
         readOnly: true
       spec:
-        $ref: '#/definitions/ComponentDefinitionSpec'
         description: Component definition specification.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/ComponentDefinitionSpec'
       type:
-        $ref: '#/definitions/v1betaComponentType'
         description: Component definition type.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaComponentType'
       tombstone:
         type: boolean
         description: |-
@@ -3872,9 +5076,10 @@ definitions:
         description: Short description of the component.
         readOnly: true
       releaseStage:
-        $ref: '#/definitions/ComponentDefinitionReleaseStage'
         description: Release stage.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/ComponentDefinitionReleaseStage'
     description: ComponentDefinition describes a certain type of Component.
   v1betaComponentDefinitionView:
     type: string
@@ -3955,13 +5160,15 @@ definitions:
           frontend applications to pull and locate the icons.
         readOnly: true
       spec:
-        $ref: '#/definitions/v1betaConnectorSpec'
         description: Connector definition specification.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaConnectorSpec'
       type:
-        $ref: '#/definitions/v1betaConnectorType'
         description: Connector definition type.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaConnectorType'
       tombstone:
         type: boolean
         description: |-
@@ -4012,9 +5219,10 @@ definitions:
         description: Short description of the connector.
         readOnly: true
       releaseStage:
-        $ref: '#/definitions/ComponentDefinitionReleaseStage'
         description: Release stage.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/ComponentDefinitionReleaseStage'
     description: |-
       A Connector is a type of pipeline component that queries, processes or sends
       the ingested unstructured data to a service or app. Users need to configure
@@ -4022,7 +5230,7 @@ definitions:
       ConnectorDefinition describes a certain type of Connector.
 
       For more information, see
-      [Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
+      [Component](https://www.instill.tech/docs/component/introduction)
       in the official documentation.
   v1betaConnectorSpec:
     type: object
@@ -4055,47 +5263,80 @@ definitions:
        - CONNECTOR_TYPE_DATA: Data connector.
        - CONNECTOR_TYPE_OPERATOR: Operator connector.
        - CONNECTOR_TYPE_APPLICATION: Application connector.
+  v1betaCreateNamespacePipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        description: The created pipeline release object.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
+    description: CreateNamespacePipelineReleaseResponse contains the created release.
+  v1betaCreateNamespacePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        description: The created pipeline resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
+    description: CreateNamespacePipelineResponse contains the created pipeline.
   v1betaCreateOrganizationPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The created pipeline release object.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: CreateOrganizationPipelineReleaseResponse contains the created release.
   v1betaCreateOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
         description: The created pipeline resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
     description: CreateOrganizationPipelineResponse contains the created pipeline.
   v1betaCreateOrganizationSecretResponse:
     type: object
     properties:
       secret:
-        $ref: '#/definitions/v1betaSecret'
         description: The created secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
     description: CreateOrganizationSecretResponse contains the created secret.
+  v1betaCreateSecretResponse:
+    type: object
+    properties:
+      secret:
+        description: The created secret resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
+    description: CreateSecretResponse contains the created secret.
   v1betaCreateUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The created pipeline release object.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: CreateUserPipelineReleaseResponse contains the created release.
   v1betaCreateUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
         description: The created pipeline resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
     description: CreateUserPipelineResponse contains the created pipeline.
   v1betaCreateUserSecretResponse:
     type: object
     properties:
       secret:
-        $ref: '#/definitions/v1betaSecret'
         description: The created secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
     description: CreateUserSecretResponse contains the created secret.
   v1betaDataSpecification:
     type: object
@@ -4103,10 +5344,18 @@ definitions:
       input:
         type: object
         description: JSON schema describing the component input data.
+        readOnly: true
       output:
         type: object
         description: JSON schema describing the component output data.
+        readOnly: true
     description: DataSpecification describes the JSON schema of component input and output.
+  v1betaDeleteNamespacePipelineReleaseResponse:
+    type: object
+    description: DeleteNamespacePipelineReleaseResponse is an empty response.
+  v1betaDeleteNamespacePipelineResponse:
+    type: object
+    description: DeleteNamespacePipelineResponse is an empty response.
   v1betaDeleteOrganizationPipelineReleaseResponse:
     type: object
     description: DeleteOrganizationPipelineReleaseResponse is an empty response.
@@ -4116,6 +5365,9 @@ definitions:
   v1betaDeleteOrganizationSecretResponse:
     type: object
     description: DeleteOrganizationSecretResponse is an empty response.
+  v1betaDeleteSecretResponse:
+    type: object
+    description: DeleteSecretResponse is an empty response.
   v1betaDeleteUserPipelineReleaseResponse:
     type: object
     description: DeleteUserPipelineReleaseResponse is an empty response.
@@ -4129,77 +5381,100 @@ definitions:
     type: object
     properties:
       connectorDefinition:
-        $ref: '#/definitions/v1betaConnectorDefinition'
         description: The connector definition resource.
+        allOf:
+          - $ref: '#/definitions/v1betaConnectorDefinition'
     description: GetConnectorDefinitionResponse contains the requested connector definition.
-  v1betaGetHubStatsResponse:
+  v1betaGetNamespacePipelineReleaseResponse:
     type: object
     properties:
-      numberOfPublicPipelines:
-        type: integer
-        format: int32
-        description: Total number of public pipelines.
-      numberOfFeaturedPipelines:
-        type: integer
-        format: int32
-        description: Total number of featured pipelines.
-    description: GetHubStatsResponse represents a response to get hub stats.
+      release:
+        description: The pipeline release resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
+    description: GetNamespacePipelineReleaseResponse contains the requested pipeline release.
+  v1betaGetNamespacePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        description: The pipeline resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
+    description: GetNamespacePipelineResponse contains the requested pipeline.
   v1betaGetOperationResponse:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: The long-running operation.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: GetOperationResponse contains the long-running operation details.
   v1betaGetOperatorDefinitionResponse:
     type: object
     properties:
       operatorDefinition:
-        $ref: '#/definitions/v1betaOperatorDefinition'
         description: The operator definition resource.
+        allOf:
+          - $ref: '#/definitions/v1betaOperatorDefinition'
     description: GetOperatorDefinitionResponse contains the requested operator definition.
   v1betaGetOrganizationPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The pipeline release resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: GetOrganizationPipelineReleaseResponse contains the requested pipeline release.
   v1betaGetOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
         description: The pipeline resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
     description: GetOrganizationPipelineResponse contains the requested pipeline.
   v1betaGetOrganizationSecretResponse:
     type: object
     properties:
       secret:
-        $ref: '#/definitions/v1betaSecret'
         description: The secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
     description: GetOrganizationSecretResponse contains the requested secret.
+  v1betaGetSecretResponse:
+    type: object
+    properties:
+      secret:
+        description: The secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
+    description: GetSecretResponse contains the requested secret.
   v1betaGetUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The pipeline release resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: GetUserPipelineReleaseResponse contains the requested pipeline release.
   v1betaGetUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
         description: The pipeline resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
     description: GetUserPipelineResponse contains the requested pipeline.
   v1betaGetUserSecretResponse:
     type: object
     properties:
       secret:
-        $ref: '#/definitions/v1betaSecret'
         description: The secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
     description: GetUserSecretResponse contains the requested secret.
   v1betaListComponentDefinitionsResponse:
     type: object
@@ -4240,6 +5515,46 @@ definitions:
         format: int32
         description: Total number of connector definitions.
     description: ListConnectorDefinitionsResponse contains a list of connector definitions.
+  v1betaListNamespacePipelineReleasesResponse:
+    type: object
+    properties:
+      releases:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipelineRelease'
+        description: A list of pipeline release resources.
+        readOnly: true
+      nextPageToken:
+        type: string
+        description: Next page token.
+        readOnly: true
+      totalSize:
+        type: integer
+        format: int32
+        description: Total number of pipeline releases.
+        readOnly: true
+    description: ListNamespacePipelineReleasesResponse contains a list of pipeline releases.
+  v1betaListNamespacePipelinesResponse:
+    type: object
+    properties:
+      pipelines:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipeline'
+        description: A list of pipeline resources.
+        readOnly: true
+      nextPageToken:
+        type: string
+        description: Next page token.
+        readOnly: true
+      totalSize:
+        type: integer
+        format: int32
+        description: Total number of pipelines.
+        readOnly: true
+    description: ListNamespacePipelinesResponse contains a list of pipelines.
   v1betaListOperatorDefinitionsResponse:
     type: object
     properties:
@@ -4359,14 +5674,37 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaPipeline'
         description: A list of pipeline resources.
+        readOnly: true
       nextPageToken:
         type: string
         description: Next page token.
+        readOnly: true
       totalSize:
         type: integer
         format: int32
         description: Total number of pipelines.
+        readOnly: true
     description: ListPipelinesResponse contains a list of pipelines.
+  v1betaListSecretsResponse:
+    type: object
+    properties:
+      secrets:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaSecret'
+        description: A list of secret resources.
+        readOnly: true
+      nextPageToken:
+        type: string
+        description: Next page secret.
+        readOnly: true
+      totalSize:
+        type: integer
+        format: int32
+        description: Total number of secret resources.
+        readOnly: true
+    description: ListSecretsResponse contains a list of secrets.
   v1betaListUserPipelineReleasesResponse:
     type: object
     properties:
@@ -4422,16 +5760,10 @@ definitions:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
         description: The requested pipeline.
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
     description: LookUpPipelineAdminResponse contains the requested pipeline.
-  v1betaLookUpPipelineResponse:
-    type: object
-    properties:
-      pipeline:
-        $ref: '#/definitions/v1betaPipeline'
-        description: The requested pipeline.
-    description: LookUpPipelineResponse contains the requested pipeline.
   v1betaOperatorDefinition:
     type: object
     properties:
@@ -4468,9 +5800,10 @@ definitions:
           frontend applications to pull and locate the icons.
         readOnly: true
       spec:
-        $ref: '#/definitions/v1betaOperatorSpec'
         description: Operator definition specification.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOperatorSpec'
       tombstone:
         type: boolean
         description: |-
@@ -4511,15 +5844,16 @@ definitions:
         description: Short description of the operator.
         readOnly: true
       releaseStage:
-        $ref: '#/definitions/ComponentDefinitionReleaseStage'
         description: Release stage.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/ComponentDefinitionReleaseStage'
     description: |-
       An Operator is a type of pipeline component that performs data injection and
       manipulation. OperatorDefinition describes a certain type of operator.
 
       For more information, see
-      [Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
+      [Component](https://www.instill.tech/docs/component/introduction)
       in the official documentation.
   v1betaOperatorSpec:
     type: object
@@ -4571,21 +5905,24 @@ definitions:
         description: Update time.
         readOnly: true
       owner:
-        $ref: '#/definitions/mgmtv1betaUser'
         description: The user that owns the organization.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/mgmtv1betaUser'
       profile:
-        $ref: '#/definitions/v1betaOrganizationProfile'
         description: Profile.
+        allOf:
+          - $ref: '#/definitions/v1betaOrganizationProfile'
       permission:
-        $ref: '#/definitions/coremgmtv1betaPermission'
         title: Permission
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/coremgmtv1betaPermission'
     description: |-
       Organizations group several users. As entities, they can own resources such
       as pipelines or releases.
     required:
-      - id
+      - profile
   v1betaOrganizationProfile:
     type: object
     properties:
@@ -4613,13 +5950,15 @@ definitions:
     type: object
     properties:
       user:
-        $ref: '#/definitions/mgmtv1betaUser'
         description: User.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/mgmtv1betaUser'
       organization:
-        $ref: '#/definitions/v1betaOrganization'
         description: Organization.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     description: Owner is a wrapper for User and Organization, used to embed owner information in other resources.
   v1betaPipeline:
     type: object
@@ -4663,8 +6002,9 @@ definitions:
         description: Pipeline delete time.
         readOnly: true
       sharing:
-        $ref: '#/definitions/v1betaSharing'
         description: Pipeline sharing information.
+        allOf:
+          - $ref: '#/definitions/v1betaSharing'
       metadata:
         type: object
         description: Metadata holds console-related data such as the pipeline builder layout.
@@ -4683,30 +6023,35 @@ definitions:
         type: string
         description: README holds the pipeline documentation.
       permission:
-        $ref: '#/definitions/vdppipelinev1betaPermission'
         description: Permission defines how a pipeline can be used.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/vdppipelinev1betaPermission'
       visibility:
-        $ref: '#/definitions/v1betaPipelineVisibility'
         description: Pipeline visibility.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineVisibility'
       owner:
-        $ref: '#/definitions/v1betaOwner'
         description: Pipeline owner.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaOwner'
       dataSpecification:
-        $ref: '#/definitions/v1betaDataSpecification'
         description: Data specifications.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaDataSpecification'
       tags:
         type: array
         items:
           type: string
         description: Tags.
       stats:
-        $ref: '#/definitions/PipelineStats'
         description: Statistic data.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/PipelineStats'
       rawRecipe:
         type: string
         description: |-
@@ -4728,9 +6073,10 @@ definitions:
       A Pipeline is an end-to-end workflow that automates a sequence of components
       to process data.
 
-      For more information, see
-      [Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline) in
+      For more information, see [Pipeline](https://www.instill.tech/docs/vdp/introduction) in
       the official documentation.
+    required:
+      - recipe
   v1betaPipelineRelease:
     type: object
     properties:
@@ -4784,9 +6130,10 @@ definitions:
         type: string
         description: README.
       dataSpecification:
-        $ref: '#/definitions/v1betaDataSpecification'
         description: Data specifications.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaDataSpecification'
       rawRecipe:
         type: string
         description: |-
@@ -4827,40 +6174,54 @@ definitions:
 
        - VISIBILITY_PRIVATE: Only the user can see the pipeline.
        - VISIBILITY_PUBLIC: Other users can see the pipeline.
+  v1betaRenameNamespacePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        description: The renamed pipeline resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
+    description: RenameNamespacePipelineResponse contains a renamed pipeline.
   v1betaRenameOrganizationPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The renamed pipeline release.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: RenameOrganizationPipelineReleaseResponse contains a renamed pipeline release.
   v1betaRenameOrganizationPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
         description: The renamed pipeline resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
     description: RenameOrganizationPipelineResponse contains a renamed pipeline.
   v1betaRenameUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The renamed pipeline release.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: RenameUserPipelineReleaseResponse contains a renamed pipeline release.
   v1betaRenameUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
         description: The renamed pipeline resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
     description: RenameUserPipelineResponse contains a renamed pipeline.
   v1betaRestoreOrganizationPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The pipeline release resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: |-
       RestoreOrganizationPipelineReleaseResponse contains the requested pipeline
       release.
@@ -4868,8 +6229,9 @@ definitions:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The pipeline release resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: RestoreUserPipelineReleaseResponse contains the requested pipeline release.
   v1betaRole:
     type: string
@@ -4935,12 +6297,13 @@ definitions:
 
           **NOTE**: For now, the only accepted key is `*/*`.
       shareCode:
-        $ref: '#/definitions/SharingShareCode'
         description: Defines the configuration to share a resource via link.
+        allOf:
+          - $ref: '#/definitions/SharingShareCode'
     description: |-
       Sharing contains the information to share a resource with other users.
 
-      For more information, see [Share Pipelines](https://www.instill.tech/docs/latest/vdp/share).
+      For more information, see [Share Pipelines](https://www.instill.tech/docs/vdp/share).
   v1betaSharingUser:
     type: object
     properties:
@@ -4948,8 +6311,9 @@ definitions:
         type: boolean
         description: Defines whether the sharing option with this user is enabled.
       role:
-        $ref: '#/definitions/v1betaRole'
         description: Defines the role the user will have over the resource.
+        allOf:
+          - $ref: '#/definitions/v1betaRole'
     description: Describes the sharing configuration with a given user.
   v1betaTrace:
     type: object
@@ -4959,23 +6323,28 @@ definitions:
         items:
           $ref: '#/definitions/v1betaTraceStatus'
         description: Statuses contains an execution status per input.
+        readOnly: true
       inputs:
         type: array
         items:
           type: object
         description: Component inputs.
+        readOnly: true
       outputs:
         type: array
         items:
           type: object
         description: Component outputs.
+        readOnly: true
       error:
         type: object
         description: Error details.
+        readOnly: true
       computeTimeInSeconds:
         type: number
         format: float
         description: Computation time in seconds.
+        readOnly: true
     description: Trace contains the execution details of a component.
   v1betaTraceStatus:
     type: string
@@ -4989,13 +6358,36 @@ definitions:
        - STATUS_COMPLETED: Successfully completed.
        - STATUS_SKIPPED: Skipped.
        - STATUS_ERROR: Aborted with error.
+  v1betaTriggerAsyncNamespacePipelineReleaseResponse:
+    type: object
+    properties:
+      operation:
+        description: Long-running operation information.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
+    description: |-
+      TriggerAsyncNamespacePipelineReleaseResponse contains the information to access
+      the status of an asynchronous pipeline execution.
+  v1betaTriggerAsyncNamespacePipelineResponse:
+    type: object
+    properties:
+      operation:
+        description: Long-running operation information.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
+    description: |-
+      TriggerAsyncNamespacePipelineResponse contains the information to access the
+      status of an asynchronous pipeline execution.
   v1betaTriggerAsyncOrganizationPipelineReleaseResponse:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: Long-running operation information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       TriggerAsyncOrganizationPipelineReleaseResponse contains the information to
       access the status of an asynchronous pipeline execution.
@@ -5003,9 +6395,10 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: Long-running operation information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       TriggerAsyncOrganizationPipelineResponse contains the information to access
       the status of an asynchronous pipeline execution.
@@ -5013,9 +6406,10 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: Long-running operation information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       TriggerAsyncUserPipelineReleaseResponse contains the information to access
       the status of an asynchronous pipeline execution.
@@ -5023,9 +6417,10 @@ definitions:
     type: object
     properties:
       operation:
-        $ref: '#/definitions/googlelongrunningOperation'
         description: Long-running operation information.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/googlelongrunningOperation'
     description: |-
       TriggerAsyncUserPipelineResponse contains the information to access the
       status of an asynchronous pipeline execution.
@@ -5051,7 +6446,59 @@ definitions:
         description: |-
           Each key in the `traces` object is a component ID. The value is a Trace
           object containing the execution details.
+        readOnly: true
     description: TriggerMetadata contains the traces of the pipeline inference.
+  v1betaTriggerNamespacePipelineReleaseResponse:
+    type: object
+    properties:
+      outputs:
+        type: array
+        items:
+          type: object
+        description: Model inference outputs.
+        readOnly: true
+      metadata:
+        description: Traces of the pipeline inference.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaTriggerMetadata'
+    description: |-
+      TriggerNamespacePipelineReleaseResponse contains the pipeline execution results,
+      i.e., the multiple model inference outputs.
+  v1betaTriggerNamespacePipelineResponse:
+    type: object
+    properties:
+      outputs:
+        type: array
+        items:
+          type: object
+        description: Model inference outputs.
+        readOnly: true
+      metadata:
+        description: Traces of the pipeline inference.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaTriggerMetadata'
+    description: |-
+      TriggerNamespacePipelineResponse contains the pipeline execution results, i.e.,
+      the multiple model inference outputs.
+  v1betaTriggerNamespacePipelineWithStreamResponse:
+    type: object
+    properties:
+      outputs:
+        type: array
+        items:
+          type: object
+        description: Model inference outputs.
+        readOnly: true
+      metadata:
+        description: Traces of the pipeline inference.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaTriggerMetadata'
+    description: |-
+      TriggerNamespacePipelineWithStreamResponse contains the pipeline execution results, i.e.,
+      the multiple model inference outputs.
   v1betaTriggerOrganizationPipelineReleaseResponse:
     type: object
     properties:
@@ -5061,8 +6508,9 @@ definitions:
           type: object
         description: Model inference outputs.
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
         description: Traces of the pipeline inference.
+        allOf:
+          - $ref: '#/definitions/v1betaTriggerMetadata'
     description: |-
       TriggerOrganizationPipelineReleaseResponse contains the pipeline execution
       results, i.e., the multiple model inference outputs.
@@ -5075,8 +6523,9 @@ definitions:
           type: object
         description: Model inference outputs.
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
         description: Traces of the pipeline inference.
+        allOf:
+          - $ref: '#/definitions/v1betaTriggerMetadata'
     description: |-
       TriggerOrganizationPipelineResponse contains the pipeline execution results,
       i.e., the multiple model inference outputs.
@@ -5089,8 +6538,9 @@ definitions:
           type: object
         description: Model inference outputs.
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
         description: Traces of the pipeline inference.
+        allOf:
+          - $ref: '#/definitions/v1betaTriggerMetadata'
     description: |-
       TriggerOrganizationPipelineResponse contains the pipeline execution results,
       i.e., the multiple model inference outputs.
@@ -5103,8 +6553,9 @@ definitions:
           type: object
         description: Model inference outputs.
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
         description: Traces of the pipeline inference.
+        allOf:
+          - $ref: '#/definitions/v1betaTriggerMetadata'
     description: |-
       TriggerUserPipelineReleaseResponse contains the pipeline execution results,
       i.e., the multiple model inference outputs.
@@ -5117,8 +6568,9 @@ definitions:
           type: object
         description: Model inference outputs.
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
         description: Traces of the pipeline inference.
+        allOf:
+          - $ref: '#/definitions/v1betaTriggerMetadata'
     description: |-
       TriggerUserPipelineResponse contains the pipeline execution results, i.e.,
       the multiple model inference outputs.
@@ -5131,17 +6583,37 @@ definitions:
           type: object
         description: Model inference outputs.
       metadata:
-        $ref: '#/definitions/v1betaTriggerMetadata'
         description: Traces of the pipeline inference.
+        allOf:
+          - $ref: '#/definitions/v1betaTriggerMetadata'
     description: |-
       TriggerUserPipelineWithStreamResponse contains the pipeline execution results, i.e.,
       the multiple model inference outputs.
+  v1betaUpdateNamespacePipelineReleaseResponse:
+    type: object
+    properties:
+      release:
+        description: The updated pipeline release resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
+    description: UpdateNamespacePipelineReleaseResponse contains the updated pipeline release.
+  v1betaUpdateNamespacePipelineResponse:
+    type: object
+    properties:
+      pipeline:
+        description: The updated pipeline resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
+    description: UpdateNamespacePipelineResponse contains the updated pipeline.
   v1betaUpdateOrganizationPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The updated pipeline release resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: |-
       UpdateOrganizationPipelineReleaseResponse contains the updated pipeline
       release.
@@ -5149,36 +6621,49 @@ definitions:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
         description: The updated pipeline resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
     description: UpdateOrganizationPipelineResponse contains the updated pipeline.
   v1betaUpdateOrganizationSecretResponse:
     type: object
     properties:
       secret:
-        $ref: '#/definitions/v1betaSecret'
         description: The updated secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
     description: UpdateOrganizationSecretResponse contains the updated secret.
+  v1betaUpdateSecretResponse:
+    type: object
+    properties:
+      secret:
+        description: The updated secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
+    description: UpdateSecretResponse contains the updated secret.
   v1betaUpdateUserPipelineReleaseResponse:
     type: object
     properties:
       release:
-        $ref: '#/definitions/v1betaPipelineRelease'
         description: The updated pipeline release resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRelease'
     description: UpdateUserPipelineReleaseResponse contains the updated pipeline release.
   v1betaUpdateUserPipelineResponse:
     type: object
     properties:
       pipeline:
-        $ref: '#/definitions/v1betaPipeline'
         description: The updated pipeline resource.
+        allOf:
+          - $ref: '#/definitions/v1betaPipeline'
     description: UpdateUserPipelineResponse contains the updated pipeline.
   v1betaUpdateUserSecretResponse:
     type: object
     properties:
       secret:
-        $ref: '#/definitions/v1betaSecret'
         description: The updated secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
     description: UpdateUserSecretResponse contains the updated secret.
   v1betaUserProfile:
     type: object
@@ -5206,6 +6691,21 @@ definitions:
           Social profile links list the links to the user's social profiles.
           The key represents the provider, and the value is the corresponding URL.
     description: UserProfile describes the public data of a user.
+  v1betaValidateNamespacePipelineResponse:
+    type: object
+    properties:
+      success:
+        type: boolean
+        title: Success
+        readOnly: true
+      errors:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipelineValidationError'
+        description: The validated pipeline resource.
+        readOnly: true
+    description: ValidateNamespacePipelineResponse contains a validated pipeline.
   v1betaValidateOrganizationPipelineResponse:
     type: object
     properties:

--- a/scripts/generate-openapi-doc-info.sh
+++ b/scripts/generate-openapi-doc-info.sh
@@ -20,8 +20,8 @@ ESCAPE_NEWLINES='s/$/\\n/g'
 PATTERN_INFO='{{\$info}}'
 PATTERN_CONF='{{\$conf}}'
 
-ESCAPED_INFO=$(sed $ESCAPE_SLASHES  common/openapi/v1beta/api_info.conf | sed $ESCAPE_NEWLINES | tr -d '\n')
-ESCAPED_CONF=$(sed $ESCAPE_SLASHES  common/openapi/v1beta/api_config.conf | sed $ESCAPE_NEWLINES | tr -d '\n')
+ESCAPED_INFO=$(sed $ESCAPE_SLASHES  common/openapi/v1beta/api_info.conf | sed $ESCAPE_NEWLINES | tr -d '\n' | sed 's/..$//')
+ESCAPED_CONF=$(sed $ESCAPE_SLASHES  common/openapi/v1beta/api_config.conf | sed $ESCAPE_NEWLINES | tr -d '\n' | sed 's/..$//')
 
 # For each template file, insert the configuration in the pattern and save it
 # as an openapi.proto file.

--- a/vdp/pipeline/v1beta/common.proto
+++ b/vdp/pipeline/v1beta/common.proto
@@ -16,7 +16,7 @@ enum Role {
 
 // Sharing contains the information to share a resource with other users.
 //
-// For more information, see [Share Pipelines](https://www.instill.tech/docs/latest/vdp/share).
+// For more information, see [Share Pipelines](https://www.instill.tech/docs/vdp/share).
 message Sharing {
   // Describes the sharing configuration with a given user.
   message User {

--- a/vdp/pipeline/v1beta/component_definition.proto
+++ b/vdp/pipeline/v1beta/component_definition.proto
@@ -130,9 +130,9 @@ message ComponentDefinition {
 // DataSpecification describes the JSON schema of component input and output.
 message DataSpecification {
   // JSON schema describing the component input data.
-  google.protobuf.Struct input = 1;
+  google.protobuf.Struct input = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // JSON schema describing the component output data.
-  google.protobuf.Struct output = 2;
+  google.protobuf.Struct output = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ConnectorSpec represents a specification data model.
@@ -175,7 +175,7 @@ enum ConnectorType {
 // ConnectorDefinition describes a certain type of Connector.
 //
 // For more information, see
-// [Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
+// [Component](https://www.instill.tech/docs/component/introduction)
 // in the official documentation.
 message ConnectorDefinition {
   option (google.api.resource) = {
@@ -250,7 +250,7 @@ message OperatorSpec {
 // manipulation. OperatorDefinition describes a certain type of operator.
 //
 // For more information, see
-// [Component](https://www.instill.tech/docs/latest/core/concepts/pipeline#pipeline-component)
+// [Component](https://www.instill.tech/docs/component/introduction)
 // in the official documentation.
 message OperatorDefinition {
   option (google.api.resource) = {

--- a/vdp/pipeline/v1beta/openapi.proto.templ
+++ b/vdp/pipeline/v1beta/openapi.proto.templ
@@ -7,29 +7,35 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 // These options define the OpenAPI definition document information.
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
-    title: "💧 VDP";
-    description: "VDP endpoints to manage pipeline resources";
-    {{$info}}
-  };
+    title: "💧 VDP"
+    description: "VDP endpoints to manage pipeline resources"
+{{$info}}
+  }
   tags: [
     {
       name: "Component"
+      description: "Component endpoints"
     },
     {
       name: "Pipeline"
+      description: "Pipeline endpoints"
     },
     {
       name: "Release"
+      description: "Pipeline Release endpoints"
     },
     {
       name: "Trigger"
+      description: "Pipeline Trigger endpoints"
     },
     {
       name: "Secret"
+      description: "Namespace Secret endpoints"
     },
     {
       name: "Utils"
+      description: "Utils endpoints"
     }
-  ];
+  ]
 {{$conf}}
 };

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -58,16 +58,9 @@ enum State {
 // A Pipeline is an end-to-end workflow that automates a sequence of components
 // to process data.
 //
-// For more information, see
-// [Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline) in
+// For more information, see [Pipeline](https://www.instill.tech/docs/vdp/introduction) in
 // the official documentation.
 message Pipeline {
-  option (google.api.resource) = {
-    type: "api.instill.tech/Pipeline"
-    pattern: "users/{user.id}/pipelines/{pipeline.id}"
-    pattern: "pipelines/{pipeline.uid}"
-  };
-
   // View defines how a Pipeline is presented.
   enum View {
     // Unspecified, equivalent to BASIC.
@@ -93,21 +86,16 @@ message Pipeline {
   // Statistic data
   message Stats {
     // Number of pipeline runs.
-    int32 number_of_runs = 1;
+    int32 number_of_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
     // Last run time.
-    google.protobuf.Timestamp last_run_time = 2;
+    google.protobuf.Timestamp last_run_time = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
     // Number of times this pipeline has been cloned.
-    int32 number_of_clones = 3;
+    int32 number_of_clones = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
 
   // The name of the pipeline, defined by its parent and ID.
   // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline_name"}
-    }
-  ];
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Pipeline UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -119,7 +107,7 @@ message Pipeline {
   // Pipeline description.
   optional string description = 4 [(google.api.field_behavior) = OPTIONAL];
   // Recipe describes the components of a Pipeline and how they are connected.
-  google.protobuf.Struct recipe = 5 [(google.api.field_behavior) = IMMUTABLE];
+  google.protobuf.Struct recipe = 5 [(google.api.field_behavior) = REQUIRED];
   // Pipeline creation time.
   google.protobuf.Timestamp create_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline update time.
@@ -145,10 +133,7 @@ message Pipeline {
   // Pipeline visibility.
   Visibility visibility = 22 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline owner.
-  optional core.mgmt.v1beta.Owner owner = 23 [
-    (google.api.field_behavior) = OPTIONAL,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+  optional core.mgmt.v1beta.Owner owner = 23 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Data specifications.
   DataSpecification data_specification = 24 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Tags.
@@ -172,7 +157,7 @@ message Pipeline {
 message TriggerMetadata {
   // Each key in the `traces` object is a component ID. The value is a Trace
   // object containing the execution details.
-  map<string, Trace> traces = 1;
+  map<string, Trace> traces = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Trace contains the execution details of a component.
@@ -189,15 +174,15 @@ message Trace {
     STATUS_ERROR = 3;
   }
   // Statuses contains an execution status per input.
-  repeated Status statuses = 1;
+  repeated Status statuses = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Component inputs.
-  repeated google.protobuf.Struct inputs = 2;
+  repeated google.protobuf.Struct inputs = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Component outputs.
-  repeated google.protobuf.Struct outputs = 3;
+  repeated google.protobuf.Struct outputs = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Error details.
-  google.protobuf.Struct error = 4;
+  google.protobuf.Struct error = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Computation time in seconds.
-  float compute_time_in_seconds = 5;
+  float compute_time_in_seconds = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetHubStatsRequest represents a request to get hub stats.
@@ -206,27 +191,17 @@ message GetHubStatsRequest {}
 // GetHubStatsResponse represents a response to get hub stats.
 message GetHubStatsResponse {
   // Total number of public pipelines.
-  int32 number_of_public_pipelines = 1;
+  int32 number_of_public_pipelines = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of featured pipelines.
-  int32 number_of_featured_pipelines = 2;
+  int32 number_of_featured_pipelines = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Pipeline releases contain the version control information of a pipeline.
 // This allows users to track changes in the pipeline over time.
 message PipelineRelease {
-  option (google.api.resource) = {
-    type: "api.instill.tech/Release"
-    pattern: "users/{user.id}/pipelines/{pipeline.id}/releases/{release.id}"
-  };
-
   // The name of the release, defined by its parent and ID.
   // - Format: `{parent_type}/{parent.id}/pipelines/{pipeline.id}/releases/{release.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "pipeline_release_name"}
-    }
-  ];
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Release UUID.
   string uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Release resource ID (used in `name` as the last segment). It must be a
@@ -286,11 +261,48 @@ message ListPipelinesRequest {
 // ListPipelinesResponse contains a list of pipelines.
 message ListPipelinesResponse {
   // A list of pipeline resources.
-  repeated Pipeline pipelines = 1;
+  repeated Pipeline pipelines = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Next page token.
-  string next_page_token = 2;
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of pipelines.
-  int32 total_size = 3;
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListNamespacePipelinesRequest represents a request to list pipelines.
+message ListNamespacePipelinesRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The maximum number of pipelines to return. If this parameter is
+  // unspecified, at most 10 pipelines will be returned. The cap value for this
+  // parameter is 100 (i.e. any value above that will be coerced to 100).
+  optional int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+  // View allows clients to specify the desired pipeline view in the response.
+  optional Pipeline.View view = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  // - Example:
+  // `recipe.components.definition_name:"operator-definitions/2ac8be70-0f7a-4b61-a33d-098b8acfa6f3"`.
+  optional string filter = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Include soft-deleted pipelines in the result.
+  optional bool show_deleted = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Limit results to pipelines with the specified visibility.
+  optional Pipeline.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+  optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListNamespacePipelinesResponse contains a list of pipelines.
+message ListNamespacePipelinesResponse {
+  // A list of pipeline resources.
+  repeated Pipeline pipelines = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Next page token.
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total number of pipelines.
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // LookUpPipelineRequest represents a request to query a pipeline by its UID.
@@ -305,7 +317,401 @@ message LookUpPipelineRequest {
 // LookUpPipelineResponse contains the requested pipeline.
 message LookUpPipelineResponse {
   // The requested pipeline.
-  Pipeline pipeline = 1;
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CreateNamespacePipelineRequest represents a request from a namespace to create a
+// pipeline.
+message CreateNamespacePipelineRequest {
+  // The namespace that creates the pipeline.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The properties of the pipeline to be created.
+  Pipeline pipeline = 2;
+}
+
+// CreateNamespacePipelineResponse contains the created pipeline.
+message CreateNamespacePipelineResponse {
+  // The created pipeline resource.
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetNamespacePipelineRequest represents a request to fetch the details of a
+// pipeline owned by a namespace.
+message GetNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // View allows clients to specify the desired pipeline view in the response.
+  optional Pipeline.View view = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetNamespacePipelineResponse contains the requested pipeline.
+message GetNamespacePipelineResponse {
+  // The pipeline resource.
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// UpdateNamespacePipelineRequest represents a request to update a pipeline owned by
+// a namespace.
+message UpdateNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The pipeline fields that will replace the existing ones.
+  Pipeline pipeline = 3;
+  // The update mask specifies the subset of fields that should be modified.
+  //
+  // For more information about this field, see
+  // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+  google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateNamespacePipelineResponse contains the updated pipeline.
+message UpdateNamespacePipelineResponse {
+  // The updated pipeline resource.
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// DeleteNamespacePipelineRequest represents a request to delete a pipeline owned by
+// a namespace.
+message DeleteNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DeleteNamespacePipelineResponse is an empty response.
+message DeleteNamespacePipelineResponse {}
+
+// ValidateNamespacePipelineRequest represents a request to validate a pipeline
+// owned by a user.
+message ValidateNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// ValidateNamespacePipelineResponse contains a validated pipeline.
+message ValidateNamespacePipelineResponse {
+  // Success
+  bool success = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The validated pipeline resource.
+  repeated PipelineValidationError errors = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// RenameNamespacePipelineRequest represents a request to rename the name of a
+// pipeline owned by a namespace.
+message RenameNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The new resource ID. This will transform the resource name into
+  // `namespaces/{namespace.id}/pipelines/{new_pipeline_id}`.
+  string new_pipeline_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RenameNamespacePipelineResponse contains a renamed pipeline.
+message RenameNamespacePipelineResponse {
+  // The renamed pipeline resource.
+  Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CloneNamespacePipelineRequest represents a request to clone a pipeline owned by a
+// user.
+message CloneNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The target pipeline. It can be under a user or an organization
+  // namespace, so the following formats are accepted:
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
+  string target = 3 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// CloneNamespacePipelineResponse contains a cloned pipeline.
+message CloneNamespacePipelineResponse {}
+
+// CloneNamespacePipelineReleaseRequest represents a request to clone a pipeline
+// release owned by a user.
+message CloneNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The target pipeline. It can be under a user or an organization
+  // namespace, so the following formats are accepted:
+  // - `{user.id}/{pipeline.id}`
+  // - `{organization.id}/{pipeline.id}`
+  string target = 4 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline description.
+  string description = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline sharing information.
+  Sharing sharing = 6 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// CloneNamespacePipelineReleaseResponse contains a cloned pipeline.
+message CloneNamespacePipelineReleaseResponse {}
+
+// TriggerNamespacePipelineRequest represents a request to trigger a user-owned
+// pipeline synchronously.
+message TriggerNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 3 [(google.api.field_behavior) = REQUIRED];
+  // Data
+  repeated TriggerData data = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerNamespacePipelineResponse contains the pipeline execution results, i.e.,
+// the multiple model inference outputs.
+message TriggerNamespacePipelineResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct outputs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Traces of the pipeline inference.
+  TriggerMetadata metadata = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TriggerNamespacePipelineWithStreamRequest represents a request to trigger a user-owned
+// pipeline synchronously and streams back the results.
+message TriggerNamespacePipelineWithStreamRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// TriggerNamespacePipelineWithStreamResponse contains the pipeline execution results, i.e.,
+// the multiple model inference outputs.
+message TriggerNamespacePipelineWithStreamResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct outputs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Traces of the pipeline inference.
+  TriggerMetadata metadata = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TriggerNamespacePipelineRequest represents a request to trigger a user-owned
+// pipeline synchronously.
+message TriggerAsyncNamespacePipelineRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// TriggerAsyncNamespacePipelineResponse contains the information to access the
+// status of an asynchronous pipeline execution.
+message TriggerAsyncNamespacePipelineResponse {
+  // Long-running operation information.
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CreateNamespacePipelineReleaseRequest represents a request to release a version
+// in a user-owned pipeline.
+message CreateNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The release information.
+  PipelineRelease release = 3;
+}
+
+// CreateNamespacePipelineReleaseResponse contains the created release.
+message CreateNamespacePipelineReleaseResponse {
+  // The created pipeline release object.
+  PipelineRelease release = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListNamespacePipelineReleasesRequest represents a request to list the releases in
+// a user-owned pipeline.
+message ListNamespacePipelineReleasesRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The maximum number of releases to return. If this parameter is
+  // unspecified, at most 10 pipelines will be returned. The cap value for this
+  // parameter is 100 (i.e. any value above that will be coerced to 100).
+  optional int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 4 [(google.api.field_behavior) = OPTIONAL];
+  // View allows clients to specify the desired pipeline view in the response.
+  optional Pipeline.View view = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Include soft-deleted pipelines in the result.
+  optional bool show_deleted = 7 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListNamespacePipelineReleasesResponse contains a list of pipeline releases.
+message ListNamespacePipelineReleasesResponse {
+  // A list of pipeline release resources.
+  repeated PipelineRelease releases = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Next page token.
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total number of pipeline releases.
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetNamespacePipelineReleaseRequest represents a request to fetchthe details of a
+// release in a user-owned pipeline.
+message GetNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // View allows clients to specify the desired pipeline view in the response.
+  optional Pipeline.View view = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetNamespacePipelineReleaseResponse contains the requested pipeline release.
+message GetNamespacePipelineReleaseResponse {
+  // The pipeline release resource.
+  PipelineRelease release = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// UpdateNamespacePipelineReleaseRequest represents a request to update a user-owned
+// pipeline release.
+message UpdateNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // The pipeline release fields that will replace the existing ones.
+  // A pipeline release resource to update
+  PipelineRelease release = 4;
+  // The update mask specifies the subset of fields that should be modified.
+  //
+  // For more information about this field, see
+  // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+  google.protobuf.FieldMask update_mask = 5 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateNamespacePipelineReleaseResponse contains the updated pipeline release.
+message UpdateNamespacePipelineReleaseResponse {
+  // The updated pipeline release resource.
+  PipelineRelease release = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// DeleteNamespacePipelineReleaseRequest represents a request to delete a release in
+// a user-owned pipeline.
+message DeleteNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DeleteNamespacePipelineReleaseResponse is an empty response.
+message DeleteNamespacePipelineReleaseResponse {}
+
+// TriggerNamespacePipelineReleaseRequest represents a request to trigger a pinned
+// release of a user-owned pipeline.
+message TriggerNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Data
+  repeated TriggerData data = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// TriggerNamespacePipelineReleaseResponse contains the pipeline execution results,
+// i.e., the multiple model inference outputs.
+message TriggerNamespacePipelineReleaseResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct outputs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Traces of the pipeline inference.
+  TriggerMetadata metadata = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TriggerNamespacePipelineReleaseRequest represents a request to trigger a pinned
+// release of a user-owned pipeline asynchronously.
+message TriggerAsyncNamespacePipelineReleaseRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // Release ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // Pipeline input parameters, it will be deprecated soon.
+  repeated google.protobuf.Struct inputs = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // Data
+  repeated TriggerData data = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// TriggerAsyncNamespacePipelineReleaseResponse contains the information to access
+// the status of an asynchronous pipeline execution.
+message TriggerAsyncNamespacePipelineReleaseResponse {
+  // Long-running operation information.
+  google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateUserPipelineRequest represents a request from a user to create a

--- a/vdp/pipeline/v1beta/pipeline_private_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_private_service.proto
@@ -2,9 +2,6 @@ syntax = "proto3";
 
 package vdp.pipeline.v1beta;
 
-// Google API
-import "google/api/annotations.proto";
-import "google/api/visibility.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
 import "vdp/pipeline/v1beta/pipeline.proto";
@@ -18,25 +15,17 @@ service PipelinePrivateService {
   //
   // This is a *private* method that allows admin users and internal clients to
   // list *all* pipeline resources.
-  rpc ListPipelinesAdmin(ListPipelinesAdminRequest) returns (ListPipelinesAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/pipelines"};
-  }
+  rpc ListPipelinesAdmin(ListPipelinesAdminRequest) returns (ListPipelinesAdminResponse) {}
 
   // Get a pipeline by UID (admin only)
   //
   // This is a *private* method that allows admin users to access any pipeline
   // resource by its UID.
-  rpc LookUpPipelineAdmin(LookUpPipelineAdminRequest) returns (LookUpPipelineAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/{permalink=pipelines/*}/lookUp"};
-  }
+  rpc LookUpPipelineAdmin(LookUpPipelineAdminRequest) returns (LookUpPipelineAdminResponse) {}
 
   // List pipeline releases (admin only)
   //
   // This is a *private* method that allows admin users to list *all* pipeline
   // releases.
-  rpc ListPipelineReleasesAdmin(ListPipelineReleasesAdminRequest) returns (ListPipelineReleasesAdminResponse) {
-    option (google.api.http) = {get: "/v1beta/admin/releases"};
-  }
-
-  option (google.api.api_visibility).restriction = "INTERNAL";
+  rpc ListPipelineReleasesAdmin(ListPipelineReleasesAdminRequest) returns (ListPipelineReleasesAdminResponse) {}
 }

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -46,6 +46,7 @@ service PipelinePublicService {
   rpc GetHubStats(GetHubStatsRequest) returns (GetHubStatsResponse) {
     option (google.api.http) = {get: "/v1beta/hub-stats"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
   // List accessible pipelines
@@ -63,7 +64,392 @@ service PipelinePublicService {
   rpc LookUpPipeline(LookUpPipelineRequest) returns (LookUpPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{permalink=pipelines/*}/lookUp"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
   }
+
+  // List namespace pipelines
+  //
+  // Returns a paginated list of pipelines of a namespace
+  rpc ListNamespacePipelines(ListNamespacePipelinesRequest) returns (ListNamespacePipelinesResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Create a new pipeline
+  //
+  // Creates a new pipeline under a namespace.
+  rpc CreateNamespacePipeline(CreateNamespacePipelineRequest) returns (CreateNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines"
+      body: "pipeline"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Get a pipeline
+  //
+  // Returns the details of a pipeline.
+  rpc GetNamespacePipeline(GetNamespacePipelineRequest) returns (GetNamespacePipelineResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Update a pipeline
+  //
+  // Udpates a pipeline, accessing it by its resource name, which is defined by
+  // the parent namespace and the ID of the pipeline. The authenticated namespace must be
+  // the parent of the pipeline in order to modify it.
+  //
+  // In REST requests, only the supplied pipeline fields will be taken into
+  // account when updating the resource.
+  rpc UpdateNamespacePipeline(UpdateNamespacePipelineRequest) returns (UpdateNamespacePipelineResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"
+      body: "pipeline"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Delete a pipeline
+  //
+  // Deletes a pipeline, accesing it by its resource name, which is defined by
+  // the parent namespace and the ID of the pipeline. The authenticated namespace must be
+  // the parent of the pipeline in order to delete it.
+  rpc DeleteNamespacePipeline(DeleteNamespacePipelineRequest) returns (DeleteNamespacePipelineResponse) {
+    option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Validate a pipeline
+  //
+  // Validates a pipeline by its resource name, which is defined by the parent
+  // namespace and the ID of the pipeline.
+  //
+  // Validation checks the recipe of the pipeline and the status of its components.
+  rpc ValidateNamespacePipeline(ValidateNamespacePipelineRequest) returns (ValidateNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/validate"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Rename a pipeline
+  //
+  // Updates the ID of a pipeline. Since this is an output-only field, a custom
+  // method is required to modify it.
+  //
+  // The pipeline name will be updated accordingly, as it is  composed by the
+  // parent namespace and ID of the pipeline (e.g.
+  // `namespaces/luigi/pipelines/pizza-recipe-generator`).
+  //
+  // The authenticated namespace must be the parent of the pipeline in order to
+  // perform this action.
+  rpc RenameNamespacePipeline(RenameNamespacePipelineRequest) returns (RenameNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/rename"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Clone a pipeline
+  //
+  // Clones a pipeline owned by a namespace. The new pipeline may have a different
+  // parent, and this can be either a namespace or an organization.
+  rpc CloneNamespacePipeline(CloneNamespacePipelineRequest) returns (CloneNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/clone"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+  }
+
+  // Trigger a pipeline
+  //
+  // Triggers the execution of a pipeline synchronously, i.e., the result is
+  // sent back to the namespace right after the data is processed. This method is
+  // intended for real-time inference when low latency is of concern.
+  //
+  // The pipeline is identified by its resource name, formed by the parent namespace
+  // and ID of the pipeline.
+  //
+  // For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+  rpc TriggerNamespacePipeline(TriggerNamespacePipelineRequest) returns (TriggerNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/trigger"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger a pipeline via streaming
+  //
+  // Triggers the execution of a pipeline asynchronously and streams back the response.
+  // This method is intended for real-time inference when low latency is of concern
+  // and the response needs to be processed incrementally.
+  //
+  // The pipeline is identified by its resource name, formed by the parent namespace
+  // and ID of the pipeline.
+  rpc TriggerNamespacePipelineWithStream(TriggerNamespacePipelineWithStreamRequest) returns (stream TriggerNamespacePipelineWithStreamResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/trigger-stream"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger a pipeline asynchronously
+  //
+  // Triggers the execution of a pipeline asynchronously, i.e., the result
+  // contains the necessary information to access the result and status of the
+  // operation. This method is intended for cases that require long-running
+  // workloads.
+  //
+  // The pipeline is identified by its resource name, formed by the parent namespace
+  // and ID of the pipeline.
+  //
+  // For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+  rpc TriggerAsyncNamespacePipeline(TriggerAsyncNamespacePipelineRequest) returns (TriggerAsyncNamespacePipelineResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/trigger-async"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Create a pipeline release
+  //
+  // Commits the version of a pipeline, identified by its resource name, which
+  // is formed by the parent namespace and ID of the pipeline.
+  //
+  // The authenticated namespace must be the parent of the pipeline in order to
+  // perform this action.
+  rpc CreateNamespacePipelineRelease(CreateNamespacePipelineReleaseRequest) returns (CreateNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases"
+      body: "release"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // List the releases in a pipeline
+  //
+  // Lists the commited versions of a pipeline, identified by its resource
+  // name, which is formed by the parent namespace and ID of the pipeline.
+  rpc ListNamespacePipelineReleases(ListNamespacePipelineReleasesRequest) returns (ListNamespacePipelineReleasesResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Get a pipeline release
+  //
+  // Gets the details of a pipeline release, where the pipeline is identified
+  // by its resource name, formed by its parent namespace and ID.
+  rpc GetNamespacePipelineRelease(GetNamespacePipelineReleaseRequest) returns (GetNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Update a pipeline release
+  //
+  // Updates the details of a pipeline release, where the pipeline is
+  // identified by its resource name, formed by its parent namespace and ID.
+  //
+  // The authenticated namespace must be the parent of the pipeline in order to
+  // perform this action.
+  rpc UpdateNamespacePipelineRelease(UpdateNamespacePipelineReleaseRequest) returns (UpdateNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"
+      body: "release"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Delete a pipeline release
+  //
+  // Deletes a pipeline release, where the pipeline is identified by its
+  // resource name, formed by its parent namespace and ID.
+  //
+  // The authenticated namespace must be the parent of the pipeline in order to
+  // perform this action.
+  rpc DeleteNamespacePipelineRelease(DeleteNamespacePipelineReleaseRequest) returns (DeleteNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Clone a pipeline release
+  //
+  // Clones a pipeline release owned by a namespace. The new pipeline may have a different
+  // parent, and this can be either a namespace or an organization.
+  rpc CloneNamespacePipelineRelease(CloneNamespacePipelineReleaseRequest) returns (CloneNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/clone"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+  }
+
+  // Trigger a pipeline release
+  //
+  // Triggers the synchronous execution of of a pipeline. While the trigger
+  // endpoint (where the release version isn't specified) triggers the pipeline
+  // at its latest release, this method allows the client to specified any
+  // committed release.
+  //
+  // The pipeline is identified by its resource name, formed by its parent namespace
+  // and ID.
+  rpc TriggerNamespacePipelineRelease(TriggerNamespacePipelineReleaseRequest) returns (TriggerNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger a pipeline release asynchronously
+  //
+  // Triggers the asynchronous execution of of a pipeline. While the trigger
+  // endpoint (where the release version isn't specified) triggers the pipeline
+  // at its latest release, this method allows the client to specified any
+  // committed release.
+  //
+  // The pipeline is identified by its resource name, formed by its parent namespace
+  // and ID.
+  rpc TriggerAsyncNamespacePipelineRelease(TriggerAsyncNamespacePipelineReleaseRequest) returns (TriggerAsyncNamespacePipelineReleaseResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/trigger-async"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Create a secret
+  //
+  // Creates a new secret under the parenthood of an namespace.
+  rpc CreateSecret(CreateSecretRequest) returns (CreateSecretResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/secrets"
+      body: "secret"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // List secrets
+  //
+  // Returns a paginated list of secrets that belong to the specified
+  // namespace.
+  rpc ListSecrets(ListSecretsRequest) returns (ListSecretsResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // Get a secret
+  //
+  // Returns the details of an namespace-owned secret by its resource name,
+  // which is defined by the parent namespace and the ID of the secret.
+  rpc GetSecret(GetSecretRequest) returns (GetSecretResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // Update a secret
+  //
+  // Udpates a secret, accessing it by its resource name, which is defined by
+  //
+  // In REST requests, only the supplied secret fields will be taken into
+  // account when updating the resource.
+  rpc UpdateSecret(UpdateSecretRequest) returns (UpdateSecretResponse) {
+    option (google.api.http) = {
+      patch: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"
+      body: "secret"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // Delete a secret
+  //
+  // Deletes a secret, accesing it by its resource name, which is defined by
+  // the parent namespace and the ID of the secret.
+  rpc DeleteSecret(DeleteSecretRequest) returns (DeleteSecretResponse) {
+    option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+  }
+
+  // List component definitions
+  //
+  // Returns a paginated list of component definitions, regardless their type.
+  // This offers a single source of truth, with pagination and filter
+  // capabilities, for the components that might be used in a VDP pipeline.
+  rpc ListComponentDefinitions(ListComponentDefinitionsRequest) returns (ListComponentDefinitionsResponse) {
+    option (google.api.http) = {get: "/v1beta/component-definitions"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+  }
+
+  // Get the details of a long-running operation
+  //
+  // This method allows requesters to request the status and outcome of
+  // long-running operations such as asynchronous pipeline triggers.
+  rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
+    option (google.api.http) = {get: "/v1beta/{name=operations/*}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // The following endpoints are all deprecated
 
   // Create a new user pipeline
   //
@@ -75,7 +461,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*}/pipelines"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // List user pipelines
@@ -86,7 +473,8 @@ service PipelinePublicService {
   // latter.
   rpc ListUserPipelines(ListUserPipelinesRequest) returns (ListUserPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a pipeline owned by a user
@@ -95,7 +483,8 @@ service PipelinePublicService {
   // by the parent user and the ID of the pipeline.
   rpc GetUserPipeline(GetUserPipelineRequest) returns (GetUserPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a pipeline owned by a user
@@ -111,7 +500,8 @@ service PipelinePublicService {
       patch: "/v1beta/{pipeline.name=users/*/pipelines/*}"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a pipeline owned by a user
@@ -121,7 +511,8 @@ service PipelinePublicService {
   // the parent of the pipeline in order to delete it.
   rpc DeleteUserPipeline(DeleteUserPipelineRequest) returns (DeleteUserPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Validate a pipeline a pipeline owned by a user
@@ -135,7 +526,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/validate"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a pipeline owned by a user
@@ -154,7 +546,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Clone a pipeline owned by a user
@@ -166,7 +559,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Clone a pipeline release owned by a user
@@ -178,7 +572,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by a user
@@ -190,23 +585,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent user
   // and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerUserPipeline(TriggerUserPipelineRequest) returns (TriggerUserPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=users/*/pipelines/*}/trigger"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by a user and stream back the response
@@ -223,15 +618,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by a user asynchronously
@@ -244,23 +640,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent user
   // and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerAsyncUserPipeline(TriggerAsyncUserPipelineRequest) returns (TriggerAsyncUserPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=users/*/pipelines/*}/triggerAsync"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Release a version of a pipeline owned by a user
@@ -275,7 +671,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*/pipelines/*}/releases"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // List the releases in a pipeline owned by a user
@@ -284,7 +681,8 @@ service PipelinePublicService {
   // name, which is formed by the parent user and ID of the pipeline.
   rpc ListUserPipelineReleases(ListUserPipelineReleasesRequest) returns (ListUserPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*/pipelines/*}/releases"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a release in a pipeline owned by a user
@@ -293,7 +691,8 @@ service PipelinePublicService {
   // by its resource name, formed by its parent user and ID.
   rpc GetUserPipelineRelease(GetUserPipelineReleaseRequest) returns (GetUserPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a release in a pipeline owned by a user
@@ -308,7 +707,8 @@ service PipelinePublicService {
       patch: "/v1beta/{release.name=users/*/pipelines/*/releases/*}"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a release in a pipeline owned by a user
@@ -320,7 +720,8 @@ service PipelinePublicService {
   // perform this action.
   rpc DeleteUserPipelineRelease(DeleteUserPipelineReleaseRequest) returns (DeleteUserPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Set the version of a pipeline owned by a user to a pinned release
@@ -334,7 +735,8 @@ service PipelinePublicService {
   // perform this action.
   rpc RestoreUserPipelineRelease(RestoreUserPipelineReleaseRequest) returns (RestoreUserPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=users/*/pipelines/*/releases/*}/restore"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a release in a pipeline owned by a user
@@ -354,7 +756,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Trigger a version of a pipeline owned by a user
@@ -372,15 +775,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger a version of a pipeline owned by a user asynchronously
@@ -398,15 +802,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Create a new organization pipeline
@@ -417,7 +822,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*}/pipelines"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // List organization pipelines
@@ -426,7 +832,8 @@ service PipelinePublicService {
   // organization.
   rpc ListOrganizationPipelines(ListOrganizationPipelinesRequest) returns (ListOrganizationPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a pipeline owned by an organization
@@ -435,7 +842,8 @@ service PipelinePublicService {
   // which is defined by the parent organization and the ID of the pipeline.
   rpc GetOrganizationPipeline(GetOrganizationPipelineRequest) returns (GetOrganizationPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a pipeline owned by an organization
@@ -449,7 +857,8 @@ service PipelinePublicService {
       patch: "/v1beta/{pipeline.name=organizations/*/pipelines/*}"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a pipeline owned by an organization
@@ -458,7 +867,8 @@ service PipelinePublicService {
   // the parent organization and the ID of the pipeline.
   rpc DeleteOrganizationPipeline(DeleteOrganizationPipelineRequest) returns (DeleteOrganizationPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Validate a pipeline a pipeline owned by an organization
@@ -473,7 +883,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/validate"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a pipeline owned by an organization
@@ -489,7 +900,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Clone a pipeline owned by an organization
@@ -501,7 +913,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Clone a pipeline release owned by an organization
@@ -513,7 +926,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by an organization
@@ -525,23 +939,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent
   // organization and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerOrganizationPipelineStream(TriggerOrganizationPipelineStreamRequest) returns (stream TriggerOrganizationPipelineStreamResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/trigger-stream"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by an organization
@@ -553,23 +967,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent
   // organization and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerOrganizationPipeline(TriggerOrganizationPipelineRequest) returns (TriggerOrganizationPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/trigger"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger a pipeline owned by an organization asynchronously
@@ -582,23 +996,23 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent
   // organization and ID of the pipeline.
   //
-  // For more information, see [Trigger
-  // Pipeline](https://www.instill.tech/docs/latest/core/concepts/pipeline#trigger-pipeline).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
   rpc TriggerAsyncOrganizationPipeline(TriggerAsyncOrganizationPipelineRequest) returns (TriggerAsyncOrganizationPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/triggerAsync"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Release a version of a pipeline owned by an organization
@@ -610,7 +1024,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*/pipelines/*}/releases"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // List the releases in a pipeline owned by an organization
@@ -619,7 +1034,8 @@ service PipelinePublicService {
   // which is formed by the parent organization and ID of the pipeline.
   rpc ListOrganizationPipelineReleases(ListOrganizationPipelineReleasesRequest) returns (ListOrganizationPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*/pipelines/*}/releases"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a release in a pipeline owned by an organization
@@ -628,7 +1044,8 @@ service PipelinePublicService {
   // its resource name, formed by its parent organization and ID.
   rpc GetOrganizationPipelineRelease(GetOrganizationPipelineReleaseRequest) returns (GetOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a release in a pipeline owned by an organization
@@ -640,7 +1057,8 @@ service PipelinePublicService {
       patch: "/v1beta/{release.name=organizations/*/pipelines/*/releases/*}"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a release in a pipeline owned by an organization
@@ -649,7 +1067,8 @@ service PipelinePublicService {
   // name, formed by its parent organization and ID.
   rpc DeleteOrganizationPipelineRelease(DeleteOrganizationPipelineReleaseRequest) returns (DeleteOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Set the version of a pipeline owned by an organization to a pinned release
@@ -660,7 +1079,8 @@ service PipelinePublicService {
   // organization and ID.
   rpc RestoreOrganizationPipelineRelease(RestoreOrganizationPipelineReleaseRequest) returns (RestoreOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/restore"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Rename a release in a pipeline owned by an organization
@@ -677,7 +1097,8 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option deprecated = true;
   }
 
   // Trigger a version of a pipeline owned by an organization
@@ -695,15 +1116,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
+    option deprecated = true;
   }
 
   // Trigger a version of a pipeline owned by an organization asynchronously
@@ -721,33 +1143,16 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
+      tags: "Trigger (Deprecated)"
       parameters: {
         headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
     };
-  }
-
-  // Get the details of a long-running operation
-  //
-  // This method allows requesters to request the status and outcome of
-  // long-running operations such as asynchronous pipeline triggers.
-  rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=operations/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Trigger";
-      parameters: {
-        headers: {
-          name: "Instill-Requester-Uid";
-          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to";
-          type: STRING;
-        };
-      };
-    };
+    option deprecated = true;
   }
 
   // List connector definitions
@@ -755,7 +1160,7 @@ service PipelinePublicService {
   // Returns a paginated list of connector definitions.
   rpc ListConnectorDefinitions(ListConnectorDefinitionsRequest) returns (ListConnectorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/connector-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
     option deprecated = true;
   }
 
@@ -764,7 +1169,7 @@ service PipelinePublicService {
   // Returns the details of a connector definition.
   rpc GetConnectorDefinition(GetConnectorDefinitionRequest) returns (GetConnectorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=connector-definitions/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
     option deprecated = true;
   }
 
@@ -773,18 +1178,8 @@ service PipelinePublicService {
   // Returns a paginated list of operator definitions.
   rpc ListOperatorDefinitions(ListOperatorDefinitionsRequest) returns (ListOperatorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/operator-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
     option deprecated = true;
-  }
-
-  // List component definitions
-  //
-  // Returns a paginated list of component definitions, regardless their type.
-  // This offers a single source of truth, with pagination and filter
-  // capabilities, for the components that might be used in a VDP pipeline.
-  rpc ListComponentDefinitions(ListComponentDefinitionsRequest) returns (ListComponentDefinitionsResponse) {
-    option (google.api.http) = {get: "/v1beta/component-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
   }
 
   // Get operator definition
@@ -792,7 +1187,7 @@ service PipelinePublicService {
   // Returns the details of an operator definition.
   rpc GetOperatorDefinition(GetOperatorDefinitionRequest) returns (GetOperatorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=operator-definitions/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
     option deprecated = true;
   }
 
@@ -805,7 +1200,8 @@ service PipelinePublicService {
       post: "/v1beta/check-name"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils (Deprecated)"};
+    option deprecated = true;
   }
 
   // Create a new user secret
@@ -816,7 +1212,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*}/secrets"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // List user secrets
@@ -825,7 +1222,8 @@ service PipelinePublicService {
   // user.
   rpc ListUserSecrets(ListUserSecretsRequest) returns (ListUserSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/secrets"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a secret owned by an user
@@ -834,7 +1232,8 @@ service PipelinePublicService {
   // which is defined by the parent user and the ID of the secret.
   rpc GetUserSecret(GetUserSecretRequest) returns (GetUserSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/secrets/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a secret owned by an user
@@ -848,7 +1247,8 @@ service PipelinePublicService {
       patch: "/v1beta/{secret.name=users/*/secrets/*}"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a secret owned by an user
@@ -857,7 +1257,8 @@ service PipelinePublicService {
   // the parent user and the ID of the secret.
   rpc DeleteUserSecret(DeleteUserSecretRequest) returns (DeleteUserSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/secrets/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Create a new organization secret
@@ -868,7 +1269,8 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*}/secrets"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // List organization secrets
@@ -877,7 +1279,8 @@ service PipelinePublicService {
   // organization.
   rpc ListOrganizationSecrets(ListOrganizationSecretsRequest) returns (ListOrganizationSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/secrets"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Get a secret owned by an organization
@@ -886,7 +1289,8 @@ service PipelinePublicService {
   // which is defined by the parent organization and the ID of the secret.
   rpc GetOrganizationSecret(GetOrganizationSecretRequest) returns (GetOrganizationSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/secrets/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Update a secret owned by an organization
@@ -900,7 +1304,8 @@ service PipelinePublicService {
       patch: "/v1beta/{secret.name=organizations/*/secrets/*}"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 
   // Delete a secret owned by an organization
@@ -909,6 +1314,7 @@ service PipelinePublicService {
   // the parent organization and the ID of the secret.
   rpc DeleteOrganizationSecret(DeleteOrganizationSecretRequest) returns (DeleteOrganizationSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/secrets/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option deprecated = true;
   }
 }

--- a/vdp/pipeline/v1beta/secret.proto
+++ b/vdp/pipeline/v1beta/secret.proto
@@ -39,6 +39,90 @@ message Secret {
   string description = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
+// CreateSecretRequest represents a request to create a secret.
+message CreateSecretRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Secret ID
+  string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The properties of the secret to be created.
+  Secret secret = 3;
+}
+
+// CreateSecretResponse contains the created secret.
+message CreateSecretResponse {
+  // The created secret resource.
+  Secret secret = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListSecretsRequest represents a request to list the secrets of a namespace.
+message ListSecretsRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The maximum number of secrets to return. If this parameter is unspecified,
+  // at most 10 pipelines will be returned. The cap value for this parameter is
+  // 100 (i.e. any value above that will be coerced to 100).
+  optional int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Page secret.
+  optional string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListSecretsResponse contains a list of secrets.
+message ListSecretsResponse {
+  // A list of secret resources.
+  repeated Secret secrets = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Next page secret.
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total number of secret resources.
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetSecretRequest represents a request to fetch the details of a secret
+message GetSecretRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Secret ID
+  string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetSecretResponse contains the requested secret.
+message GetSecretResponse {
+  // The secret resource.
+  Secret secret = 1;
+}
+
+// UpdateSecretRequest represents a request to update a namespace secret.
+message UpdateSecretRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Secret ID
+  string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The secret fields to update.
+  Secret secret = 3;
+  // The update mask specifies the subset of fields that should be modified.
+  //
+  // For more information about this field, see
+  // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
+  google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateSecretResponse contains the updated secret.
+message UpdateSecretResponse {
+  // The updated secret resource.
+  Secret secret = 1;
+}
+
+// DeleteSecretRequest represents a request to delete a secret resource.
+message DeleteSecretRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Secret ID
+  string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DeleteSecretResponse is an empty response.
+message DeleteSecretResponse {}
+
 // CreateUserSecretRequest represents a request to create a secret.
 message CreateUserSecretRequest {
   // The properties of the secret to be created.


### PR DESCRIPTION
Because

- We'd like to simplify the API endpoints by merging users and organization endpoints into namespace endpoints.

This commit

- Introduces new namespace endpoints.
- Fixes several bugs for OpenAPI generation.
- Makes the path parameters explicit.
- Uses `rdme` cli tool for CI and validation.