### PR TITLE
feat: adjust namespace secret endpoint name

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -457,6 +457,50 @@ message CheckNamespaceAdminResponse {
   Namespace type = 1;
   // Namespace UID.
   string uid = 2;
+  // The owner, which can be either a User or an Organization.
+  oneof owner {
+    // User.
+    core.mgmt.v1beta.User user = 3;
+    // Organization.
+    core.mgmt.v1beta.Organization organization = 4;
+  }
+}
+
+// CheckNamespaceByUIDAdminRequest represents a request to verify if a namespace is
+// available.
+message CheckNamespaceByUIDAdminRequest {
+  // The namespace UID to be checked.
+  string uid = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CheckNamespaceByUIDAdminResponse contains the availability of a namespace or the type
+// of resource that's using it.
+message CheckNamespaceByUIDAdminResponse {
+  // Namespace contains information about the availability of a namespace.
+  enum Namespace {
+    // Unspecified.
+    NAMESPACE_UNSPECIFIED = 0;
+    // Available.
+    NAMESPACE_AVAILABLE = 1;
+    // Namespace belongs to a user.
+    NAMESPACE_USER = 2;
+    // Namespace belongs to an organization.
+    NAMESPACE_ORGANIZATION = 3;
+    // Reserved.
+    NAMESPACE_RESERVED = 4;
+  }
+
+  // Namespace type.
+  Namespace type = 1;
+  // Namespace ID.
+  string id = 2;
+  // The owner, which can be either a User or an Organization.
+  oneof owner {
+    // User.
+    core.mgmt.v1beta.User user = 3;
+    // Organization.
+    core.mgmt.v1beta.Organization organization = 4;
+  }
 }
 
 // API tokens allow users to make requests to the Instill AI API.

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -61,4 +61,10 @@ service MgmtPrivateService {
   // Returns the availability of a namespace or, alternatively, the type of
   // resource that is using it.
   rpc CheckNamespaceAdmin(CheckNamespaceAdminRequest) returns (CheckNamespaceAdminResponse) {}
+
+  // Check if a namespace is in use by UID
+  //
+  // Returns the availability of a namespace or, alternatively, the type of
+  // resource that is using it.
+  rpc CheckNamespaceByUIDAdmin(CheckNamespaceByUIDAdminRequest) returns (CheckNamespaceByUIDAdminResponse) {}
 }

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1220,10 +1220,53 @@ definitions:
       uid:
         type: string
         description: Namespace UID.
+      user:
+        description: User.
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
+      organization:
+        description: Organization.
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
     description: |-
       CheckNamespaceAdminResponse contains the availability of a namespace or the type
       of resource that's using it.
   v1betaCheckNamespaceAdminResponseNamespace:
+    type: string
+    enum:
+      - NAMESPACE_AVAILABLE
+      - NAMESPACE_USER
+      - NAMESPACE_ORGANIZATION
+      - NAMESPACE_RESERVED
+    description: |-
+      Namespace contains information about the availability of a namespace.
+
+       - NAMESPACE_AVAILABLE: Available.
+       - NAMESPACE_USER: Namespace belongs to a user.
+       - NAMESPACE_ORGANIZATION: Namespace belongs to an organization.
+       - NAMESPACE_RESERVED: Reserved.
+  v1betaCheckNamespaceByUIDAdminResponse:
+    type: object
+    properties:
+      type:
+        description: Namespace type.
+        allOf:
+          - $ref: '#/definitions/v1betaCheckNamespaceByUIDAdminResponseNamespace'
+      id:
+        type: string
+        description: Namespace ID.
+      user:
+        description: User.
+        allOf:
+          - $ref: '#/definitions/v1betaUser'
+      organization:
+        description: Organization.
+        allOf:
+          - $ref: '#/definitions/v1betaOrganization'
+    description: |-
+      CheckNamespaceByUIDAdminResponse contains the availability of a namespace or the type
+      of resource that's using it.
+  v1betaCheckNamespaceByUIDAdminResponseNamespace:
     type: string
     enum:
       - NAMESPACE_AVAILABLE

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1019,12 +1019,12 @@ paths:
       description: |-
         Returns a paginated list of secrets that belong to the specified
         namespace.
-      operationId: PipelinePublicService_ListSecrets
+      operationId: PipelinePublicService_ListNamespaceSecrets
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListSecretsResponse'
+            $ref: '#/definitions/v1betaListNamespaceSecretsResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -1057,12 +1057,12 @@ paths:
     post:
       summary: Create a secret
       description: Creates a new secret under the parenthood of an namespace.
-      operationId: PipelinePublicService_CreateSecret
+      operationId: PipelinePublicService_CreateNamespaceSecret
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaCreateSecretResponse'
+            $ref: '#/definitions/v1betaCreateNamespaceSecretResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -1082,11 +1082,6 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/v1betaSecret'
-        - name: secretId
-          description: Secret ID
-          in: query
-          required: true
-          type: string
       tags:
         - Secret
   /v1beta/namespaces/{namespaceId}/secrets/{secretId}:
@@ -1095,12 +1090,12 @@ paths:
       description: |-
         Returns the details of an namespace-owned secret by its resource name,
         which is defined by the parent namespace and the ID of the secret.
-      operationId: PipelinePublicService_GetSecret
+      operationId: PipelinePublicService_GetNamespaceSecret
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetSecretResponse'
+            $ref: '#/definitions/v1betaGetNamespaceSecretResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -1126,12 +1121,12 @@ paths:
       description: |-
         Deletes a secret, accesing it by its resource name, which is defined by
         the parent namespace and the ID of the secret.
-      operationId: PipelinePublicService_DeleteSecret
+      operationId: PipelinePublicService_DeleteNamespaceSecret
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaDeleteSecretResponse'
+            $ref: '#/definitions/v1betaDeleteNamespaceSecretResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -1159,12 +1154,12 @@ paths:
 
         In REST requests, only the supplied secret fields will be taken into
         account when updating the resource.
-      operationId: PipelinePublicService_UpdateSecret
+      operationId: PipelinePublicService_UpdateNamespaceSecret
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaUpdateSecretResponse'
+            $ref: '#/definitions/v1betaUpdateNamespaceSecretResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -5281,6 +5276,15 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1betaPipeline'
     description: CreateNamespacePipelineResponse contains the created pipeline.
+  v1betaCreateNamespaceSecretResponse:
+    type: object
+    properties:
+      secret:
+        description: The created secret resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
+    description: CreateNamespaceSecretResponse contains the created secret.
   v1betaCreateOrganizationPipelineReleaseResponse:
     type: object
     properties:
@@ -5305,15 +5309,6 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1betaSecret'
     description: CreateOrganizationSecretResponse contains the created secret.
-  v1betaCreateSecretResponse:
-    type: object
-    properties:
-      secret:
-        description: The created secret resource.
-        readOnly: true
-        allOf:
-          - $ref: '#/definitions/v1betaSecret'
-    description: CreateSecretResponse contains the created secret.
   v1betaCreateUserPipelineReleaseResponse:
     type: object
     properties:
@@ -5356,6 +5351,9 @@ definitions:
   v1betaDeleteNamespacePipelineResponse:
     type: object
     description: DeleteNamespacePipelineResponse is an empty response.
+  v1betaDeleteNamespaceSecretResponse:
+    type: object
+    description: DeleteNamespaceSecretResponse is an empty response.
   v1betaDeleteOrganizationPipelineReleaseResponse:
     type: object
     description: DeleteOrganizationPipelineReleaseResponse is an empty response.
@@ -5365,9 +5363,6 @@ definitions:
   v1betaDeleteOrganizationSecretResponse:
     type: object
     description: DeleteOrganizationSecretResponse is an empty response.
-  v1betaDeleteSecretResponse:
-    type: object
-    description: DeleteSecretResponse is an empty response.
   v1betaDeleteUserPipelineReleaseResponse:
     type: object
     description: DeleteUserPipelineReleaseResponse is an empty response.
@@ -5403,6 +5398,14 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1betaPipeline'
     description: GetNamespacePipelineResponse contains the requested pipeline.
+  v1betaGetNamespaceSecretResponse:
+    type: object
+    properties:
+      secret:
+        description: The secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
+    description: GetNamespaceSecretResponse contains the requested secret.
   v1betaGetOperationResponse:
     type: object
     properties:
@@ -5444,14 +5447,6 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1betaSecret'
     description: GetOrganizationSecretResponse contains the requested secret.
-  v1betaGetSecretResponse:
-    type: object
-    properties:
-      secret:
-        description: The secret resource.
-        allOf:
-          - $ref: '#/definitions/v1betaSecret'
-    description: GetSecretResponse contains the requested secret.
   v1betaGetUserPipelineReleaseResponse:
     type: object
     properties:
@@ -5555,6 +5550,26 @@ definitions:
         description: Total number of pipelines.
         readOnly: true
     description: ListNamespacePipelinesResponse contains a list of pipelines.
+  v1betaListNamespaceSecretsResponse:
+    type: object
+    properties:
+      secrets:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaSecret'
+        description: A list of secret resources.
+        readOnly: true
+      nextPageToken:
+        type: string
+        description: Next page secret.
+        readOnly: true
+      totalSize:
+        type: integer
+        format: int32
+        description: Total number of secret resources.
+        readOnly: true
+    description: ListNamespaceSecretsResponse contains a list of secrets.
   v1betaListOperatorDefinitionsResponse:
     type: object
     properties:
@@ -5685,26 +5700,6 @@ definitions:
         description: Total number of pipelines.
         readOnly: true
     description: ListPipelinesResponse contains a list of pipelines.
-  v1betaListSecretsResponse:
-    type: object
-    properties:
-      secrets:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaSecret'
-        description: A list of secret resources.
-        readOnly: true
-      nextPageToken:
-        type: string
-        description: Next page secret.
-        readOnly: true
-      totalSize:
-        type: integer
-        format: int32
-        description: Total number of secret resources.
-        readOnly: true
-    description: ListSecretsResponse contains a list of secrets.
   v1betaListUserPipelineReleasesResponse:
     type: object
     properties:
@@ -6607,6 +6602,14 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1betaPipeline'
     description: UpdateNamespacePipelineResponse contains the updated pipeline.
+  v1betaUpdateNamespaceSecretResponse:
+    type: object
+    properties:
+      secret:
+        description: The updated secret resource.
+        allOf:
+          - $ref: '#/definitions/v1betaSecret'
+    description: UpdateNamespaceSecretResponse contains the updated secret.
   v1betaUpdateOrganizationPipelineReleaseResponse:
     type: object
     properties:
@@ -6633,14 +6636,6 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1betaSecret'
     description: UpdateOrganizationSecretResponse contains the updated secret.
-  v1betaUpdateSecretResponse:
-    type: object
-    properties:
-      secret:
-        description: The updated secret resource.
-        allOf:
-          - $ref: '#/definitions/v1betaSecret'
-    description: UpdateSecretResponse contains the updated secret.
   v1betaUpdateUserPipelineReleaseResponse:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -372,7 +372,7 @@ service PipelinePublicService {
   // Create a secret
   //
   // Creates a new secret under the parenthood of an namespace.
-  rpc CreateSecret(CreateSecretRequest) returns (CreateSecretResponse) {
+  rpc CreateNamespaceSecret(CreateNamespaceSecretRequest) returns (CreateNamespaceSecretResponse) {
     option (google.api.http) = {
       post: "/v1beta/namespaces/{namespace_id}/secrets"
       body: "secret"
@@ -384,7 +384,7 @@ service PipelinePublicService {
   //
   // Returns a paginated list of secrets that belong to the specified
   // namespace.
-  rpc ListSecrets(ListSecretsRequest) returns (ListSecretsResponse) {
+  rpc ListNamespaceSecrets(ListNamespaceSecretsRequest) returns (ListNamespaceSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
@@ -393,7 +393,7 @@ service PipelinePublicService {
   //
   // Returns the details of an namespace-owned secret by its resource name,
   // which is defined by the parent namespace and the ID of the secret.
-  rpc GetSecret(GetSecretRequest) returns (GetSecretResponse) {
+  rpc GetNamespaceSecret(GetNamespaceSecretRequest) returns (GetNamespaceSecretResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }
@@ -404,7 +404,7 @@ service PipelinePublicService {
   //
   // In REST requests, only the supplied secret fields will be taken into
   // account when updating the resource.
-  rpc UpdateSecret(UpdateSecretRequest) returns (UpdateSecretResponse) {
+  rpc UpdateNamespaceSecret(UpdateNamespaceSecretRequest) returns (UpdateNamespaceSecretResponse) {
     option (google.api.http) = {
       patch: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"
       body: "secret"
@@ -416,7 +416,7 @@ service PipelinePublicService {
   //
   // Deletes a secret, accesing it by its resource name, which is defined by
   // the parent namespace and the ID of the secret.
-  rpc DeleteSecret(DeleteSecretRequest) returns (DeleteSecretResponse) {
+  rpc DeleteNamespaceSecret(DeleteNamespaceSecretRequest) returns (DeleteNamespaceSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret"};
   }

--- a/vdp/pipeline/v1beta/secret.proto
+++ b/vdp/pipeline/v1beta/secret.proto
@@ -39,24 +39,22 @@ message Secret {
   string description = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// CreateSecretRequest represents a request to create a secret.
-message CreateSecretRequest {
+// CreateamespaceSecretRequest represents a request to create a secret.
+message CreateNamespaceSecretRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Secret ID
-  string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
   // The properties of the secret to be created.
-  Secret secret = 3;
+  Secret secret = 2;
 }
 
-// CreateSecretResponse contains the created secret.
-message CreateSecretResponse {
+// CreateNamespaceSecretResponse contains the created secret.
+message CreateNamespaceSecretResponse {
   // The created secret resource.
   Secret secret = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ListSecretsRequest represents a request to list the secrets of a namespace.
-message ListSecretsRequest {
+// ListNamespaceSecretsRequest represents a request to list the secrets of a namespace.
+message ListNamespaceSecretsRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // The maximum number of secrets to return. If this parameter is unspecified,
@@ -67,8 +65,8 @@ message ListSecretsRequest {
   optional string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// ListSecretsResponse contains a list of secrets.
-message ListSecretsResponse {
+// ListNamespaceSecretsResponse contains a list of secrets.
+message ListNamespaceSecretsResponse {
   // A list of secret resources.
   repeated Secret secrets = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Next page secret.
@@ -77,22 +75,22 @@ message ListSecretsResponse {
   int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetSecretRequest represents a request to fetch the details of a secret
-message GetSecretRequest {
+// GetNamespaceSecretRequest represents a request to fetch the details of a secret
+message GetNamespaceSecretRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Secret ID
   string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// GetSecretResponse contains the requested secret.
-message GetSecretResponse {
+// GetNamespaceSecretResponse contains the requested secret.
+message GetNamespaceSecretResponse {
   // The secret resource.
   Secret secret = 1;
 }
 
-// UpdateSecretRequest represents a request to update a namespace secret.
-message UpdateSecretRequest {
+// UpdateNamespaceSecretRequest represents a request to update a namespace secret.
+message UpdateNamespaceSecretRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Secret ID
@@ -106,22 +104,22 @@ message UpdateSecretRequest {
   google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
-// UpdateSecretResponse contains the updated secret.
-message UpdateSecretResponse {
+// UpdateNamespaceSecretResponse contains the updated secret.
+message UpdateNamespaceSecretResponse {
   // The updated secret resource.
   Secret secret = 1;
 }
 
-// DeleteSecretRequest represents a request to delete a secret resource.
-message DeleteSecretRequest {
+// DeleteNamespaceSecretRequest represents a request to delete a secret resource.
+message DeleteNamespaceSecretRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Secret ID
   string secret_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// DeleteSecretResponse is an empty response.
-message DeleteSecretResponse {}
+// DeleteNamespaceSecretResponse is an empty response.
+message DeleteNamespaceSecretResponse {}
 
 // CreateUserSecretRequest represents a request to create a secret.
 message CreateUserSecretRequest {


### PR DESCRIPTION
Because

- The namespace secret endpoint naming style is inconsistent

This commit

- Adjusts the namespace secret endpoint naming
- Adds a private endpoint `CheckNamespaceByUIDAdmin`