### PR TITLE
chore(vdp,model): add deprecated tags in OpenAPI

### DIFF
--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -332,7 +332,10 @@ service ModelPublicService {
   // the results will contain the models that are visible to the latter.
   rpc ListUserModels(ListUserModelsRequest) returns (ListUserModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/{parent=users/*}/models"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -348,7 +351,10 @@ service ModelPublicService {
       post: "/v1alpha/{parent=users/*}/models"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -357,7 +363,10 @@ service ModelPublicService {
   // Returns the detail of a model, accessing it by the model ID and its parent user.
   rpc GetUserModel(GetUserModelRequest) returns (GetUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -373,7 +382,10 @@ service ModelPublicService {
       patch: "/v1alpha/{model.name=users/*/models/*}"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -383,7 +395,10 @@ service ModelPublicService {
   // parent user and the ID of the model.
   rpc DeleteUserModel(DeleteUserModelRequest) returns (DeleteUserModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -396,7 +411,10 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -409,7 +427,10 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/publish"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -422,7 +443,10 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/unpublish"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -432,7 +456,10 @@ service ModelPublicService {
   // enhancing it with metadata. The model is accessed by its resource name.
   rpc GetUserModelCard(GetUserModelCardRequest) returns (GetUserModelCardResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*/readme}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -443,7 +470,10 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchUserModel(WatchUserModelRequest) returns (WatchUserModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions/{version=*}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Version (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -454,7 +484,10 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchUserLatestModel(WatchUserLatestModelRequest) returns (WatchUserLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Version (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -464,7 +497,10 @@ service ModelPublicService {
   // Contains model version and digest.
   rpc ListUserModelVersions(ListUserModelVersionsRequest) returns (ListUserModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/versions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Version (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -474,7 +510,10 @@ service ModelPublicService {
   // parent user and the ID of the model, and version.
   rpc DeleteUserModelVersion(DeleteUserModelVersionRequest) returns (DeleteUserModelVersionResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=users/*/models/*}/versions/{version=*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Version (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -491,6 +530,7 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -513,6 +553,7 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -535,6 +576,7 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -557,6 +599,7 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -575,6 +618,7 @@ service ModelPublicService {
   rpc TriggerUserModelBinaryFileUpload(stream TriggerUserModelBinaryFileUploadRequest) returns (TriggerUserModelBinaryFileUploadResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -593,7 +637,10 @@ service ModelPublicService {
   // the results will contain the models that are visible to the latter.
   rpc ListOrganizationModels(ListOrganizationModelsRequest) returns (ListOrganizationModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/{parent=organizations/*}/models"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -609,7 +656,10 @@ service ModelPublicService {
       post: "/v1alpha/{parent=organizations/*}/models"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -618,7 +668,10 @@ service ModelPublicService {
   // Returns the detail of a model, accessing it by the model ID and its parent organization.
   rpc GetOrganizationModel(GetOrganizationModelRequest) returns (GetOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -634,7 +687,10 @@ service ModelPublicService {
       patch: "/v1alpha/{model.name=organizations/*/models/*}"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -644,7 +700,10 @@ service ModelPublicService {
   // parent organization and the ID of the model.
   rpc DeleteOrganizationModel(DeleteOrganizationModelRequest) returns (DeleteOrganizationModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/models/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -657,7 +716,10 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -670,7 +732,10 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/publish"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -683,7 +748,10 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/unpublish"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -693,7 +761,10 @@ service ModelPublicService {
   // enhancing it with metadata. The model is accessed by its resource name.
   rpc GetOrganizationModelCard(GetOrganizationModelCardRequest) returns (GetOrganizationModelCardResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*/readme}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Model (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -704,7 +775,10 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchOrganizationModel(WatchOrganizationModelRequest) returns (WatchOrganizationModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Version (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -715,7 +789,10 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchOrganizationLatestModel(WatchOrganizationLatestModelRequest) returns (WatchOrganizationLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Version (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -725,7 +802,10 @@ service ModelPublicService {
   // Contains model version and digest.
   rpc ListOrganizationModelVersions(ListOrganizationModelVersionsRequest) returns (ListOrganizationModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/versions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Version (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -735,7 +815,10 @@ service ModelPublicService {
   // parent organization and the ID of the model, and version.
   rpc DeleteOrganizationModelVersion(DeleteOrganizationModelVersionRequest) returns (DeleteOrganizationModelVersionResponse) {
     option (google.api.http) = {delete: "/v1alpha/{name=organizations/*/models/*}/versions/{version=*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Version (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Version (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -752,6 +835,7 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -774,6 +858,7 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -796,6 +881,7 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -818,6 +904,7 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -836,6 +923,7 @@ service ModelPublicService {
   rpc TriggerOrganizationModelBinaryFileUpload(stream TriggerOrganizationModelBinaryFileUploadRequest) returns (TriggerOrganizationModelBinaryFileUploadResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -853,7 +941,10 @@ service ModelPublicService {
   // long-running operations in a model, such as deployment.
   rpc GetUserLatestModelOperation(GetUserLatestModelOperationRequest) returns (GetUserLatestModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*}/operation"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -863,7 +954,10 @@ service ModelPublicService {
   // long-running operations in a model, such as deployment.
   rpc GetOrganizationLatestModelOperation(GetOrganizationLatestModelOperationRequest) returns (GetOrganizationLatestModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*}/operation"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 }

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -1096,6 +1096,7 @@ paths:
           type: string
       tags:
         - Model (Deprecated)
+      deprecated: true
     post:
       summary: Create a new model
       description: |-
@@ -1134,6 +1135,7 @@ paths:
             $ref: '#/definitions/v1alphaModel'
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}:
     get:
       summary: Get a model
@@ -1175,6 +1177,7 @@ paths:
             - VIEW_FULL
       tags:
         - Model (Deprecated)
+      deprecated: true
     delete:
       summary: Delete a model
       description: |-
@@ -1205,6 +1208,7 @@ paths:
           pattern: users/[^/]+/models/[^/]+
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{model_name}:
     patch:
       summary: Update a model
@@ -1359,6 +1363,7 @@ paths:
               - hardware
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/rename:
     post:
       summary: Rename a model
@@ -1395,6 +1400,7 @@ paths:
             $ref: '#/definitions/ModelPublicServiceRenameUserModelBody'
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/publish:
     post:
       summary: Publish a model
@@ -1431,6 +1437,7 @@ paths:
             $ref: '#/definitions/ModelPublicServicePublishUserModelBody'
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/unpublish:
     post:
       summary: Unpublish a model
@@ -1467,6 +1474,7 @@ paths:
             $ref: '#/definitions/ModelPublicServiceUnpublishUserModelBody'
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_card_name}:
     get:
       summary: Get a model card
@@ -1498,6 +1506,7 @@ paths:
           pattern: users/[^/]+/models/[^/]+/readme
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/versions/{version}/watch:
     get:
       summary: Watch the state of a model version
@@ -1536,6 +1545,7 @@ paths:
           pattern: '[^/]+'
       tags:
         - Version (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/watch:
     get:
       summary: Watch the state of the latest model version
@@ -1568,6 +1578,7 @@ paths:
           pattern: users/[^/]+/models/[^/]+
       tags:
         - Version (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/versions:
     get:
       summary: List user model versions
@@ -1615,6 +1626,7 @@ paths:
           format: int32
       tags:
         - Version (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/versions/{version}:
     delete:
       summary: Delete a model version
@@ -1652,6 +1664,7 @@ paths:
           pattern: '[^/]+'
       tags:
         - Version (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/versions/{version}/trigger:
     post:
       summary: Trigger model inference
@@ -1699,6 +1712,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/versions/{version}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -1746,6 +1760,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/trigger:
     post:
       summary: Trigger model inference
@@ -1787,6 +1802,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -1828,6 +1844,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1alpha/{organization_name}/models:
     get:
       summary: List organization models
@@ -1917,6 +1934,7 @@ paths:
           type: string
       tags:
         - Model (Deprecated)
+      deprecated: true
     post:
       summary: Create a new model
       description: |-
@@ -1955,6 +1973,7 @@ paths:
             $ref: '#/definitions/v1alphaModel'
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}:
     get:
       summary: Get a model
@@ -1996,6 +2015,7 @@ paths:
             - VIEW_FULL
       tags:
         - Model (Deprecated)
+      deprecated: true
     delete:
       summary: Delete a model
       description: |-
@@ -2026,6 +2046,7 @@ paths:
           pattern: organizations/[^/]+/models/[^/]+
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{model_name_1}:
     patch:
       summary: Update a model
@@ -2180,6 +2201,7 @@ paths:
               - hardware
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/rename:
     post:
       summary: Rename a model
@@ -2216,6 +2238,7 @@ paths:
             $ref: '#/definitions/ModelPublicServiceRenameOrganizationModelBody'
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/publish:
     post:
       summary: Publish a model
@@ -2252,6 +2275,7 @@ paths:
             $ref: '#/definitions/ModelPublicServicePublishOrganizationModelBody'
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/unpublish:
     post:
       summary: Unpublish a model
@@ -2288,6 +2312,7 @@ paths:
             $ref: '#/definitions/ModelPublicServiceUnpublishOrganizationModelBody'
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_card_name}:
     get:
       summary: Get a model card
@@ -2319,6 +2344,7 @@ paths:
           pattern: organizations/[^/]+/models/[^/]+/readme
       tags:
         - Model (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/versions/{version}/watch:
     get:
       summary: Watch the state of a model version
@@ -2357,6 +2383,7 @@ paths:
           pattern: '[^/]+'
       tags:
         - Version (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/watch:
     get:
       summary: Watch the state of the latest model version
@@ -2389,6 +2416,7 @@ paths:
           pattern: organizations/[^/]+/models/[^/]+
       tags:
         - Version (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/versions:
     get:
       summary: List organization model versions
@@ -2436,6 +2464,7 @@ paths:
           format: int32
       tags:
         - Version (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/versions/{version}:
     delete:
       summary: Delete a model version
@@ -2475,6 +2504,7 @@ paths:
           pattern: '[^/]+'
       tags:
         - Version (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/versions/{version}/trigger:
     post:
       summary: Trigger model inference
@@ -2522,6 +2552,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/versions/{version}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -2569,6 +2600,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/trigger:
     post:
       summary: Trigger model inference
@@ -2610,6 +2642,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/triggerAsync:
     post:
       summary: Trigger model inference asynchronously
@@ -2651,6 +2684,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1alpha/{user_model_name}/operation:
     get:
       summary: Get the details of the latest long-running operation from a user model
@@ -2694,6 +2728,7 @@ paths:
             - VIEW_FULL
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1alpha/{organization_model_name}/operation:
     get:
       summary: Get the details of the latest long-running operation from a organization model
@@ -2737,6 +2772,7 @@ paths:
             - VIEW_FULL
       tags:
         - Trigger (Deprecated)
+      deprecated: true
 definitions:
   ModelPublicServicePublishNamespaceModelBody:
     type: object

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1375,6 +1375,7 @@ paths:
           type: string
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
     post:
       summary: Create a new user pipeline
       description: |-
@@ -1411,6 +1412,7 @@ paths:
             $ref: '#/definitions/v1betaPipeline'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_name}:
     get:
       summary: Get a pipeline owned by a user
@@ -1456,6 +1458,7 @@ paths:
             - VIEW_RECIPE
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
     delete:
       summary: Delete a pipeline owned by a user
       description: |-
@@ -1487,6 +1490,7 @@ paths:
           pattern: users/[^/]+/pipelines/[^/]+
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{pipeline.name}:
     patch:
       summary: Update a pipeline owned by a user
@@ -1631,6 +1635,7 @@ paths:
               - recipe
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_name}/validate:
     post:
       summary: Validate a pipeline a pipeline owned by a user
@@ -1669,6 +1674,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceValidateUserPipelineBody'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_name}/rename:
     post:
       summary: Rename a pipeline owned by a user
@@ -1712,6 +1718,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceRenameUserPipelineBody'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_name}/clone:
     post:
       summary: Clone a pipeline owned by a user
@@ -1748,6 +1755,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceCloneUserPipelineBody'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_release_name}/clone:
     post:
       summary: Clone a pipeline release owned by a user
@@ -1783,6 +1791,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceCloneUserPipelineReleaseBody'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by a user
@@ -1830,6 +1839,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_name}/trigger-stream:
     post:
       summary: Trigger a pipeline owned by a user and stream back the response
@@ -1881,6 +1891,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_name}/triggerAsync:
     post:
       summary: Trigger a pipeline owned by a user asynchronously
@@ -1929,6 +1940,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/{user_name}/releases:
     get:
       summary: List the releases in a pipeline owned by a user
@@ -2000,6 +2012,7 @@ paths:
           type: boolean
       tags:
         - Release (Deprecated)
+      deprecated: true
     post:
       summary: Release a version of a pipeline owned by a user
       description: |-
@@ -2038,6 +2051,7 @@ paths:
             $ref: '#/definitions/v1betaPipelineRelease'
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_release_name}:
     get:
       summary: Get a release in a pipeline owned by a user
@@ -2083,6 +2097,7 @@ paths:
             - VIEW_RECIPE
       tags:
         - Release (Deprecated)
+      deprecated: true
     delete:
       summary: Delete a release in a pipeline owned by a user
       description: |-
@@ -2116,6 +2131,7 @@ paths:
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{release.name}:
     patch:
       summary: Update a release in a pipeline owned by a user
@@ -2214,6 +2230,7 @@ paths:
               A pipeline release resource to update
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_release_name}/restore:
     post:
       summary: Set the version of a pipeline owned by a user to a pinned release
@@ -2250,6 +2267,7 @@ paths:
           pattern: users/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by a user
@@ -2294,6 +2312,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceRenameUserPipelineReleaseBody'
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_release_name}/trigger:
     post:
       summary: Trigger a version of a pipeline owned by a user
@@ -2340,6 +2359,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/{user_pipeline_release_name}/triggerAsync:
     post:
       summary: Trigger a version of a pipeline owned by a user asynchronously
@@ -2386,6 +2406,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/{organization_name}/pipelines:
     get:
       summary: List organization pipelines
@@ -2478,6 +2499,7 @@ paths:
           type: string
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
     post:
       summary: Create a new organization pipeline
       description: Creates a new pipeline under the parenthood of an organization.
@@ -2511,6 +2533,7 @@ paths:
             $ref: '#/definitions/v1betaPipeline'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_name}:
     get:
       summary: Get a pipeline owned by an organization
@@ -2556,6 +2579,7 @@ paths:
             - VIEW_RECIPE
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
     delete:
       summary: Delete a pipeline owned by an organization
       description: |-
@@ -2586,6 +2610,7 @@ paths:
           pattern: organizations/[^/]+/pipelines/[^/]+
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{pipeline.name_1}:
     patch:
       summary: Update a pipeline owned by an organization
@@ -2728,6 +2753,7 @@ paths:
               - recipe
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_name}/validate:
     post:
       summary: Validate a pipeline a pipeline owned by an organization
@@ -2767,6 +2793,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceValidateOrganizationPipelineBody'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_name}/rename:
     post:
       summary: Rename a pipeline owned by an organization
@@ -2807,6 +2834,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceRenameOrganizationPipelineBody'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{org_pipeline_name}/clone:
     post:
       summary: Clone a pipeline owned by an organization
@@ -2843,6 +2871,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineBody'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{org_pipeline_release_name}/clone:
     post:
       summary: Clone a pipeline release owned by an organization
@@ -2878,6 +2907,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceCloneOrganizationPipelineReleaseBody'
       tags:
         - Pipeline (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_name}/trigger-stream:
     post:
       summary: Trigger a pipeline owned by an organization
@@ -2931,6 +2961,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_name}/trigger:
     post:
       summary: Trigger a pipeline owned by an organization
@@ -2978,6 +3009,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_name}/triggerAsync:
     post:
       summary: Trigger a pipeline owned by an organization asynchronously
@@ -3026,6 +3058,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/{organization_name}/releases:
     get:
       summary: List the releases in a pipeline owned by an organization
@@ -3097,6 +3130,7 @@ paths:
           type: boolean
       tags:
         - Release (Deprecated)
+      deprecated: true
     post:
       summary: Release a version of a pipeline owned by an organization
       description: |-
@@ -3132,6 +3166,7 @@ paths:
             $ref: '#/definitions/v1betaPipelineRelease'
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_release_name}:
     get:
       summary: Get a release in a pipeline owned by an organization
@@ -3178,6 +3213,7 @@ paths:
             - VIEW_RECIPE
       tags:
         - Release (Deprecated)
+      deprecated: true
     delete:
       summary: Delete a release in a pipeline owned by an organization
       description: |-
@@ -3209,6 +3245,7 @@ paths:
           pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{release.name_1}:
     patch:
       summary: Update a release in a pipeline owned by an organization
@@ -3304,6 +3341,7 @@ paths:
               A pipeline release resource to update
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_release_name}/restore:
     post:
       summary: Set the version of a pipeline owned by an organization to a pinned release
@@ -3338,6 +3376,7 @@ paths:
           pattern: organizations/[^/]+/pipelines/[^/]+/releases/[^/]+
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_release_name}/rename:
     post:
       summary: Rename a release in a pipeline owned by an organization
@@ -3380,6 +3419,7 @@ paths:
             $ref: '#/definitions/PipelinePublicServiceRenameOrganizationPipelineReleaseBody'
       tags:
         - Release (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_release_name}/trigger:
     post:
       summary: Trigger a version of a pipeline owned by an organization
@@ -3427,6 +3467,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/{organization_pipeline_release_name}/triggerAsync:
     post:
       summary: Trigger a version of a pipeline owned by an organization asynchronously
@@ -3474,6 +3515,7 @@ paths:
           type: string
       tags:
         - Trigger (Deprecated)
+      deprecated: true
   /v1beta/connector-definitions:
     get:
       summary: List connector definitions
@@ -3529,6 +3571,7 @@ paths:
             - VIEW_FULL
       tags:
         - Component (Deprecated)
+      deprecated: true
   /v1beta/{connector_definition_name}:
     get:
       summary: Get connector definition
@@ -3570,6 +3613,7 @@ paths:
             - VIEW_FULL
       tags:
         - Component (Deprecated)
+      deprecated: true
   /v1beta/operator-definitions:
     get:
       summary: List operator definitions
@@ -3626,6 +3670,7 @@ paths:
             - VIEW_FULL
       tags:
         - Component (Deprecated)
+      deprecated: true
   /v1beta/{operator_definition_name}:
     get:
       summary: Get operator definition
@@ -3667,6 +3712,7 @@ paths:
             - VIEW_FULL
       tags:
         - Component (Deprecated)
+      deprecated: true
   /v1beta/check-name:
     post:
       summary: Check the availibity of a resource name
@@ -3697,6 +3743,7 @@ paths:
             $ref: '#/definitions/v1betaCheckNameRequest'
       tags:
         - Utils (Deprecated)
+      deprecated: true
   /v1beta/{user_name}/secrets:
     get:
       summary: List user secrets
@@ -3741,6 +3788,7 @@ paths:
           type: string
       tags:
         - Secret (Deprecated)
+      deprecated: true
     post:
       summary: Create a new user secret
       description: Creates a new secret under the parenthood of an user.
@@ -3774,6 +3822,7 @@ paths:
             $ref: '#/definitions/v1betaSecret'
       tags:
         - Secret (Deprecated)
+      deprecated: true
   /v1beta/{user_secret_name}:
     get:
       summary: Get a secret owned by an user
@@ -3804,6 +3853,7 @@ paths:
           pattern: users/[^/]+/secrets/[^/]+
       tags:
         - Secret (Deprecated)
+      deprecated: true
     delete:
       summary: Delete a secret owned by an user
       description: |-
@@ -3833,6 +3883,7 @@ paths:
           pattern: users/[^/]+/secrets/[^/]+
       tags:
         - Secret (Deprecated)
+      deprecated: true
   /v1beta/{secret.name}:
     patch:
       summary: Update a secret owned by an user
@@ -3900,6 +3951,7 @@ paths:
             title: The secret fields to update.
       tags:
         - Secret (Deprecated)
+      deprecated: true
   /v1beta/{organization_name}/secrets:
     get:
       summary: List organization secrets
@@ -3944,6 +3996,7 @@ paths:
           type: string
       tags:
         - Secret (Deprecated)
+      deprecated: true
     post:
       summary: Create a new organization secret
       description: Creates a new secret under the parenthood of an organization.
@@ -3977,6 +4030,7 @@ paths:
             $ref: '#/definitions/v1betaSecret'
       tags:
         - Secret (Deprecated)
+      deprecated: true
   /v1beta/{organization_secret_name}:
     get:
       summary: Get a secret owned by an organization
@@ -4007,6 +4061,7 @@ paths:
           pattern: organizations/[^/]+/secrets/[^/]+
       tags:
         - Secret (Deprecated)
+      deprecated: true
     delete:
       summary: Delete a secret owned by an organization
       description: |-
@@ -4036,6 +4091,7 @@ paths:
           pattern: organizations/[^/]+/secrets/[^/]+
       tags:
         - Secret (Deprecated)
+      deprecated: true
   /v1beta/{secret.name_1}:
     patch:
       summary: Update a secret owned by an organization
@@ -4103,6 +4159,7 @@ paths:
             title: The secret fields to update.
       tags:
         - Secret (Deprecated)
+      deprecated: true
 definitions:
   CheckNameResponseName:
     type: string

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -461,7 +461,10 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*}/pipelines"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -473,7 +476,10 @@ service PipelinePublicService {
   // latter.
   rpc ListUserPipelines(ListUserPipelinesRequest) returns (ListUserPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -483,7 +489,10 @@ service PipelinePublicService {
   // by the parent user and the ID of the pipeline.
   rpc GetUserPipeline(GetUserPipelineRequest) returns (GetUserPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -500,7 +509,10 @@ service PipelinePublicService {
       patch: "/v1beta/{pipeline.name=users/*/pipelines/*}"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -511,7 +523,10 @@ service PipelinePublicService {
   // the parent of the pipeline in order to delete it.
   rpc DeleteUserPipeline(DeleteUserPipelineRequest) returns (DeleteUserPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -526,7 +541,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/validate"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -546,7 +564,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -559,7 +580,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -572,7 +596,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -593,6 +620,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -619,6 +647,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -648,6 +677,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -671,7 +701,10 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*/pipelines/*}/releases"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -681,7 +714,10 @@ service PipelinePublicService {
   // name, which is formed by the parent user and ID of the pipeline.
   rpc ListUserPipelineReleases(ListUserPipelineReleasesRequest) returns (ListUserPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*/pipelines/*}/releases"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -691,7 +727,10 @@ service PipelinePublicService {
   // by its resource name, formed by its parent user and ID.
   rpc GetUserPipelineRelease(GetUserPipelineReleaseRequest) returns (GetUserPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -707,7 +746,10 @@ service PipelinePublicService {
       patch: "/v1beta/{release.name=users/*/pipelines/*/releases/*}"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -720,7 +762,10 @@ service PipelinePublicService {
   // perform this action.
   rpc DeleteUserPipelineRelease(DeleteUserPipelineReleaseRequest) returns (DeleteUserPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/pipelines/*/releases/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -735,7 +780,10 @@ service PipelinePublicService {
   // perform this action.
   rpc RestoreUserPipelineRelease(RestoreUserPipelineReleaseRequest) returns (RestoreUserPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=users/*/pipelines/*/releases/*}/restore"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -756,7 +804,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=users/*/pipelines/*/releases/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -776,6 +827,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -803,6 +855,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -822,7 +875,10 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*}/pipelines"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -832,7 +888,10 @@ service PipelinePublicService {
   // organization.
   rpc ListOrganizationPipelines(ListOrganizationPipelinesRequest) returns (ListOrganizationPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -842,7 +901,10 @@ service PipelinePublicService {
   // which is defined by the parent organization and the ID of the pipeline.
   rpc GetOrganizationPipeline(GetOrganizationPipelineRequest) returns (GetOrganizationPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -857,7 +919,10 @@ service PipelinePublicService {
       patch: "/v1beta/{pipeline.name=organizations/*/pipelines/*}"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -867,7 +932,10 @@ service PipelinePublicService {
   // the parent organization and the ID of the pipeline.
   rpc DeleteOrganizationPipeline(DeleteOrganizationPipelineRequest) returns (DeleteOrganizationPipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -883,7 +951,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/validate"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -900,7 +971,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -913,7 +987,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -926,7 +1003,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Pipeline (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -947,6 +1027,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -975,6 +1056,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -1004,6 +1086,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -1024,7 +1107,10 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*/pipelines/*}/releases"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1034,7 +1120,10 @@ service PipelinePublicService {
   // which is formed by the parent organization and ID of the pipeline.
   rpc ListOrganizationPipelineReleases(ListOrganizationPipelineReleasesRequest) returns (ListOrganizationPipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*/pipelines/*}/releases"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1044,7 +1133,10 @@ service PipelinePublicService {
   // its resource name, formed by its parent organization and ID.
   rpc GetOrganizationPipelineRelease(GetOrganizationPipelineReleaseRequest) returns (GetOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1057,7 +1149,10 @@ service PipelinePublicService {
       patch: "/v1beta/{release.name=organizations/*/pipelines/*/releases/*}"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1067,7 +1162,10 @@ service PipelinePublicService {
   // name, formed by its parent organization and ID.
   rpc DeleteOrganizationPipelineRelease(DeleteOrganizationPipelineReleaseRequest) returns (DeleteOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/pipelines/*/releases/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1079,7 +1177,10 @@ service PipelinePublicService {
   // organization and ID.
   rpc RestoreOrganizationPipelineRelease(RestoreOrganizationPipelineReleaseRequest) returns (RestoreOrganizationPipelineReleaseResponse) {
     option (google.api.http) = {post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/restore"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1097,7 +1198,10 @@ service PipelinePublicService {
       post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Release (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Release (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1117,6 +1221,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -1144,6 +1249,7 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger (Deprecated)"
+      deprecated: true
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -1160,7 +1266,10 @@ service PipelinePublicService {
   // Returns a paginated list of connector definitions.
   rpc ListConnectorDefinitions(ListConnectorDefinitionsRequest) returns (ListConnectorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/connector-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Component (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1169,7 +1278,10 @@ service PipelinePublicService {
   // Returns the details of a connector definition.
   rpc GetConnectorDefinition(GetConnectorDefinitionRequest) returns (GetConnectorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=connector-definitions/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Component (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1178,7 +1290,10 @@ service PipelinePublicService {
   // Returns a paginated list of operator definitions.
   rpc ListOperatorDefinitions(ListOperatorDefinitionsRequest) returns (ListOperatorDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/operator-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Component (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1187,7 +1302,10 @@ service PipelinePublicService {
   // Returns the details of an operator definition.
   rpc GetOperatorDefinition(GetOperatorDefinitionRequest) returns (GetOperatorDefinitionResponse) {
     option (google.api.http) = {get: "/v1beta/{name=operator-definitions/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Component (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Component (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1200,7 +1318,10 @@ service PipelinePublicService {
       post: "/v1beta/check-name"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Utils (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Utils (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1212,7 +1333,10 @@ service PipelinePublicService {
       post: "/v1beta/{parent=users/*}/secrets"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1222,7 +1346,10 @@ service PipelinePublicService {
   // user.
   rpc ListUserSecrets(ListUserSecretsRequest) returns (ListUserSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=users/*}/secrets"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1232,7 +1359,10 @@ service PipelinePublicService {
   // which is defined by the parent user and the ID of the secret.
   rpc GetUserSecret(GetUserSecretRequest) returns (GetUserSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=users/*/secrets/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1247,7 +1377,10 @@ service PipelinePublicService {
       patch: "/v1beta/{secret.name=users/*/secrets/*}"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1257,7 +1390,10 @@ service PipelinePublicService {
   // the parent user and the ID of the secret.
   rpc DeleteUserSecret(DeleteUserSecretRequest) returns (DeleteUserSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=users/*/secrets/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1269,7 +1405,10 @@ service PipelinePublicService {
       post: "/v1beta/{parent=organizations/*}/secrets"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1279,7 +1418,10 @@ service PipelinePublicService {
   // organization.
   rpc ListOrganizationSecrets(ListOrganizationSecretsRequest) returns (ListOrganizationSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/{parent=organizations/*}/secrets"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1289,7 +1431,10 @@ service PipelinePublicService {
   // which is defined by the parent organization and the ID of the secret.
   rpc GetOrganizationSecret(GetOrganizationSecretRequest) returns (GetOrganizationSecretResponse) {
     option (google.api.http) = {get: "/v1beta/{name=organizations/*/secrets/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1304,7 +1449,10 @@ service PipelinePublicService {
       patch: "/v1beta/{secret.name=organizations/*/secrets/*}"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 
@@ -1314,7 +1462,10 @@ service PipelinePublicService {
   // the parent organization and the ID of the secret.
   rpc DeleteOrganizationSecret(DeleteOrganizationSecretRequest) returns (DeleteOrganizationSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/{name=organizations/*/secrets/*}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Secret (Deprecated)"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Secret (Deprecated)"
+      deprecated: true
+    };
     option deprecated = true;
   }
 }


### PR DESCRIPTION
Because

- The gRPC `deprecated` tags were not synced to the OpenAPI document

This commit

- Adds `deprecated` tags to the OpenAPI document