### PR TITLE
feat(vdp,model): use explicit operation_id for operation endpoints

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1674,8 +1674,7 @@ message TriggerOrganizationModelBinaryFileUploadResponse {
 // operation performed on a model.
 message GetModelOperationRequest {
   // The resource name of the model, which allows its access ID.
-  // - Format: `operations/{operation.id}`.
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
+  string operation_id = 1 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired model view in the response.
   optional View view = 2 [
     deprecated = true,

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -319,7 +319,7 @@ service ModelPublicService {
   // This method allows requesters to request the status and outcome of
   // long-running operations in a model, such as deployment.
   rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=operations/*}"};
+    option (google.api.http) = {get: "/v1alpha/operations/{operation_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -965,7 +965,7 @@ paths:
             - VIEW_FULL
       tags:
         - Model
-  /v1alpha/{name}:
+  /v1alpha/operations/{operationId}:
     get:
       summary: Get the details of a long-running operation
       description: |-
@@ -985,14 +985,11 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: name
-          description: |-
-            The resource name of the model, which allows its access ID.
-            - Format: `operations/{operation.id}`.
+        - name: operationId
+          description: The resource name of the model, which allows its access ID.
           in: path
           required: true
           type: string
-          pattern: operations/[^/]+
         - name: view
           description: |-
             View allows clients to specify the desired model view in the response.

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1246,7 +1246,7 @@ paths:
           format: int32
       tags:
         - Component
-  /v1beta/{name}:
+  /v1beta/operations/{operationId}:
     get:
       summary: Get the details of a long-running operation
       description: |-
@@ -1266,14 +1266,13 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: name
+        - name: operationId
           description: |-
             The name of the operation resource. Asynchronous methods will contain this
             information in their response.
           in: path
           required: true
           type: string
-          pattern: operations/[^/]+
         - name: Instill-Requester-Uid
           description: Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to
           in: header

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1798,7 +1798,7 @@ message TriggerAsyncOrganizationPipelineReleaseResponse {
 message GetOperationRequest {
   // The name of the operation resource. Asynchronous methods will contain this
   // information in their response.
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
+  string operation_id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetOperationResponse contains the long-running operation details.

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -436,7 +436,7 @@ service PipelinePublicService {
   // This method allows requesters to request the status and outcome of
   // long-running operations such as asynchronous pipeline triggers.
   rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
-    option (google.api.http) = {get: "/v1beta/{name=operations/*}"};
+    option (google.api.http) = {get: "/v1beta/operations/{operation_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger"
       parameters: {


### PR DESCRIPTION
Because

- We should avoid using ambiguous `name` parameter in operation endpoint requests.

This commit

- Uses explicit `operation_id` in operation endpoint requests.