### PR TITLE
fix(mgmt): remove aggregationWindow from pipeline trigger count request

### DIFF
--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -74,17 +74,12 @@ message PipelineTriggerChartRecord {
 message GetPipelineTriggerCountRequest {
   // The ID of the namespace that requested the pipeline triggers.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Aggregation window. The value is a positive duration string, i.e. a
-  // sequence of decimal numbers, each with optional fraction and a unit
-  // suffix, such as "300ms", "1.5h" or "2h45m".
-  // The minimum (and default) window is 1h.
-  optional string aggregation_window = 2;
   // Beginning of the time range from which the records will be fetched.
   // The default value is the beginning of the current day, in UTC.
-  optional google.protobuf.Timestamp start = 3;
+  optional google.protobuf.Timestamp start = 2;
   // End of the time range from which the records will be fetched.
   // The default value is the current timestamp.
-  optional google.protobuf.Timestamp stop = 4;
+  optional google.protobuf.Timestamp stop = 3;
 }
 
 // GetPipelineTriggerCountResponse contains the trigger count, grouped by

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -893,15 +893,6 @@ paths:
           in: query
           required: true
           type: string
-        - name: aggregationWindow
-          description: |-
-            Aggregation window. The value is a positive duration string, i.e. a
-            sequence of decimal numbers, each with optional fraction and a unit
-            suffix, such as "300ms", "1.5h" or "2h45m".
-            The minimum (and default) window is 1h.
-          in: query
-          required: false
-          type: string
         - name: start
           description: |-
             Beginning of the time range from which the records will be fetched.


### PR DESCRIPTION
Because

- `aggregation_window` was copied as a param by accident (trigger count is not aggregated).

This commit

- Removes the parameter from the trigger count request.
