### PR TITLE
chore(mgmt): remove max_seats in organization subscription

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1147,8 +1147,8 @@ message OrganizationSubscription {
   Plan plan = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Details of the associated Stripe subscription.
   StripeSubscriptionDetail detail = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Maximum number of seats allowed.
-  int32 max_seats = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reserved for max_seats
+  reserved 3;
   // Number of used seats within the organization subscription.
   int32 used_seats = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -1825,11 +1825,6 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/v1betaStripeSubscriptionDetail'
-      maxSeats:
-        type: integer
-        format: int32
-        description: Maximum number of seats allowed.
-        readOnly: true
       usedSeats:
         type: integer
         format: int32


### PR DESCRIPTION
Because

- We no longer charge organizations based on seats.

This commit

- Removes the `max_seats` attribute from the organization subscription.