### PR TITLE
chore(model): add missing and retire unused model methods

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -217,32 +217,6 @@ message Model {
   repeated string tags = 30 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ModelCard represents a README.md file that accompanies the model to describe
-// handy information with additional model metadata. Under the hood, a model
-// card is associated with a specific model. It is an crucial for
-// reproducibility, sharing and discoverability.
-//
-// Each model has exactly one README card.
-message ModelCard {
-  option (google.api.resource) = {
-    type: "api.instill.tech/ModelCard"
-    pattern: "users/{user.id}/models/{model.id}/readme"
-  };
-
-  // The resource name of the model card, which allows its access by parent
-  // user and model ID.
-  // - Format: `users/{user.id}/models/{model.id}/readme`.
-  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Size of the file in bytes.
-  int32 size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Type of the resource. Its value is fixed to `file`.
-  string type = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Content of the README file in bytes and base64 format.
-  bytes content = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Encoding type of the content. Its value is fixed to `base64`.
-  string encoding = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
 // ListModelsRequest represents a request to list  models.
 message ListModelsRequest {
   // The maximum number of models to return. If this parameter is unspecified,
@@ -406,49 +380,6 @@ message RenameNamespaceModelRequest {
 message RenameNamespaceModelResponse {
   // The renamed model resource.
   Model model = 1;
-}
-
-// PublishNamespacehModelRequest represents a request to publish a model.
-message PublishNamespaceModelRequest {
-  // Namespace ID
-  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Model ID
-  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
-}
-
-// PublishNamespaceModelResponse contains a published model.
-message PublishNamespaceModelResponse {
-  // The published model resource.
-  Model model = 1;
-}
-
-// UnpublishNamespaceModelRequest represents a request to unpublish a model.
-message UnpublishNamespaceModelRequest {
-  // Namespace ID
-  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Model ID
-  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
-}
-
-// UnpublishNamespaceModelResponse contains an unpublished model.
-message UnpublishNamespaceModelResponse {
-  // The unpublished model resource.
-  Model model = 1;
-}
-
-// GetNamespaceModelCardRequest represents a request to fetch the README card of a
-// model.
-message GetNamespaceModelCardRequest {
-  // Namespace ID
-  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Model ID
-  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
-}
-
-// GetNamespaceModelCardResponse contains the model's README card.
-message GetNamespaceModelCardResponse {
-  // A model card resource.
-  ModelCard readme = 1;
 }
 
 // WatchNamespaceModelRequest represents a request to fetch current state of a model
@@ -628,6 +559,25 @@ message TriggerNamespaceModelBinaryFileUploadResponse {
   repeated TaskOutput task_outputs = 2 [(google.api.field_behavior) = REQUIRED];
   // Model version tag
   string version = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerNamespaceModelLatestBinaryFileUploadRequest represents a request trigger a model
+// inference by uploading a binary file as the input.
+message TriggerNamespaceLatestModelBinaryFileUploadRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model ID
+  string model_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Inference input as a binary file.
+  TaskInputStream task_input = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TriggerNamespaceLatestModelBinaryFileUploadResponse contains the model inference results.
+message TriggerNamespaceLatestModelBinaryFileUploadResponse {
+  // Task type.
+  common.task.v1alpha.Task task = 1 [(google.api.field_behavior) = REQUIRED];
+  // Model inference outputs.
+  repeated TaskOutput task_outputs = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetNamespaceLatestModelOperationRequest represents a request to fetch the latest long-running
@@ -829,67 +779,6 @@ message RenameUserModelRequest {
 message RenameUserModelResponse {
   // The renamed model resource.
   Model model = 1;
-}
-
-// PublisUserhModelRequest represents a request to publish a model.
-message PublishUserModelRequest {
-  // The resource name of the model, which allows its access by parent user
-  // and ID.
-  // - Format: `users/{user.id}/models/{model.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Model",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_model_name"}
-    }
-  ];
-}
-
-// PublishUserModelResponse contains a published model.
-message PublishUserModelResponse {
-  // The published model resource.
-  Model model = 1;
-}
-
-// UnpublishUserModelRequest represents a request to unpublish a model.
-message UnpublishUserModelRequest {
-  // The resource name of the model, which allows its access by parent user
-  // and ID.
-  // - Format: `users/{user.id}/models/{model.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Model",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_model_name"}
-    }
-  ];
-}
-
-// UnpublishUserModelResponse contains an unpublished model.
-message UnpublishUserModelResponse {
-  // The unpublished model resource.
-  Model model = 1;
-}
-
-// GetUserModelCardRequest represents a request to fetch the README card of a
-// model.
-message GetUserModelCardRequest {
-  // The resource name of the model card, which allows its access by parent
-  // user and model ID.
-  // - Format: `users/{user.id}/models/{model.id}/readme`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelCard",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_model_card_name"}
-    }
-  ];
-}
-
-// GetUserModelCardResponse contains the model's README card.
-message GetUserModelCardResponse {
-  // A model card resource.
-  ModelCard readme = 1;
 }
 
 // WatchUserModelRequest represents a request to fetch current state of a model
@@ -1373,67 +1262,6 @@ message RenameOrganizationModelRequest {
 message RenameOrganizationModelResponse {
   // The renamed model resource.
   Model model = 1;
-}
-
-// PublisOrganizationhModelRequest represents a request to publish a model.
-message PublishOrganizationModelRequest {
-  // The resource name of the model, which allows its access by parent organization
-  // and ID.
-  // - Format: `organizations/{organization.id}/models/{model.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Model",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_model_name"}
-    }
-  ];
-}
-
-// PublishOrganizationModelResponse contains a published model.
-message PublishOrganizationModelResponse {
-  // The published model resource.
-  Model model = 1;
-}
-
-// UnpublishOrganizationModelRequest represents a request to unpublish a model.
-message UnpublishOrganizationModelRequest {
-  // The resource name of the model, which allows its access by parent organization
-  // and ID.
-  // - Format: `organizations/{organization.id}/models/{model.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/Model",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_model_name"}
-    }
-  ];
-}
-
-// UnpublishOrganizationModelResponse contains an unpublished model.
-message UnpublishOrganizationModelResponse {
-  // The unpublished model resource.
-  Model model = 1;
-}
-
-// GetOrganizationModelCardRequest represents a request to fetch the README card of a
-// model.
-message GetOrganizationModelCardRequest {
-  // The resource name of the model card, which allows its access by parent
-  // organization and model ID.
-  // - Format: `organizations/{organization.id}/models/{model.id}/readme`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "api.instill.tech/ModelCard",
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "organization_model_card_name"}
-    }
-  ];
-}
-
-// GetOrganizationModelCardResponse contains the model's README card.
-message GetOrganizationModelCardResponse {
-  // A model card resource.
-  ModelCard readme = 1;
 }
 
 // WatchOrganizationModelRequest represents a request to fetch current state of a model.

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -150,39 +150,6 @@ service ModelPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
   }
 
-  // Publish a model
-  //
-  // Updates the visibility in a model to PUBLIC. The model is accessed by its
-  // resource name, defined by the model ID and its parent namespace.
-  rpc PublishNamespaceModel(PublishNamespaceModelRequest) returns (PublishNamespaceModelResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/publish"
-      body: "*"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
-  }
-
-  // Unpublish a model
-  //
-  // Updates the visibility in a model to PRIVATE. The model is accessed by its
-  // resource name, defined by the model ID and its parent namespace.
-  rpc UnpublishNamespaceModel(UnpublishNamespaceModelRequest) returns (UnpublishNamespaceModelResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/unpublish"
-      body: "*"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
-  }
-
-  // Get a model card
-  //
-  // Returns the README file that accompanies a model, describing it and
-  // enhancing it with metadata. The model is accessed by its resource name.
-  rpc GetNamespaceModelCard(GetNamespaceModelCardRequest) returns (GetNamespaceModelCardResponse) {
-    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/readme"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Model"};
-  }
-
   // Watch the state of a model version
   //
   // Returns the state of a model. The model resource allocation and scaling actions take some
@@ -305,6 +272,40 @@ service ModelPublicService {
     };
   }
 
+  // Trigger model inference with a binary input
+  //
+  // Triggers a deployed model to infer the result of a task or question,
+  // submitted as a binary file.
+  rpc TriggerNamespaceModelBinaryFileUpload(stream TriggerNamespaceModelBinaryFileUploadRequest) returns (TriggerNamespaceModelBinaryFileUploadResponse) {
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // Trigger model inference with a binary input
+  //
+  // Triggers the latest deployed model version to infer the result of a set of task or
+  // questions, submitted as a binary file.
+  rpc TriggerNamespaceLatestModelBinaryFileUpload(stream TriggerNamespaceLatestModelBinaryFileUploadRequest) returns (TriggerNamespaceLatestModelBinaryFileUploadResponse) {
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated user is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
   // Get the details of the latest long-running operation from a namespace model
   //
   // This method allows requesters to request the status and outcome of
@@ -411,51 +412,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=users/*/models/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model (Deprecated)"
-      deprecated: true
-    };
-    option deprecated = true;
-  }
-
-  // Publish a model
-  //
-  // Updates the visibility in a model to PUBLIC. The model is accessed by its
-  // resource name, defined by the model ID and its parent user.
-  rpc PublishUserModel(PublishUserModelRequest) returns (PublishUserModelResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/{name=users/*/models/*}/publish"
-      body: "*"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model (Deprecated)"
-      deprecated: true
-    };
-    option deprecated = true;
-  }
-
-  // Unpublish a model
-  //
-  // Updates the visibility in a model to PRIVATE. The model is accessed by its
-  // resource name, defined by the model ID and its parent user.
-  rpc UnpublishUserModel(UnpublishUserModelRequest) returns (UnpublishUserModelResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/{name=users/*/models/*}/unpublish"
-      body: "*"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model (Deprecated)"
-      deprecated: true
-    };
-    option deprecated = true;
-  }
-
-  // Get a model card
-  //
-  // Returns the README file that accompanies a model, describing it and
-  // enhancing it with metadata. The model is accessed by its resource name.
-  rpc GetUserModelCard(GetUserModelCardRequest) returns (GetUserModelCardResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=users/*/models/*/readme}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Model (Deprecated)"
       deprecated: true
@@ -716,51 +672,6 @@ service ModelPublicService {
       post: "/v1alpha/{name=organizations/*/models/*}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model (Deprecated)"
-      deprecated: true
-    };
-    option deprecated = true;
-  }
-
-  // Publish a model
-  //
-  // Updates the visibility in a model to PUBLIC. The model is accessed by its
-  // resource name, defined by the model ID and its parent organization.
-  rpc PublishOrganizationModel(PublishOrganizationModelRequest) returns (PublishOrganizationModelResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/{name=organizations/*/models/*}/publish"
-      body: "*"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model (Deprecated)"
-      deprecated: true
-    };
-    option deprecated = true;
-  }
-
-  // Unpublish a model
-  //
-  // Updates the visibility in a model to PRIVATE. The model is accessed by its
-  // resource name, defined by the model ID and its parent organization.
-  rpc UnpublishOrganizationModel(UnpublishOrganizationModelRequest) returns (UnpublishOrganizationModelResponse) {
-    option (google.api.http) = {
-      post: "/v1alpha/{name=organizations/*/models/*}/unpublish"
-      body: "*"
-    };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Model (Deprecated)"
-      deprecated: true
-    };
-    option deprecated = true;
-  }
-
-  // Get a model card
-  //
-  // Returns the README file that accompanies a model, describing it and
-  // enhancing it with metadata. The model is accessed by its resource name.
-  rpc GetOrganizationModelCard(GetOrganizationModelCardRequest) returns (GetOrganizationModelCardResponse) {
-    option (google.api.http) = {get: "/v1alpha/{name=organizations/*/models/*/readme}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Model (Deprecated)"
       deprecated: true

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -483,112 +483,6 @@ paths:
             $ref: '#/definitions/ModelPublicServiceRenameNamespaceModelBody'
       tags:
         - Model
-  /v1alpha/namespaces/{namespaceId}/models/{modelId}/publish:
-    post:
-      summary: Publish a model
-      description: |-
-        Updates the visibility in a model to PUBLIC. The model is accessed by its
-        resource name, defined by the model ID and its parent namespace.
-      operationId: ModelPublicService_PublishNamespaceModel
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaPublishNamespaceModelResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: namespaceId
-          description: Namespace ID
-          in: path
-          required: true
-          type: string
-        - name: modelId
-          description: Model ID
-          in: path
-          required: true
-          type: string
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/ModelPublicServicePublishNamespaceModelBody'
-      tags:
-        - Model
-  /v1alpha/namespaces/{namespaceId}/models/{modelId}/unpublish:
-    post:
-      summary: Unpublish a model
-      description: |-
-        Updates the visibility in a model to PRIVATE. The model is accessed by its
-        resource name, defined by the model ID and its parent namespace.
-      operationId: ModelPublicService_UnpublishNamespaceModel
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaUnpublishNamespaceModelResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: namespaceId
-          description: Namespace ID
-          in: path
-          required: true
-          type: string
-        - name: modelId
-          description: Model ID
-          in: path
-          required: true
-          type: string
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/ModelPublicServiceUnpublishNamespaceModelBody'
-      tags:
-        - Model
-  /v1alpha/namespaces/{namespaceId}/models/{modelId}/readme:
-    get:
-      summary: Get a model card
-      description: |-
-        Returns the README file that accompanies a model, describing it and
-        enhancing it with metadata. The model is accessed by its resource name.
-      operationId: ModelPublicService_GetNamespaceModelCard
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetNamespaceModelCardResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: namespaceId
-          description: Namespace ID
-          in: path
-          required: true
-          type: string
-        - name: modelId
-          description: Model ID
-          in: path
-          required: true
-          type: string
-      tags:
-        - Model
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}/watch:
     get:
       summary: Watch the state of a model version
@@ -1398,112 +1292,6 @@ paths:
       tags:
         - Model (Deprecated)
       deprecated: true
-  /v1alpha/{user_model_name}/publish:
-    post:
-      summary: Publish a model
-      description: |-
-        Updates the visibility in a model to PUBLIC. The model is accessed by its
-        resource name, defined by the model ID and its parent user.
-      operationId: ModelPublicService_PublishUserModel
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaPublishUserModelResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_model_name
-          description: |-
-            The resource name of the model, which allows its access by parent user
-            and ID.
-            - Format: `users/{user.id}/models/{model.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/models/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/ModelPublicServicePublishUserModelBody'
-      tags:
-        - Model (Deprecated)
-      deprecated: true
-  /v1alpha/{user_model_name}/unpublish:
-    post:
-      summary: Unpublish a model
-      description: |-
-        Updates the visibility in a model to PRIVATE. The model is accessed by its
-        resource name, defined by the model ID and its parent user.
-      operationId: ModelPublicService_UnpublishUserModel
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaUnpublishUserModelResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_model_name
-          description: |-
-            The resource name of the model, which allows its access by parent user
-            and ID.
-            - Format: `users/{user.id}/models/{model.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/models/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/ModelPublicServiceUnpublishUserModelBody'
-      tags:
-        - Model (Deprecated)
-      deprecated: true
-  /v1alpha/{user_model_card_name}:
-    get:
-      summary: Get a model card
-      description: |-
-        Returns the README file that accompanies a model, describing it and
-        enhancing it with metadata. The model is accessed by its resource name.
-      operationId: ModelPublicService_GetUserModelCard
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetUserModelCardResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: user_model_card_name
-          description: |-
-            The resource name of the model card, which allows its access by parent
-            user and model ID.
-            - Format: `users/{user.id}/models/{model.id}/readme`.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/models/[^/]+/readme
-      tags:
-        - Model (Deprecated)
-      deprecated: true
   /v1alpha/{user_model_name}/versions/{version}/watch:
     get:
       summary: Watch the state of a model version
@@ -2236,112 +2024,6 @@ paths:
       tags:
         - Model (Deprecated)
       deprecated: true
-  /v1alpha/{organization_model_name}/publish:
-    post:
-      summary: Publish a model
-      description: |-
-        Updates the visibility in a model to PUBLIC. The model is accessed by its
-        resource name, defined by the model ID and its parent organization.
-      operationId: ModelPublicService_PublishOrganizationModel
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaPublishOrganizationModelResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_model_name
-          description: |-
-            The resource name of the model, which allows its access by parent organization
-            and ID.
-            - Format: `organizations/{organization.id}/models/{model.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/models/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/ModelPublicServicePublishOrganizationModelBody'
-      tags:
-        - Model (Deprecated)
-      deprecated: true
-  /v1alpha/{organization_model_name}/unpublish:
-    post:
-      summary: Unpublish a model
-      description: |-
-        Updates the visibility in a model to PRIVATE. The model is accessed by its
-        resource name, defined by the model ID and its parent organization.
-      operationId: ModelPublicService_UnpublishOrganizationModel
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaUnpublishOrganizationModelResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_model_name
-          description: |-
-            The resource name of the model, which allows its access by parent organization
-            and ID.
-            - Format: `organizations/{organization.id}/models/{model.id}`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/models/[^/]+
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/ModelPublicServiceUnpublishOrganizationModelBody'
-      tags:
-        - Model (Deprecated)
-      deprecated: true
-  /v1alpha/{organization_model_card_name}:
-    get:
-      summary: Get a model card
-      description: |-
-        Returns the README file that accompanies a model, describing it and
-        enhancing it with metadata. The model is accessed by its resource name.
-      operationId: ModelPublicService_GetOrganizationModelCard
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1alphaGetOrganizationModelCardResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/googlerpcStatus'
-      parameters:
-        - name: organization_model_card_name
-          description: |-
-            The resource name of the model card, which allows its access by parent
-            organization and model ID.
-            - Format: `organizations/{organization.id}/models/{model.id}/readme`.
-          in: path
-          required: true
-          type: string
-          pattern: organizations/[^/]+/models/[^/]+/readme
-      tags:
-        - Model (Deprecated)
-      deprecated: true
   /v1alpha/{organization_model_name}/versions/{version}/watch:
     get:
       summary: Watch the state of a model version
@@ -2771,15 +2453,6 @@ paths:
         - Trigger (Deprecated)
       deprecated: true
 definitions:
-  ModelPublicServicePublishNamespaceModelBody:
-    type: object
-    description: PublishNamespacehModelRequest represents a request to publish a model.
-  ModelPublicServicePublishOrganizationModelBody:
-    type: object
-    description: PublisOrganizationhModelRequest represents a request to publish a model.
-  ModelPublicServicePublishUserModelBody:
-    type: object
-    description: PublisUserhModelRequest represents a request to publish a model.
   ModelPublicServiceRenameNamespaceModelBody:
     type: object
     properties:
@@ -2973,15 +2646,6 @@ definitions:
     description: TriggerUserModelRequest represents a request to trigger a model inference.
     required:
       - taskInputs
-  ModelPublicServiceUnpublishNamespaceModelBody:
-    type: object
-    description: UnpublishNamespaceModelRequest represents a request to unpublish a model.
-  ModelPublicServiceUnpublishOrganizationModelBody:
-    type: object
-    description: UnpublishOrganizationModelRequest represents a request to unpublish a model.
-  ModelPublicServiceUnpublishUserModelBody:
-    type: object
-    description: UnpublishUserModelRequest represents a request to unpublish a model.
   googlelongrunningOperation:
     type: object
     properties:
@@ -3134,8 +2798,7 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com. As of May 2023, there are no widely used type server
-          implementations and no plans to implement one.
+          type.googleapis.com.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -3170,7 +2833,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-       Example 3: Pack and unpack a message in Python.
+      Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -3180,7 +2843,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-       Example 4: Pack and unpack a message in Go
+      Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -3200,7 +2863,7 @@ definitions:
       name "y.z".
 
       JSON
-      ====
+
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -3232,7 +2895,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-      The JSON representation for `NullValue` is JSON `null`.
+       The JSON representation for `NullValue` is JSON `null`.
   v1alphaBoundingBox:
     type: object
     properties:
@@ -3439,14 +3102,6 @@ definitions:
     description: |-
       GetNamespaceLatestModelOperationRequest represents a request to query a long-running
       operation.
-  v1alphaGetNamespaceModelCardResponse:
-    type: object
-    properties:
-      readme:
-        description: A model card resource.
-        allOf:
-          - $ref: '#/definitions/v1alphaModelCard'
-    description: GetNamespaceModelCardResponse contains the model's README card.
   v1alphaGetNamespaceModelResponse:
     type: object
     properties:
@@ -3465,14 +3120,6 @@ definitions:
     description: |-
       GetOrganizationLatestModelOperationRequest represents a request to query a long-running
       operation.
-  v1alphaGetOrganizationModelCardResponse:
-    type: object
-    properties:
-      readme:
-        description: A model card resource.
-        allOf:
-          - $ref: '#/definitions/v1alphaModelCard'
-    description: GetOrganizationModelCardResponse contains the model's README card.
   v1alphaGetOrganizationModelResponse:
     type: object
     properties:
@@ -3491,14 +3138,6 @@ definitions:
     description: |-
       GetUserLatestModelOperationRequest represents a request to query a long-running
       operation.
-  v1alphaGetUserModelCardResponse:
-    type: object
-    properties:
-      readme:
-        description: A model card resource.
-        allOf:
-          - $ref: '#/definitions/v1alphaModelCard'
-    description: GetUserModelCardResponse contains the model's README card.
   v1alphaGetUserModelResponse:
     type: object
     properties:
@@ -4066,41 +3705,6 @@ definitions:
       - visibility
       - region
       - hardware
-  v1alphaModelCard:
-    type: object
-    properties:
-      name:
-        type: string
-        description: |-
-          The resource name of the model card, which allows its access by parent
-          user and model ID.
-          - Format: `users/{user.id}/models/{model.id}/readme`.
-        readOnly: true
-      size:
-        type: integer
-        format: int32
-        description: Size of the file in bytes.
-        readOnly: true
-      type:
-        type: string
-        description: Type of the resource. Its value is fixed to `file`.
-        readOnly: true
-      content:
-        type: string
-        format: byte
-        description: Content of the README file in bytes and base64 format.
-        readOnly: true
-      encoding:
-        type: string
-        description: Encoding type of the content. Its value is fixed to `base64`.
-        readOnly: true
-    description: |-
-      ModelCard represents a README.md file that accompanies the model to describe
-      handy information with additional model metadata. Under the hood, a model
-      card is associated with a specific model. It is an crucial for
-      reproducibility, sharing and discoverability.
-
-      Each model has exactly one README card.
   v1alphaModelDefinition:
     type: object
     properties:
@@ -4269,30 +3873,6 @@ definitions:
         type: string
         description: Base64-encoded image.
     description: PromptImage is an image input for model inference.
-  v1alphaPublishNamespaceModelResponse:
-    type: object
-    properties:
-      model:
-        description: The published model resource.
-        allOf:
-          - $ref: '#/definitions/v1alphaModel'
-    description: PublishNamespaceModelResponse contains a published model.
-  v1alphaPublishOrganizationModelResponse:
-    type: object
-    properties:
-      model:
-        description: The published model resource.
-        allOf:
-          - $ref: '#/definitions/v1alphaModel'
-    description: PublishOrganizationModelResponse contains a published model.
-  v1alphaPublishUserModelResponse:
-    type: object
-    properties:
-      model:
-        description: The published model resource.
-        allOf:
-          - $ref: '#/definitions/v1alphaModel'
-    description: PublishUserModelResponse contains a published model.
   v1alphaRegion:
     type: object
     properties:
@@ -4819,6 +4399,23 @@ definitions:
     description: |-
       TriggerAsyncUserModelResponse contains the information to access the
       status of an asynchronous model inference.
+  v1alphaTriggerNamespaceLatestModelBinaryFileUploadResponse:
+    type: object
+    properties:
+      task:
+        description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
+      taskOutputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskOutput'
+        description: Model inference outputs.
+    description: TriggerNamespaceLatestModelBinaryFileUploadResponse contains the model inference results.
+    required:
+      - task
+      - taskOutputs
   v1alphaTriggerNamespaceLatestModelResponse:
     type: object
     properties:
@@ -4833,6 +4430,27 @@ definitions:
           $ref: '#/definitions/v1alphaTaskOutput'
         description: Model inference outputs.
     description: TriggerNamespaceLatestModelResponse contains the model inference results.
+  v1alphaTriggerNamespaceModelBinaryFileUploadResponse:
+    type: object
+    properties:
+      task:
+        description: Task type.
+        allOf:
+          - $ref: '#/definitions/v1alphaTask'
+      taskOutputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaTaskOutput'
+        description: Model inference outputs.
+      version:
+        type: string
+        title: Model version tag
+    description: TriggerNamespaceModelBinaryFileUploadResponse contains the model inference results.
+    required:
+      - task
+      - taskOutputs
+      - version
   v1alphaTriggerNamespaceModelResponse:
     type: object
     properties:
@@ -4950,30 +4568,6 @@ definitions:
   v1alphaUndeployUserModelAdminResponse:
     type: object
     title: UndeployUserModelAdminResponse represents a response for a undeployed model
-  v1alphaUnpublishNamespaceModelResponse:
-    type: object
-    properties:
-      model:
-        description: The unpublished model resource.
-        allOf:
-          - $ref: '#/definitions/v1alphaModel'
-    description: UnpublishNamespaceModelResponse contains an unpublished model.
-  v1alphaUnpublishOrganizationModelResponse:
-    type: object
-    properties:
-      model:
-        description: The unpublished model resource.
-        allOf:
-          - $ref: '#/definitions/v1alphaModel'
-    description: UnpublishOrganizationModelResponse contains an unpublished model.
-  v1alphaUnpublishUserModelResponse:
-    type: object
-    properties:
-      model:
-        description: The unpublished model resource.
-        allOf:
-          - $ref: '#/definitions/v1alphaModel'
-    description: UnpublishUserModelResponse contains an unpublished model.
   v1alphaUnspecifiedInput:
     type: object
     properties:

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2798,7 +2798,8 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com.
+          type.googleapis.com. As of May 2023, there are no widely used type server
+          implementations and no plans to implement one.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -2833,7 +2834,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-      Example 3: Pack and unpack a message in Python.
+       Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -2843,7 +2844,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-      Example 4: Pack and unpack a message in Go
+       Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -2863,7 +2864,7 @@ definitions:
       name "y.z".
 
       JSON
-
+      ====
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -2895,7 +2896,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-       The JSON representation for `NullValue` is JSON `null`.
+      The JSON representation for `NullValue` is JSON `null`.
   v1alphaBoundingBox:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4890,7 +4890,8 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com.
+          type.googleapis.com. As of May 2023, there are no widely used type server
+          implementations and no plans to implement one.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -4925,7 +4926,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-      Example 3: Pack and unpack a message in Python.
+       Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -4935,7 +4936,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-      Example 4: Pack and unpack a message in Go
+       Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -4955,7 +4956,7 @@ definitions:
       name "y.z".
 
       JSON
-
+      ====
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -4987,7 +4988,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-       The JSON representation for `NullValue` is JSON `null`.
+      The JSON representation for `NullValue` is JSON `null`.
   v1betaCheckNameRequest:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4890,8 +4890,7 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com. As of May 2023, there are no widely used type server
-          implementations and no plans to implement one.
+          type.googleapis.com.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -4926,7 +4925,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-       Example 3: Pack and unpack a message in Python.
+      Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -4936,7 +4935,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-       Example 4: Pack and unpack a message in Go
+      Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -4956,7 +4955,7 @@ definitions:
       name "y.z".
 
       JSON
-      ====
+
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -4988,7 +4987,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-      The JSON representation for `NullValue` is JSON `null`.
+       The JSON representation for `NullValue` is JSON `null`.
   v1betaCheckNameRequest:
     type: object
     properties:


### PR DESCRIPTION
Because

- Missing public endpoint for binary file trigger
- Some endpoints are no longer supported in the backend

This commit

- add missing model endpoints for triggering with binary file
- remove unused model endpoints
