### PR TITLE
chore(model): update latestOperation input and output type

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1519,10 +1519,14 @@ message GetModelOperationResponse {
 
 // LatestOperation represents an internal message for GetLatestModelOperation Response
 message LatestOperation {
+  // Deprecated input request type
+  reserved 1;
+  // Deprecated output response type
+  reserved 2;
   // Input request
-  TriggerUserModelRequest request = 1;
+  TriggerNamespaceModelRequest request = 3;
   // Output response
-  TriggerUserModelResponse response = 2;
+  TriggerNamespaceModelResponse response = 4;
 }
 
 // GetUserLatestModelOperationRequest represents a request to fetch the latest long-running


### PR DESCRIPTION
Because

- Previous message type is deprecated

This commit

- update latestOperation input and output type
