### PR TITLE
chore(mgmt): rename Starter plan to Pro plan

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1119,8 +1119,8 @@ message UserSubscription {
     PLAN_UNSPECIFIED = 0;
     // Free plan.
     PLAN_FREE = 1;
-    // Starter plan.
-    PLAN_STARTER = 2;
+    // Pro plan.
+    PLAN_PRO = 2;
   }
 
   // Plan identifier.

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -2116,12 +2116,12 @@ definitions:
     type: string
     enum:
       - PLAN_FREE
-      - PLAN_STARTER
+      - PLAN_PRO
     description: |-
       Enumerates the plan types for the user subscription.
 
        - PLAN_FREE: Free plan.
-       - PLAN_STARTER: Starter plan.
+       - PLAN_PRO: Pro plan.
   v1betaValidateTokenResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- The Starter plan will be renamed to Pro plan

This commit

- Renames the Starter plan to Pro plan.
