### PR TITLE
fix(mgmt): restore pipeline dashboard enpoints

### DIFF
--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -38,6 +38,7 @@ message PipelineTriggerCount {
   optional Status status = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+/*
 // PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
 // contains a collection of (timestamp, count) pairs that represent the total
 // pipeline triggers in a given time bucket.
@@ -68,6 +69,7 @@ message PipelineTriggerChartRecord {
   // The ID of the namespace that requested the pipeline triggers.
   string namespace_id = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
+*/
 
 // GetPipelineTriggerCountRequest represents a request to fetch the trigger
 // count of a requester over a time period.
@@ -89,6 +91,7 @@ message GetPipelineTriggerCountResponse {
   repeated PipelineTriggerCount pipeline_trigger_counts = 1;
 }
 
+/*
 // ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
 // trigger chart records for a given requester, grouped by time buckets.
 message ListPipelineTriggerChartRecordsRequest {
@@ -125,6 +128,7 @@ message ListPipelineTriggerChartRecordsResponse {
   // ID, trigger mode, final status or other fields.
   repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
 }
+*/
 
 // CreditConsumptionChartRecord represents a timeline of Instill Credit
 // consumption. It contains a collection of (timestamp, amount) pairs that
@@ -168,4 +172,89 @@ message ListCreditConsumptionChartRecordsResponse {
   // the request. This won't be returned anymore as we need to aggregate the
   // consumption by source.
   reserved 2;
+}
+
+// Deprecated messages, to be removed with the new dashboard implementation.
+
+// PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
+// pipeline ID.
+message PipelineTriggerTableRecord {
+  // Pipeline ID.
+  string pipeline_id = 1;
+  // Pipeline UUID.
+  string pipeline_uid = 2;
+  // Number of triggers with `STATUS_COMPLETED`.
+  int32 trigger_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Number of triggers with `STATUS_ERRORED`.
+  int32 trigger_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Release UUID for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListPipelineTriggerTableRecordsRequest represents a request to list the
+// pipeline triggers metrics, aggregated by pipeline ID.
+message ListPipelineTriggerTableRecordsRequest {
+  // The maximum number of results to return. If this parameter is unspecified,
+  // at most 100 pipelines will be returned. The cap value for this parameter
+  // is 1000 (i.e. any value above that will be coerced to 1000).
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page token.
+  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListPipelineTriggerTableRecordsResponse contains the pipeline metrics.
+message ListPipelineTriggerTableRecordsResponse {
+  // A list of pipeline trigger tables.
+  repeated PipelineTriggerTableRecord pipeline_trigger_table_records = 1;
+  // Next page token.
+  string next_page_token = 2;
+  // Total number of pipeline trigger records
+  int32 total_size = 3;
+}
+
+// ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
+// trigger metrics, aggregated by pipeline ID and time frame.
+message ListPipelineTriggerChartRecordsRequest {
+  // Aggregation window in nanoseconds.
+  int32 aggregation_window = 1;
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
+// chart records.
+message ListPipelineTriggerChartRecordsResponse {
+  // A list of pipeline trigger records.
+  repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
+}
+
+// PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
+// pipeline ID and time frame.
+message PipelineTriggerChartRecord {
+  // Pipeline ID.
+  string pipeline_id = 1;
+  // Pipeline UUID.
+  string pipeline_uid = 2;
+  // Trigger mode.
+  Mode trigger_mode = 3;
+  // Final status.
+  Status status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Time buckets.
+  repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Aggregated trigger count in each time bucket.
+  repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total computation time duration in each time bucket.
+  repeated float compute_time_duration = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Version for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Release UUID for the triggered pipeline if it is a release pipeline.
+  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -290,13 +290,26 @@ service MgmtPublicService {
   rpc GetPipelineTriggerCount(GetPipelineTriggerCountRequest) returns (GetPipelineTriggerCountResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/trigger-count"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
+    // This endpoint will remain hidden until the new dashboard is implemented
+    // in the frontend. Until then, the server might return empty data.
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List pipeline trigger metrics
+  //
+  // Returns a paginated list of pipeline executions aggregated by pipeline ID.
+  // NOTE: This method is deprecated and will be retired soon.
+  rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};
+    option deprecated  = true;
   }
 
   // List pipeline trigger time charts
   //
-  // Returns a timeline of pipline trigger counts for a given requester. The
-  // response will contain one set of records (datapoints), representing the
-  // amount of triggers in a time bucket.
+  // Returns a timeline of pipline trigger counts for the pipelines of a given
+  // owner.
+  // NOTE: This method will soon return the trigger counts of a given requester.
   rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Metric"};

--- a/openapiv2/core/service.swagger.yaml
+++ b/openapiv2/core/service.swagger.yaml
@@ -868,18 +868,18 @@ paths:
             $ref: '#/definitions/v1betaCheckNamespaceRequest'
       tags:
         - Utils
-  /v1beta/metrics/vdp/pipeline/trigger-count:
+  /v1beta/metrics/vdp/pipeline/tables:
     get:
-      summary: Get pipeline trigger count
+      summary: List pipeline trigger metrics
       description: |-
-        Returns the pipeline trigger count of a given requester within a timespan.
-        Results are grouped by trigger status.
-      operationId: MgmtPublicService_GetPipelineTriggerCount
+        Returns a paginated list of pipeline executions aggregated by pipeline ID.
+        NOTE: This method is deprecated and will be retired soon.
+      operationId: MgmtPublicService_ListPipelineTriggerTableRecords
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaGetPipelineTriggerCountResponse'
+            $ref: '#/definitions/v1betaListPipelineTriggerTableRecordsResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -888,36 +888,37 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: namespaceId
-          description: The ID of the namespace that requested the pipeline triggers.
-          in: query
-          required: true
-          type: string
-        - name: start
+        - name: pageSize
           description: |-
-            Beginning of the time range from which the records will be fetched.
-            The default value is the beginning of the current day, in UTC.
+            The maximum number of results to return. If this parameter is unspecified,
+            at most 100 pipelines will be returned. The cap value for this parameter
+            is 1000 (i.e. any value above that will be coerced to 1000).
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageToken
+          description: Page token.
           in: query
           required: false
           type: string
-          format: date-time
-        - name: stop
+        - name: filter
           description: |-
-            End of the time range from which the records will be fetched.
-            The default value is the current timestamp.
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression.
+            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
           in: query
           required: false
           type: string
-          format: date-time
       tags:
         - Metric
   /v1beta/metrics/vdp/pipeline/charts:
     get:
       summary: List pipeline trigger time charts
       description: |-
-        Returns a timeline of pipline trigger counts for a given requester. The
-        response will contain one set of records (datapoints), representing the
-        amount of triggers in a time bucket.
+        Returns a timeline of pipline trigger counts for the pipelines of a given
+        owner.
+        NOTE: This method will soon return the trigger counts of a given requester.
       operationId: MgmtPublicService_ListPipelineTriggerChartRecords
       responses:
         "200":
@@ -932,36 +933,20 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: namespaceId
-          description: The ID of the namespace that requested the pipeline triggers.
-          in: query
-          required: true
-          type: string
         - name: aggregationWindow
+          description: Aggregation window in nanoseconds.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: filter
           description: |-
-            Aggregation window. The value is a positive duration string, i.e. a
-            sequence of decimal numbers, each with optional fraction and a unit
-            suffix, such as "300ms", "1.5h" or "2h45m".
-            The minimum (and default) window is 1h.
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression.
+            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
           in: query
           required: false
           type: string
-        - name: start
-          description: |-
-            Beginning of the time range from which the records will be fetched.
-            The default value is the beginning of the current day, in UTC.
-          in: query
-          required: false
-          type: string
-          format: date-time
-        - name: stop
-          description: |-
-            End of the time range from which the records will be fetched.
-            The default value is the current timestamp.
-          in: query
-          required: false
-          type: string
-          format: date-time
       tags:
         - Metric
   /v1beta/metrics/credit/charts:
@@ -1427,18 +1412,6 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1betaOrganizationSubscription'
     description: GetOrganizationSubscriptionResponse contains the requested subscription.
-  v1betaGetPipelineTriggerCountResponse:
-    type: object
-    properties:
-      pipelineTriggerCounts:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaPipelineTriggerCount'
-        description: The trigger counts, grouped by status.
-    description: |-
-      GetPipelineTriggerCountResponse contains the trigger count, grouped by
-      trigger status.
   v1betaGetRemainingCreditAdminResponse:
     type: object
     properties:
@@ -1585,14 +1558,27 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/v1betaPipelineTriggerChartRecord'
-        description: |-
-          Pipeline trigger counts. Until we allow filtering or grouping by fields
-          like pipeline ID, this list will contain only one element with the
-          timeline of trigger counts for a given requester, regardless the pipeline
-          ID, trigger mode, final status or other fields.
+        description: A list of pipeline trigger records.
     description: |-
       ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
       chart records.
+  v1betaListPipelineTriggerTableRecordsResponse:
+    type: object
+    properties:
+      pipelineTriggerTableRecords:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipelineTriggerTableRecord'
+        description: A list of pipeline trigger tables.
+      nextPageToken:
+        type: string
+        description: Next page token.
+      totalSize:
+        type: integer
+        format: int32
+        title: Total number of pipeline trigger records
+    description: ListPipelineTriggerTableRecordsResponse contains the pipeline metrics.
   v1betaListTokensResponse:
     type: object
     properties:
@@ -1685,6 +1671,16 @@ definitions:
        - MEMBERSHIP_STATE_ACTIVE: Active.
        - MEMBERSHIP_STATE_PENDING: Pending, i.e., a request has been sent to the user to join an
       organization.
+  v1betaMode:
+    type: string
+    enum:
+      - MODE_SYNC
+      - MODE_ASYNC
+    description: |-
+      Mode describes the execution mode of the pipeline (sync or async).
+
+       - MODE_SYNC: Synchronous (result is returned in the response).
+       - MODE_ASYNC: Asynchronous (response only contains acknowledgement).
   v1betaOnboardingStatus:
     type: string
     enum:
@@ -1858,8 +1854,19 @@ definitions:
     properties:
       pipelineId:
         type: string
-        description: This field will be present present when the information is grouped by pipeline.
+        description: Pipeline ID.
+      pipelineUid:
+        type: string
+        description: Pipeline UUID.
+      triggerMode:
+        description: Trigger mode.
+        allOf:
+          - $ref: '#/definitions/v1betaMode'
+      status:
+        description: Final status.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/mgmtv1betaStatus'
       timeBuckets:
         type: array
         items:
@@ -1874,31 +1881,54 @@ definitions:
           format: int32
         description: Aggregated trigger count in each time bucket.
         readOnly: true
-      namespaceId:
+      computeTimeDuration:
+        type: array
+        items:
+          type: number
+          format: float
+        description: Total computation time duration in each time bucket.
+        readOnly: true
+      pipelineReleaseId:
         type: string
-        description: The ID of the namespace that requested the pipeline triggers.
+        description: Version for the triggered pipeline if it is a release pipeline.
+        readOnly: true
+      pipelineReleaseUid:
+        type: string
+        description: Release UUID for the triggered pipeline if it is a release pipeline.
         readOnly: true
     description: |-
-      PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
-      contains a collection of (timestamp, count) pairs that represent the total
-      pipeline triggers in a given time bucket.
+      PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
       pipeline ID and time frame.
-  v1betaPipelineTriggerCount:
+  v1betaPipelineTriggerTableRecord:
     type: object
     properties:
-      triggerCount:
+      pipelineId:
+        type: string
+        description: Pipeline ID.
+      pipelineUid:
+        type: string
+        description: Pipeline UUID.
+      triggerCountCompleted:
         type: integer
         format: int32
-        description: Number of triggers.
+        description: Number of triggers with `STATUS_COMPLETED`.
         readOnly: true
-      status:
-        description: This field will be present when results are grouped by trigger status.
+      triggerCountErrored:
+        type: integer
+        format: int32
+        description: Number of triggers with `STATUS_ERRORED`.
         readOnly: true
-        allOf:
-          - $ref: '#/definitions/mgmtv1betaStatus'
+      pipelineReleaseId:
+        type: string
+        description: Version for the triggered pipeline if it is a release pipeline.
+        readOnly: true
+      pipelineReleaseUid:
+        type: string
+        description: Release UUID for the triggered pipeline if it is a release pipeline.
+        readOnly: true
     description: |-
-      PipelineTriggerCount represents a pipeline execution count with some
-      aggregation params (e.g. trigger status).
+      PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
+      pipeline ID.
   v1betaStripeSubscriptionDetail:
     type: object
     properties:


### PR DESCRIPTION
Because

- The new dashboard endpoints introduced breaking changes and the clients won't be ready for the upcoming release.

This commit

- Restores the previous dashboard endpoints
  - `ListPipelineTriggerRecords` isn't added back as it had no clients.
