### PR TITLE
chore(vdp): add new generic component type

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -5168,6 +5168,7 @@ definitions:
       - COMPONENT_TYPE_DATA
       - COMPONENT_TYPE_OPERATOR
       - COMPONENT_TYPE_APPLICATION
+      - COMPONENT_TYPE_GENERIC
     description: |-
       ComponentType defines the component type based on its task features.
 
@@ -5175,6 +5176,7 @@ definitions:
        - COMPONENT_TYPE_DATA: Connect with a remote data source.
        - COMPONENT_TYPE_OPERATOR: Manipulate data.
        - COMPONENT_TYPE_APPLICATION: Connect with an external application.
+       - COMPONENT_TYPE_GENERIC: Generic.
   v1betaConnectorDefinition:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/common.proto
+++ b/vdp/pipeline/v1beta/common.proto
@@ -119,4 +119,6 @@ enum ComponentType {
   COMPONENT_TYPE_OPERATOR = 4;
   // Connect with an external application.
   COMPONENT_TYPE_APPLICATION = 5;
+  // Generic.
+  COMPONENT_TYPE_GENERIC = 6;
 }


### PR DESCRIPTION
Because

- We need a new component type called `generic`.

This commit

- Adds a new `generic` component type.