### PR TITLE
chore(vdp): add new generic component type in connector-definitions API

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -5309,6 +5309,7 @@ definitions:
       - CONNECTOR_TYPE_DATA
       - CONNECTOR_TYPE_OPERATOR
       - CONNECTOR_TYPE_APPLICATION
+      - CONNECTOR_TYPE_GENERIC
     description: |-
       ConnectorType defines the connector type based on its task features.
 
@@ -5316,6 +5317,7 @@ definitions:
        - CONNECTOR_TYPE_DATA: Data connector.
        - CONNECTOR_TYPE_OPERATOR: Operator connector.
        - CONNECTOR_TYPE_APPLICATION: Application connector.
+       - CONNECTOR_TYPE_GENERIC: Generic.
   v1betaCreateNamespacePipelineReleaseResponse:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/component_definition.proto
+++ b/vdp/pipeline/v1beta/component_definition.proto
@@ -167,6 +167,8 @@ enum ConnectorType {
   CONNECTOR_TYPE_OPERATOR = 6;
   // Application connector.
   CONNECTOR_TYPE_APPLICATION = 7;
+  // Generic.
+  CONNECTOR_TYPE_GENERIC = 8;
 }
 
 // A Connector is a type of pipeline component that queries, processes or sends


### PR DESCRIPTION
Because

- We need a new component type called `generic`.

This commit

- Adds a new `generic` type in connector-definitions API.