### PR TITLE
feat(vdp): add run-on-event endpoints

### DIFF
--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -474,6 +474,48 @@ message CloneNamespacePipelineReleaseRequest {
 // CloneNamespacePipelineReleaseResponse contains a cloned pipeline.
 message CloneNamespacePipelineReleaseResponse {}
 
+//SendNamespacePipelineEventRequest
+message SendNamespacePipelineEventRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Event
+  string event = 3;
+  // Code
+  string code = 4;
+  // Input data
+  google.protobuf.Struct data = 5;
+}
+
+//SendNamespacePipelineEventResponse
+message SendNamespacePipelineEventResponse {
+  // data
+  google.protobuf.Struct data = 1;
+}
+
+//SendNamespacePipelineReleaseEventRequest
+message SendNamespacePipelineReleaseEventRequest {
+  // Namespace ID
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline ID
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Pipeline ID
+  string release_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // Event
+  string event = 4;
+  // Code
+  string code = 5;
+  // Input data
+  google.protobuf.Struct data = 6;
+}
+
+//SendNamespacePipelineReleaseEventResponse
+message SendNamespacePipelineReleaseEventResponse {
+  // data
+  google.protobuf.Struct data = 1;
+}
+
 // TriggerNamespacePipelineRequest represents a request to trigger a user-owned
 // pipeline synchronously.
 message TriggerNamespacePipelineRequest {

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -165,6 +165,26 @@ service PipelinePublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Pipeline"};
   }
 
+  // SendNamespacePipelineEvent
+  rpc SendNamespacePipelineEvent(SendNamespacePipelineEventRequest) returns (SendNamespacePipelineEventResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/events"
+      body: "data"
+      response_body: "data"
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // SendNamespacePipelineReleaseEvent
+  rpc SendNamespacePipelineReleaseEvent(SendNamespacePipelineReleaseEventRequest) returns (SendNamespacePipelineReleaseEventResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/events"
+      body: "data"
+      response_body: "data"
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
   // Trigger a pipeline
   //
   // Triggers the execution of a pipeline synchronously, i.e., the result is


### PR DESCRIPTION
Because

- We are introducing the run-on-event pipeline, which requires endpoints to receive webhook events.

This commit

- Adds run-on-event endpoints.