### PR TITLE
fix(catalog): update topk to topK

### DIFF
--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -90,7 +90,7 @@ message SimilarityChunksSearchRequest {
   // text prompt
   string text_prompt = 3;
   // topk
-  uint32 topk = 4;
+  uint32 top_k = 4;
 }
 
 // Similar chunnk search response

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -89,7 +89,7 @@ message SimilarityChunksSearchRequest {
   string catalog_id = 2;
   // text prompt
   string text_prompt = 3;
-  // topk
+  // top k
   uint32 top_k = 4;
 }
 

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -503,7 +503,7 @@ definitions:
       topK:
         type: integer
         format: int64
-        title: topk
+        title: top k
     title: Similar chunnk search request
   ArtifactPublicServiceUpdateCatalogBody:
     type: object

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -500,7 +500,7 @@ definitions:
       textPrompt:
         type: string
         title: text prompt
-      topk:
+      topK:
         type: integer
         format: int64
         title: topk


### PR DESCRIPTION
Because

topK is more precise

This commit

change the parameter name
