### PR TITLE
fix(catalog): update topk to topK

### DIFF
--- a/artifact/artifact/v1alpha/qa.proto
+++ b/artifact/artifact/v1alpha/qa.proto
@@ -14,8 +14,8 @@ message QuestionAnsweringRequest {
     string catalog_id = 2;
     // question to be answered
     string question = 3;
-    // topk default to 5
-    int32 topk = 4;
+    // top k default to 5
+    int32 top_k = 4;
   }
   
 // QuestionAnsweringResponse

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -489,10 +489,10 @@ definitions:
       question:
         type: string
         title: question to be answered
-      topk:
+      topK:
         type: integer
         format: int32
-        title: topk default to 5
+        title: top k default to 5
     title: QuestionAnsweringRequest
   ArtifactPublicServiceSimilarityChunksSearchBody:
     type: object


### PR DESCRIPTION
Because

topk is not precise.

This commit

update topk to topK
