### PR TITLE
feat(vdp): pipeline run logging query APIs

### DIFF
--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -875,7 +875,7 @@ service ModelPublicService {
   // List model runs
   //
   // Returns a paginated list of model runs.
-  rpc ListModelTriggers(ListModelRunsRequest) returns (ListModelRunsResponse) {
+  rpc ListModelRuns(ListModelRunsRequest) returns (ListModelRunsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/models/{model_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2447,7 +2447,7 @@ paths:
     get:
       summary: List model runs
       description: Returns a paginated list of model runs.
-      operationId: ModelPublicService_ListModelTriggers
+      operationId: ModelPublicService_ListModelRuns
       responses:
         "200":
           description: A successful response.

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4159,6 +4159,81 @@ paths:
       tags:
         - Secret (Deprecated)
       deprecated: true
+  /v1beta/{namespace}/pipeline-runs:
+    get:
+      summary: ListPipelineRuns retrieves a paginated list of pipeline runs for a given user and namespace.
+      operationId: PipelinePublicService_ListPipelineRuns
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaListPipelineRunsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespace
+          description: The namespace to list pipeline runs for.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/namespaces/[^/]+
+        - name: page
+          description: The page number to retrieve (1-based).
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageSize
+          description: The number of items per page.
+          in: query
+          required: false
+          type: integer
+          format: int32
+  /v1beta/{namespace}/pipeline-runs/{pipelineTriggerUid}/component-runs:
+    get:
+      summary: ListComponentRuns retrieves a paginated list of component runs for a specific pipeline run.
+      operationId: PipelinePublicService_ListComponentRuns
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaListComponentRunsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: namespace
+          description: The namespace of the pipeline run.
+          in: path
+          required: true
+          type: string
+          pattern: users/[^/]+/namespaces/[^/]+
+        - name: pipelineTriggerUid
+          description: The unique identifier of the pipeline run to list component runs for.
+          in: path
+          required: true
+          type: string
+        - name: page
+          description: The page number to retrieve (1-based).
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageSize
+          description: The number of items per page.
+          in: query
+          required: false
+          type: integer
+          format: int32
 definitions:
   CheckNameResponseName:
     type: string
@@ -5143,6 +5218,63 @@ definitions:
        - VIEW_BASIC: Default view, only includes basic information (removes the `spec`
       field).
        - VIEW_FULL: Full representation.
+  v1betaComponentRun:
+    type: object
+    properties:
+      pipelineTriggerUid:
+        type: string
+        description: Links to the parent PipelineRun.
+      componentId:
+        type: string
+        description: Unique identifier for each pipeline component.
+      status:
+        description: Completion status of the component.
+        allOf:
+          - $ref: '#/definitions/v1betaComponentRunStatus'
+      totalDuration:
+        type: string
+        format: int64
+        description: Time taken to execute the component in nanoseconds.
+      startedTime:
+        type: string
+        format: date-time
+        description: Time when the component started execution.
+      completedTime:
+        type: string
+        format: date-time
+        description: Time when the component finished execution.
+      errorMsg:
+        type: string
+        description: Error message if the component failed.
+      inputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaFileReference'
+        description: Input files for the component.
+      outputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaFileReference'
+        description: Output files from the component.
+      creditsUsed:
+        type: number
+        format: double
+        description: Credits used of internal accounting metric.
+    description: ComponentRun represents the execution details of a single component within a pipeline run.
+  v1betaComponentRunStatus:
+    type: string
+    enum:
+      - COMPONENT_RUN_STATUS_RUNNING
+      - COMPONENT_RUN_STATUS_COMPLETED
+      - COMPONENT_RUN_STATUS_FAILED
+    description: |-
+      ComponentRunStatus represents the possible states of a component run.
+
+       - COMPONENT_RUN_STATUS_RUNNING: The component run is currently in progress.
+       - COMPONENT_RUN_STATUS_COMPLETED: The component run has completed successfully.
+       - COMPONENT_RUN_STATUS_FAILED: The component run has failed.
   v1betaComponentTask:
     type: object
     properties:
@@ -5432,6 +5564,23 @@ definitions:
   v1betaDeleteUserSecretResponse:
     type: object
     description: DeleteUserSecretResponse is an empty response.
+  v1betaFileReference:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the file.
+      type:
+        type: string
+        description: Format of the file (e.g., PDF, TXT, JPG).
+      size:
+        type: string
+        format: int64
+        description: Size of the file in bytes.
+      url:
+        type: string
+        description: URL of the file (e.g., S3 URL).
+    description: FileReference represents metadata for a file.
   v1betaGetConnectorDefinitionResponse:
     type: object
     properties:
@@ -5553,6 +5702,28 @@ definitions:
         format: int32
         description: The requested page offset.
     description: ListComponentDefinitionsResponse contains a list of component definitions.
+  v1betaListComponentRunsResponse:
+    type: object
+    properties:
+      componentRuns:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaComponentRun'
+        description: The list of component runs.
+      totalCount:
+        type: string
+        format: int64
+        description: The total number of component runs matching the request.
+      page:
+        type: integer
+        format: int32
+        description: The current page number.
+      pageSize:
+        type: integer
+        format: int32
+        description: The number of items per page.
+    description: ListComponentRunsResponse is the response message for ListComponentRuns.
   v1betaListConnectorDefinitionsResponse:
     type: object
     properties:
@@ -5719,6 +5890,28 @@ definitions:
       requested by an admin user.
       For the moment, the pipeline recipes will be UID-based (permalink) instead
       of name-based. This is a temporary solution.
+  v1betaListPipelineRunsResponse:
+    type: object
+    properties:
+      pipelineRuns:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipelineRun'
+        description: The list of pipeline runs.
+      totalCount:
+        type: string
+        format: int64
+        description: The total number of pipeline runs matching the request.
+      page:
+        type: integer
+        format: int32
+        description: The current page number.
+      pageSize:
+        type: integer
+        format: int32
+        description: The number of items per page.
+    description: ListPipelineRunsResponse is the response message for ListPipelineRuns.
   v1betaListPipelinesAdminResponse:
     type: object
     properties:
@@ -6197,6 +6390,82 @@ definitions:
     description: |-
       Pipeline releases contain the version control information of a pipeline.
       This allows users to track changes in the pipeline over time.
+  v1betaPipelineRun:
+    type: object
+    properties:
+      pipelineUid:
+        type: string
+        description: Unique identifier for the pipeline.
+      pipelineTriggerUid:
+        type: string
+        description: Unique identifier for each run.
+      pipelineVersion:
+        type: string
+        description: Pipeline version used in the run.
+      status:
+        description: Current status of the run.
+        allOf:
+          - $ref: '#/definitions/v1betaPipelineRunStatus'
+      source:
+        type: string
+        description: Origin of the run (e.g., Web click, API).
+      totalDuration:
+        type: string
+        format: int64
+        description: Time taken to complete the run in nanoseconds.
+      triggeredBy:
+        type: string
+        description: Identity of the user who initiated the run.
+      namespace:
+        type: string
+        description: Namespace of the pipeline (user or organization).
+      inputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaFileReference'
+        description: Input files for the run.
+      outputs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaFileReference'
+        description: Output files from the run.
+      recipeSnapshot:
+        type: object
+        description: Snapshot of the pipeline recipe used for this run.
+      triggeredTime:
+        type: string
+        format: date-time
+        description: Time when the run was triggered.
+      startedTime:
+        type: string
+        format: date-time
+        description: Time when the run started execution.
+      completedTime:
+        type: string
+        format: date-time
+        description: Time when the run completed.
+      errorMsg:
+        type: string
+        description: Error message if the run failed.
+      creditsUsed:
+        type: number
+        format: double
+        description: Credits used of internal accounting metric.
+    description: PipelineRun represents a single execution of a pipeline.
+  v1betaPipelineRunStatus:
+    type: string
+    enum:
+      - PIPELINE_RUN_STATUS_RUNNING
+      - PIPELINE_RUN_STATUS_COMPLETED
+      - PIPELINE_RUN_STATUS_FAILED
+    description: |-
+      PipelineRunStatus represents the possible states of a pipeline run.
+
+       - PIPELINE_RUN_STATUS_RUNNING: The pipeline run is currently in progress.
+       - PIPELINE_RUN_STATUS_COMPLETED: The pipeline run has completed successfully.
+       - PIPELINE_RUN_STATUS_FAILED: The pipeline run has failed.
   v1betaPipelineValidationError:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4159,9 +4159,14 @@ paths:
       tags:
         - Secret (Deprecated)
       deprecated: true
-  /v1beta/{namespace}/pipeline-runs:
+  /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/runs:
     get:
-      summary: ListPipelineRuns retrieves a paginated list of pipeline runs for a given user and namespace.
+      summary: List Pipeline Runs
+      description: |-
+        Returns a paginated list of runs for a given pipeline. When the requester
+        is the owner of the pipeline, they will be able to all the pipeline runs,
+        regardless the requester. Other requesters will only be able to see the
+        runs requested by themselves.
       operationId: PipelinePublicService_ListPipelineRuns
       responses:
         "200":
@@ -4176,27 +4181,51 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: namespace
-          description: The namespace to list pipeline runs for.
+        - name: namespaceId
+          description: The ID of the owner of the pipeline.
           in: path
           required: true
           type: string
-          pattern: users/[^/]+/namespaces/[^/]+
+        - name: pipelineId
+          description: The ID of the pipeline for which the runs will be listed.
+          in: path
+          required: true
+          type: string
         - name: page
-          description: The page number to retrieve (1-based).
+          description: The page number to retrieve.
           in: query
           required: false
           type: integer
           format: int32
         - name: pageSize
-          description: The number of items per page.
+          description: |-
+            The maximum number of items per page to return. The default and cap values
+            are 10 and 100, respectively.
           in: query
           required: false
           type: integer
           format: int32
-  /v1beta/{namespace}/pipeline-runs/{pipelineTriggerUid}/component-runs:
+        - name: view
+          description: |-
+            View allows clients to specify the desired run view in the response.
+            The basic view excludes input / output data.
+
+             - VIEW_BASIC: Default view, only includes basic information.
+             - VIEW_FULL: Full representation.
+             - VIEW_RECIPE: Contains the recipe of the resource.
+          in: query
+          required: false
+          type: string
+          enum:
+            - VIEW_BASIC
+            - VIEW_FULL
+            - VIEW_RECIPE
+      tags:
+        - Trigger
+  /v1beta/pipeline-runs/{pipelineRunId}/component-runs:
     get:
-      summary: ListComponentRuns retrieves a paginated list of component runs for a specific pipeline run.
+      summary: List Component runs
+      description: Returns the information of each component execution within a pipeline run.
       operationId: PipelinePublicService_ListComponentRuns
       responses:
         "200":
@@ -4211,29 +4240,27 @@ paths:
           schema:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
-        - name: namespace
-          description: The namespace of the pipeline run.
-          in: path
-          required: true
-          type: string
-          pattern: users/[^/]+/namespaces/[^/]+
-        - name: pipelineTriggerUid
+        - name: pipelineRunId
           description: The unique identifier of the pipeline run to list component runs for.
           in: path
           required: true
           type: string
         - name: page
-          description: The page number to retrieve (1-based).
+          description: The page number to retrieve.
           in: query
           required: false
           type: integer
           format: int32
         - name: pageSize
-          description: The number of items per page.
+          description: |-
+            The maximum number of items per page to return. The default and cap values
+            are 10 and 100, respectively.
           in: query
           required: false
           type: integer
           format: int32
+      tags:
+        - Trigger
 definitions:
   CheckNameResponseName:
     type: string
@@ -4773,6 +4800,16 @@ definitions:
     description: |-
       ValidateUserPipelineRequest represents a request to validate a pipeline
       owned by a user.
+  PipelineRunRunSource:
+    type: string
+    enum:
+      - RUN_SOURCE_CONSOLE
+      - RUN_SOURCE_API
+    description: |-
+      RunSource defines the source of a pipeline run.
+
+       - RUN_SOURCE_CONSOLE: The request was triggered from Instill Console.
+       - RUN_SOURCE_API: The request was triggered from the API or SDK.
   PipelineStats:
     type: object
     properties:
@@ -5221,60 +5258,57 @@ definitions:
   v1betaComponentRun:
     type: object
     properties:
-      pipelineTriggerUid:
+      pipelineRunUid:
         type: string
         description: Links to the parent PipelineRun.
+        readOnly: true
       componentId:
         type: string
         description: Unique identifier for each pipeline component.
+        readOnly: true
       status:
         description: Completion status of the component.
+        readOnly: true
         allOf:
-          - $ref: '#/definitions/v1betaComponentRunStatus'
+          - $ref: '#/definitions/v1betaRunStatus'
       totalDuration:
         type: string
-        format: int64
-        description: Time taken to execute the component in nanoseconds.
-      startedTime:
+        description: Time taken to execute the component.
+        readOnly: true
+      startTime:
         type: string
         format: date-time
         description: Time when the component started execution.
-      completedTime:
+        readOnly: true
+      completeTime:
         type: string
         format: date-time
         description: Time when the component finished execution.
-      errorMsg:
+        readOnly: true
+      error:
         type: string
         description: Error message if the component failed.
+        readOnly: true
       inputs:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaFileReference'
         description: Input files for the component.
+        readOnly: true
       outputs:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaFileReference'
         description: Output files from the component.
-      creditsUsed:
+        readOnly: true
+      creditAmount:
         type: number
-        format: double
+        format: float
         description: Credits used of internal accounting metric.
+        readOnly: true
     description: ComponentRun represents the execution details of a single component within a pipeline run.
-  v1betaComponentRunStatus:
-    type: string
-    enum:
-      - COMPONENT_RUN_STATUS_RUNNING
-      - COMPONENT_RUN_STATUS_COMPLETED
-      - COMPONENT_RUN_STATUS_FAILED
-    description: |-
-      ComponentRunStatus represents the possible states of a component run.
-
-       - COMPONENT_RUN_STATUS_RUNNING: The component run is currently in progress.
-       - COMPONENT_RUN_STATUS_COMPLETED: The component run has completed successfully.
-       - COMPONENT_RUN_STATUS_FAILED: The component run has failed.
   v1betaComponentTask:
     type: object
     properties:
@@ -5581,6 +5615,11 @@ definitions:
         type: string
         description: URL of the file (e.g., S3 URL).
     description: FileReference represents metadata for a file.
+    required:
+      - name
+      - type
+      - size
+      - url
   v1betaGetConnectorDefinitionResponse:
     type: object
     properties:
@@ -5711,18 +5750,22 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaComponentRun'
         description: The list of component runs.
-      totalCount:
+        readOnly: true
+      totalSize:
         type: string
         format: int64
         description: The total number of component runs matching the request.
+        readOnly: true
       page:
         type: integer
         format: int32
         description: The current page number.
+        readOnly: true
       pageSize:
         type: integer
         format: int32
         description: The number of items per page.
+        readOnly: true
     description: ListComponentRunsResponse is the response message for ListComponentRuns.
   v1betaListConnectorDefinitionsResponse:
     type: object
@@ -5899,18 +5942,22 @@ definitions:
           type: object
           $ref: '#/definitions/v1betaPipelineRun'
         description: The list of pipeline runs.
-      totalCount:
+        readOnly: true
+      totalSize:
         type: string
         format: int64
         description: The total number of pipeline runs matching the request.
+        readOnly: true
       page:
         type: integer
         format: int32
         description: The current page number.
+        readOnly: true
       pageSize:
         type: integer
         format: int32
         description: The number of items per page.
+        readOnly: true
     description: ListPipelineRunsResponse is the response message for ListPipelineRuns.
   v1betaListPipelinesAdminResponse:
     type: object
@@ -6396,76 +6443,71 @@ definitions:
       pipelineUid:
         type: string
         description: Unique identifier for the pipeline.
-      pipelineTriggerUid:
+        readOnly: true
+      pipelineRunUid:
         type: string
         description: Unique identifier for each run.
+        readOnly: true
       pipelineVersion:
         type: string
         description: Pipeline version used in the run.
+        readOnly: true
       status:
         description: Current status of the run.
+        readOnly: true
         allOf:
-          - $ref: '#/definitions/v1betaPipelineRunStatus'
+          - $ref: '#/definitions/v1betaRunStatus'
       source:
-        type: string
-        description: Origin of the run (e.g., Web click, API).
+        description: Origin of the run.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/PipelineRunRunSource'
       totalDuration:
         type: string
-        format: int64
-        description: Time taken to complete the run in nanoseconds.
-      triggeredBy:
+        description: Time taken to complete the run.
+        readOnly: true
+      requesterId:
         type: string
         description: Identity of the user who initiated the run.
-      namespace:
-        type: string
-        description: Namespace of the pipeline (user or organization).
+        readOnly: true
       inputs:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaFileReference'
         description: Input files for the run.
+        readOnly: true
       outputs:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1betaFileReference'
         description: Output files from the run.
+        readOnly: true
       recipeSnapshot:
         type: object
         description: Snapshot of the pipeline recipe used for this run.
-      triggeredTime:
-        type: string
-        format: date-time
-        description: Time when the run was triggered.
-      startedTime:
+        readOnly: true
+      startTime:
         type: string
         format: date-time
         description: Time when the run started execution.
-      completedTime:
+        readOnly: true
+      completeTime:
         type: string
         format: date-time
         description: Time when the run completed.
-      errorMsg:
+        readOnly: true
+      error:
         type: string
         description: Error message if the run failed.
-      creditsUsed:
+        readOnly: true
+      creditAmount:
         type: number
-        format: double
+        format: float
         description: Credits used of internal accounting metric.
+        readOnly: true
     description: PipelineRun represents a single execution of a pipeline.
-  v1betaPipelineRunStatus:
-    type: string
-    enum:
-      - PIPELINE_RUN_STATUS_RUNNING
-      - PIPELINE_RUN_STATUS_COMPLETED
-      - PIPELINE_RUN_STATUS_FAILED
-    description: |-
-      PipelineRunStatus represents the possible states of a pipeline run.
-
-       - PIPELINE_RUN_STATUS_RUNNING: The pipeline run is currently in progress.
-       - PIPELINE_RUN_STATUS_COMPLETED: The pipeline run has completed successfully.
-       - PIPELINE_RUN_STATUS_FAILED: The pipeline run has failed.
   v1betaPipelineValidationError:
     type: object
     properties:
@@ -6567,6 +6609,18 @@ definitions:
 
        - ROLE_VIEWER: Viewers can see the resource properties.
        - ROLE_EXECUTOR: Executors can execute the resource (e.g. trigger a pipeline).
+  v1betaRunStatus:
+    type: string
+    enum:
+      - RUN_STATUS_RUNNING
+      - RUN_STATUS_COMPLETED
+      - RUN_STATUS_FAILED
+    description: |-
+      RunStatus represents the possible states of a pipeline or component run.
+
+       - RUN_STATUS_RUNNING: The run is currently in progress.
+       - RUN_STATUS_COMPLETED: The run has completed successfully.
+       - RUN_STATUS_FAILED: The run has failed.
   v1betaSecret:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -13,6 +13,7 @@ import "google/longrunning/operations.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
 // VDP definitions
@@ -1941,74 +1942,78 @@ message LookUpPipelineAdminResponse {
 
 // ListPipelineRunsRequest is the request message for ListPipelineRuns.
 message ListPipelineRunsRequest {
-  // The namespace to list pipeline runs for.
-  string namespace = 1;
+  // The ID of the owner of the pipeline.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The ID of the pipeline for which the runs will be listed.
+  string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The page number to retrieve.
+  int32 page = 3 [(google.api.field_behavior) = OPTIONAL];
 
-  // The page number to retrieve (1-based).
-  int32 page = 2;
+  // The maximum number of items per page to return. The default and cap values
+  // are 10 and 100, respectively.
+  int32 page_size = 4 [(google.api.field_behavior) = OPTIONAL];
 
-  // The number of items per page.
-  int32 page_size = 3;
+  // View allows clients to specify the desired run view in the response.
+  // The basic view excludes input / output data.
+  optional Pipeline.View view = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListPipelineRunsResponse is the response message for ListPipelineRuns.
 message ListPipelineRunsResponse {
   // The list of pipeline runs.
-  repeated PipelineRun pipeline_runs = 1;
+  repeated PipelineRun pipeline_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The total number of pipeline runs matching the request.
-  int64 total_count = 2;
+  int64 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The current page number.
-  int32 page = 3;
+  int32 page = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The number of items per page.
-  int32 page_size = 4;
+  int32 page_size = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListComponentRunsRequest is the request message for ListComponentRuns.
 message ListComponentRunsRequest {
-  // The namespace of the pipeline run.
-  string namespace = 1;
-
   // The unique identifier of the pipeline run to list component runs for.
-  string pipeline_trigger_uid = 2;
+  string pipeline_run_id = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // The page number to retrieve (1-based).
-  int32 page = 3;
+  // The page number to retrieve.
+  optional int32 page = 3 [(google.api.field_behavior) = OPTIONAL];
 
-  // The number of items per page.
-  int32 page_size = 4;
+  // The maximum number of items per page to return. The default and cap values
+  // are 10 and 100, respectively.
+  optional int32 page_size = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListComponentRunsResponse is the response message for ListComponentRuns.
 message ListComponentRunsResponse {
   // The list of component runs.
-  repeated ComponentRun component_runs = 1;
+  repeated ComponentRun component_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The total number of component runs matching the request.
-  int64 total_count = 2;
+  int64 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The current page number.
-  int32 page = 3;
+  int32 page = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The number of items per page.
-  int32 page_size = 4;
+  int32 page_size = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // FileReference represents metadata for a file.
 message FileReference {
   // Name of the file.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Format of the file (e.g., PDF, TXT, JPG).
-  string type = 2;
+  string type = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Size of the file in bytes.
-  int64 size = 3;
+  int64 size = 3 [(google.api.field_behavior) = REQUIRED];
 
   // URL of the file (e.g., S3 URL).
-  string url = 4;
+  string url = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // PipelineRun represents a single execution of a pipeline.
@@ -2017,25 +2022,35 @@ message PipelineRun {
   string pipeline_uid = 1;
 
   // Unique identifier for each run.
-  string pipeline_trigger_uid = 2;
+  string pipeline_run_uid = 2;
 
   // Pipeline version used in the run.
   string pipeline_version = 3;
 
   // Current status of the run.
-  PipelineRunStatus status = 4;
+  RunStatus status = 4;
 
-  // Origin of the run (e.g., Web click, API).
-  string source = 5;
+  // RunSource defines the source of a pipeline trigger
+  enum RunSource {
+    // Unspecified.
+    RUN_SOURCE_UNSPECIFIED = 0;
+    // The request was triggered from Instill Console.
+    RUN_SOURCE_CONSOLE = 1;
+    // The request was triggered from the API or SDK.
+    RUN_SOURCE_API = 2;
+  }
 
-  // Time taken to complete the run in nanoseconds.
-  int64 total_duration = 6;
+  // Origin of the run.
+  RunSource source = 5;
+
+  // Time taken to complete the run.
+  optional google.protobuf.Duration total_duration = 6 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
   // Identity of the user who initiated the run.
-  string triggered_by = 7;
-
-  // Namespace of the pipeline (user or organization).
-  string namespace = 8;
+  string requester_id = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Input files for the run.
   repeated FileReference inputs = 9;
@@ -2050,16 +2065,15 @@ message PipelineRun {
   google.protobuf.Timestamp triggered_time = 12;
 
   // Time when the run started execution.
-  google.protobuf.Timestamp started_time = 13;
-
+  google.protobuf.Timestamp start_time = 13;
   // Time when the run completed.
-  google.protobuf.Timestamp completed_time = 14;
+  google.protobuf.Timestamp complete_time = 14;
 
   // Error message if the run failed.
-  string error_msg = 15;
+  optional string error = 15;
 
   // Credits used of internal accounting metric.
-  double credits_used = 16;
+  float credit_amount = 16;
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.
@@ -2071,19 +2085,21 @@ message ComponentRun {
   string component_id = 2;
 
   // Completion status of the component.
-  ComponentRunStatus status = 3;
+  RunStatus status = 3;
 
-  // Time taken to execute the component in nanoseconds.
-  int64 total_duration = 4;
+  // Time taken to execute the component.
+  optional google.protobuf.Duration total_duration = 4 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
   // Time when the component started execution.
-  google.protobuf.Timestamp started_time = 5;
-
+  google.protobuf.Timestamp start_time = 5;
   // Time when the component finished execution.
-  google.protobuf.Timestamp completed_time = 6;
+  google.protobuf.Timestamp complete_time = 6;
 
   // Error message if the component failed.
-  string error_msg = 7;
+  optional string error = 7;
 
   // Input files for the component.
   repeated FileReference inputs = 8;
@@ -2092,35 +2108,20 @@ message ComponentRun {
   repeated FileReference outputs = 9;
 
   // Credits used of internal accounting metric.
-  double credits_used = 10;
+  float credit_amount = 10;
 }
 
-// PipelineRunStatus represents the possible states of a pipeline run.
-enum PipelineRunStatus {
+// RunStatus represents the possible states of a pipeline or component run.
+enum RunStatus {
   // The status is unknown or not set.
-  PIPELINE_RUN_STATUS_UNSPECIFIED = 0;
+  RUN_STATUS_UNSPECIFIED = 0;
 
-  // The pipeline run is currently in progress.
-  PIPELINE_RUN_STATUS_RUNNING = 1;
+  // The run is currently in progress.
+  RUN_STATUS_RUNNING = 1;
 
-  // The pipeline run has completed successfully.
-  PIPELINE_RUN_STATUS_COMPLETED = 2;
+  // The run has completed successfully.
+  RUN_STATUS_COMPLETED = 2;
 
-  // The pipeline run has failed.
-  PIPELINE_RUN_STATUS_FAILED = 3;
-}
-
-// ComponentRunStatus represents the possible states of a component run.
-enum ComponentRunStatus {
-  // The status is unknown or not set.
-  COMPONENT_RUN_STATUS_UNSPECIFIED = 0;
-
-  // The component run is currently in progress.
-  COMPONENT_RUN_STATUS_RUNNING = 1;
-
-  // The component run has completed successfully.
-  COMPONENT_RUN_STATUS_COMPLETED = 2;
-
-  // The component run has failed.
-  COMPONENT_RUN_STATUS_FAILED = 3;
+  // The run has failed.
+  RUN_STATUS_FAILED = 3;
 }

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -2019,18 +2019,18 @@ message FileReference {
 // PipelineRun represents a single execution of a pipeline.
 message PipelineRun {
   // Unique identifier for the pipeline.
-  string pipeline_uid = 1;
+  string pipeline_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Unique identifier for each run.
-  string pipeline_run_uid = 2;
+  string pipeline_run_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Pipeline version used in the run.
-  string pipeline_version = 3;
+  string pipeline_version = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Current status of the run.
-  RunStatus status = 4;
+  RunStatus status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // RunSource defines the source of a pipeline trigger
+  // RunSource defines the source of a pipeline run.
   enum RunSource {
     // Unspecified.
     RUN_SOURCE_UNSPECIFIED = 0;
@@ -2041,7 +2041,7 @@ message PipelineRun {
   }
 
   // Origin of the run.
-  RunSource source = 5;
+  RunSource source = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Time taken to complete the run.
   optional google.protobuf.Duration total_duration = 6 [
@@ -2053,39 +2053,45 @@ message PipelineRun {
   string requester_id = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Input files for the run.
-  repeated FileReference inputs = 9;
+  repeated FileReference inputs = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Output files from the run.
-  repeated FileReference outputs = 10;
+  repeated FileReference outputs = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Snapshot of the pipeline recipe used for this run.
-  google.protobuf.Struct recipe_snapshot = 11;
-
-  // Time when the run was triggered.
-  google.protobuf.Timestamp triggered_time = 12;
+  google.protobuf.Struct recipe_snapshot = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Time when the run started execution.
-  google.protobuf.Timestamp start_time = 13;
+  google.protobuf.Timestamp start_time = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Time when the run completed.
-  google.protobuf.Timestamp complete_time = 14;
+  optional google.protobuf.Timestamp complete_time = 14 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
   // Error message if the run failed.
-  optional string error = 15;
+  optional string error = 15 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
   // Credits used of internal accounting metric.
-  float credit_amount = 16;
+  optional float credit_amount = 16 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.
 message ComponentRun {
   // Links to the parent PipelineRun.
-  string pipeline_trigger_uid = 1;
+  string pipeline_run_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Unique identifier for each pipeline component.
-  string component_id = 2;
+  string component_id = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Completion status of the component.
-  RunStatus status = 3;
+  RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Time taken to execute the component.
   optional google.protobuf.Duration total_duration = 4 [
@@ -2094,21 +2100,30 @@ message ComponentRun {
   ];
 
   // Time when the component started execution.
-  google.protobuf.Timestamp start_time = 5;
+  google.protobuf.Timestamp start_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Time when the component finished execution.
-  google.protobuf.Timestamp complete_time = 6;
+  optional google.protobuf.Timestamp complete_time = 6 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
   // Error message if the component failed.
-  optional string error = 7;
+  optional string error = 7 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
   // Input files for the component.
-  repeated FileReference inputs = 8;
+  repeated FileReference inputs = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Output files from the component.
-  repeated FileReference outputs = 9;
+  repeated FileReference outputs = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Credits used of internal accounting metric.
-  float credit_amount = 10;
+  optional float credit_amount = 10 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 // RunStatus represents the possible states of a pipeline or component run.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1938,3 +1938,189 @@ message LookUpPipelineAdminResponse {
   // The requested pipeline.
   Pipeline pipeline = 1;
 }
+
+// ListPipelineRunsRequest is the request message for ListPipelineRuns.
+message ListPipelineRunsRequest {
+  // The namespace to list pipeline runs for.
+  string namespace = 1;
+
+  // The page number to retrieve (1-based).
+  int32 page = 2;
+
+  // The number of items per page.
+  int32 page_size = 3;
+}
+
+// ListPipelineRunsResponse is the response message for ListPipelineRuns.
+message ListPipelineRunsResponse {
+  // The list of pipeline runs.
+  repeated PipelineRun pipeline_runs = 1;
+
+  // The total number of pipeline runs matching the request.
+  int64 total_count = 2;
+
+  // The current page number.
+  int32 page = 3;
+
+  // The number of items per page.
+  int32 page_size = 4;
+}
+
+// ListComponentRunsRequest is the request message for ListComponentRuns.
+message ListComponentRunsRequest {
+  // The namespace of the pipeline run.
+  string namespace = 1;
+
+  // The unique identifier of the pipeline run to list component runs for.
+  string pipeline_trigger_uid = 2;
+
+  // The page number to retrieve (1-based).
+  int32 page = 3;
+
+  // The number of items per page.
+  int32 page_size = 4;
+}
+
+// ListComponentRunsResponse is the response message for ListComponentRuns.
+message ListComponentRunsResponse {
+  // The list of component runs.
+  repeated ComponentRun component_runs = 1;
+
+  // The total number of component runs matching the request.
+  int64 total_count = 2;
+
+  // The current page number.
+  int32 page = 3;
+
+  // The number of items per page.
+  int32 page_size = 4;
+}
+
+// FileReference represents metadata for a file.
+message FileReference {
+  // Name of the file.
+  string name = 1;
+
+  // Format of the file (e.g., PDF, TXT, JPG).
+  string type = 2;
+
+  // Size of the file in bytes.
+  int64 size = 3;
+
+  // URL of the file (e.g., S3 URL).
+  string url = 4;
+}
+
+// PipelineRun represents a single execution of a pipeline.
+message PipelineRun {
+  // Unique identifier for the pipeline.
+  string pipeline_uid = 1;
+
+  // Unique identifier for each run.
+  string pipeline_trigger_uid = 2;
+
+  // Pipeline version used in the run.
+  string pipeline_version = 3;
+
+  // Current status of the run.
+  PipelineRunStatus status = 4;
+
+  // Origin of the run (e.g., Web click, API).
+  string source = 5;
+
+  // Time taken to complete the run in nanoseconds.
+  int64 total_duration = 6;
+
+  // Identity of the user who initiated the run.
+  string triggered_by = 7;
+
+  // Namespace of the pipeline (user or organization).
+  string namespace = 8;
+
+  // Input files for the run.
+  repeated FileReference inputs = 9;
+
+  // Output files from the run.
+  repeated FileReference outputs = 10;
+
+  // Snapshot of the pipeline recipe used for this run.
+  google.protobuf.Struct recipe_snapshot = 11;
+
+  // Time when the run was triggered.
+  google.protobuf.Timestamp triggered_time = 12;
+
+  // Time when the run started execution.
+  google.protobuf.Timestamp started_time = 13;
+
+  // Time when the run completed.
+  google.protobuf.Timestamp completed_time = 14;
+
+  // Error message if the run failed.
+  string error_msg = 15;
+
+  // Credits used of internal accounting metric.
+  double credits_used = 16;
+}
+
+// ComponentRun represents the execution details of a single component within a pipeline run.
+message ComponentRun {
+  // Links to the parent PipelineRun.
+  string pipeline_trigger_uid = 1;
+
+  // Unique identifier for each pipeline component.
+  string component_id = 2;
+
+  // Completion status of the component.
+  ComponentRunStatus status = 3;
+
+  // Time taken to execute the component in nanoseconds.
+  int64 total_duration = 4;
+
+  // Time when the component started execution.
+  google.protobuf.Timestamp started_time = 5;
+
+  // Time when the component finished execution.
+  google.protobuf.Timestamp completed_time = 6;
+
+  // Error message if the component failed.
+  string error_msg = 7;
+
+  // Input files for the component.
+  repeated FileReference inputs = 8;
+
+  // Output files from the component.
+  repeated FileReference outputs = 9;
+
+  // Credits used of internal accounting metric.
+  double credits_used = 10;
+}
+
+// PipelineRunStatus represents the possible states of a pipeline run.
+enum PipelineRunStatus {
+  // The status is unknown or not set.
+  PIPELINE_RUN_STATUS_UNSPECIFIED = 0;
+
+  // The pipeline run is currently in progress.
+  PIPELINE_RUN_STATUS_RUNNING = 1;
+
+  // The pipeline run has completed successfully.
+  PIPELINE_RUN_STATUS_COMPLETED = 2;
+
+  // The pipeline run has failed.
+  PIPELINE_RUN_STATUS_FAILED = 3;
+}
+
+// ComponentRunStatus represents the possible states of a component run.
+enum ComponentRunStatus {
+  // The status is unknown or not set.
+  COMPONENT_RUN_STATUS_UNSPECIFIED = 0;
+
+  // The component run is currently in progress.
+  COMPONENT_RUN_STATUS_RUNNING = 1;
+
+  // The component run has completed successfully.
+  COMPONENT_RUN_STATUS_COMPLETED = 2;
+
+  // The component run has failed.
+  COMPONENT_RUN_STATUS_FAILED = 3;
+}

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -1489,18 +1489,26 @@ service PipelinePublicService {
     option deprecated = true;
   }
 
-  // ListPipelineRuns retrieves a paginated list of pipeline runs for a given user and namespace.
+  // List Pipeline Runs
+  //
+  // Returns a paginated list of runs for a given pipeline. When the requester
+  // is the owner of the pipeline, they will be able to all the pipeline runs,
+  // regardless the requester. Other requesters will only be able to see the
+  // runs requested by themselves.
   rpc ListPipelineRuns(ListPipelineRunsRequest) returns (ListPipelineRunsResponse) {
     option (google.api.http) = {
-      get: "/v1beta/{namespace=users/*/namespaces/*}/pipeline-runs"
+      get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/runs"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 
-  // ListComponentRuns retrieves a paginated list of component runs for a specific pipeline run.
+  // List Component runs
+  //
+  // Returns the information of each component execution within a pipeline run.
   rpc ListComponentRuns(ListComponentRunsRequest) returns (ListComponentRunsResponse) {
     option (google.api.http) = {
-      get: "/v1beta/{namespace=users/*/namespaces/*}/pipeline-runs/{pipeline_trigger_uid}/component-runs"
+      get: "/v1beta/pipeline-runs/{pipeline_run_id}/component-runs"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
-
 }

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -1488,4 +1488,19 @@ service PipelinePublicService {
     };
     option deprecated = true;
   }
+
+  // ListPipelineRuns retrieves a paginated list of pipeline runs for a given user and namespace.
+  rpc ListPipelineRuns(ListPipelineRunsRequest) returns (ListPipelineRunsResponse) {
+    option (google.api.http) = {
+      get: "/v1beta/{namespace=users/*/namespaces/*}/pipeline-runs"
+    };
+  }
+
+  // ListComponentRuns retrieves a paginated list of component runs for a specific pipeline run.
+  rpc ListComponentRuns(ListComponentRunsRequest) returns (ListComponentRunsResponse) {
+    option (google.api.http) = {
+      get: "/v1beta/{namespace=users/*/namespaces/*}/pipeline-runs/{pipeline_trigger_uid}/component-runs"
+    };
+  }
+
 }


### PR DESCRIPTION
- **feat(vdp): Add Paginated List of logged Pipeline Runs Endpoint Because:**
- **chore: auto-gen by protobufs**
- **feat(vdp): resolved comments**

Because:

- Users need to retrieve pipeline runs efficiently, either for specific pipelines or across all accessible pipelines.

This commit:

- Returns a paginated list of pipeline runs and components
