### PR TITLE
feat(model): updated model run task input type

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -11,11 +11,11 @@ import "core/mgmt/v1beta/mgmt.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/longrunning/operations.proto";
-import "google/protobuf/duration.proto";
 // Protobuf standard
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 // Model definitions
 import "model/model/v1alpha/common.proto";
 import "model/model/v1alpha/model_definition.proto";
@@ -1783,8 +1783,11 @@ message ModelRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
-  // Run requester ID.
-  string requester_id = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Run requester ID. If current viewing requester is not the owner, it will return null.
+  optional string requester_id = 7 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
   // The amount of Instill Credit consumed by the run. This field will only be present on Instill Cloud.
   optional float credit_amount = 8 [
     (google.api.field_behavior) = OUTPUT_ONLY,
@@ -1802,9 +1805,9 @@ message ModelRun {
   // The model version identifier, which is same as image tag.
   string version = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model inference input.
-  repeated google.protobuf.Struct task_inputs = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated TaskInput task_inputs = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model inference outputs.
-  repeated google.protobuf.Struct task_outputs = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated TaskOutput task_outputs = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListModelRunsRequest represents a request to list of model runs.

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -875,7 +875,7 @@ service ModelPublicService {
   // List model runs
   //
   // Returns a paginated list of model runs.
-  rpc ListModelTriggers(ListModelRunsRequest) returns (ListModelRunsResponse) {
+  rpc ListModelRuns(ListModelRunsRequest) returns (ListModelRunsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/models/{model_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2467,7 +2467,7 @@ paths:
     get:
       summary: List model runs
       description: Returns a paginated list of model runs.
-      operationId: ModelPublicService_ListModelTriggers
+      operationId: ModelPublicService_ListModelRuns
       responses:
         "200":
           description: A successful response.
@@ -3940,7 +3940,7 @@ definitions:
         readOnly: true
       requesterId:
         type: string
-        description: Run requester ID.
+        description: Run requester ID. If current viewing requester is not the owner, it will return null.
         readOnly: true
       creditAmount:
         type: number
@@ -3969,12 +3969,14 @@ definitions:
         type: array
         items:
           type: object
+          $ref: '#/definitions/v1alphaTaskInput'
         description: Model inference input.
         readOnly: true
       taskOutputs:
         type: array
         items:
           type: object
+          $ref: '#/definitions/v1alphaTaskOutput'
         description: Model inference outputs.
         readOnly: true
     description: ModelRun contains information about a run of models.


### PR DESCRIPTION
Because

- model run logging needs to store original task inputs

This commit

- fixed task inputs type
