### PR TITLE
chore(common): added common import for run status & source

### DIFF
--- a/common/run/v1alpha/run.proto
+++ b/common/run/v1alpha/run.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package common.run.v1alpha;
+
+// RunStatus defines the status of a pipeline or model run.
+enum RunStatus {
+  // Unspecified.
+  RUN_STATUS_UNSPECIFIED = 0;
+  // Run in progress.
+  RUN_STATUS_PROCESSING = 1;
+  // Run succeeded.
+  RUN_STATUS_COMPLETED = 2;
+  // Run failed.
+  RUN_STATUS_FAILED = 3;
+  // Run is waiting to be executed.
+  RUN_STATUS_QUEUED = 4;
+}
+
+// RunSource defines the source of a pipeline or model run.
+enum RunSource {
+  // Unspecified.
+  RUN_SOURCE_UNSPECIFIED = 0;
+  // Run from frontend UI.
+  RUN_SOURCE_CONSOLE = 1;
+  // Run from API or SDK.
+  RUN_SOURCE_API = 2;
+}

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -5,6 +5,7 @@ package model.model.v1alpha;
 // common definitions
 import "common/healthcheck/v1beta/healthcheck.proto";
 import "common/task/v1alpha/task.proto";
+import "common/run/v1alpha/run.proto";
 // Core definitions
 import "core/mgmt/v1beta/mgmt.proto";
 // Google API
@@ -1741,38 +1742,14 @@ message UndeployOrganizationModelAdminResponse {}
 
 // ModelRun contains information about a run of models.
 message ModelRun {
-  // RunStatus defines the status of a model run.
-  enum RunStatus {
-    // Unspecified.
-    RUN_STATUS_UNSPECIFIED = 0;
-    // Model run in progress.
-    RUN_STATUS_PROCESSING = 1;
-    // Model run succeeded.
-    RUN_STATUS_COMPLETED = 2;
-    // Model run failed.
-    RUN_STATUS_FAILED = 3;
-    // Model run is waiting to be executed.
-    RUN_STATUS_QUEUED = 4;
-  }
-
-  // RunSource defines the source of a model run.
-  enum RunSource {
-    // Unspecified.
-    RUN_SOURCE_UNSPECIFIED = 0;
-    // Model run from frontend UI.
-    RUN_SOURCE_CONSOLE = 1;
-    // Model run from API or SDK.
-    RUN_SOURCE_API = 2;
-  }
-
   // Model Run UUID.
   string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model UUID.
   string model_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model run status.
-  RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  common.run.v1alpha.RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Run source.
-  RunSource source = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  common.run.v1alpha.RunSource source = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Run total duration.
   optional google.protobuf.Duration total_duration = 5 [
     (google.api.field_behavior) = OUTPUT_ONLY,

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2734,30 +2734,6 @@ definitions:
     description: TriggerUserModelRequest represents a request to trigger a model inference.
     required:
       - taskInputs
-  ModelRunRunSource:
-    type: string
-    enum:
-      - RUN_SOURCE_CONSOLE
-      - RUN_SOURCE_API
-    description: |-
-      RunSource defines the source of a model run.
-
-       - RUN_SOURCE_CONSOLE: Model run from frontend UI.
-       - RUN_SOURCE_API: Model run from API or SDK.
-  ModelRunRunStatus:
-    type: string
-    enum:
-      - RUN_STATUS_PROCESSING
-      - RUN_STATUS_COMPLETED
-      - RUN_STATUS_FAILED
-      - RUN_STATUS_QUEUED
-    description: |-
-      RunStatus defines the status of a model run.
-
-       - RUN_STATUS_PROCESSING: Model run in progress.
-       - RUN_STATUS_COMPLETED: Model run succeeded.
-       - RUN_STATUS_FAILED: Model run failed.
-       - RUN_STATUS_QUEUED: Model run is waiting to be executed.
   googlelongrunningOperation:
     type: object
     properties:
@@ -3923,12 +3899,12 @@ definitions:
         description: Model run status.
         readOnly: true
         allOf:
-          - $ref: '#/definitions/ModelRunRunStatus'
+          - $ref: '#/definitions/v1alphaRunStatus'
       source:
         description: Run source.
         readOnly: true
         allOf:
-          - $ref: '#/definitions/ModelRunRunSource'
+          - $ref: '#/definitions/v1alphaRunSource'
       totalDuration:
         type: string
         description: Run total duration.
@@ -4142,6 +4118,30 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1alphaModel'
     description: RenameUserModelResponse contains a renamed model.
+  v1alphaRunSource:
+    type: string
+    enum:
+      - RUN_SOURCE_CONSOLE
+      - RUN_SOURCE_API
+    description: |-
+      RunSource defines the source of a pipeline or model run.
+
+       - RUN_SOURCE_CONSOLE: Run from frontend UI.
+       - RUN_SOURCE_API: Run from API or SDK.
+  v1alphaRunStatus:
+    type: string
+    enum:
+      - RUN_STATUS_PROCESSING
+      - RUN_STATUS_COMPLETED
+      - RUN_STATUS_FAILED
+      - RUN_STATUS_QUEUED
+    description: |-
+      RunStatus defines the status of a pipeline or model run.
+
+       - RUN_STATUS_PROCESSING: Run in progress.
+       - RUN_STATUS_COMPLETED: Run succeeded.
+       - RUN_STATUS_FAILED: Run failed.
+       - RUN_STATUS_QUEUED: Run is waiting to be executed.
   v1alphaSemanticSegmentationInput:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4800,16 +4800,6 @@ definitions:
     description: |-
       ValidateUserPipelineRequest represents a request to validate a pipeline
       owned by a user.
-  PipelineRunRunSource:
-    type: string
-    enum:
-      - RUN_SOURCE_CONSOLE
-      - RUN_SOURCE_API
-    description: |-
-      RunSource defines the source of a pipeline run.
-
-       - RUN_SOURCE_CONSOLE: The request was triggered from Instill Console.
-       - RUN_SOURCE_API: The request was triggered from the API or SDK.
   PipelineStats:
     type: object
     properties:
@@ -5101,6 +5091,30 @@ definitions:
       `Value` type union.
 
       The JSON representation for `NullValue` is JSON `null`.
+  v1alphaRunSource:
+    type: string
+    enum:
+      - RUN_SOURCE_CONSOLE
+      - RUN_SOURCE_API
+    description: |-
+      RunSource defines the source of a pipeline or model run.
+
+       - RUN_SOURCE_CONSOLE: Run from frontend UI.
+       - RUN_SOURCE_API: Run from API or SDK.
+  v1alphaRunStatus:
+    type: string
+    enum:
+      - RUN_STATUS_PROCESSING
+      - RUN_STATUS_COMPLETED
+      - RUN_STATUS_FAILED
+      - RUN_STATUS_QUEUED
+    description: |-
+      RunStatus defines the status of a pipeline or model run.
+
+       - RUN_STATUS_PROCESSING: Run in progress.
+       - RUN_STATUS_COMPLETED: Run succeeded.
+       - RUN_STATUS_FAILED: Run failed.
+       - RUN_STATUS_QUEUED: Run is waiting to be executed.
   v1betaCheckNameRequest:
     type: object
     properties:
@@ -5270,7 +5284,7 @@ definitions:
         description: Completion status of the component.
         readOnly: true
         allOf:
-          - $ref: '#/definitions/v1betaRunStatus'
+          - $ref: '#/definitions/v1alphaRunStatus'
       totalDuration:
         type: string
         description: Time taken to execute the component.
@@ -6456,12 +6470,12 @@ definitions:
         description: Current status of the run.
         readOnly: true
         allOf:
-          - $ref: '#/definitions/v1betaRunStatus'
+          - $ref: '#/definitions/v1alphaRunStatus'
       source:
         description: Origin of the run.
         readOnly: true
         allOf:
-          - $ref: '#/definitions/PipelineRunRunSource'
+          - $ref: '#/definitions/v1alphaRunSource'
       totalDuration:
         type: string
         description: Time taken to complete the run.
@@ -6609,18 +6623,6 @@ definitions:
 
        - ROLE_VIEWER: Viewers can see the resource properties.
        - ROLE_EXECUTOR: Executors can execute the resource (e.g. trigger a pipeline).
-  v1betaRunStatus:
-    type: string
-    enum:
-      - RUN_STATUS_RUNNING
-      - RUN_STATUS_COMPLETED
-      - RUN_STATUS_FAILED
-    description: |-
-      RunStatus represents the possible states of a pipeline or component run.
-
-       - RUN_STATUS_RUNNING: The run is currently in progress.
-       - RUN_STATUS_COMPLETED: The run has completed successfully.
-       - RUN_STATUS_FAILED: The run has failed.
   v1betaSecret:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package vdp.pipeline.v1beta;
 
 import "common/healthcheck/v1beta/healthcheck.proto";
+import "common/run/v1alpha/run.proto";
 // Core definitions
 import "core/mgmt/v1beta/mgmt.proto";
 // Google API
@@ -2028,20 +2029,10 @@ message PipelineRun {
   string pipeline_version = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Current status of the run.
-  RunStatus status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // RunSource defines the source of a pipeline run.
-  enum RunSource {
-    // Unspecified.
-    RUN_SOURCE_UNSPECIFIED = 0;
-    // The request was triggered from Instill Console.
-    RUN_SOURCE_CONSOLE = 1;
-    // The request was triggered from the API or SDK.
-    RUN_SOURCE_API = 2;
-  }
+  common.run.v1alpha.RunStatus status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Origin of the run.
-  RunSource source = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  common.run.v1alpha.RunSource source = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Time taken to complete the run.
   optional google.protobuf.Duration total_duration = 6 [
@@ -2091,7 +2082,7 @@ message ComponentRun {
   string component_id = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Completion status of the component.
-  RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  common.run.v1alpha.RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // Time taken to execute the component.
   optional google.protobuf.Duration total_duration = 4 [
@@ -2124,19 +2115,4 @@ message ComponentRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
-}
-
-// RunStatus represents the possible states of a pipeline or component run.
-enum RunStatus {
-  // The status is unknown or not set.
-  RUN_STATUS_UNSPECIFIED = 0;
-
-  // The run is currently in progress.
-  RUN_STATUS_RUNNING = 1;
-
-  // The run has completed successfully.
-  RUN_STATUS_COMPLETED = 2;
-
-  // The run has failed.
-  RUN_STATUS_FAILED = 3;
 }


### PR DESCRIPTION
Because

- model and pipeline run logging should use same enums

This commit

- added common import for run status & source
