### PR TITLE
feat(run): updated total duration type

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -16,7 +16,6 @@ import "google/longrunning/operations.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-import "google/protobuf/duration.proto";
 // Model definitions
 import "model/model/v1alpha/common.proto";
 import "model/model/v1alpha/model_definition.proto";
@@ -1750,8 +1749,8 @@ message ModelRun {
   common.run.v1alpha.RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Run source.
   common.run.v1alpha.RunSource source = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Run total duration.
-  optional google.protobuf.Duration total_duration = 5 [
+  // Run total duration in milliseconds.
+  optional int32 total_duration = 5 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -876,7 +876,7 @@ service ModelPublicService {
   //
   // Returns a paginated list of model runs.
   rpc ListModelRuns(ListModelRunsRequest) returns (ListModelRunsResponse) {
-    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/models/{model_id}/runs"};
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
   }
 }

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2463,7 +2463,7 @@ paths:
       tags:
         - Trigger (Deprecated)
       deprecated: true
-  /v1beta/namespaces/{namespaceId}/models/{modelId}/runs:
+  /v1alpha/namespaces/{namespaceId}/models/{modelId}/runs:
     get:
       summary: List model runs
       description: Returns a paginated list of model runs.
@@ -3906,8 +3906,9 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1alphaRunSource'
       totalDuration:
-        type: string
-        description: Run total duration.
+        type: integer
+        format: int32
+        description: Run total duration in milliseconds.
         readOnly: true
       endTime:
         type: string

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -5286,8 +5286,9 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1alphaRunStatus'
       totalDuration:
-        type: string
-        description: Time taken to execute the component.
+        type: integer
+        format: int32
+        description: Time taken to execute the component in milliseconds.
         readOnly: true
       startTime:
         type: string
@@ -6477,8 +6478,9 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1alphaRunSource'
       totalDuration:
-        type: string
-        description: Time taken to complete the run.
+        type: integer
+        format: int32
+        description: Time taken to complete the run in milliseconds.
         readOnly: true
       requesterId:
         type: string

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -14,7 +14,6 @@ import "google/longrunning/operations.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-import "google/protobuf/duration.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
 // VDP definitions
@@ -2034,8 +2033,8 @@ message PipelineRun {
   // Origin of the run.
   common.run.v1alpha.RunSource source = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Time taken to complete the run.
-  optional google.protobuf.Duration total_duration = 6 [
+  // Time taken to complete the run in milliseconds.
+  optional int32 total_duration = 6 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
@@ -2084,8 +2083,8 @@ message ComponentRun {
   // Completion status of the component.
   common.run.v1alpha.RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Time taken to execute the component.
-  optional google.protobuf.Duration total_duration = 4 [
+  // Time taken to execute the component in milliseconds.
+  optional int32 total_duration = 4 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];


### PR DESCRIPTION
Because

- FE supports duration in milliseconds better than protobuf duration type

This commit

- updated total duration type to int in milliseconds
