### PR TITLE
fix(catalog): add total size in list api

### DIFF
--- a/artifact/artifact/v1alpha/conversation.proto
+++ b/artifact/artifact/v1alpha/conversation.proto
@@ -85,6 +85,8 @@ message ListConversationsResponse {
     repeated Conversation conversations = 1;
     // next page token
     string next_page_token = 2;
+    // total size
+    int32 total_size = 3;
 }
 
 // UpdateConversationRequest is used to update a conversation
@@ -165,6 +167,8 @@ message ListMessagesResponse {
     repeated Message messages = 1;
     // next page token
     string next_page_token = 2;
+    // total size
+    int32 total_size = 3;
 }
 
 // UpdateMessageRequest is used to update a message

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -1407,6 +1407,10 @@ definitions:
       nextPageToken:
         type: string
         title: next page token
+      totalSize:
+        type: integer
+        format: int32
+        title: total size
     title: ListConversationsResponse returns a list of conversations
   v1alphaListMessagesResponse:
     type: object
@@ -1420,6 +1424,10 @@ definitions:
       nextPageToken:
         type: string
         title: next page token
+      totalSize:
+        type: integer
+        format: int32
+        title: total size
     title: ListMessagesResponse returns a list of messages
   v1alphaListRepositoryTagsResponse:
     type: object


### PR DESCRIPTION
Because

list conversations and messages is missing total size in return

This commit

add total_size in return
