### PR TITLE
feat(model): add model run count

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -134,6 +134,14 @@ message Model {
     VISIBILITY_PUBLIC = 2;
   }
 
+  // Statistic data
+  message Stats {
+    // Number of model runs.
+    int32 number_of_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Last run time.
+    google.protobuf.Timestamp last_run_time = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+
   // The resource name of the model, which allows its access by owner and ID.
   // - Format: `users/{user.id}/models/{model.id}`.
   string name = 1 [
@@ -222,6 +230,8 @@ message Model {
   repeated string tags = 30 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Version names.
   repeated string versions = 31 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Statistic data.
+  Stats stats = 32 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListModelsRequest represents a request to list  models.

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -1248,6 +1248,11 @@ paths:
                   type: string
                 description: Version names.
                 readOnly: true
+              stats:
+                description: Statistic data.
+                readOnly: true
+                allOf:
+                  - $ref: '#/definitions/ModelStats'
             title: The model to update
             required:
               - id
@@ -1986,6 +1991,11 @@ paths:
                   type: string
                 description: Version names.
                 readOnly: true
+              stats:
+                description: Statistic data.
+                readOnly: true
+                allOf:
+                  - $ref: '#/definitions/ModelStats'
             title: The model to update
             required:
               - id
@@ -2734,6 +2744,20 @@ definitions:
     description: TriggerUserModelRequest represents a request to trigger a model inference.
     required:
       - taskInputs
+  ModelStats:
+    type: object
+    properties:
+      numberOfRuns:
+        type: integer
+        format: int32
+        description: Number of model runs.
+        readOnly: true
+      lastRunTime:
+        type: string
+        format: date-time
+        description: Last run time.
+        readOnly: true
+    title: Statistic data
   googlelongrunningOperation:
     type: object
     properties:
@@ -2888,8 +2912,7 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com. As of May 2023, there are no widely used type server
-          implementations and no plans to implement one.
+          type.googleapis.com.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -2924,7 +2947,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-       Example 3: Pack and unpack a message in Python.
+      Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -2934,7 +2957,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-       Example 4: Pack and unpack a message in Go
+      Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -2954,7 +2977,7 @@ definitions:
       name "y.z".
 
       JSON
-      ====
+
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -2986,7 +3009,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-      The JSON representation for `NullValue` is JSON `null`.
+       The JSON representation for `NullValue` is JSON `null`.
   v1alphaBoundingBox:
     type: object
     properties:
@@ -3817,6 +3840,11 @@ definitions:
           type: string
         description: Version names.
         readOnly: true
+      stats:
+        description: Statistic data.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/ModelStats'
     title: |-
       Model represents an AI model, i.e. a program that performs tasks as decision
       making or or pattern recognition based on its training data

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -2912,7 +2912,8 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com.
+          type.googleapis.com. As of May 2023, there are no widely used type server
+          implementations and no plans to implement one.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -2947,7 +2948,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-      Example 3: Pack and unpack a message in Python.
+       Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -2957,7 +2958,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-      Example 4: Pack and unpack a message in Go
+       Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -2977,7 +2978,7 @@ definitions:
       name "y.z".
 
       JSON
-
+      ====
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -3009,7 +3010,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-       The JSON representation for `NullValue` is JSON `null`.
+      The JSON representation for `NullValue` is JSON `null`.
   v1alphaBoundingBox:
     type: object
     properties:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -5008,7 +5008,8 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com.
+          type.googleapis.com. As of May 2023, there are no widely used type server
+          implementations and no plans to implement one.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -5043,7 +5044,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-      Example 3: Pack and unpack a message in Python.
+       Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -5053,7 +5054,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-      Example 4: Pack and unpack a message in Go
+       Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -5073,7 +5074,7 @@ definitions:
       name "y.z".
 
       JSON
-
+      ====
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -5105,7 +5106,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-       The JSON representation for `NullValue` is JSON `null`.
+      The JSON representation for `NullValue` is JSON `null`.
   v1alphaRunSource:
     type: string
     enum:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -5008,8 +5008,7 @@ definitions:
 
           Note: this functionality is not currently available in the official
           protobuf release, and it is not used for type URLs beginning with
-          type.googleapis.com. As of May 2023, there are no widely used type server
-          implementations and no plans to implement one.
+          type.googleapis.com.
 
           Schemes other than `http`, `https` (or the empty scheme) might be
           used with implementation specific semantics.
@@ -5044,7 +5043,7 @@ definitions:
             foo = any.unpack(Foo.getDefaultInstance());
           }
 
-       Example 3: Pack and unpack a message in Python.
+      Example 3: Pack and unpack a message in Python.
 
           foo = Foo(...)
           any = Any()
@@ -5054,7 +5053,7 @@ definitions:
             any.Unpack(foo)
             ...
 
-       Example 4: Pack and unpack a message in Go
+      Example 4: Pack and unpack a message in Go
 
            foo := &pb.Foo{...}
            any, err := anypb.New(foo)
@@ -5074,7 +5073,7 @@ definitions:
       name "y.z".
 
       JSON
-      ====
+
       The JSON representation of an `Any` value uses the regular
       representation of the deserialized, embedded message, with an
       additional field `@type` which contains the type URL. Example:
@@ -5106,7 +5105,7 @@ definitions:
       `NullValue` is a singleton enumeration to represent the null value for the
       `Value` type union.
 
-      The JSON representation for `NullValue` is JSON `null`.
+       The JSON representation for `NullValue` is JSON `null`.
   v1alphaRunSource:
     type: string
     enum:


### PR DESCRIPTION
Because

- On the Explore page, all models are publicly available. Displaying the "Run" count will help new users who are unsure of what they need to start with the most popular models. One of the indicators for popularity is the number of times a model has been run.
- For users managing their own resources, it allows a quick understanding of the popularity of their models, whether public or private.

This commit

- add model run count in model message
