### PR TITLE
feat(mgmt): update metrics endpoints to serve new dashboard design

### DIFF
--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -76,75 +76,48 @@ message GetModelTriggerCountResponse {
   repeated TriggerCount model_trigger_counts = 1;
 }
 
-/*
-   // PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
-   // contains a collection of (timestamp, count) pairs that represent the total
-   // pipeline triggers in a given time bucket.
-   // pipeline ID and time frame.
-   message PipelineTriggerChartRecord {
-     // This field will be present present when the information is grouped by pipeline.
-     optional string pipeline_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-     // 2 is reserved for the pipeline UUID.
-     reserved 2;
-     // 3 is reserved for the trigger mode. The server wasn't grouping results by this
-     // field.
-     reserved 3;
-     // 4 is reserved for the trigger status. The server wasn't grouping results
-     // by this field.
-     reserved 4;
-     // Time buckets.
-     repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-     // Aggregated trigger count in each time bucket.
-     repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-     // 7 is reserved for the trigger execution duration.
-     reserved 7;
-     // 8 is reserved for the pipeline release ID. The server wasn't grouping
-     // results by this field.
-     reserved 8;
-     // 9 is reserved for the pipeline release UUID. The server wasn't grouping
-     // results by this field.
-     reserved 9;
-     // The ID of the namespace that requested the pipeline triggers.
-     string namespace_id = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-   }
+// PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
+// contains a collection of (timestamp, count) pairs that represent the total
+// pipeline triggers in a given time bucket.
+// pipeline ID and time frame.
+message PipelineTriggerChartRecord {
+  // This field will be present present when the information is grouped by pipeline.
+  optional string pipeline_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Time buckets.
+  repeated google.protobuf.Timestamp time_buckets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Aggregated trigger count in each time bucket.
+  repeated int32 trigger_counts = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The ID of the namespace that requested the pipeline triggers.
+  string requester_id = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
 
-   // ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
-   // trigger chart records for a given requester, grouped by time buckets.
-   message ListPipelineTriggerChartRecordsRequest {
-     // 1 is reserved for the aggregation window in nanoseconds. This is
-     // deprecated in favour of an aggregation window string that represents a
-     // duration.
-     reserved 1;
-     // 2 is reserved for the filter. For now, this endpoint won't allow filtering
-     // but in the future we might implement a filter to show the trigger count of
-     // only certain pipelines and to group by the pipeline ID.
-     reserved 2;
+// ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
+// trigger chart records for a given requester, grouped by time buckets.
+message ListPipelineTriggerChartRecordsRequest {
+  // The ID of the namespace that requested the pipeline triggers.
+  string requester_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 2;
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 3;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 4;
+}
 
-     // The ID of the namespace that requested the pipeline triggers.
-     string namespace_id = 3 [(google.api.field_behavior) = REQUIRED];
-     // Aggregation window. The value is a positive duration string, i.e. a
-     // sequence of decimal numbers, each with optional fraction and a unit
-     // suffix, such as "300ms", "1.5h" or "2h45m".
-     // The minimum (and default) window is 1h.
-     optional string aggregation_window = 4;
-     // Beginning of the time range from which the records will be fetched.
-     // The default value is the beginning of the current day, in UTC.
-     optional google.protobuf.Timestamp start = 5;
-     // End of the time range from which the records will be fetched.
-     // The default value is the current timestamp.
-     optional google.protobuf.Timestamp stop = 6;
-   }
-
-   // ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
-   // chart records.
-   message ListPipelineTriggerChartRecordsResponse {
-     // Pipeline trigger counts. Until we allow filtering or grouping by fields
-     // like pipeline ID, this list will contain only one element with the
-     // timeline of trigger counts for a given requester, regardless the pipeline
-     // ID, trigger mode, final status or other fields.
-     repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
-   }
-*/
+// ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
+// chart records.
+message ListPipelineTriggerChartRecordsResponse {
+  // Pipeline trigger counts. Until we allow filtering or grouping by fields
+  // like pipeline ID, this list will contain only one element with the
+  // timeline of trigger counts for a given requester, regardless the pipeline
+  // ID, trigger mode, final status or other fields.
+  repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
+}
 
 // ModelTriggerChartRecord represents a timeline of model triggers. It
 // contains a collection of (timestamp, count) pairs that represent the total
@@ -164,18 +137,18 @@ message ModelTriggerChartRecord {
 // trigger metrics, aggregated by model ID and time frame.
 message ListModelTriggerChartRecordsRequest {
   // The ID of the namespace that requested the model triggers.
-  string requester_id = 3 [(google.api.field_behavior) = REQUIRED];
+  string requester_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Aggregation window. The value is a positive duration string, i.e. a
   // sequence of decimal numbers, each with optional fraction and a unit
   // suffix, such as "300ms", "1.5h" or "2h45m".
   // The minimum (and default) window is 1h.
-  optional string aggregation_window = 4;
+  optional string aggregation_window = 2;
   // Beginning of the time range from which the records will be fetched.
   // The default value is the beginning of the current day, in UTC.
-  optional google.protobuf.Timestamp start = 5;
+  optional google.protobuf.Timestamp start = 3;
   // End of the time range from which the records will be fetched.
   // The default value is the current timestamp.
-  optional google.protobuf.Timestamp stop = 6;
+  optional google.protobuf.Timestamp stop = 4;
 }
 
 // ListModelTriggerChartRecordsResponse contains a list of model trigger

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -36,39 +36,6 @@ message TriggerCount {
   optional Status status = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-/*
-   // PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
-   // contains a collection of (timestamp, count) pairs that represent the total
-   // pipeline triggers in a given time bucket.
-   // pipeline ID and time frame.
-   message PipelineTriggerChartRecord {
-     // This field will be present present when the information is grouped by pipeline.
-     optional string pipeline_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-     // 2 is reserved for the pipeline UUID.
-     reserved 2;
-     // 3 is reserved for the trigger mode. The server wasn't grouping results by this
-     // field.
-     reserved 3;
-     // 4 is reserved for the trigger status. The server wasn't grouping results
-     // by this field.
-     reserved 4;
-     // Time buckets.
-     repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-     // Aggregated trigger count in each time bucket.
-     repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-     // 7 is reserved for the trigger execution duration.
-     reserved 7;
-     // 8 is reserved for the pipeline release ID. The server wasn't grouping
-     // results by this field.
-     reserved 8;
-     // 9 is reserved for the pipeline release UUID. The server wasn't grouping
-     // results by this field.
-     reserved 9;
-     // The ID of the namespace that requested the pipeline triggers.
-     string namespace_id = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-   }
-*/
-
 // GetPipelineTriggerCountRequest represents a request to fetch the trigger
 // count of a requester over a time period.
 message GetPipelineTriggerCountRequest {
@@ -110,6 +77,37 @@ message GetModelTriggerCountResponse {
 }
 
 /*
+   // PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
+   // contains a collection of (timestamp, count) pairs that represent the total
+   // pipeline triggers in a given time bucket.
+   // pipeline ID and time frame.
+   message PipelineTriggerChartRecord {
+     // This field will be present present when the information is grouped by pipeline.
+     optional string pipeline_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+     // 2 is reserved for the pipeline UUID.
+     reserved 2;
+     // 3 is reserved for the trigger mode. The server wasn't grouping results by this
+     // field.
+     reserved 3;
+     // 4 is reserved for the trigger status. The server wasn't grouping results
+     // by this field.
+     reserved 4;
+     // Time buckets.
+     repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+     // Aggregated trigger count in each time bucket.
+     repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+     // 7 is reserved for the trigger execution duration.
+     reserved 7;
+     // 8 is reserved for the pipeline release ID. The server wasn't grouping
+     // results by this field.
+     reserved 8;
+     // 9 is reserved for the pipeline release UUID. The server wasn't grouping
+     // results by this field.
+     reserved 9;
+     // The ID of the namespace that requested the pipeline triggers.
+     string namespace_id = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+   }
+
    // ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
    // trigger chart records for a given requester, grouped by time buckets.
    message ListPipelineTriggerChartRecordsRequest {
@@ -147,6 +145,48 @@ message GetModelTriggerCountResponse {
      repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
    }
 */
+
+// ModelTriggerChartRecord represents a timeline of model triggers. It
+// contains a collection of (timestamp, count) pairs that represent the total
+// model triggers in a given time bucket.
+message ModelTriggerChartRecord {
+  // This field will be present present when the information is grouped by model.
+  optional string model_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Time buckets.
+  repeated google.protobuf.Timestamp time_buckets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Aggregated trigger count in each time bucket.
+  repeated int32 trigger_counts = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The ID of the namespace that requested the model triggers.
+  string requester_id = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListModelTriggerChartRecordsRequest represents a request to list model
+// trigger metrics, aggregated by model ID and time frame.
+message ListModelTriggerChartRecordsRequest {
+  // The ID of the namespace that requested the model triggers.
+  string requester_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 4;
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 5;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 6;
+}
+
+// ListModelTriggerChartRecordsResponse contains a list of model trigger
+// chart records.
+message ListModelTriggerChartRecordsResponse {
+  // Model trigger counts. Until we allow filtering or grouping by fields
+  // like model ID, this list will contain only one element with the
+  // timeline of trigger counts for a given requester, regardless the model
+  // ID, trigger mode, final status or other fields.
+  repeated ModelTriggerChartRecord model_trigger_chart_records = 1;
+}
 
 // CreditConsumptionChartRecord represents a timeline of Instill Credit
 // consumption. It contains a collection of (timestamp, amount) pairs that
@@ -192,7 +232,9 @@ message ListCreditConsumptionChartRecordsResponse {
   reserved 2;
 }
 
+// =============================================================================
 // Deprecated messages, to be removed with the new dashboard implementation.
+// =============================================================================
 
 // PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
 // pipeline ID.
@@ -236,9 +278,9 @@ message ListPipelineTriggerTableRecordsResponse {
   int32 total_size = 3;
 }
 
-// ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
-// trigger metrics, aggregated by pipeline ID and time frame.
-message ListPipelineTriggerChartRecordsRequest {
+// ListPipelineTriggerChartRecordsV0Request represents a request to list
+// pipeline trigger metrics, aggregated by pipeline ID and time frame.
+message ListPipelineTriggerChartRecordsV0Request {
   // Aggregation window in nanoseconds.
   int32 aggregation_window = 1;
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
@@ -247,44 +289,16 @@ message ListPipelineTriggerChartRecordsRequest {
   optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// ListModelTriggerChartRecordsRequest represents a request to list model
-// trigger metrics, aggregated by model ID and time frame.
-message ListModelTriggerChartRecordsRequest {
-  // The ID of the namespace that requested the model triggers.
-  string requester_id = 3 [(google.api.field_behavior) = REQUIRED];
-  // Aggregation window. The value is a positive duration string, i.e. a
-  // sequence of decimal numbers, each with optional fraction and a unit
-  // suffix, such as "300ms", "1.5h" or "2h45m".
-  // The minimum (and default) window is 1h.
-  optional string aggregation_window = 4;
-  // Beginning of the time range from which the records will be fetched.
-  // The default value is the beginning of the current day, in UTC.
-  optional google.protobuf.Timestamp start = 5;
-  // End of the time range from which the records will be fetched.
-  // The default value is the current timestamp.
-  optional google.protobuf.Timestamp stop = 6;
-}
-
-// ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
-// chart records.
-message ListPipelineTriggerChartRecordsResponse {
+// ListPipelineTriggerChartRecordsV0Response contains a list of pipeline
+// trigger chart records.
+message ListPipelineTriggerChartRecordsV0Response {
   // A list of pipeline trigger records.
-  repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
+  repeated PipelineTriggerChartRecordV0 pipeline_trigger_chart_records = 1;
 }
 
-// ListModelTriggerChartRecordsResponse contains a list of model trigger
-// chart records.
-message ListModelTriggerChartRecordsResponse {
-  // Model trigger counts. Until we allow filtering or grouping by fields
-  // like model ID, this list will contain only one element with the
-  // timeline of trigger counts for a given requester, regardless the model
-  // ID, trigger mode, final status or other fields.
-  repeated ModelTriggerChartRecord model_trigger_chart_records = 1;
-}
-
-// PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
-// pipeline ID and time frame.
-message PipelineTriggerChartRecord {
+// PipelineTriggerChartRecordV0 contains pipeline trigger metrics, aggregated
+// by pipeline ID and time frame.
+message PipelineTriggerChartRecordV0 {
   // Pipeline ID.
   string pipeline_id = 1;
   // Pipeline UUID.
@@ -350,18 +364,4 @@ message ListPipelineTriggerRecordsResponse {
   string next_page_token = 2;
   // Total number of pipeline triggers.
   int32 total_size = 3;
-}
-
-// ModelTriggerChartRecord represents a timeline of model triggers. It
-// contains a collection of (timestamp, count) pairs that represent the total
-// model triggers in a given time bucket.
-message ModelTriggerChartRecord {
-  // This field will be present present when the information is grouped by model.
-  optional string model_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Time buckets.
-  repeated google.protobuf.Timestamp time_buckets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Aggregated trigger count in each time bucket.
-  repeated int32 trigger_counts = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // The ID of the namespace that requested the model triggers.
-  string requester_id = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -27,8 +27,6 @@ enum Status {
   STATUS_ERRORED = 2;
 }
 
-// ========== Pipeline endpoints
-
 // TriggerCount represents a execution count with some
 // aggregation params (e.g. trigger status).
 message TriggerCount {
@@ -75,19 +73,6 @@ message TriggerCount {
 // count of a requester over a time period.
 message GetPipelineTriggerCountRequest {
   // The ID of the namespace that requested the pipeline triggers.
-  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Beginning of the time range from which the records will be fetched.
-  // The default value is the beginning of the current day, in UTC.
-  optional google.protobuf.Timestamp start = 2;
-  // End of the time range from which the records will be fetched.
-  // The default value is the current timestamp.
-  optional google.protobuf.Timestamp stop = 3;
-}
-
-// GetModelTriggerCountRequest represents a request to fetch the trigger
-// count of a requester over a time period.
-message GetModelTriggerCountRequest {
-  // The ID of the requester that triggered the model.
   string requester_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Beginning of the time range from which the records will be fetched.
   // The default value is the beginning of the current day, in UTC.
@@ -102,6 +87,19 @@ message GetModelTriggerCountRequest {
 message GetPipelineTriggerCountResponse {
   // The trigger counts, grouped by status.
   repeated TriggerCount pipeline_trigger_counts = 1;
+}
+
+// GetModelTriggerCountRequest represents a request to fetch the trigger
+// count of a requester over a time period.
+message GetModelTriggerCountRequest {
+  // The ID of the requester that triggered the model.
+  string requester_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 2;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 3;
 }
 
 // GetModelTriggerCountResponse contains the trigger count, grouped by

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -475,6 +475,22 @@ service MgmtPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
+  // List pipeline trigger time charts
+  //
+  // Returns a timeline of pipline trigger counts for a given requester. The
+  // response will contain one set of records (datapoints), representing the
+  // amount of triggers in a time bucket.
+  rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/pipeline-runs/query-charts"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
+  }
+
   // List model trigger time charts
   //
   // Returns a timeline of model trigger counts for a given requester. The

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -439,20 +439,6 @@ service MgmtPublicService {
     };
   }
 
-  // List pipeline triggers
-  //
-  // Returns a paginated list of pipeline executions.
-  rpc ListPipelineTriggerRecords(ListPipelineTriggerRecordsRequest) returns (ListPipelineTriggerRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/triggers"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "📊 Metrics"
-      extensions: {
-        key: "x-stage"
-        value: {string_value: "beta"}
-      }
-    };
-  }
-
   // Get pipeline trigger count
   //
   // Returns the pipeline trigger count of a given requester within a timespan.
@@ -487,39 +473,6 @@ service MgmtPublicService {
     // This endpoint will remain hidden until the new dashboard is implemented
     // in the frontend. Until then, the server might return empty data.
     option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // List pipeline trigger metrics
-  //
-  // Returns a paginated list of pipeline executions aggregated by pipeline ID.
-  // NOTE: This method is deprecated and will be retired soon.
-  rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "📊 Metrics"
-      extensions: {
-        key: "x-stage"
-        value: {string_value: "beta"}
-      }
-    };
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // List pipeline trigger time charts
-  //
-  // Returns a timeline of pipline trigger counts for the pipelines of a given
-  // owner.
-  // NOTE: This method will soon return the trigger counts of a given requester.
-  rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "📊 Metrics"
-      extensions: {
-        key: "x-stage"
-        value: {string_value: "beta"}
-      }
-    };
   }
 
   // List model trigger time charts
@@ -604,6 +557,65 @@ service MgmtPublicService {
   // Checks the validity of an access token.
   rpc AuthValidateAccessToken(AuthValidateAccessTokenRequest) returns (AuthValidateAccessTokenResponse) {
     option (google.api.http) = {post: "/v1beta/auth/validate_access_token"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // ===========================================================================
+  // Deprecated endpoints, to be retired after new pipeline dashboard is rolled
+  // out.
+  // ===========================================================================
+
+  // List pipeline triggers
+  //
+  // Returns a paginated list of pipeline executions.
+  // NOTE: This method is deprecated and will be retired soon.
+  rpc ListPipelineTriggerRecords(ListPipelineTriggerRecordsRequest) returns (ListPipelineTriggerRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/triggers"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
+    option deprecated = true;
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+
+  // List pipeline trigger metrics
+  //
+  // Returns a paginated list of pipeline executions aggregated by pipeline ID.
+  // NOTE: This method is deprecated and will be retired soon.
+  rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
+    option deprecated = true;
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // List pipeline trigger time charts
+  //
+  // Returns a timeline of pipline trigger counts for the pipelines of a given
+  // owner.
+  // NOTE: This method will soon be retired and replaced by
+  // ListPipelineTriggerchartRecords.
+  rpc ListPipelineTriggerChartRecordsV0(ListPipelineTriggerChartRecordsV0Request) returns (ListPipelineTriggerChartRecordsV0Response) {
+    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
+    option deprecated = true;
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 }

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -458,7 +458,7 @@ service MgmtPublicService {
   // Returns the pipeline trigger count of a given requester within a timespan.
   // Results are grouped by trigger status.
   rpc GetPipelineTriggerCount(GetPipelineTriggerCountRequest) returns (GetPipelineTriggerCountResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/trigger-count"};
+    option (google.api.http) = {get: "/v1beta/pipeline-runs/count"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "📊 Metrics"
       extensions: {

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -544,8 +544,10 @@ service MgmtPublicService {
   // response will contain one set of records (datapoints) per consumption
   // source (e.g. "pipeline", "model"). Each datapoint represents the amount
   // consumed in a time bucket.
+  //
+  // This endpoint is only exposed on Instill Cloud.
   rpc ListCreditConsumptionChartRecords(ListCreditConsumptionChartRecordsRequest) returns (ListCreditConsumptionChartRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/credit/charts"};
+    option (google.api.http) = {get: "/v1beta/credit/query-charts"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "📊 Metrics"
       extensions: {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -2133,56 +2133,13 @@ paths:
       tags:
         - "\U0001FA86 Namespace"
       x-stage: beta
-  /v1beta/metrics/vdp/pipeline/triggers:
-    get:
-      summary: List pipeline triggers
-      description: Returns a paginated list of pipeline executions.
-      operationId: MgmtPublicService_ListPipelineTriggerRecords
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/ListPipelineTriggerRecordsResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpc.Status'
-      parameters:
-        - name: pageSize
-          description: |-
-            The maximum number of triggers to return. If this parameter is unspecified,
-            at most 100 pipelines will be returned. The cap value for this parameter is
-            1000 (i.e. any value above that will be coerced to 100).
-          in: query
-          required: false
-          type: integer
-          format: int32
-        - name: pageToken
-          description: Page token.
-          in: query
-          required: false
-          type: string
-        - name: filter
-          description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
-            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-          in: query
-          required: false
-          type: string
-      tags:
-        - "\U0001F4CA Metrics"
-      x-stage: beta
-  /v1beta/metrics/vdp/pipeline/charts:
+  /v1beta/pipeline-runs/query-charts:
     get:
       summary: List pipeline trigger time charts
       description: |-
-        Returns a timeline of pipline trigger counts for the pipelines of a given
-        owner.
-        NOTE: This method will soon return the trigger counts of a given requester.
+        Returns a timeline of pipline trigger counts for a given requester. The
+        response will contain one set of records (datapoints), representing the
+        amount of triggers in a time bucket.
       operationId: MgmtPublicService_ListPipelineTriggerChartRecords
       responses:
         "200":
@@ -2197,20 +2154,36 @@ paths:
           schema:
             $ref: '#/definitions/rpc.Status'
       parameters:
-        - name: aggregationWindow
-          description: Aggregation window in nanoseconds.
+        - name: requesterId
+          description: The ID of the namespace that requested the pipeline triggers.
           in: query
-          required: false
-          type: integer
-          format: int32
-        - name: filter
+          required: true
+          type: string
+        - name: aggregationWindow
           description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
-            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+            Aggregation window. The value is a positive duration string, i.e. a
+            sequence of decimal numbers, each with optional fraction and a unit
+            suffix, such as "300ms", "1.5h" or "2h45m".
+            The minimum (and default) window is 1h.
           in: query
           required: false
           type: string
+        - name: start
+          description: |-
+            Beginning of the time range from which the records will be fetched.
+            The default value is the beginning of the current day, in UTC.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: stop
+          description: |-
+            End of the time range from which the records will be fetched.
+            The default value is the current timestamp.
+          in: query
+          required: false
+          type: string
+          format: date-time
       tags:
         - "\U0001F4CA Metrics"
       x-stage: beta
@@ -2268,7 +2241,7 @@ paths:
       tags:
         - "\U0001F4CA Metrics"
       x-stage: beta
-  /v1beta/metrics/credit/charts:
+  /v1beta/credit/query-charts:
     get:
       summary: List Instill Credit consumption time charts
       description: |-
@@ -2276,6 +2249,8 @@ paths:
         response will contain one set of records (datapoints) per consumption
         source (e.g. "pipeline", "model"). Each datapoint represents the amount
         consumed in a time bucket.
+
+        This endpoint is only exposed on Instill Cloud.
       operationId: MgmtPublicService_ListCreditConsumptionChartRecords
       responses:
         "200":
@@ -7953,27 +7928,14 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/PipelineTriggerChartRecord'
-        description: A list of pipeline trigger records.
+        description: |-
+          Pipeline trigger counts. Until we allow filtering or grouping by fields
+          like pipeline ID, this list will contain only one element with the
+          timeline of trigger counts for a given requester, regardless the pipeline
+          ID, trigger mode, final status or other fields.
     description: |-
       ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
       chart records.
-  ListPipelineTriggerRecordsResponse:
-    type: object
-    properties:
-      pipelineTriggerRecords:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/PipelineTriggerRecord'
-        description: A list of pipeline triggers.
-      nextPageToken:
-        type: string
-        description: Next page token.
-      totalSize:
-        type: integer
-        format: int32
-        description: Total number of pipeline triggers.
-    description: ListPipelineTriggerRecordsResponse contains a list of pipeline triggers.
   ListPipelinesAdminResponse:
     type: object
     properties:
@@ -8210,16 +8172,6 @@ definitions:
        - METHOD_DICTIONARY: Key-value collection. The user is responsible of fetching the connection
       details from the 3rd party service.
        - METHOD_OAUTH: Access token created via OAuth 2.0 authorization.
-  Mode:
-    type: string
-    enum:
-      - MODE_SYNC
-      - MODE_ASYNC
-    description: |-
-      Mode describes the execution mode of the pipeline (sync or async).
-
-       - MODE_SYNC: Synchronous (result is returned in the response).
-       - MODE_ASYNC: Asynchronous (response only contains acknowledgement).
   Model:
     type: object
     properties:
@@ -9193,19 +9145,8 @@ definitions:
     properties:
       pipelineId:
         type: string
-        description: Pipeline ID.
-      pipelineUid:
-        type: string
-        description: Pipeline UUID.
-      triggerMode:
-        description: Trigger mode.
-        allOf:
-          - $ref: '#/definitions/Mode'
-      status:
-        description: Final status.
+        description: This field will be present present when the information is grouped by pipeline.
         readOnly: true
-        allOf:
-          - $ref: '#/definitions/v1beta.Status'
       timeBuckets:
         type: array
         items:
@@ -9220,63 +9161,15 @@ definitions:
           format: int32
         description: Aggregated trigger count in each time bucket.
         readOnly: true
-      computeTimeDuration:
-        type: array
-        items:
-          type: number
-          format: float
-        description: Total computation time duration in each time bucket.
-        readOnly: true
-      pipelineReleaseId:
+      requesterId:
         type: string
-        description: Version for the triggered pipeline if it is a release pipeline.
-        readOnly: true
-      pipelineReleaseUid:
-        type: string
-        description: Release UUID for the triggered pipeline if it is a release pipeline.
+        description: The ID of the namespace that requested the pipeline triggers.
         readOnly: true
     description: |-
-      PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
+      PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
+      contains a collection of (timestamp, count) pairs that represent the total
+      pipeline triggers in a given time bucket.
       pipeline ID and time frame.
-  PipelineTriggerRecord:
-    type: object
-    properties:
-      triggerTime:
-        type: string
-        format: date-time
-        description: The moment when the pipeline was triggered.
-      pipelineTriggerId:
-        type: string
-        description: UUID of the trigger.
-      pipelineId:
-        type: string
-        description: Pipeline ID.
-      pipelineUid:
-        type: string
-        description: Pipeline UUID.
-      triggerMode:
-        description: Trigger mode.
-        allOf:
-          - $ref: '#/definitions/Mode'
-      computeTimeDuration:
-        type: number
-        format: float
-        description: Total execution duration.
-        readOnly: true
-      status:
-        description: Final status.
-        readOnly: true
-        allOf:
-          - $ref: '#/definitions/v1beta.Status'
-      pipelineReleaseId:
-        type: string
-        description: If a release of the pipeline was triggered, pipeline version.
-        readOnly: true
-      pipelineReleaseUid:
-        type: string
-        description: If a release of the pipeline was triggered, release UUID.
-        readOnly: true
-    description: PipelineTriggerRecord represents a pipeline execution event.
   ProcessCatalogFilesRequest:
     type: object
     properties:
@@ -10745,16 +10638,6 @@ definitions:
 
        - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
        - VIEW_FULL: Full representation.
-  v1beta.Status:
-    type: string
-    enum:
-      - STATUS_COMPLETED
-      - STATUS_ERRORED
-    description: |-
-      Status describes the output of an execution.
-
-       - STATUS_COMPLETED: Successfully completed.
-       - STATUS_ERRORED: Finished with error.
   v1beta.User:
     type: object
     properties:


### PR DESCRIPTION
Because

- Pipeline and credit endpoints have different params and schemas.
- Some of the information served by the existing endpoints will be handled by the pipeline run feature.

This commit

- Adds endpoints to serve the new dashboard design:
  - `GetPipelineTriggerCount` path is updated to align with API guidelines.
  - `ListCreditConsumptionChartRecords` path is updated to align with API guidelines (previous path will be kept in the gateway to keep the current UX running).
  - `ListPipelineTriggerChartRecords` is added.
- A separate PR will take care of removing the deprecated endpoints once the new dashboard is rolled out.