### PR TITLE
feat(run): add recipe schema in pipeline run logging

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -6592,6 +6592,11 @@ definitions:
         format: float
         description: Credits used of internal accounting metric.
         readOnly: true
+      dataSpecification:
+        description: Data specifications.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaDataSpecification'
     description: PipelineRun represents a single execution of a pipeline.
   v1betaPipelineValidationError:
     type: object

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -2101,6 +2101,8 @@ message PipelineRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
+  // Data specifications.
+  DataSpecification data_specification = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.


### PR DESCRIPTION
Because

- FE needs data schema for displaying recipe

This commit

- add `data_specification` in pipeline run response
