### PR TITLE
chore(ci): migrate individual buf actions to consolidated action

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -1,0 +1,21 @@
+name: Buf CI
+on:
+  pull_request:
+    paths:
+      - '**.proto'
+      - '**/buf.yaml'
+      - '**/buf.lock'
+      - '**/buf.md'
+      - 'buf.gen.yaml'
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v1
+        with:
+          token: ${{ secrets.botBufToken }}

--- a/.github/workflows/buf-push-gen.yaml
+++ b/.github/workflows/buf-push-gen.yaml
@@ -4,17 +4,7 @@ on:
   push:
     branches:
       - main
-
 jobs:
-  push-buf:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1
-      - uses: bufbuild/buf-push-action@v1
-        with:
-          buf_token: ${{ secrets.botBufToken }}
-
   gen-buf-protogen-go:
     runs-on: ubuntu-latest
     needs: push-buf
@@ -53,7 +43,6 @@ jobs:
             git commit -S -m "chore: auto-gen by protobufs" -m "triggered by commit: https://github.com/instill-ai/protobufs/commit/${GITHUB_SHA}"
             git push
           fi
-
   gen-buf-protogen-python:
     runs-on: ubuntu-latest
     needs: push-buf


### PR DESCRIPTION
Because

- Buf has created a [consolidated GitHub Action](https://github.com/marketplace/actions/buf-action?_hsenc=p2ANqtz-_Jwa34-K_ZfzESN_DUGsZLrHvGwMrJV4w2FgfaZ7AWLsnBBovUUc2OfH0l5ysnny1vB9KcKf5HqESQGUfnMasV77-pkA&_hsmi=321439226#migrating-from-individual-buf-actions) that runs the individual steps we had scattered across 2 actions.


This commit

- Migrates individual actions to new consolidated Buf action.
