### PR TITLE
fix(pipeline): update filter param on integration list endpoints

### DIFF
--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -75,7 +75,7 @@ message ListNamespaceConnectionsRequest {
   // expression.
   // The following filters are supported:
   // - `integration_id`
-  // - `q` (fuzzy search on connection ID, integration title or vendor)
+  // - `qConnection` (fuzzy search on connection ID, integration title or vendor)
   // Examples:
   // - List connections where app name, vendor or connection ID match `googl`:
   // `q="googl"`.
@@ -212,7 +212,7 @@ message ListIntegrationsRequest {
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // The following filters are supported:
-  // - `q` (fuzzy search on title or vendor)
+  // - `qIntegration` (fuzzy search on title or vendor)
   // - `featured`
   // Examples:
   // - List integrations where app name or vendor match `googl`: `q="googl"`.


### PR DESCRIPTION
Because

- The transpiler needs a unique filter name to implement the fuzzy search on the table columns.

This commit

- Updates the fuzzy search filters on the integration and connection endpoints.
