### PR TITLE
fix(pipeline): add UID to integration object

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -6357,6 +6357,10 @@ definitions:
   v1betaIntegration:
     type: object
     properties:
+      uid:
+        type: string
+        description: UUID-formatted unique identifier. It references a component definition.
+        readOnly: true
       id:
         type: string
         description: |-

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -175,16 +175,18 @@ message Integration {
     // different data to connect to the 3rd party app.
     google.protobuf.Struct schema = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
+  // UUID-formatted unique identifier. It references a component definition.
+  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Identifier of the integration, which references a component definition.
   // Components with that definition ID will be able to use the connections
   // produced by this integration.
-  string id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string id = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Title, reflects the app name.
-  string title = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string title = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Short description of the integrated app.
-  string description = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string description = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Integrated app vendor name.
-  string vendor = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string vendor = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Integration icon. This is a path that's relative to the root of
   // the component implementation and that allows frontend applications to pull
   // and locate the icons.


### PR DESCRIPTION
Because

- Connections reference integrations by UID internally, so it makes sense to
  have that field in the proto object instead of creating an internal
  representation. In component definitions, this field is already public.

This commit

- Adds a UID field to the connection object.
