### PR TITLE
fix(pipeline): make connection ID mutable

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4349,7 +4349,7 @@ paths:
             Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
             expression.
             The following filters are supported:
-            - `integration_id`
+            - `integrationId`
             - `qConnection` (fuzzy search on connection ID, integration title or vendor)
             Examples:
             - List connections where app name, vendor or connection ID match `googl`:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4517,7 +4517,7 @@ paths:
               - setup
       tags:
         - Integration
-  /v1beta/namespaces/{connection.namespaceId}/connections/{connection.id}:
+  /v1beta/namespaces/{connection.namespaceId}/connections/{connectionId}:
     patch:
       summary: Update a connection
       description: Updates a connection with the supplied connection fields.
@@ -4540,13 +4540,16 @@ paths:
           in: path
           required: true
           type: string
-        - name: connection.id
-          description: ID.
+        - name: connectionId
+          description: ID of the connection to be updated, as present in the database.
           in: path
           required: true
           type: string
         - name: connection
-          description: Properties of the connection to be updated.
+          description: |-
+            Connection object with the new properties to be updated. Immutable and
+            output-only fields will be ignored. The Setup property must be updated
+            in block (no partial update is supported).
           in: body
           required: true
           schema:
@@ -4556,6 +4559,9 @@ paths:
                 type: string
                 description: UUID-formatted unique identifier.
                 readOnly: true
+              id:
+                type: string
+                description: ID.
               integrationId:
                 type: string
                 description: |-
@@ -4596,8 +4602,12 @@ paths:
                 format: date-time
                 description: Last update timestamp.
                 readOnly: true
-            title: Properties of the connection to be updated.
+            title: |-
+              Connection object with the new properties to be updated. Immutable and
+              output-only fields will be ignored. The Setup property must be updated
+              in block (no partial update is supported).
             required:
+              - id
               - integrationId
               - method
               - setup

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -26,17 +26,20 @@ message Connection {
     METHOD_OAUTH = 2;
   }
   // UUID-formatted unique identifier.
-  string uid = 1 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    (google.api.field_behavior) = IMMUTABLE
-  ];
+  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // ID.
   string id = 2 [(google.api.field_behavior) = REQUIRED];
   // ID of the namespace owning the connection.
-  string namespace_id = 3 [(google.api.field_behavior) = REQUIRED];
+  string namespace_id = 3 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
   // Integration ID. It determines for which type of components can reference
   // this connection.
-  string integration_id = 4 [(google.api.field_behavior) = REQUIRED];
+  string integration_id = 4 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_behavior) = IMMUTABLE
+  ];
   // Integration title. This helps the console display the results grouped by
   // integration ID without needing an extra call to fetch title by integration
   // ID.
@@ -69,7 +72,7 @@ message ListNamespaceConnectionsRequest {
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // The following filters are supported:
-  // - `integration_id`
+  // - `integrationId`
   // - `qConnection` (fuzzy search on connection ID, integration title or vendor)
   // Examples:
   // - List connections where app name, vendor or connection ID match `googl`:

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -122,13 +122,17 @@ message CreateNamespaceConnectionResponse {
 // UpdateNamespaceConnectionRequest represents a request to update a
 // connection.
 message UpdateNamespaceConnectionRequest {
-  // Properties of the connection to be updated.
-  Connection connection = 1 [(google.api.field_behavior) = REQUIRED];
+  // ID of the connection to be updated, as present in the database.
+  string connection_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Connection object with the new properties to be updated. Immutable and
+  // output-only fields will be ignored. The Setup property must be updated
+  // in block (no partial update is supported).
+  Connection connection = 2 [(google.api.field_behavior) = REQUIRED];
   // The update mask specifies the subset of fields that should be modified.
   //
   // For more information about this field, see
   // https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#field-mask.
-  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+  google.protobuf.FieldMask update_mask = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // UpdateNamespaceConnectionResponse contains the updated connection.

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -1541,7 +1541,7 @@ service PipelinePublicService {
   // Updates a connection with the supplied connection fields.
   rpc UpdateNamespaceConnection(UpdateNamespaceConnectionRequest) returns (UpdateNamespaceConnectionResponse) {
     option (google.api.http) = {
-      patch: "/v1beta/namespaces/{connection.namespace_id}/connections/{connection.id}"
+      patch: "/v1beta/namespaces/{connection.namespace_id}/connections/{connection_id}"
       body: "connection"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Integration"};


### PR DESCRIPTION
Because

- The path for the connection update had a `{connection.id}` segment, the ID in the request body was overriden by the ID in the path, making the ID impossible to update.

This commit

- Use different parameters for the connection ID (path) and the updated object (body).
- Correct minor documentation issues.
