### PR TITLE
feat(vdp): support OAuth configuration on integrations

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -4498,6 +4498,21 @@ paths:
                 description: |-
                   Connection details. This field is required on creation, optional on view.
                   When viewing the connection details, the setup values will be redacted.
+              scopes:
+                type: array
+                items:
+                  type: string
+                description: |-
+                  A list of scopes that identify the resources that the connection will be
+                  able to access on the user's behalf. This is typically passed on creation
+                  when the setup has been generated through an OAuth flow with a limited set
+                  of scopes.
+              oAuthAccessDetails:
+                type: object
+                description: |-
+                  When the connection method is METHOD_OAUTH, the access token might come
+                  with some extra information that might vary across vendors. This
+                  information is passed as connection metadata.
               view:
                 description: |-
                   View defines how the integration is presented. The `setup` field is only
@@ -4591,6 +4606,21 @@ paths:
                 description: |-
                   Connection details. This field is required on creation, optional on view.
                   When viewing the connection details, the setup values will be redacted.
+              scopes:
+                type: array
+                items:
+                  type: string
+                description: |-
+                  A list of scopes that identify the resources that the connection will be
+                  able to access on the user's behalf. This is typically passed on creation
+                  when the setup has been generated through an OAuth flow with a limited set
+                  of scopes.
+              oAuthAccessDetails:
+                type: object
+                description: |-
+                  When the connection method is METHOD_OAUTH, the access token might come
+                  with some extra information that might vary across vendors. This
+                  information is passed as connection metadata.
               view:
                 description: |-
                   View defines how the integration is presented. The `setup` field is only
@@ -4872,6 +4902,44 @@ definitions:
        - METHOD_DICTIONARY: Key-value collection. The user is responsible of fetching the connection
       details from the 3rd party service.
        - METHOD_OAUTH: Access token created via OAuth 2.0 authorization.
+  IntegrationLink:
+    type: object
+    properties:
+      text:
+        type: string
+        description: Text contains the message to display.
+        readOnly: true
+      url:
+        type: string
+        description: URL contains the reference the link will redirect to.
+        readOnly: true
+    description: Link contains the information to display an reference to an external URL.
+  IntegrationOAuthConfig:
+    type: object
+    properties:
+      authUrl:
+        type: string
+        description: |-
+          The URL of the OAuth server to initiate the authentication and
+          authorization process.
+        readOnly: true
+      accessUrl:
+        type: string
+        description: |-
+          The URL of the OAuth server to exchange the authorization code for an
+          access token.
+        readOnly: true
+      scopes:
+        type: array
+        items:
+          type: string
+        description: |-
+          A list of scopes that identify the resources that the connection will be
+          able to access on the user's behalf.
+        readOnly: true
+    description: |-
+      OAuthConfig contains the configuration parameters for fetching an access
+      token via an OAuth 2.0 flow.
   IntegrationSetupSchema:
     type: object
     properties:
@@ -4886,7 +4954,9 @@ definitions:
           The connection setup field definitions. Each integration will require
           different data to connect to the 3rd party app.
         readOnly: true
-    description: SetupSchema defines the schema for a connection setup.
+    description: |-
+      SetupSchema defines the schema for a connection setup.
+      This message is deprecated.
   PipelinePublicServiceCloneNamespacePipelineBody:
     type: object
     properties:
@@ -5963,6 +6033,21 @@ definitions:
         description: |-
           Connection details. This field is required on creation, optional on view.
           When viewing the connection details, the setup values will be redacted.
+      scopes:
+        type: array
+        items:
+          type: string
+        description: |-
+          A list of scopes that identify the resources that the connection will be
+          able to access on the user's behalf. This is typically passed on creation
+          when the setup has been generated through an OAuth flow with a limited set
+          of scopes.
+      oAuthAccessDetails:
+        type: object
+        description: |-
+          When the connection method is METHOD_OAUTH, the access token might come
+          with some extra information that might vary across vendors. This
+          information is passed as connection metadata.
       view:
         description: |-
           View defines how the integration is presented. The `setup` field is only
@@ -6444,23 +6529,45 @@ definitions:
           information.
         readOnly: true
       helpLink:
-        type: string
         description: Reference to the vendor's documentation to expand the integration details.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/IntegrationLink'
+      setupSchema:
+        type: object
+        description: |-
+          The connection setup field definitions. Each integration will require
+          different data to connect to the 3rd party app.
+        readOnly: true
+      oAuthConfig:
+        description: |-
+          Configuration parameters required for the OAuth setup flow. This field
+          will be present only if the integration supports OAuth 2.0.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/IntegrationOAuthConfig'
+      view:
+        title: |-
+          View defines how the integration is presented. The following fields are
+          only shown in the FULL view:
+          - schemas
+          - setupSchema
+          - oAuthConfig
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/vdppipelinev1betaView'
       schemas:
         type: array
         items:
           type: object
           $ref: '#/definitions/IntegrationSetupSchema'
-        description: Schemas defines the supported schemas for the connection setup.
-        readOnly: true
-      view:
         description: |-
-          View defines how the integration is presented. The `spec` field is only
-          showed in the FULL view.
+          Schemas defines the supported schemas for the connection setup.
+          We haven't found a case for a schema that changes on the connection method
+          (components don't care about how the connection was built), so the schema
+          will be provided in the setupSchema field and the OAuth support and
+          configuration will be provided in oAuthConfig.
         readOnly: true
-        allOf:
-          - $ref: '#/definitions/vdppipelinev1betaView'
     description: |-
       Integration contains the parameters to create a connection between
       components and 3rd party apps.

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -55,6 +55,15 @@ message Connection {
   // Connection details. This field is required on creation, optional on view.
   // When viewing the connection details, the setup values will be redacted.
   google.protobuf.Struct setup = 7 [(google.api.field_behavior) = REQUIRED];
+  // A list of scopes that identify the resources that the connection will be
+  // able to access on the user's behalf. This is typically passed on creation
+  // when the setup has been generated through an OAuth flow with a limited set
+  // of scopes.
+  repeated string scopes = 11 [(google.api.field_behavior) = OPTIONAL];
+  // When the connection method is METHOD_OAUTH, the access token might come
+  // with some extra information that might vary across vendors. This
+  // information is passed as connection metadata.
+  optional google.protobuf.Struct o_auth_access_details = 12 [(google.api.field_behavior) = OPTIONAL];
   // View defines how the integration is presented. The `setup` field is only
   // showed in the FULL view.
   View view = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -175,21 +184,32 @@ message TestNamespaceConnectionResponse {}
 // Integration contains the parameters to create a connection between
 // components and 3rd party apps.
 message Integration {
-  // SetupSchema defines the schema for a connection setup.
-  message SetupSchema {
-    // The connection method, which will define the fields in the schema.
-    Connection.Method method = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // The connection setup field definitions. Each integration will require
-    // different data to connect to the 3rd party app.
-    google.protobuf.Struct schema = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  }
-
   // Link contains the information to display an reference to an external URL.
   message Link {
     // Text contains the message to display.
     string text = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
     // URL contains the reference the link will redirect to.
     string url = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+
+  // OAuthConfig contains the configuration parameters for fetching an access
+  // token via an OAuth 2.0 flow.
+  message OAuthConfig {
+    // The URL of the OAuth server to initiate the authentication and
+    // authorization process.
+    string auth_url = 1 [
+      (validate.rules).string.uri = true,
+      (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+    // The URL of the OAuth server to exchange the authorization code for an
+    // access token.
+    string access_url = 2 [
+      (validate.rules).string.uri = true,
+      (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+    // A list of scopes that identify the resources that the connection will be
+    // able to access on the user's behalf.
+    repeated string scopes = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
 
   // UUID-formatted unique identifier. It references a component definition.
@@ -214,12 +234,45 @@ message Integration {
   // information.
   string icon = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Reference to the vendor's documentation to expand the integration details.
-  optional string help_link = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Schemas defines the supported schemas for the connection setup.
-  repeated SetupSchema schemas = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // View defines how the integration is presented. The `spec` field is only
-  // showed in the FULL view.
+  optional Link help_link = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The connection setup field definitions. Each integration will require
+  // different data to connect to the 3rd party app.
+  google.protobuf.Struct setup_schema = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Configuration parameters required for the OAuth setup flow. This field
+  // will be present only if the integration supports OAuth 2.0.
+  optional OAuthConfig o_auth_config = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // View defines how the integration is presented. The following fields are
+  // only shown in the FULL view:
+  // - schemas
+  // - setupSchema
+  // - oAuthConfig
   View view = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // SetupSchema defines the schema for a connection setup.
+  // This message is deprecated.
+  message SetupSchema {
+    // The connection method, which will define the fields in the schema.
+    Connection.Method method = 1 [
+      deprecated = true,
+      (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+    // The connection setup field definitions. Each integration will require
+    // different data to connect to the 3rd party app.
+    google.protobuf.Struct schema = 2 [
+      deprecated = true,
+      (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+  }
+
+  // Schemas defines the supported schemas for the connection setup.
+  // We haven't found a case for a schema that changes on the connection method
+  // (components don't care about how the connection was built), so the schema
+  // will be provided in the setupSchema field and the OAuth support and
+  // configuration will be provided in oAuthConfig.
+  repeated SetupSchema schemas = 8 [
+    deprecated = true,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 }
 
 // ListPipelineIDsByConnectionIDRequest represents a request to list the

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -29,7 +29,7 @@ message Connection {
   }
   // UUID-formatted unique identifier.
   string uid = 1 [
-    (validate.rules).string.uuid = true,
+    (validate.rules).string = {ignore_empty: true, uuid: true},
     (google.api.field_behavior) = OUTPUT_ONLY
   ];
   // ID.

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -29,7 +29,10 @@ message Connection {
   }
   // UUID-formatted unique identifier.
   string uid = 1 [
-    (validate.rules).string = {ignore_empty: true, uuid: true},
+    (validate.rules).string = {
+      ignore_empty: true
+      uuid: true
+    },
     (google.api.field_behavior) = OUTPUT_ONLY
   ];
   // ID.


### PR DESCRIPTION
Because

- There was a wrong assumption about integrations, where the setup schema of a connection was different depending on the connection method (key-value or OAuth).

This commit

- Returns a single setup schema per integration.
- Corrects the type of the HelpLink (breaking change, but this field is not used yet).
- Returns the OAuth connection details in the integration.
