### PR TITLE
fix(buf): correct go package name

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -10,7 +10,7 @@ managed:
       module: buf.build/envoyproxy/protoc-gen-validate
   override:
     - file_option: go_package_prefix
-      value: github.com/instill-ai/protobufs/gen/go
+      value: github.com/instill-ai/protogen-go
 plugins:
   - remote: buf.build/protocolbuffers/python:v23.1
     out: gen/python


### PR DESCRIPTION
Because

- Last PR introduced a change in the Go package name that was intended only for local development.

This commit

- Restores Go package name
