### PR TITLE
fix(buf): use source_relative option to remove residual generated dir

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -22,6 +22,7 @@ plugins:
     out: gen/python
   - remote: buf.build/bufbuild/validate-go
     out: gen/go
+    opt: paths=source_relative
   - remote: buf.build/protocolbuffers/go:v1.30.0
     out: gen/go
     opt: paths=source_relative


### PR DESCRIPTION
Because

- Option was missing from Buf generator, producing an unwanted directory in `protogen-go`

This commit

- Uses `source_relative` option in the validate plugin
