### PR TITLE
fix(buf): rename type conflicting with protoc validator

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -6251,6 +6251,18 @@ definitions:
   v1betaDeleteUserSecretResponse:
     type: object
     description: DeleteUserSecretResponse is an empty response.
+  v1betaErrPipelineValidation:
+    type: object
+    properties:
+      location:
+        type: string
+        title: Location
+      error:
+        type: string
+        title: error
+    description: |-
+      ErrPipelineValidation contains information about a failed pipeline
+      validation.
   v1betaFileReference:
     type: object
     properties:
@@ -7312,16 +7324,6 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1betaDataSpecification'
     description: PipelineRun represents a single execution of a pipeline.
-  v1betaPipelineValidationError:
-    type: object
-    properties:
-      location:
-        type: string
-        title: Location
-      error:
-        type: string
-        title: error
-    title: PipelineValidation
   v1betaPipelineView:
     type: string
     enum:
@@ -7884,7 +7886,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineValidationError'
+          $ref: '#/definitions/v1betaErrPipelineValidation'
         description: The validated pipeline resource.
         readOnly: true
     description: ValidateNamespacePipelineResponse contains a validated pipeline.
@@ -7898,7 +7900,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineValidationError'
+          $ref: '#/definitions/v1betaErrPipelineValidation'
         description: The validated pipeline resource.
     description: ValidateOrganizationPipelineResponse contains a validated pipeline.
   v1betaValidateUserPipelineResponse:
@@ -7911,7 +7913,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1betaPipelineValidationError'
+          $ref: '#/definitions/v1betaErrPipelineValidation'
         description: The validated pipeline resource.
     description: ValidateUserPipelineResponse contains a validated pipeline.
   vdppipelinev1betaPermission:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -405,7 +405,7 @@ message ValidateNamespacePipelineResponse {
   // Success
   bool success = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // The validated pipeline resource.
-  repeated PipelineValidationError errors = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated ErrPipelineValidation errors = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // RenameNamespacePipelineRequest represents a request to rename the name of a
@@ -883,8 +883,9 @@ message DeleteUserPipelineRequest {
 // DeleteUserPipelineResponse is an empty response.
 message DeleteUserPipelineResponse {}
 
-// PipelineValidation
-message PipelineValidationError {
+// ErrPipelineValidation contains information about a failed pipeline
+// validation.
+message ErrPipelineValidation {
   // Location
   string location = 1;
   // error
@@ -911,7 +912,7 @@ message ValidateUserPipelineResponse {
   // Success
   bool success = 1;
   // The validated pipeline resource.
-  repeated PipelineValidationError errors = 2;
+  repeated ErrPipelineValidation errors = 2;
 }
 
 // RenameUserPipelineRequest represents a request to rename the name of a
@@ -1448,7 +1449,7 @@ message ValidateOrganizationPipelineResponse {
   // Success
   bool success = 1;
   // The validated pipeline resource.
-  repeated PipelineValidationError errors = 2;
+  repeated ErrPipelineValidation errors = 2;
 }
 
 // RenameOrganizationPipelineRequest represents a request to rename the name of


### PR DESCRIPTION
Because

- `PipelineValidationError` is a type generated by the validator package, and an existing type already had that name.

This commit

- Renames `vdp`'s type to `ErrPipelineValidation`.
