### PR TITLE
feat(vdp): add a field to hide cloud only component

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         entry: make openapi
         language: system
   - repo: https://github.com/bufbuild/buf.git
-    rev: v1.35.0
+    rev: v1.42.0
     hooks:
       - id: buf-format
       - id: buf-lint

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1246,6 +1246,11 @@ paths:
           required: false
           type: integer
           format: int32
+        - name: excludeCloudOnly
+          description: Exclude cloud-only components.
+          in: query
+          required: false
+          type: boolean
       tags:
         - Component
   /v1beta/operations/{operationId}:

--- a/vdp/pipeline/v1beta/component_definition.proto
+++ b/vdp/pipeline/v1beta/component_definition.proto
@@ -331,6 +331,8 @@ message ListComponentDefinitionsRequest {
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // Page number.
   optional int32 page = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Exclude cloud-only components.
+  optional bool exclude_cloud_only = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListComponentDefinitionsResponse contains a list of component definitions.


### PR DESCRIPTION
Because

- we only provide instill app for ee

This commit

- add a filed to exclude the ee component in ce
