### PR TITLE
feat(artifact): support csv file type

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -301,10 +301,12 @@ enum FileType {
   FILE_TYPE_PPT = 10;
   // PPTX
   FILE_TYPE_PPTX = 11;
-  // XLS(not supported yet)
+  // XLS
   FILE_TYPE_XLS = 12;
   // XLSX
   FILE_TYPE_XLSX = 13;
+  // CSV
+  FILE_TYPE_CSV = 14;
 }
 
 // file

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -128,7 +128,16 @@ service ArtifactPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/chunks/retrieve"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Catalog"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Catalog"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
   }
 
   // Ask a question
@@ -137,7 +146,16 @@ service ArtifactPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/ask"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Catalog"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Catalog"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
   }
 
   // Get file catalog

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -430,6 +430,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ArtifactPublicServiceSimilarityChunksSearchBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Catalog
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/ask:
@@ -464,6 +469,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/ArtifactPublicServiceQuestionAnsweringBody'
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Catalog
 definitions:
@@ -838,6 +848,7 @@ definitions:
       - FILE_TYPE_PPTX
       - FILE_TYPE_XLS
       - FILE_TYPE_XLSX
+      - FILE_TYPE_CSV
     description: |-
       - FILE_TYPE_TEXT: text
        - FILE_TYPE_PDF: PDF
@@ -850,8 +861,9 @@ definitions:
        - FILE_TYPE_DOC: DOC
        - FILE_TYPE_PPT: PPT
        - FILE_TYPE_PPTX: PPTX
-       - FILE_TYPE_XLS: XLS(not supported yet)
+       - FILE_TYPE_XLS: XLS
        - FILE_TYPE_XLSX: XLSX
+       - FILE_TYPE_CSV: CSV
     title: file type
   v1alphaGetFileCatalogResponse:
     type: object


### PR DESCRIPTION
Because

1. document component is going to support csv and xls
2. Ask & Retrieve API lakcs Instill-Requester-Uid header information

This commit

1. add file type in API spec
2. add Instill-Requester-Uid header info in protobuf 
