### PR TITLE
feat(vdp): add the `endpoints` field to the pipeline response

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1637,6 +1637,11 @@ paths:
               profileImage:
                 type: string
                 description: Pipeline profile image in base64 format.
+              endpoints:
+                description: Pipeline endpoints.
+                readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaEndpoints'
             title: The pipeline fields that will replace the existing ones.
             required:
               - recipe
@@ -2232,6 +2237,11 @@ paths:
                 description: |-
                   Recipe in YAML format describes the components of a pipeline and how they
                   are connected.
+              endpoints:
+                description: Pipeline endpoints.
+                readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaEndpoints'
             title: |-
               The pipeline release fields that will replace the existing ones.
               A pipeline release resource to update
@@ -2755,6 +2765,11 @@ paths:
               profileImage:
                 type: string
                 description: Pipeline profile image in base64 format.
+              endpoints:
+                description: Pipeline endpoints.
+                readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaEndpoints'
             title: The pipeline fields that will replace the existing ones.
             required:
               - recipe
@@ -3343,6 +3358,11 @@ paths:
                 description: |-
                   Recipe in YAML format describes the components of a pipeline and how they
                   are connected.
+              endpoints:
+                description: Pipeline endpoints.
+                readOnly: true
+                allOf:
+                  - $ref: '#/definitions/v1betaEndpoints'
             title: |-
               The pipeline release fields that will replace the existing ones.
               A pipeline release resource to update
@@ -4908,6 +4928,18 @@ definitions:
        - METHOD_DICTIONARY: Key-value collection. The user is responsible of fetching the connection
       details from the 3rd party service.
        - METHOD_OAUTH: Access token created via OAuth 2.0 authorization.
+  EndpointsWebhookEndpoint:
+    type: object
+    properties:
+      url:
+        type: string
+        description: Webhook URL.
+        readOnly: true
+      description:
+        type: string
+        description: Description.
+        readOnly: true
+    description: WebhookEndpoint describe a webhook endpoint.
   IntegrationLink:
     type: object
     properties:
@@ -6351,6 +6383,16 @@ definitions:
   v1betaDeleteUserSecretResponse:
     type: object
     description: DeleteUserSecretResponse is an empty response.
+  v1betaEndpoints:
+    type: object
+    properties:
+      webhooks:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/EndpointsWebhookEndpoint'
+        description: Webhook endpoints.
+        readOnly: true
+    description: Endpoints describe the endpoints of a pipeline.
   v1betaErrPipelineValidation:
     type: object
     properties:
@@ -7284,6 +7326,11 @@ definitions:
       profileImage:
         type: string
         description: Pipeline profile image in base64 format.
+      endpoints:
+        description: Pipeline endpoints.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaEndpoints'
     description: |-
       A Pipeline is an end-to-end workflow that automates a sequence of components
       to process data.
@@ -7354,6 +7401,11 @@ definitions:
         description: |-
           Recipe in YAML format describes the components of a pipeline and how they
           are connected.
+      endpoints:
+        description: Pipeline endpoints.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1betaEndpoints'
     description: |-
       Pipeline releases contain the version control information of a pipeline.
       This allows users to track changes in the pipeline over time.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -56,6 +56,20 @@ enum State {
   STATE_ERROR = 3;
 }
 
+// Endpoints describe the endpoints of a pipeline.
+message Endpoints {
+  // WebhookEndpoint describe a webhook endpoint.
+  message WebhookEndpoint {
+    // Webhook URL.
+    string url = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Description.
+    string description = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+
+  // Webhook endpoints.
+  map<string, WebhookEndpoint> webhooks = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // A Pipeline is an end-to-end workflow that automates a sequence of components
 // to process data.
 //
@@ -152,6 +166,8 @@ message Pipeline {
   optional string license = 30 [(google.api.field_behavior) = OPTIONAL];
   // Pipeline profile image in base64 format.
   optional string profile_image = 31 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline endpoints.
+  Endpoints endpoints = 32 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // TriggerMetadata contains the traces of the pipeline inference.
@@ -232,6 +248,8 @@ message PipelineRelease {
   // Recipe in YAML format describes the components of a pipeline and how they
   // are connected.
   string raw_recipe = 15 [(google.api.field_behavior) = OPTIONAL];
+  // Pipeline endpoints.
+  Endpoints endpoints = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListPipelinesRequest represents a request to list pipelines.


### PR DESCRIPTION
Because

- We need to return the webhook endpoint URLs in the pipeline response so Console can display them to users.

This commit

- Adds the `endpoints` field to the pipeline response.