### PR TITLE
feat(catalog): add catalog uid in response

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -163,12 +163,14 @@ message DeleteRepositoryTagResponse {}
 
 // Catalog represents a catalog.
 message Catalog {
+  // The catalog uid.
+  string catalog_uid = 1;
   // The catalog id.
-  string catalog_id = 1;
+  string catalog_id = 2;
   // The catalog name.
-  string name = 2;
+  string name = 3;
   // The catalog description.
-  string description = 3;
+  string description = 4;
   // The creation time of the catalog.
   string create_time = 5;
   // The last update time of the catalog.

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -655,6 +655,9 @@ definitions:
   v1alphaCatalog:
     type: object
     properties:
+      catalogUid:
+        type: string
+        description: The catalog uid.
       catalogId:
         type: string
         description: The catalog id.


### PR DESCRIPTION
Because

we have to provide the catalog `uid` in list catalog api, frontend can know the corresponging catalog `id`.

This commit

add the uid field
