### PR TITLE
feat(artifact): catalog run logging

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -3,10 +3,12 @@ syntax = "proto3";
 package artifact.artifact.v1alpha;
 
 import "common/healthcheck/v1beta/healthcheck.proto";
+import "common/run/v1alpha/run.proto";
 // Google API
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 // Protocol Buffers Well-Known Types
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 // LivenessRequest represents a request to check a service liveness status
@@ -420,4 +422,128 @@ message ListCatalogFilesResponse {
   string next_page_token = 4;
   // The filter.
   ListCatalogFilesFilter filter = 5;
+}
+
+// CatalogRunAction describes the actions a user has over a catalog.
+enum CatalogRunAction {
+  // Unspecified.
+  CATALOG_RUN_ACTION_UNSPECIFIED = 0;
+  // Create catalog.
+  CATALOG_RUN_ACTION_CREATE = 1;
+  // Update catalog.
+  CATALOG_RUN_ACTION_UPDATE = 2;
+  // Delete catalog.
+  CATALOG_RUN_ACTION_DELETE = 3;
+  // Upload catalog file.
+  CATALOG_RUN_ACTION_CREATE_FILE = 4;
+  // Process catalog file.
+  CATALOG_RUN_ACTION_PROCESS_FILE = 5;
+  // Delete catalog file.
+  CATALOG_RUN_ACTION_DELETE_FILE = 6;
+}
+
+// CatalogRun represents a single execution of a catalog action.
+message CatalogRun {
+  // Unique identifier for each run.
+  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // catalog uid
+  string catalog_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The file uids.
+  repeated string file_uids = 3 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Action of the catalog run.
+  CatalogRunAction action = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Current status of the run.
+  common.run.v1alpha.RunStatus status = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Origin of the run.
+  common.run.v1alpha.RunSource source = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Time taken to complete the run in milliseconds.
+  optional int32 total_duration = 7 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Runner ID. (User UID)
+  optional string runner_id = 8 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Namespace ID.
+  optional string namespace_id = 9 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Run request payload.
+  optional google.protobuf.Struct payload = 11 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Time when the run started execution.
+  google.protobuf.Timestamp start_time = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Time when the run completed.
+  optional google.protobuf.Timestamp complete_time = 15 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Error message if the run failed.
+  optional string error = 16 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Credits used of internal accounting metric.
+  optional float credit_amount = 17 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+}
+
+// ListCatalogRunsResponse is the response message for ListCatalogRuns.
+message ListCatalogRunsResponse {
+  // The list of runs.
+  repeated CatalogRun catalog_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The total number of runs matching the request.
+  int64 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The current page number.
+  int32 page = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The number of items per page.
+  int32 page_size = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListCatalogRunsRequest is the request message for ListCatalogRuns.
+message ListCatalogRunsRequest {
+  // The ID of the owner of the catalog.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The ID of the catalog for which the runs will be listed.
+  string catalog_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The page number to retrieve.
+  int32 page = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // The maximum number of items per page to return. The default and cap values
+  // are 10 and 100, respectively.
+  int32 page_size = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+  optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -174,4 +174,10 @@ service ArtifactPublicService {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Catalog"};
   }
+
+  // List Catalog Runs
+  rpc ListCatalogRuns(ListCatalogRunsRequest) returns (ListCatalogRunsResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/catalogs/{catalog_id}/runs"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Catalog"};
+  }
 }

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -484,6 +484,64 @@ paths:
           type: string
       tags:
         - Catalog
+  /v1beta/namespaces/{namespaceId}/catalogs/{catalogId}/runs:
+    get:
+      summary: List Catalog Runs
+      operationId: ArtifactPublicService_ListCatalogRuns
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListCatalogRunsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: namespaceId
+          description: The ID of the owner of the catalog.
+          in: path
+          required: true
+          type: string
+        - name: catalogId
+          description: The ID of the catalog for which the runs will be listed.
+          in: path
+          required: true
+          type: string
+        - name: page
+          description: The page number to retrieve.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageSize
+          description: |-
+            The maximum number of items per page to return. The default and cap values
+            are 10 and 100, respectively.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: filter
+          description: |-
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression.
+            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+          in: query
+          required: false
+          type: string
+        - name: orderBy
+          description: |-
+            Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+            Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+          in: query
+          required: false
+          type: string
+      tags:
+        - Catalog
 definitions:
   ArtifactPublicServiceCreateCatalogBody:
     type: object
@@ -639,6 +697,13 @@ definitions:
       '@type':
         type: string
     additionalProperties: {}
+  protobufNullValue:
+    type: string
+    description: |-
+      `NullValue` is a singleton enumeration to represent the null value for the
+      `Value` type union.
+
+      The JSON representation for `NullValue` is JSON `null`.
   rpcStatus:
     type: object
     properties:
@@ -714,6 +779,93 @@ definitions:
         format: uint64
         description: The current used storage in catalog.
     description: Catalog represents a catalog.
+  v1alphaCatalogRun:
+    type: object
+    properties:
+      uid:
+        type: string
+        description: Unique identifier for each run.
+        readOnly: true
+      catalogUid:
+        type: string
+        title: catalog uid
+        readOnly: true
+      fileUids:
+        type: array
+        items:
+          type: string
+        description: The file uids.
+        readOnly: true
+      action:
+        description: Action of the catalog run.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaCatalogRunAction'
+      status:
+        description: Current status of the run.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaRunStatus'
+      source:
+        description: Origin of the run.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alphaRunSource'
+      totalDuration:
+        type: integer
+        format: int32
+        description: Time taken to complete the run in milliseconds.
+        readOnly: true
+      runnerId:
+        type: string
+        title: Runner ID. (User UID)
+        readOnly: true
+      namespaceId:
+        type: string
+        description: Namespace ID.
+        readOnly: true
+      payload:
+        type: object
+        description: Run request payload.
+        readOnly: true
+      startTime:
+        type: string
+        format: date-time
+        description: Time when the run started execution.
+        readOnly: true
+      completeTime:
+        type: string
+        format: date-time
+        description: Time when the run completed.
+        readOnly: true
+      error:
+        type: string
+        description: Error message if the run failed.
+        readOnly: true
+      creditAmount:
+        type: number
+        format: float
+        description: Credits used of internal accounting metric.
+        readOnly: true
+    description: CatalogRun represents a single execution of a catalog action.
+  v1alphaCatalogRunAction:
+    type: string
+    enum:
+      - CATALOG_RUN_ACTION_CREATE
+      - CATALOG_RUN_ACTION_UPDATE
+      - CATALOG_RUN_ACTION_DELETE
+      - CATALOG_RUN_ACTION_CREATE_FILE
+      - CATALOG_RUN_ACTION_PROCESS_FILE
+      - CATALOG_RUN_ACTION_DELETE_FILE
+    description: |-
+      CatalogRunAction describes the actions a user has over a catalog.
+
+       - CATALOG_RUN_ACTION_CREATE: Create catalog.
+       - CATALOG_RUN_ACTION_UPDATE: Update catalog.
+       - CATALOG_RUN_ACTION_DELETE: Delete catalog.
+       - CATALOG_RUN_ACTION_CREATE_FILE: Upload catalog file.
+       - CATALOG_RUN_ACTION_PROCESS_FILE: Process catalog file.
+       - CATALOG_RUN_ACTION_DELETE_FILE: Delete catalog file.
   v1alphaCreateCatalogResponse:
     type: object
     properties:
@@ -988,6 +1140,32 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1alphaListCatalogFilesFilter'
     title: list files response
+  v1alphaListCatalogRunsResponse:
+    type: object
+    properties:
+      catalogRuns:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaCatalogRun'
+        description: The list of runs.
+        readOnly: true
+      totalSize:
+        type: string
+        format: int64
+        description: The total number of runs matching the request.
+        readOnly: true
+      page:
+        type: integer
+        format: int32
+        description: The current page number.
+        readOnly: true
+      pageSize:
+        type: integer
+        format: int32
+        description: The number of items per page.
+        readOnly: true
+    description: ListCatalogRunsResponse is the response message for ListCatalogRuns.
   v1alphaListCatalogsResponse:
     type: object
     properties:
@@ -1086,6 +1264,30 @@ definitions:
     description: |-
       RepositoryTag contains information about the version of some content in a
       repository.
+  v1alphaRunSource:
+    type: string
+    enum:
+      - RUN_SOURCE_CONSOLE
+      - RUN_SOURCE_API
+    description: |-
+      RunSource defines the source of a pipeline or model run.
+
+       - RUN_SOURCE_CONSOLE: Run from frontend UI.
+       - RUN_SOURCE_API: Run from API or SDK.
+  v1alphaRunStatus:
+    type: string
+    enum:
+      - RUN_STATUS_PROCESSING
+      - RUN_STATUS_COMPLETED
+      - RUN_STATUS_FAILED
+      - RUN_STATUS_QUEUED
+    description: |-
+      RunStatus defines the status of a pipeline or model run.
+
+       - RUN_STATUS_PROCESSING: Run in progress.
+       - RUN_STATUS_COMPLETED: Run succeeded.
+       - RUN_STATUS_FAILED: Run failed.
+       - RUN_STATUS_QUEUED: Run is waiting to be executed.
   v1alphaSimilarityChunk:
     type: object
     properties:


### PR DESCRIPTION
Because:

- Users need to retrieve catalog runs efficiently, either for specific catalogs or across all accessible catalogs.

This commit:

- Returns a paginated list of catalog runs
