### PR TITLE
feat(app): upload API reference to readme.com

### DIFF
--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -39,10 +39,10 @@ jobs:
         with:
           rdme: openapi openapiv2/artifact/service.swagger.yaml --title "💾 Artifact (PR ${{ github.ref_name }})" --key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c6531
 
-      # - name: Sync App 💾
-      #   uses: readmeio/rdme@v8
-      #   with:
-      #     rdme: openapi openapiv2/app/service.swagger.yaml --title "📱 App (PR ${{ github.ref_name }})" --key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c6531
+      - name: Sync App 📱
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/app/service.swagger.yaml --title "📱 App (PR ${{ github.ref_name }})" --key=${{ secrets.README_API_KEY }} --id=66f3f3781c34e9001ff23013
 
   sync-openapi-private-staging:
     name: Keep private (staging) docs in sync with `main`
@@ -78,10 +78,10 @@ jobs:
         with:
           rdme: openapi openapiv2/artifact/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=66f40c5c346c5d004a090999
 
-      # - name: Sync App 💾
-      #   uses: readmeio/rdme@v8
-      #   with:
-      #     rdme: openapi openapiv2/app/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=669fb97f2071e2004a8f9183
+      - name: Sync App 📱
+        uses: readmeio/rdme@v8
+        with:
+          rdme: openapi openapiv2/app/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=66f40c5c346c5d004a09099a
 
       - name: Check new release 🔍
         id: check-new-release

--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -8,27 +8,16 @@ on:
       # pushed to the `main` branch.
       - main
     paths:
-      - 'openapiv2/artifact/**'
-      - 'openapiv2/app/**'
-      - 'openapiv2/common/**'
-      - 'openapiv2/core/**'
-      - 'openapiv2/model/**'
-      - 'openapiv2/vdp/**'
+      - 'openapiv2/**'
 
 jobs:
   sync-openapi-private-dev:
     name: Keep private (dev) docs in sync with latest pull request
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    outputs:
-      old_release: ${{ steps.check-new-release.outputs.old_release }}
-      new_release: ${{ steps.check-new-release.outputs.new_release }}
     steps:
       - name: Check out repo 📚
         uses: actions/checkout@v3
-        with:
-          # Needed in check-new-release to compare with the previous commit.
-          fetch-depth: 0
 
       - name: Sync Core 🔮
         uses: readmeio/rdme@v8
@@ -54,25 +43,6 @@ jobs:
       #   uses: readmeio/rdme@v8
       #   with:
       #     rdme: openapi openapiv2/app/service.swagger.yaml --title "📱 App (PR ${{ github.ref_name }})" --key=${{ secrets.README_API_KEY }} --id=669fb9c72dd8c500184c6531
-
-      - name: Check new release 🔍
-        id: check-new-release
-        run: |
-          # If the version in the OpenAPI configuration has changed, extract
-          # the old and new release versions (without the "v" prefix) to
-          # variables.
-          version_file=common/openapi/v1beta/api_info.conf
-          capture_old='^-\s\+\<version:'
-          capture_new='^+\s\+\<version:'
-          extract_version='s/.*"v\(.*\)".*/\1/'
-
-          old_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_old | sed $extract_version)
-          new_version=$(git diff ${{ github.event.before }} ${{ github.event.after }} $version_file | grep $capture_new | sed $extract_version)
-
-          if [[ $new_version ]]; then
-            echo "new_release=$new_version" >> $GITHUB_OUTPUT
-            echo "old_release=$old_version" >> $GITHUB_OUTPUT
-          fi
 
   sync-openapi-private-staging:
     name: Keep private (staging) docs in sync with `main`

--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -61,22 +61,22 @@ jobs:
       - name: Sync Core 🔮
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/core/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65bcfc78e72e300017c0b162
+          rdme: openapi openapiv2/core/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=66f40c5c346c5d004a090996
 
       - name: Sync Model ⚗️
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/model/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65bcfc78e72e300017c0b163
+          rdme: openapi openapiv2/model/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=66f40c5c346c5d004a090997
 
       - name: Sync VDP 💧
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/vdp/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=65bcfc78e72e300017c0b164
+          rdme: openapi openapiv2/vdp/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=66f40c5c346c5d004a090998
 
       - name: Sync Artifact 💾
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi openapiv2/artifact/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=669fb97f2071e2004a8f9183
+          rdme: openapi openapiv2/artifact/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --id=66f40c5c346c5d004a090999
 
       # - name: Sync App 💾
       #   uses: readmeio/rdme@v8

--- a/app/app/v1alpha/app.proto
+++ b/app/app/v1alpha/app.proto
@@ -33,15 +33,13 @@ message ReadinessResponse {
 }
 
 /*
-
    This API is under development and, therefore, some of its entities and
-   endpoints are not implemented yet. This section aims to give context about the
-   current interface and how it fits in the App vision.
+   endpoints are not implemented yet. This section aims to give context about
+   the current interface and how it fits in the App vision.
 
    # App
 
    The App domain is responsible of ready-to-use AI applications.
-
 */
 
 // App represents a app.
@@ -60,8 +58,8 @@ message App {
   repeated string tags = 6 [(google.api.field_behavior) = OPTIONAL];
   // metadata for the app.
   oneof metadata {
-    // The ai assistant app metadata.
-    AiAssistantAppMetadata ai_assistant_app = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // The AI assistant app metadata.
+    AIAssistantAppMetadata ai_assistant_app = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
   // The app type.
   AppType app_type = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -71,13 +69,13 @@ message App {
   string creator_uid = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// AiAssistantAppMetadata represents the metadata for the ai assistant app.
-message AiAssistantAppMetadata {
-  // The ai assistant app catalog uid.
+// AIAssistantAppMetadata represents the metadata for the AI assistant app.
+message AIAssistantAppMetadata {
+  // The AI assistant app catalog uid.
   string catalog_uid = 1 [(google.api.field_behavior) = REQUIRED];
-  // The ai assistant app top k.
+  // The AI assistant app top k.
   int32 top_k = 2 [(google.api.field_behavior) = REQUIRED];
-  // The ai assistant app conversation uid.
+  // The AI assistant app conversation uid.
   string conversation_uid = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
@@ -133,9 +131,9 @@ message UpdateAppRequest {
   string new_description = 4 [(google.api.field_behavior) = OPTIONAL];
   // The app tags.
   repeated string new_tags = 5 [(google.api.field_behavior) = OPTIONAL];
-  // last ai assistant app catalog uid
+  // last AI assistant app catalog uid
   string last_ai_assistant_app_catalog_uid = 6 [(google.api.field_behavior) = OPTIONAL];
-  // last ai assistant app top k
+  // last AI assistant app top k
   int32 last_ai_assistant_app_top_k = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -156,27 +154,23 @@ message DeleteAppRequest {
 // DeleteAppResponse represents a response for deleting a app.
 message DeleteAppResponse {}
 
-// UpdateAiAssistantAppPlaygroundRequest represents a request to update a ai assistant app playground.
-// after the update, the app's metadata will be updated with the last ai assistant app
-// uses catalog uid, top k, and conversation uid.
-// parameters:
-// - namespace_id: the namespace id.
-// - app_id: the app id.
-// - last_ai_app_catalog_uid: the last ai app catalog uid.
-// - last_ai_app_top_k: the last ai app top k.
-// - last_ai_app_conversation_uid: the last ai app conversation uid.
-message UpdateAiAssistantAppPlaygroundRequest {
+// UpdateAIAssistantAppPlaygroundRequest represents a request to update an AI
+// assistant app playground.
+// After the update, the app's metadata will be updated with the last AI
+// assistant app uses catalog UID, top k, and conversation UID.
+message UpdateAIAssistantAppPlaygroundRequest {
   // The namespace id.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // The app id.
   string app_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // The last ai app uses catalog uid.
+  // The last AI app uses catalog uid.
   string last_ai_app_catalog_uid = 3 [(google.api.field_behavior) = OPTIONAL];
-  // The last ai app uses top k.
+  // The last AI app uses top k.
   int32 last_ai_app_top_k = 4 [(google.api.field_behavior) = OPTIONAL];
-  // The last ai app uses conversation uid.
+  // The last AI app uses conversation uid.
   string last_ai_app_conversation_uid = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// UpdateAiAssistantAppPlaygroundResponse represents a response for updating a ai assistant app playground.
-message UpdateAiAssistantAppPlaygroundResponse {}
+// UpdateAIAssistantAppPlaygroundResponse represents a response for updating a
+// AI assistant app playground.
+message UpdateAIAssistantAppPlaygroundResponse {}

--- a/app/app/v1alpha/app_public_service.proto
+++ b/app/app/v1alpha/app_public_service.proto
@@ -76,12 +76,12 @@ service AppPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Conversation"};
   }
   // List conversations
   rpc ListConversations(ListConversationsRequest) returns (ListConversationsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Conversation"};
   }
   // Update a conversation
   rpc UpdateConversation(UpdateConversationRequest) returns (UpdateConversationResponse) {
@@ -89,12 +89,12 @@ service AppPublicService {
       put: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Conversation"};
   }
   // Delete a conversation
   rpc DeleteConversation(DeleteConversationRequest) returns (DeleteConversationResponse) {
     option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Conversation"};
   }
   // Create a message
   rpc CreateMessage(CreateMessageRequest) returns (CreateMessageResponse) {
@@ -102,12 +102,12 @@ service AppPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}/messages"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Message"};
   }
   // List messages
   rpc ListMessages(ListMessagesRequest) returns (ListMessagesResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}/messages"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Message"};
   }
   // Update a message
   rpc UpdateMessage(UpdateMessageRequest) returns (UpdateMessageResponse) {
@@ -115,15 +115,15 @@ service AppPublicService {
       put: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}/messages/{message_uid}"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Message"};
   }
   // Delete a message
   rpc DeleteMessage(DeleteMessageRequest) returns (DeleteMessageResponse) {
     option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}/messages/{message_uid}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Message"};
   }
-  // Update ai assistant app playground
-  rpc UpdateAiAssistantAppPlayground(UpdateAiAssistantAppPlaygroundRequest) returns (UpdateAiAssistantAppPlaygroundResponse) {
+  // Update AI assistant app playground
+  rpc UpdateAIAssistantAppPlayground(UpdateAIAssistantAppPlaygroundRequest) returns (UpdateAIAssistantAppPlaygroundResponse) {
     option (google.api.http) = {
       put: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/ai_assistant_playground"
       body: "*"

--- a/app/app/v1alpha/openapi.proto.templ
+++ b/app/app/v1alpha/openapi.proto.templ
@@ -8,13 +8,21 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
     title: "📱 App "
-    description: "App endpoints to manage app resources"
+    description: "App endpoints to manage ready-to-use AI applications"
 {{$info}}
   }
   tags: [
     {
       name: "App"
       description: "App endpoints"
+    },
+    {
+      name: "Conversation"
+      description: "Conversation endpoints"
+    },
+    {
+      name: "Message"
+      description: "Message endpoints"
     }
   ]
 {{$conf}}

--- a/openapiv2/app/service.swagger.yaml
+++ b/openapiv2/app/service.swagger.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   title: "\U0001F4F1 App "
-  description: App endpoints to manage app resources
+  description: App endpoints to manage ready-to-use AI applications
   version: v0.41.0-beta
   contact:
     name: Instill AI
@@ -13,6 +13,10 @@ info:
 tags:
   - name: App
     description: App endpoints
+  - name: Conversation
+    description: Conversation endpoints
+  - name: Message
+    description: Message endpoints
 host: api.instill.tech
 schemes:
   - https
@@ -192,7 +196,7 @@ paths:
           required: false
           type: boolean
       tags:
-        - App
+        - Conversation
     post:
       summary: Create a Conversation
       operationId: AppPublicService_CreateConversation
@@ -225,7 +229,7 @@ paths:
           schema:
             $ref: '#/definitions/AppPublicServiceCreateConversationBody'
       tags:
-        - App
+        - Conversation
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/conversations/{conversationId}:
     delete:
       summary: Delete a conversation
@@ -259,7 +263,7 @@ paths:
           required: true
           type: string
       tags:
-        - App
+        - Conversation
     put:
       summary: Update a conversation
       operationId: AppPublicService_UpdateConversation
@@ -297,7 +301,7 @@ paths:
           schema:
             $ref: '#/definitions/AppPublicServiceUpdateConversationBody'
       tags:
-        - App
+        - Conversation
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/conversations/{conversationId}/messages:
     get:
       summary: List messages
@@ -363,7 +367,7 @@ paths:
           required: false
           type: string
       tags:
-        - App
+        - Message
     post:
       summary: Create a message
       operationId: AppPublicService_CreateMessage
@@ -401,7 +405,7 @@ paths:
           schema:
             $ref: '#/definitions/AppPublicServiceCreateMessageBody'
       tags:
-        - App
+        - Message
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/conversations/{conversationId}/messages/{messageUid}:
     delete:
       summary: Delete a message
@@ -440,7 +444,7 @@ paths:
           required: true
           type: string
       tags:
-        - App
+        - Message
     put:
       summary: Update a message
       operationId: AppPublicService_UpdateMessage
@@ -483,16 +487,16 @@ paths:
           schema:
             $ref: '#/definitions/AppPublicServiceUpdateMessageBody'
       tags:
-        - App
+        - Message
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/ai_assistant_playground:
     put:
-      summary: Update ai assistant app playground
-      operationId: AppPublicService_UpdateAiAssistantAppPlayground
+      summary: Update AI assistant app playground
+      operationId: AppPublicService_UpdateAIAssistantAppPlayground
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaUpdateAiAssistantAppPlaygroundResponse'
+            $ref: '#/definitions/v1alphaUpdateAIAssistantAppPlaygroundResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -515,7 +519,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/AppPublicServiceUpdateAiAssistantAppPlaygroundBody'
+            $ref: '#/definitions/AppPublicServiceUpdateAIAssistantAppPlaygroundBody'
       tags:
         - App
 definitions:
@@ -566,29 +570,24 @@ definitions:
       - content
       - role
       - type
-  AppPublicServiceUpdateAiAssistantAppPlaygroundBody:
+  AppPublicServiceUpdateAIAssistantAppPlaygroundBody:
     type: object
     properties:
       lastAiAppCatalogUid:
         type: string
-        description: The last ai app uses catalog uid.
+        description: The last AI app uses catalog uid.
       lastAiAppTopK:
         type: integer
         format: int32
-        description: The last ai app uses top k.
+        description: The last AI app uses top k.
       lastAiAppConversationUid:
         type: string
-        description: The last ai app uses conversation uid.
+        description: The last AI app uses conversation uid.
     description: |-
-      UpdateAiAssistantAppPlaygroundRequest represents a request to update a ai assistant app playground.
-      after the update, the app's metadata will be updated with the last ai assistant app
-      uses catalog uid, top k, and conversation uid.
-      parameters:
-      - namespace_id: the namespace id.
-      - app_id: the app id.
-      - last_ai_app_catalog_uid: the last ai app catalog uid.
-      - last_ai_app_top_k: the last ai app top k.
-      - last_ai_app_conversation_uid: the last ai app conversation uid.
+      UpdateAIAssistantAppPlaygroundRequest represents a request to update an AI
+      assistant app playground.
+      After the update, the app's metadata will be updated with the last AI
+      assistant app uses catalog UID, top k, and conversation UID.
   AppPublicServiceUpdateAppBody:
     type: object
     properties:
@@ -605,11 +604,11 @@ definitions:
         description: The app tags.
       lastAiAssistantAppCatalogUid:
         type: string
-        title: last ai assistant app catalog uid
+        title: last AI assistant app catalog uid
       lastAiAssistantAppTopK:
         type: integer
         format: int32
-        title: last ai assistant app top k
+        title: last AI assistant app top k
     description: UpdateAppRequest represents a request to update a app.
   AppPublicServiceUpdateConversationBody:
     type: object
@@ -654,20 +653,20 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/protobufAny'
-  v1alphaAiAssistantAppMetadata:
+  v1alphaAIAssistantAppMetadata:
     type: object
     properties:
       catalogUid:
         type: string
-        description: The ai assistant app catalog uid.
+        description: The AI assistant app catalog uid.
       topK:
         type: integer
         format: int32
-        description: The ai assistant app top k.
+        description: The AI assistant app top k.
       conversationUid:
         type: string
-        description: The ai assistant app conversation uid.
-    description: AiAssistantAppMetadata represents the metadata for the ai assistant app.
+        description: The AI assistant app conversation uid.
+    description: AIAssistantAppMetadata represents the metadata for the AI assistant app.
     required:
       - catalogUid
       - topK
@@ -701,10 +700,10 @@ definitions:
           type: string
         description: The app tags.
       aiAssistantApp:
-        description: The ai assistant app metadata.
+        description: The AI assistant app metadata.
         readOnly: true
         allOf:
-          - $ref: '#/definitions/v1alphaAiAssistantAppMetadata'
+          - $ref: '#/definitions/v1alphaAIAssistantAppMetadata'
       appType:
         description: The app type.
         readOnly: true
@@ -919,9 +918,11 @@ definitions:
     description: |-
       MessageSenderProfile describes the public data of a message sender.
       refer to core.mgmt.v1beta.UserProfile for more details.
-  v1alphaUpdateAiAssistantAppPlaygroundResponse:
+  v1alphaUpdateAIAssistantAppPlaygroundResponse:
     type: object
-    description: UpdateAiAssistantAppPlaygroundResponse represents a response for updating a ai assistant app playground.
+    description: |-
+      UpdateAIAssistantAppPlaygroundResponse represents a response for updating a
+      AI assistant app playground.
   v1alphaUpdateAppResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- App service API will be public and needs to be part of the CI step syncing the OpenAPI files with readme.com
- The old staging version had duplicated Artifact API references and they couldn't be erased from the readme.com UI. A new staging version was created, which contains new IDs

This commit

- Improves App documentation
- Removes unnecessary step in OpenAPI sync CI.
- Updates staging API reference IDs.
- Adds App API reference to the public and private docs at readme.com
