### PR TITLE
feat(catalog): list chunks by uid

### DIFF
--- a/app/app/v1alpha/app.proto
+++ b/app/app/v1alpha/app.proto
@@ -121,19 +121,24 @@ message ListAppsResponse {
 
 // UpdateAppRequest represents a request to update a app.
 message UpdateAppRequest {
-  // namespace id
+  // Namespace id.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // app id
+  // App id.
   string app_id = 2 [(google.api.field_behavior) = REQUIRED];
   // The app id needs to follow the kebab case format.
+  // if the new app id is not provided, the app id will not be updated.
   string new_app_id = 3 [(google.api.field_behavior) = OPTIONAL];
   // The app description.
+  // If the new description is empty, the description will be set to empty.
   string new_description = 4 [(google.api.field_behavior) = OPTIONAL];
   // The app tags.
+  // If the new tags is empty, the tags will be set to empty.
   repeated string new_tags = 5 [(google.api.field_behavior) = OPTIONAL];
   // last AI assistant app catalog uid
+  // If the last AI assistant app catalog uid is empty, the last AI assistant app catalog uid will be set to empty.
   string last_ai_assistant_app_catalog_uid = 6 [(google.api.field_behavior) = OPTIONAL];
   // last AI assistant app top k
+  // If the last AI assistant app top k is empty, the last AI assistant app top k will be set to empty.
   int32 last_ai_assistant_app_top_k = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -167,8 +172,6 @@ message UpdateAIAssistantAppPlaygroundRequest {
   string last_ai_app_catalog_uid = 3 [(google.api.field_behavior) = OPTIONAL];
   // The last AI app uses top k.
   int32 last_ai_app_top_k = 4 [(google.api.field_behavior) = OPTIONAL];
-  // The last AI app uses conversation uid.
-  string last_ai_app_conversation_uid = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // UpdateAIAssistantAppPlaygroundResponse represents a response for updating a

--- a/app/app/v1alpha/app_public_service.proto
+++ b/app/app/v1alpha/app_public_service.proto
@@ -40,7 +40,7 @@ service AppPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // Create a App
+  // Create a app
   rpc CreateApp(CreateAppRequest) returns (CreateAppResponse) {
     option (google.api.http) = {
       post: "/v1alpha/namespaces/{namespace_id}/apps"
@@ -49,7 +49,7 @@ service AppPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};
   }
 
-  // Get all apps info
+  // List all apps info
   rpc ListApps(ListAppsRequest) returns (ListAppsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/apps"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "App"};

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -24,6 +24,9 @@ message Chunk {
 }
 
 // The ListChunksRequest message represents a request to list chunks in the artifact system.
+// 
+// The response will be a list of chunks based on the request, i.e., response will 
+// have chunks of the file with file_uid and chunks specified in chunk_uids.
 message ListChunksRequest {
   // owner/namespace id (not uid)
   string namespace_id = 1;
@@ -31,6 +34,8 @@ message ListChunksRequest {
   string catalog_id = 2;
   // unique identifier of the file
   string file_uid = 3;
+  // repeated chunk uid
+  repeated string chunk_uids = 4;
 }
 
 // The ListChunksResponse message represents a response containing a list of chunks in the artifact system.

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -24,8 +24,7 @@ message Chunk {
 }
 
 // The ListChunksRequest message represents a request to list chunks in the artifact system.
-// 
-// The response will be a list of chunks based on the request, i.e., response will 
+// The response will be a list of chunks based on the request, i.e., response will
 // have chunks of the file with file_uid and chunks specified in chunk_uids.
 message ListChunksRequest {
   // owner/namespace id (not uid)

--- a/openapiv2/app/service.swagger.yaml
+++ b/openapiv2/app/service.swagger.yaml
@@ -30,7 +30,7 @@ produces:
 paths:
   /v1alpha/namespaces/{namespaceId}/apps:
     get:
-      summary: Get all apps info
+      summary: List all apps info
       operationId: AppPublicService_ListApps
       responses:
         "200":
@@ -53,7 +53,7 @@ paths:
       tags:
         - App
     post:
-      summary: Create a App
+      summary: Create a app
       operationId: AppPublicService_CreateApp
       responses:
         "200":
@@ -126,12 +126,12 @@ paths:
             $ref: '#/definitions/rpcStatus'
       parameters:
         - name: namespaceId
-          description: namespace id
+          description: Namespace id.
           in: path
           required: true
           type: string
         - name: appId
-          description: app id
+          description: App id.
           in: path
           required: true
           type: string
@@ -644,9 +644,6 @@ definitions:
         type: integer
         format: int32
         description: The last AI app uses top k.
-      lastAiAppConversationUid:
-        type: string
-        description: The last AI app uses conversation uid.
     description: |-
       UpdateAIAssistantAppPlaygroundRequest represents a request to update an AI
       assistant app playground.
@@ -657,22 +654,32 @@ definitions:
     properties:
       newAppId:
         type: string
-        description: The app id needs to follow the kebab case format.
+        description: |-
+          The app id needs to follow the kebab case format.
+          if the new app id is not provided, the app id will not be updated.
       newDescription:
         type: string
-        description: The app description.
+        description: |-
+          The app description.
+          If the new description is empty, the description will be set to empty.
       newTags:
         type: array
         items:
           type: string
-        description: The app tags.
+        description: |-
+          The app tags.
+          If the new tags is empty, the tags will be set to empty.
       lastAiAssistantAppCatalogUid:
         type: string
-        title: last AI assistant app catalog uid
+        description: |-
+          last AI assistant app catalog uid
+          If the last AI assistant app catalog uid is empty, the last AI assistant app catalog uid will be set to empty.
       lastAiAssistantAppTopK:
         type: integer
         format: int32
-        title: last AI assistant app top k
+        description: |-
+          last AI assistant app top k
+          If the last AI assistant app top k is empty, the last AI assistant app top k will be set to empty.
     description: UpdateAppRequest represents a request to update a app.
   AppPublicServiceUpdateConversationBody:
     type: object

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -341,6 +341,14 @@ paths:
           in: query
           required: false
           type: string
+        - name: chunkUids
+          description: repeated chunk uid
+          in: query
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
       tags:
         - Catalog
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/files/{fileUid}/source:


### PR DESCRIPTION
Because

1.  app will not be bound to only one conversation
2. FE needs to fetch chunks by uid
3. update app comment lack informative

This commit

1. remove the `last_ai_app_conversation_uid`
2. add chunk_uids in list chunk apis
3. add more info in update app request
