### PR TITLE
feat(artifact): rename SimilarityChunksSearch to ViewChunks

### DIFF
--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -133,8 +133,8 @@ service ArtifactPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Catalog"};
   }
 
-  // Retrieve similar chunks
-  rpc SimilarityChunksSearch(SimilarityChunksSearchRequest) returns (SimilarityChunksSearchResponse) {
+  // View similar chunks
+  rpc ViewChunks(ViewChunksRequest) returns (ViewChunksResponse) {
     option (google.api.http) = {
       post: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/chunks/retrieve"
       body: "*"

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -85,8 +85,8 @@ message UpdateChunkResponse {
   Chunk chunk = 1;
 }
 
-// Similar chunk search request
-message SimilarityChunksSearchRequest {
+// View chunks request
+message ViewChunksRequest {
   // owner/namespace id
   string namespace_id = 1;
   // catalog id
@@ -97,8 +97,8 @@ message SimilarityChunksSearchRequest {
   uint32 top_k = 4;
 }
 
-// Similar chunk search response
-message SimilarityChunksSearchResponse {
+// View chunks response
+message ViewChunksResponse {
   // chunks
   repeated SimilarityChunk similar_chunks = 1;
 }

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -416,13 +416,13 @@ paths:
         - Catalog
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/chunks/retrieve:
     post:
-      summary: Retrieve similar chunks
-      operationId: ArtifactPublicService_SimilarityChunksSearch
+      summary: View similar chunks
+      operationId: ArtifactPublicService_ViewChunks
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaSimilarityChunksSearchResponse'
+            $ref: '#/definitions/v1alphaViewChunksResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -445,7 +445,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/ArtifactPublicServiceSimilarityChunksSearchBody'
+            $ref: '#/definitions/ArtifactPublicServiceViewChunksBody'
         - name: Instill-Requester-Uid
           description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
           in: header
@@ -577,17 +577,6 @@ definitions:
         format: int32
         title: top k default to 5
     title: QuestionAnsweringRequest
-  ArtifactPublicServiceSimilarityChunksSearchBody:
-    type: object
-    properties:
-      textPrompt:
-        type: string
-        title: text prompt
-      topK:
-        type: integer
-        format: int64
-        title: top k
-    title: Similar chunk search request
   ArtifactPublicServiceUpdateCatalogBody:
     type: object
     properties:
@@ -607,6 +596,17 @@ definitions:
         type: boolean
         title: whether the chunk is retrievable
     title: Create chunk response
+  ArtifactPublicServiceViewChunksBody:
+    type: object
+    properties:
+      textPrompt:
+        type: string
+        title: text prompt
+      topK:
+        type: integer
+        format: int64
+        title: top k
+    title: View chunks request
   GetFileCatalogResponseChunkType:
     type: string
     enum:
@@ -1313,16 +1313,6 @@ definitions:
         type: string
         title: source file
     title: similarity chunks
-  v1alphaSimilarityChunksSearchResponse:
-    type: object
-    properties:
-      similarChunks:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1alphaSimilarityChunk'
-        title: chunks
-    title: Similar chunk search response
   v1alphaSourceFile:
     type: object
     properties:
@@ -1365,6 +1355,16 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1alphaFile'
     title: upload file response
+  v1alphaViewChunksResponse:
+    type: object
+    properties:
+      similarChunks:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaSimilarityChunk'
+        title: chunks
+    title: View chunks response
 securityDefinitions:
   Bearer:
     type: apiKey


### PR DESCRIPTION
Because

- Python SDK artifact_client functions, and the documentation should be consistent to ensure clarity and ease of use.

This commit

- rename SimilarityChunksSearch to ViewChunks
