### PR TITLE
fix(buf): remove protoc-gen-validate

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -6,8 +6,6 @@ managed:
       module: buf.build/googleapis/googleapis
     - file_option: go_package
       module: buf.build/grpc-ecosystem/grpc-gateway
-    - file_option: go_package
-      module: buf.build/envoyproxy/protoc-gen-validate
   override:
     - file_option: go_package_prefix
       value: github.com/instill-ai/protogen-go
@@ -20,9 +18,6 @@ plugins:
     out: gen/python
   - remote: buf.build/community/nipunn1313-mypy-grpc:v3.5.0
     out: gen/python
-  - remote: buf.build/bufbuild/validate-go
-    out: gen/go
-    opt: paths=source_relative
   - remote: buf.build/protocolbuffers/go:v1.30.0
     out: gen/go
     opt: paths=source_relative

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -8,8 +8,6 @@ import "google/api/field_behavior.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-// protoc-gen-validate message validators
-import "validate/validate.proto";
 // VDP definitions
 import "vdp/pipeline/v1beta/common.proto";
 
@@ -28,13 +26,7 @@ message Connection {
     METHOD_OAUTH = 2;
   }
   // UUID-formatted unique identifier.
-  string uid = 1 [
-    (validate.rules).string = {
-      ignore_empty: true
-      uuid: true
-    },
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // ID.
   string id = 2 [(google.api.field_behavior) = REQUIRED];
   // ID of the namespace owning the connection.
@@ -203,26 +195,17 @@ message Integration {
   message OAuthConfig {
     // The URL of the OAuth server to initiate the authentication and
     // authorization process.
-    string auth_url = 1 [
-      (validate.rules).string.uri = true,
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
+    string auth_url = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
     // The URL of the OAuth server to exchange the authorization code for an
     // access token.
-    string access_url = 2 [
-      (validate.rules).string.uri = true,
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
+    string access_url = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
     // A list of scopes that identify the resources that the connection will be
     // able to access on the user's behalf.
     repeated string scopes = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
 
   // UUID-formatted unique identifier. It references a component definition.
-  string uid = 1 [
-    (validate.rules).string.uuid = true,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Identifier of the integration, which references a component definition.
   // Components with that definition ID will be able to use the connections
   // produced by this integration.


### PR DESCRIPTION
Because

- protoc-gen-validate does not fully support as buf plugin for generating python code

This commit

- remove protoc-gen-validate
