### PR TITLE
chore(app): add optional to top_k

### DIFF
--- a/app/app/v1alpha/conversation.proto
+++ b/app/app/v1alpha/conversation.proto
@@ -249,7 +249,7 @@ message ChatRequest {
   // User message
   string message = 5 [(google.api.field_behavior) = REQUIRED];
   // top k, defaults to 5
-  uint32 top_k = 6;
+  optional uint32 top_k = 6;
 }
 
 // ChatResponse contains the chatbot response.


### PR DESCRIPTION
Because

- chat endpoint `top_k` should be optional

This commit

- add optional to top_k
