### PR TITLE
feat(artifact): add more chunk info in response

### DIFF
--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -111,6 +111,8 @@ message SimilarityChunk {
   float similarity_score = 2;
   // content
   string text_content = 3;
-  // source file
+  // source file's name
   string source_file = 4;
+  // chunk
+  Chunk chunk_meta = 5;
 }

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -114,5 +114,5 @@ message SimilarityChunk {
   // source file's name
   string source_file = 4;
   // chunk
-  Chunk chunk_meta = 5;
+  Chunk chunk_metadata = 5;
 }

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -33,7 +33,7 @@ message ListChunksRequest {
   string catalog_id = 2;
   // unique identifier of the file
   string file_uid = 3;
-  // repeated chunk uid
+  // repeated chunk uid(not implemented yet)
   repeated string chunk_uids = 4;
 }
 

--- a/openapiv2/app/service.swagger.yaml
+++ b/openapiv2/app/service.swagger.yaml
@@ -886,6 +886,35 @@ definitions:
         title: Reference chunks
         readOnly: true
     description: ChatResponse contains the chatbot response.
+  v1alphaChunk:
+    type: object
+    properties:
+      chunkUid:
+        type: string
+        title: unique identifier of the chunk
+      retrievable:
+        type: boolean
+        title: whether the chunk is retrievable
+      startPos:
+        type: integer
+        format: int64
+        title: start position of the chunk in the source file
+      endPos:
+        type: integer
+        format: int64
+        title: end position of the chunk in the source file
+      tokens:
+        type: integer
+        format: int64
+        title: tokens of the chunk
+      createTime:
+        type: string
+        format: date-time
+        title: creation time of the chunk
+      originalFileUid:
+        type: string
+        title: original file unique identifier
+    description: The Chunk message represents a chunk of data in the artifact system.
   v1alphaConversation:
     type: object
     properties:
@@ -1109,7 +1138,11 @@ definitions:
         title: content
       sourceFile:
         type: string
-        title: source file
+        title: source file's name
+      chunkMeta:
+        title: chunk
+        allOf:
+          - $ref: '#/definitions/v1alphaChunk'
     title: similarity chunks
   v1alphaUpdateAIAssistantAppPlaygroundResponse:
     type: object

--- a/openapiv2/app/service.swagger.yaml
+++ b/openapiv2/app/service.swagger.yaml
@@ -1139,7 +1139,7 @@ definitions:
       sourceFile:
         type: string
         title: source file's name
-      chunkMeta:
+      chunkMetadata:
         title: chunk
         allOf:
           - $ref: '#/definitions/v1alphaChunk'

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -342,7 +342,7 @@ paths:
           required: false
           type: string
         - name: chunkUids
-          description: repeated chunk uid
+          description: repeated chunk uid(not implemented yet)
           in: query
           required: false
           type: array
@@ -1312,7 +1312,7 @@ definitions:
       sourceFile:
         type: string
         title: source file's name
-      chunkMeta:
+      chunkMetadata:
         title: chunk
         allOf:
           - $ref: '#/definitions/artifactv1alphaChunk'

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -1311,7 +1311,11 @@ definitions:
         title: content
       sourceFile:
         type: string
-        title: source file
+        title: source file's name
+      chunkMeta:
+        title: chunk
+        allOf:
+          - $ref: '#/definitions/artifactv1alphaChunk'
     title: similarity chunks
   v1alphaSimilarityChunksSearchResponse:
     type: object


### PR DESCRIPTION
Because

we'd like to provide as much as possible information about chunk

This commit

add chunk meta data in response
