### PR TITLE
feat(app): add topk and catalog in conv message

### DIFF
--- a/app/app/v1alpha/conversation.proto
+++ b/app/app/v1alpha/conversation.proto
@@ -20,10 +20,14 @@ message Conversation {
   string app_id = 3 [(google.api.field_behavior) = REQUIRED];
   // conversation id/name
   string id = 4 [(google.api.field_behavior) = REQUIRED];
+  // last used catalog uid
+  optional string last_used_catalog_uid = 5 [(google.api.field_behavior) = OPTIONAL];
+  // last used top k
+  optional uint32 last_used_top_k = 6 [(google.api.field_behavior) = OPTIONAL];
   // creation time of the conversation
-  google.protobuf.Timestamp create_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Timestamp create_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
   // update time of the conversation
-  google.protobuf.Timestamp update_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Timestamp update_time = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Message represents a single message in a conversation
@@ -109,7 +113,11 @@ message UpdateConversationRequest {
   // conversation id
   string conversation_id = 3 [(google.api.field_behavior) = REQUIRED];
   // new conversation id
-  string new_conversation_id = 4 [(google.api.field_behavior) = REQUIRED];
+  optional string new_conversation_id = 4 [(google.api.field_behavior) = OPTIONAL];
+  // last used catalog uid
+  optional string last_used_catalog_uid = 5 [(google.api.field_behavior) = OPTIONAL];
+  // last used top k
+  optional uint32 last_used_top_k = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // UpdateConversationResponse returns the updated conversation

--- a/openapiv2/app/service.swagger.yaml
+++ b/openapiv2/app/service.swagger.yaml
@@ -748,9 +748,14 @@ definitions:
       newConversationId:
         type: string
         title: new conversation id
+      lastUsedCatalogUid:
+        type: string
+        title: last used catalog uid
+      lastUsedTopK:
+        type: integer
+        format: int64
+        title: last used top k
     title: UpdateConversationRequest is used to update a conversation
-    required:
-      - newConversationId
   AppPublicServiceUpdateMessageBody:
     type: object
     properties:
@@ -925,6 +930,13 @@ definitions:
       id:
         type: string
         title: conversation id/name
+      lastUsedCatalogUid:
+        type: string
+        title: last used catalog uid
+      lastUsedTopK:
+        type: integer
+        format: int64
+        title: last used top k
       createTime:
         type: string
         format: date-time


### PR DESCRIPTION
Because

FE needs to restore the last chosen catalog and top K.

This commit

adds the corresponding data in message.