### PR TITLE
fix(vdp): the type of `total_size` is wrong

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -3112,8 +3112,8 @@ definitions:
         description: The list of component runs.
         readOnly: true
       totalSize:
-        type: string
-        format: int64
+        type: integer
+        format: int32
         description: The total number of component runs matching the request.
         readOnly: true
       page:
@@ -3278,8 +3278,8 @@ definitions:
         description: The list of pipeline runs.
         readOnly: true
       totalSize:
-        type: string
-        format: int64
+        type: integer
+        format: int32
         description: The total number of pipeline runs matching the request.
         readOnly: true
       page:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1990,7 +1990,7 @@ message ListPipelineRunsResponse {
   repeated PipelineRun pipeline_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The total number of pipeline runs matching the request.
-  int64 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  int32 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The current page number.
   int32 page = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -2029,7 +2029,7 @@ message ListComponentRunsResponse {
   repeated ComponentRun component_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The total number of component runs matching the request.
-  int64 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  int32 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The current page number.
   int32 page = 3 [(google.api.field_behavior) = OUTPUT_ONLY];


### PR DESCRIPTION
Because

- We initially used `int64` for `total_size`, but it gets converted to a string when using `grpc-gateway`, which is not ideal.

This commit

- changes the `total_size` type to `int32` to ensure better compatibility with `grpc-gateway` and JSON formatting.