### PR TITLE
chore(vdp): remove inputs_reference and outputs_reference from PipelineRun message

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
   - repo: https://github.com/bufbuild/buf.git
-    rev: v1.35.0
+    rev: v1.43.0
     hooks:
       - id: buf-generate
   - repo: local
@@ -22,7 +22,7 @@ repos:
         entry: make openapi
         language: system
   - repo: https://github.com/bufbuild/buf.git
-    rev: v1.35.0
+    rev: v1.43.0
     hooks:
       - id: buf-format
       - id: buf-lint

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -3656,25 +3656,11 @@ definitions:
         type: string
         description: Runner ID. If current viewing requester does not have enough permission, it will return null.
         readOnly: true
-      inputsReference:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaFileReference'
-        description: Input files for the run.
-        readOnly: true
       inputs:
         type: array
         items:
           type: object
         description: Pipeline input parameters.
-        readOnly: true
-      outputsReference:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1betaFileReference'
-        description: Output files from the run.
         readOnly: true
       outputs:
         type: array

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -2082,16 +2082,18 @@ message PipelineRun {
     (google.api.field_behavior) = OPTIONAL
   ];
 
-  // Input files for the run.
-  repeated FileReference inputs_reference = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reversed for `inputs_reference`
+  reserved 9;
+
   // Pipeline input parameters.
   repeated google.protobuf.Struct inputs = 10 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
 
-  // Output files from the run.
-  repeated FileReference outputs_reference = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reversed for `outputs_reference`
+  reserved 11;
+
   // Pipeline inference outputs.
   repeated google.protobuf.Struct outputs = 12 [
     (google.api.field_behavior) = OUTPUT_ONLY,


### PR DESCRIPTION
Because

- The `inputs_reference` and `outputs_reference` data are not accessible to users.

This commit

- removes `inputs_reference` and `outputs_reference` from the `PipelineRun` message.