### PR TITLE
fix(integration): correct integrationId filter documentation

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1453,9 +1453,7 @@ paths:
           required: true
           type: string
         - name: pageSize
-          description: |-
-            The maximum number of items to return. The default and cap values are 10
-            and 100, respectively.
+          description: The maximum number of items to return. The default and cap values are 10 and 100, respectively.
           in: query
           required: false
           type: integer
@@ -1467,16 +1465,14 @@ paths:
           type: string
         - name: filter
           description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
             The following filters are supported:
             - `integrationId`
             - `qConnection` (fuzzy search on connection ID, integration title or vendor)
-            Examples:
-            - List connections where app name, vendor or connection ID match `googl`:
-            `q="googl"`.
-            - List connections where the component type is `openai` (e.g. to setup a
-            connector within a pipeline): `integrationId="openai"`.
+
+            **Examples**:
+            - List connections where app name, vendor or connection ID match `googl`: `q="googl"`.
+            - List connections where the component type is `openai` (e.g. to setup a connector within a pipeline): `integrationId="openai"`.
           in: query
           required: false
           type: string
@@ -1839,9 +1835,7 @@ paths:
           required: true
           type: string
         - name: pageSize
-          description: |-
-            The maximum number of items to return. The default and cap values are 10
-            and 100, respectively.
+          description: The maximum number of items to return. The default and cap values are 10 and 100, respectively.
           in: query
           required: false
           type: integer
@@ -1853,8 +1847,7 @@ paths:
           type: string
         - name: filter
           description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
             The following filters are supported:
             - `q` (fuzzy search on pipeline ID)
           in: query
@@ -1881,9 +1874,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: pageSize
-          description: |-
-            The maximum number of items to return. The default and cap values are 10
-            and 100, respectively.
+          description: The maximum number of items to return. The default and cap values are 10 and 100, respectively.
           in: query
           required: false
           type: integer
@@ -1895,11 +1886,11 @@ paths:
           type: string
         - name: filter
           description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
             The following filters are supported:
             - `qIntegration` (fuzzy search on title or vendor)
-            Examples:
+
+            **Examples**:
             - List integrations where app name or vendor match `googl`: `q="googl"`.
           in: query
           required: false

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1476,7 +1476,7 @@ paths:
             - List connections where app name, vendor or connection ID match `googl`:
             `q="googl"`.
             - List connections where the component type is `openai` (e.g. to setup a
-            connector within a pipeline): `integration_id="openai"`.
+            connector within a pipeline): `integrationId="openai"`.
           in: query
           required: false
           type: string

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -90,7 +90,7 @@ message ListNamespaceConnectionsRequest {
   // - List connections where app name, vendor or connection ID match `googl`:
   // `q="googl"`.
   // - List connections where the component type is `openai` (e.g. to setup a
-  // connector within a pipeline): `integration_id="openai"`.
+  // connector within a pipeline): `integrationId="openai"`.
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -76,22 +76,18 @@ message Connection {
 message ListNamespaceConnectionsRequest {
   // Namespace ID.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // The maximum number of items to return. The default and cap values are 10
-  // and 100, respectively.
+  // The maximum number of items to return. The default and cap values are 10 and 100, respectively.
   optional int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
   // Page token. By default, the first page will be returned.
   optional string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
   // The following filters are supported:
   // - `integrationId`
   // - `qConnection` (fuzzy search on connection ID, integration title or vendor)
   //
   // **Examples**:
-  // - List connections where app name, vendor or connection ID match `googl`:
-  // `q="googl"`.
-  // - List connections where the component type is `openai` (e.g. to setup a
-  // connector within a pipeline): `integrationId="openai"`.
+  // - List connections where app name, vendor or connection ID match `googl`: `q="googl"`.
+  // - List connections where the component type is `openai` (e.g. to setup a connector within a pipeline): `integrationId="openai"`.
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -272,13 +268,11 @@ message ListPipelineIDsByConnectionIDRequest {
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Connection ID.
   string connection_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // The maximum number of items to return. The default and cap values are 10
-  // and 100, respectively.
+  // The maximum number of items to return. The default and cap values are 10 and 100, respectively.
   optional int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
   // Page token. By default, the first page will be returned.
   optional string page_token = 4 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
   // The following filters are supported:
   // - `q` (fuzzy search on pipeline ID)
   optional string filter = 5 [(google.api.field_behavior) = OPTIONAL];
@@ -297,13 +291,11 @@ message ListPipelineIDsByConnectionIDResponse {
 // ListIntegrationsRequest represents a request to list the available
 // integrations.
 message ListIntegrationsRequest {
-  // The maximum number of items to return. The default and cap values are 10
-  // and 100, respectively.
+  // The maximum number of items to return. The default and cap values are 10 and 100, respectively.
   optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page token. By default, the first page will be returned.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
   // The following filters are supported:
   // - `qIntegration` (fuzzy search on title or vendor)
   //

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -86,7 +86,8 @@ message ListNamespaceConnectionsRequest {
   // The following filters are supported:
   // - `integrationId`
   // - `qConnection` (fuzzy search on connection ID, integration title or vendor)
-  // Examples:
+  //
+  // **Examples**:
   // - List connections where app name, vendor or connection ID match `googl`:
   // `q="googl"`.
   // - List connections where the component type is `openai` (e.g. to setup a
@@ -305,7 +306,8 @@ message ListIntegrationsRequest {
   // expression.
   // The following filters are supported:
   // - `qIntegration` (fuzzy search on title or vendor)
-  // Examples:
+  //
+  // **Examples**:
   // - List integrations where app name or vendor match `googl`: `q="googl"`.
   optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
 }


### PR DESCRIPTION
Because

- Example in this filter param contains the old `snake_case` format.

This commit

- Update documentation with a correct example.

