### PR TITLE
chore(integration): add identity to OAuth connection

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1618,6 +1618,12 @@ paths:
                   able to access on the user's behalf. This is typically passed on creation
                   when the setup has been generated through an OAuth flow with a limited set
                   of scopes.
+              identity:
+                type: string
+                description: |-
+                  When the connection method is METHOD_OAUTH, this field will hold the
+                  identity (e.g., email, username) with which the access token has been
+                  generated.
               oAuthAccessDetails:
                 type: object
                 description: |-
@@ -1729,6 +1735,12 @@ paths:
                   able to access on the user's behalf. This is typically passed on creation
                   when the setup has been generated through an OAuth flow with a limited set
                   of scopes.
+              identity:
+                type: string
+                description: |-
+                  When the connection method is METHOD_OAUTH, this field will hold the
+                  identity (e.g., email, username) with which the access token has been
+                  generated.
               oAuthAccessDetails:
                 type: object
                 description: |-
@@ -2799,6 +2811,12 @@ definitions:
           able to access on the user's behalf. This is typically passed on creation
           when the setup has been generated through an OAuth flow with a limited set
           of scopes.
+      identity:
+        type: string
+        description: |-
+          When the connection method is METHOD_OAUTH, this field will hold the
+          identity (e.g., email, username) with which the access token has been
+          generated.
       oAuthAccessDetails:
         type: object
         description: |-

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -55,6 +55,10 @@ message Connection {
   // when the setup has been generated through an OAuth flow with a limited set
   // of scopes.
   repeated string scopes = 11 [(google.api.field_behavior) = OPTIONAL];
+  // When the connection method is METHOD_OAUTH, this field will hold the
+  // identity (e.g., email, username) with which the access token has been
+  // generated.
+  optional string identity = 13 [(google.api.field_behavior) = OPTIONAL];
   // When the connection method is METHOD_OAUTH, the access token might come
   // with some extra information that might vary across vendors. This
   // information is passed as connection metadata.


### PR DESCRIPTION
Because

- When a user authorizes an Instill component using OAuth, we want to
  display the identity that they used.

This commit

- Add identity field to OAuth connections.
