### PR TITLE
refactor(vdp): refactor params in Clone API

### DIFF
--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -2086,13 +2086,6 @@ definitions:
   PipelinePublicServiceCloneNamespacePipelineBody:
     type: object
     properties:
-      target:
-        type: string
-        title: |-
-          The target pipeline. It can be under a user or an organization
-          namespace, so the following formats are accepted:
-          - `{user.id}/{pipeline.id}`
-          - `{organization.id}/{pipeline.id}`
       description:
         type: string
         description: Pipeline description.
@@ -2100,21 +2093,21 @@ definitions:
         description: Pipeline sharing information.
         allOf:
           - $ref: '#/definitions/v1betaSharing'
+      targetNamespaceId:
+        type: string
+        description: Target Namespace ID.
+      targetPipelineId:
+        type: string
+        description: Target Pipeline ID.
     description: |-
       CloneNamespacePipelineRequest represents a request to clone a pipeline owned by a
       user.
     required:
-      - target
+      - targetNamespaceId
+      - targetPipelineId
   PipelinePublicServiceCloneNamespacePipelineReleaseBody:
     type: object
     properties:
-      target:
-        type: string
-        title: |-
-          The target pipeline. It can be under a user or an organization
-          namespace, so the following formats are accepted:
-          - `{user.id}/{pipeline.id}`
-          - `{organization.id}/{pipeline.id}`
       description:
         type: string
         description: Pipeline description.
@@ -2122,11 +2115,18 @@ definitions:
         description: Pipeline sharing information.
         allOf:
           - $ref: '#/definitions/v1betaSharing'
+      targetNamespaceId:
+        type: string
+        description: Target Namespace ID.
+      targetPipelineId:
+        type: string
+        description: Target Pipeline ID.
     description: |-
       CloneNamespacePipelineReleaseRequest represents a request to clone a pipeline
       release owned by a user.
     required:
-      - target
+      - targetNamespaceId
+      - targetPipelineId
   PipelinePublicServiceRenameNamespacePipelineBody:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -450,18 +450,20 @@ message RenameNamespacePipelineResponse {
 message CloneNamespacePipelineRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-
   // Pipeline ID
   string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // The target pipeline. It can be under a user or an organization
-  // namespace, so the following formats are accepted:
-  // - `{user.id}/{pipeline.id}`
-  // - `{organization.id}/{pipeline.id}`
-  string target = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // Deprecated `target` field
+  reserved 3;
+
   // Pipeline description.
   string description = 4 [(google.api.field_behavior) = OPTIONAL];
   // Pipeline sharing information.
   Sharing sharing = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Target Namespace ID.
+  string target_namespace_id = 6 [(google.api.field_behavior) = REQUIRED];
+  // Target Pipeline ID.
+  string target_pipeline_id = 7 [(google.api.field_behavior) = REQUIRED];
 }
 
 // CloneNamespacePipelineResponse contains a cloned pipeline.
@@ -472,22 +474,22 @@ message CloneNamespacePipelineResponse {}
 message CloneNamespacePipelineReleaseRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-
   // Pipeline ID
   string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
-
   // Release ID
   string release_id = 3 [(google.api.field_behavior) = REQUIRED];
 
-  // The target pipeline. It can be under a user or an organization
-  // namespace, so the following formats are accepted:
-  // - `{user.id}/{pipeline.id}`
-  // - `{organization.id}/{pipeline.id}`
-  string target = 4 [(google.api.field_behavior) = REQUIRED];
+  // Deprecated `target` field
+  reserved 4;
+
   // Pipeline description.
   string description = 5 [(google.api.field_behavior) = OPTIONAL];
   // Pipeline sharing information.
   Sharing sharing = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Target Namespace ID.
+  string target_namespace_id = 7 [(google.api.field_behavior) = REQUIRED];
+  // Target Pipeline ID.
+  string target_pipeline_id = 8 [(google.api.field_behavior) = REQUIRED];
 }
 
 // CloneNamespacePipelineReleaseResponse contains a cloned pipeline.
@@ -956,59 +958,6 @@ message RenameUserPipelineResponse {
   // The renamed pipeline resource.
   Pipeline pipeline = 1;
 }
-
-// CloneUserPipelineRequest represents a request to clone a pipeline owned by a
-// user.
-message CloneUserPipelineRequest {
-  // The resource name of the pipeline, which allows its access by parent user
-  // and ID.
-  // - Format: `users/{user.id}/pipelines/{pipeline.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_name"}
-    }
-  ];
-  // The target pipeline. It can be under a user or an organization
-  // namespace, so the following formats are accepted:
-  // - `{user.id}/{pipeline.id}`
-  // - `{organization.id}/{pipeline.id}`
-  string target = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline description.
-  string description = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Pipeline sharing information.
-  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// CloneUserPipelineResponse contains a cloned pipeline.
-message CloneUserPipelineResponse {}
-
-// CloneUserPipelineReleaseRequest represents a request to clone a pipeline
-// release owned by a user.
-message CloneUserPipelineReleaseRequest {
-  // The resource name of the pipeline release.
-  // - Format: `users/{user.id}/pipelines/{pipeline.id}/releases/{version}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "user_pipeline_release_name"}
-    }
-  ];
-  // The target pipeline. It can be under a user or an organization
-  // namespace, so the following formats are accepted:
-  // - `{user.id}/{pipeline.id}`
-  // - `{organization.id}/{pipeline.id}`
-  string target = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline description.
-  string description = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Pipeline sharing information.
-  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// CloneUserPipelineReleaseResponse contains a cloned pipeline.
-message CloneUserPipelineReleaseResponse {}
 
 // TriggerUserPipelineRequest represents a request to trigger a user-owned
 // pipeline synchronously.
@@ -1493,59 +1442,6 @@ message RenameOrganizationPipelineResponse {
   // The renamed pipeline resource.
   Pipeline pipeline = 1;
 }
-
-// CloneOrganizationPipelineRequest represents a request to clone a pipeline
-// owned by an organization.
-message CloneOrganizationPipelineRequest {
-  // The resource name of the pipeline, which allows its access by parent
-  // organization and ID.
-  // - Format: `organizations/{organization.id}/pipelines/{pipeline.id}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "org_pipeline_name"}
-    }
-  ];
-  // The target pipeline. It can be under a user or an organization
-  // namespace, so the following formats are accepted:
-  // - `{user.id}/{pipeline.id}`
-  // - `{organization.id}/{pipeline.id}`
-  string target = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline description.
-  string description = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Pipeline sharing information.
-  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// CloneOrganizationPipelineResponse contains a cloned pipeline.
-message CloneOrganizationPipelineResponse {}
-
-// CloneOrganizationPipelineReleaseRequest represents a request to clone a pipeline
-// release owned by an organization.
-message CloneOrganizationPipelineReleaseRequest {
-  // The resource name of the pipeline release
-  // - Format: `organizations/{org.id}/pipelines/{pipeline.id}/releases/{version}`.
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {type: "api.instill.tech/Pipeline"},
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      field_configuration: {path_param_name: "org_pipeline_release_name"}
-    }
-  ];
-  // The target pipeline. It can be under a user or an organization
-  // namespace, so the following formats are accepted:
-  // - `{user.id}/{pipeline.id}`
-  // - `{organization.id}/{pipeline.id}`
-  string target = 2 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline description.
-  string description = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Pipeline sharing information.
-  Sharing sharing = 4 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// CloneOrganizationPipelineReleaseResponse contains a cloned pipeline.
-message CloneOrganizationPipelineReleaseResponse {}
 
 // TriggerOrganizationPipelineRequest represents a request to trigger an
 // organization-owned pipeline synchronously.

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -571,32 +571,6 @@ service PipelinePublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // Clone a pipeline owned by a user
-  //
-  // Clones a pipeline owned by a user. The new pipeline may have a different
-  // parent, and this can be either a user or an organization.
-  rpc CloneUserPipeline(CloneUserPipelineRequest) returns (CloneUserPipelineResponse) {
-    option (google.api.http) = {
-      post: "/v1beta/{name=users/*/pipelines/*}/clone"
-      body: "*"
-    };
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // Clone a pipeline release owned by a user
-  //
-  // Clones a pipeline release owned by a user. The new pipeline may have a different
-  // parent, and this can be either a user or an organization.
-  rpc CloneUserPipelineRelease(CloneUserPipelineReleaseRequest) returns (CloneUserPipelineReleaseResponse) {
-    option (google.api.http) = {
-      post: "/v1beta/{name=users/*/pipelines/*/releases/*}/clone"
-      body: "*"
-    };
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
   // Trigger a pipeline owned by a user
   //
   // Triggers the execution of a pipeline synchronously, i.e., the result is
@@ -874,32 +848,6 @@ service PipelinePublicService {
   rpc RenameOrganizationPipeline(RenameOrganizationPipelineRequest) returns (RenameOrganizationPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/rename"
-      body: "*"
-    };
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // Clone a pipeline owned by an organization
-  //
-  // Clones a pipeline owned by an organization. The new pipeline may have a
-  // different parent, and this can be either a user or an organization.
-  rpc CloneOrganizationPipeline(CloneOrganizationPipelineRequest) returns (CloneOrganizationPipelineResponse) {
-    option (google.api.http) = {
-      post: "/v1beta/{name=organizations/*/pipelines/*}/clone"
-      body: "*"
-    };
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // Clone a pipeline release owned by an organization
-  //
-  // Clones a pipeline release owned by an organization. The new pipeline may
-  // have a different parent, and this can be either a user or an organization.
-  rpc CloneOrganizationPipelineRelease(CloneOrganizationPipelineReleaseRequest) returns (CloneOrganizationPipelineReleaseResponse) {
-    option (google.api.http) = {
-      post: "/v1beta/{name=organizations/*/pipelines/*/releases/*}/clone"
       body: "*"
     };
     option deprecated = true;


### PR DESCRIPTION
Because

- Users should explicitly set the target namespace and pipeline ID when cloning a pipeline.

This commit

- Refactors parameters in the Clone API to support this functionality.