### PR TITLE
feat(run): run logging dashboard list APIs for model and pipeline

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1765,6 +1765,11 @@ message ModelRun {
   repeated google.protobuf.Struct task_inputs = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Model inference outputs.
   repeated google.protobuf.Struct task_outputs = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Model ID.
+  optional string model_id = 15 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 // ListModelRunsRequest represents a request to list of model runs.
@@ -1774,9 +1779,9 @@ message ListModelRunsRequest {
   optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page number.
   optional int32 page = 2 [(google.api.field_behavior) = OPTIONAL];
-  // View allows clients to specify the desired run view in the response.
+  // Deprecated: View allows clients to specify the desired run view in the response.
   // The basic view excludes input / output data.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  reserved 3;
   // Sort the results by the given expression.
   // Format: `field [ASC | DESC], where `field` can be:
   // - `create_time`
@@ -1795,8 +1800,47 @@ message ListModelRunsRequest {
   optional string filter = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
+// ListModelRunsByCreditOwnerRequest is the request message for ListModelRunsByCreditOwner.
+message ListModelRunsByCreditOwnerRequest {
+  // The maximum number of runs to return. The default and cap values are 10
+  // and 100, respectively.
+  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Page number.
+  optional int32 page = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Sort the results by the given expression.
+  // Format: `field [ASC | DESC], where `field` can be:
+  // - `create_time`
+  // - `update_time`
+  // By default, results are sorted by descending creation time.
+  optional string order_by = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  // The filter can be applied to the following fields:
+  // - `create_time`
+  optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 5;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 6;
+}
+
 // ListModelRunsResponse contains a list of model runs.
 message ListModelRunsResponse {
+  // A list of runs resources.
+  repeated ModelRun runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total number of runs.
+  int32 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The requested page size.
+  int32 page_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The requested page offset.
+  int32 page = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListModelRunsByCreditOwnerResponse is the request message for ListModelRunsByCreditOwner.
+message ListModelRunsByCreditOwnerResponse {
   // A list of runs resources.
   repeated ModelRun runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of runs.

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -738,7 +738,7 @@ service ModelPublicService {
   // Returns a paginated list of runs for 1 or more models. This is mainly used by credit dashboard.
   // The requester can view all the runs that consumed their credits across different models.
   rpc ListModelRunsByCreditOwner(ListModelRunsByCreditOwnerRequest) returns (ListModelRunsByCreditOwnerResponse) {
-    option (google.api.http) = {get: "/v1beta/dashboard/models/runs"};
+    option (google.api.http) = {get: "/v1alpha/dashboard/models/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger"
       parameters: {

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -721,6 +721,33 @@ service ModelPublicService {
   // Returns a paginated list of model runs.
   rpc ListModelRuns(ListModelRunsRequest) returns (ListModelRunsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/runs"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // List Model Runs of a Namespace (user or organization)
+  //
+  // Returns a paginated list of runs for 1 or more models. This is mainly used by credit dashboard.
+  // The requester can view all the runs that consumed their credits across different models.
+  rpc ListModelRunsByCreditOwner(ListModelRunsByCreditOwnerRequest) returns (ListModelRunsByCreditOwnerResponse) {
+    option (google.api.http) = {get: "/v1beta/dashboard/models/runs"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
   }
 }

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -990,19 +990,6 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: view
-          description: |-
-            View allows clients to specify the desired run view in the response.
-            The basic view excludes input / output data.
-
-             - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
-             - VIEW_FULL: Full representation.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
         - name: orderBy
           description: |-
             Sort the results by the given expression.
@@ -1021,6 +1008,88 @@ paths:
             The filter can be applied to the following fields:
             - `create_time`
           in: query
+          required: false
+          type: string
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1alpha/dashboard/models/runs:
+    get:
+      summary: List Model Runs of a Namespace (user or organization)
+      description: |-
+        Returns a paginated list of runs for 1 or more models. This is mainly used by credit dashboard.
+        The requester can view all the runs that consumed their credits across different models.
+      operationId: ModelPublicService_ListModelRunsByCreditOwner
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaListModelRunsByCreditOwnerResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pageSize
+          description: |-
+            The maximum number of runs to return. The default and cap values are 10
+            and 100, respectively.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: page
+          description: Page number.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: orderBy
+          description: |-
+            Sort the results by the given expression.
+            Format: `field [ASC | DESC], where `field` can be:
+            - `create_time`
+            - `update_time`
+            By default, results are sorted by descending creation time.
+          in: query
+          required: false
+          type: string
+        - name: filter
+          description: |-
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression.
+            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+            The filter can be applied to the following fields:
+            - `create_time`
+          in: query
+          required: false
+          type: string
+        - name: start
+          description: |-
+            Beginning of the time range from which the records will be fetched.
+            The default value is the beginning of the current day, in UTC.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: stop
+          description: |-
+            End of the time range from which the records will be fetched.
+            The default value is the current timestamp.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
           required: false
           type: string
       tags:
@@ -1458,6 +1527,32 @@ definitions:
         format: int32
         description: Total number of model definitions.
     description: ListModelDefinitionsResponse contains a list of model definitions.
+  v1alphaListModelRunsByCreditOwnerResponse:
+    type: object
+    properties:
+      runs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1alphaModelRun'
+        description: A list of runs resources.
+        readOnly: true
+      totalSize:
+        type: integer
+        format: int32
+        description: Total number of runs.
+        readOnly: true
+      pageSize:
+        type: integer
+        format: int32
+        description: The requested page size.
+        readOnly: true
+      page:
+        type: integer
+        format: int32
+        description: The requested page offset.
+        readOnly: true
+    description: ListModelRunsByCreditOwnerResponse is the request message for ListModelRunsByCreditOwner.
   v1alphaListModelRunsResponse:
     type: object
     properties:
@@ -1828,6 +1923,10 @@ definitions:
         items:
           type: object
         description: Model inference outputs.
+        readOnly: true
+      modelId:
+        type: string
+        description: Model ID.
         readOnly: true
     description: ModelRun contains information about a run of models.
   v1alphaModelVersion:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1328,21 +1328,6 @@ paths:
           required: false
           type: integer
           format: int32
-        - name: view
-          description: |-
-            View allows clients to specify the desired run view in the response.
-            The basic view excludes input / output data.
-
-             - VIEW_BASIC: Default view, only includes basic information.
-             - VIEW_FULL: Full representation.
-             - VIEW_RECIPE: Contains the recipe of the resource.
-          in: query
-          required: false
-          type: string
-          enum:
-            - VIEW_BASIC
-            - VIEW_FULL
-            - VIEW_RECIPE
         - name: filter
           description: |-
             Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
@@ -1356,6 +1341,11 @@ paths:
             Order by field, with options for ordering by `id`, `create_time` or `update_time`.
             Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
           in: query
+          required: false
+          type: string
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
           required: false
           type: string
       tags:
@@ -1427,6 +1417,83 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
             - VIEW_RECIPE
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
+      tags:
+        - Trigger
+  /v1beta/dashboard/pipelines/runs:
+    get:
+      summary: List Pipeline Runs of a Namespace (user or organization)
+      description: |-
+        Returns a paginated list of runs for 1 or more pipelines. This is mainly used by credit dashboard.
+        The requester can view all the runs that consumed their credits across different pipelines.
+      operationId: PipelinePublicService_ListPipelineRunsByCreditOwner
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1betaListPipelineRunsByCreditOwnerResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: page
+          description: The page number to retrieve.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageSize
+          description: |-
+            The maximum number of items per page to return. The default and cap values
+            are 10 and 100, respectively.
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: filter
+          description: |-
+            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+            expression.
+            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+          in: query
+          required: false
+          type: string
+        - name: orderBy
+          description: |-
+            Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+            Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+          in: query
+          required: false
+          type: string
+        - name: start
+          description: |-
+            Beginning of the time range from which the records will be fetched.
+            The default value is the beginning of the current day, in UTC.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: stop
+          description: |-
+            End of the time range from which the records will be fetched.
+            The default value is the current timestamp.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: Instill-Requester-Uid
+          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
+          in: header
+          required: false
+          type: string
       tags:
         - Trigger
   /v1beta/namespaces/{namespaceId}/connections:
@@ -3276,6 +3343,32 @@ definitions:
       requested by an admin user.
       For the moment, the pipeline recipes will be UID-based (permalink) instead
       of name-based. This is a temporary solution.
+  v1betaListPipelineRunsByCreditOwnerResponse:
+    type: object
+    properties:
+      pipelineRuns:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1betaPipelineRun'
+        description: The list of pipeline runs.
+        readOnly: true
+      totalSize:
+        type: integer
+        format: int32
+        description: The total number of pipeline runs matching the request.
+        readOnly: true
+      page:
+        type: integer
+        format: int32
+        description: The current page number.
+        readOnly: true
+      pageSize:
+        type: integer
+        format: int32
+        description: The number of items per page.
+        readOnly: true
+    description: ListPipelineRunsByCreditOwnerResponse is the response message for ListPipelineRunsByCreditOwner.
   v1betaListPipelineRunsResponse:
     type: object
     properties:
@@ -3705,6 +3798,10 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/v1betaDataSpecification'
+      pipelineId:
+        type: string
+        title: The ID of the pipeline
+        readOnly: true
     description: PipelineRun represents a single execution of a pipeline.
   v1betaPipelineView:
     type: string

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1925,7 +1925,7 @@ message ListPipelineRunsByCreditOwnerResponse {
   repeated PipelineRun pipeline_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The total number of pipeline runs matching the request.
-  int64 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  int32 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The current page number.
   int32 page = 3 [(google.api.field_behavior) = OUTPUT_ONLY];

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1868,9 +1868,9 @@ message ListPipelineRunsRequest {
   // are 10 and 100, respectively.
   int32 page_size = 4 [(google.api.field_behavior) = OPTIONAL];
 
-  // View allows clients to specify the desired run view in the response.
+  // Deprecated: View allows clients to specify the desired run view in the response.
   // The basic view excludes input / output data.
-  optional Pipeline.View view = 5 [(google.api.field_behavior) = OPTIONAL];
+  reserved 5;
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
@@ -1880,6 +1880,30 @@ message ListPipelineRunsRequest {
   optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
+// ListPipelineRunsByCreditOwnerRequest is the request message for ListPipelineRunsByCreditOwner.
+message ListPipelineRunsByCreditOwnerRequest {
+  // The page number to retrieve.
+  int32 page = 1 [(google.api.field_behavior) = OPTIONAL];
+
+  // The maximum number of items per page to return. The default and cap values
+  // are 10 and 100, respectively.
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
+  // expression.
+  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
+  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+  optional string order_by = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 5;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 6;
+}
+
 // ListPipelineRunsResponse is the response message for ListPipelineRuns.
 message ListPipelineRunsResponse {
   // The list of pipeline runs.
@@ -1887,6 +1911,21 @@ message ListPipelineRunsResponse {
 
   // The total number of pipeline runs matching the request.
   int32 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The current page number.
+  int32 page = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The number of items per page.
+  int32 page_size = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListPipelineRunsByCreditOwnerResponse is the response message for ListPipelineRunsByCreditOwner.
+message ListPipelineRunsByCreditOwnerResponse {
+  // The list of pipeline runs.
+  repeated PipelineRun pipeline_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The total number of pipeline runs matching the request.
+  int64 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The current page number.
   int32 page = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -2020,6 +2059,12 @@ message PipelineRun {
   ];
   // Data specifications.
   DataSpecification data_specification = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The ID of the pipeline
+  optional string pipeline_id = 19 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -1205,7 +1205,16 @@ service PipelinePublicService {
   // runs requested by themselves.
   rpc ListPipelineRuns(ListPipelineRunsRequest) returns (ListPipelineRunsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/runs"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
   }
 
   // List Component runs
@@ -1213,7 +1222,34 @@ service PipelinePublicService {
   // Returns the information of each component execution within a pipeline run.
   rpc ListComponentRuns(ListComponentRunsRequest) returns (ListComponentRunsResponse) {
     option (google.api.http) = {get: "/v1beta/pipeline-runs/{pipeline_run_id}/component-runs"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Trigger"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
+  }
+
+  // List Pipeline Runs of a Namespace (user or organization)
+  //
+  // Returns a paginated list of runs for 1 or more pipelines. This is mainly used by credit dashboard.
+  // The requester can view all the runs that consumed their credits across different pipelines.
+  rpc ListPipelineRunsByCreditOwner(ListPipelineRunsByCreditOwnerRequest) returns (ListPipelineRunsByCreditOwnerResponse) {
+    option (google.api.http) = {get: "/v1beta/dashboard/pipelines/runs"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Trigger"
+      parameters: {
+        headers: {
+          name: "Instill-Requester-Uid"
+          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
+          type: STRING
+        }
+      }
+    };
   }
 
   // List namespace connections


### PR DESCRIPTION
This pull request is related to https://github.com/instill-ai/protobufs/pull/472 but only includes the ones for run logging data lists, excluding metrics APIs

Because

- the data that users could see on dashboard are different from what they can see on Runs page in a single pipeline or model

This commit

- add new run logging API for dashboard
