### PR TITLE
feat(artifact): provide object download and upload

### DIFF
--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -6,6 +6,7 @@ package artifact.artifact.v1alpha;
 import "artifact/artifact/v1alpha/artifact.proto";
 import "artifact/artifact/v1alpha/chunk.proto";
 import "artifact/artifact/v1alpha/file_catalog.proto";
+import "artifact/artifact/v1alpha/object.proto";
 import "artifact/artifact/v1alpha/qa.proto";
 // Google API
 import "google/api/annotations.proto";
@@ -179,5 +180,17 @@ service ArtifactPublicService {
   rpc ListCatalogRuns(ListCatalogRunsRequest) returns (ListCatalogRunsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/catalogs/{catalog_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Catalog"};
+  }
+
+  // Get Object Upload URL
+  rpc GetObjectUploadURL(GetObjectUploadURLRequest) returns (GetObjectUploadURLResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/object-upload-url"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Object"};
+  }
+
+  // Get Object Download URL
+  rpc GetObjectDownloadURL(GetObjectDownloadURLRequest) returns (GetObjectDownloadURLResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/object-download-url"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "Object"};
   }
 }

--- a/artifact/artifact/v1alpha/object.proto
+++ b/artifact/artifact/v1alpha/object.proto
@@ -1,0 +1,89 @@
+syntax = "proto3";
+
+package artifact.artifact.v1alpha;
+
+// Google API
+import "google/api/field_behavior.proto";
+// Protocol Buffers Well-Known Types
+import "google/protobuf/timestamp.proto";
+
+// Object
+message Object {
+  // uid
+  string uid = 1;
+  // name of the object
+  string name = 2;
+  // size in bytes
+  int64 size = 3;
+  // content type
+  // this is from content-type header of http request
+  string content_type = 4;
+  // namespace uid
+  string namespace_uid = 6;
+  // creator
+  string creator = 7;
+  // if file is uploaded
+  bool is_uploaded = 8;
+  // object path(optional)
+  optional string path = 9;
+  // object live time in days
+  // minimum is 1 day. if not set, the object will not be deleted automatically
+  int32 object_expire_days = 10;
+  // created time
+  google.protobuf.Timestamp created_time = 11;
+  // updated time
+  google.protobuf.Timestamp updated_time = 12;
+}
+
+// GetObjectUploadURLRequest
+message GetObjectUploadURLRequest {
+  // id of the namespace
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // name of the object with length limit to 1024 characters.
+  // this is the unique identifier of the object in the namespace
+  string object_name = 2 [(google.api.field_behavior) = REQUIRED];
+  // expiration time in minutes for the URL with a default value of 1440 minutes (1 day).
+  // minimum is 60 minutes (1 hour) and maximum is 20160 minutes (14 days)
+  int32 expiration_time = 3 [(google.api.field_behavior) = OPTIONAL];
+  // last modified time this value is provided by the client when the object url is created
+  google.protobuf.Timestamp last_modified_time = 4 [(google.api.field_behavior) = OPTIONAL];
+  // object live time in days
+  // minimum is 1 day. if not set, the object will not be deleted automatically
+  int32 object_expire_days = 5 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetObjectUploadURLResponse
+message GetObjectUploadURLResponse {
+  // upload url
+  string upload_url = 1;
+  // expire at in UTC (UTC+0)
+  google.protobuf.Timestamp url_expire_at = 2;
+  // object
+  Object object = 3;
+}
+
+// GetObjectDownloadURLRequest
+message GetObjectDownloadURLRequest {
+  // id of the namespace
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // uid of the object
+  // if provided, object name is not required
+  // uid has priority over name
+  string object_uid = 2 [(google.api.field_behavior) = OPTIONAL];
+  // object name
+  // if provided, object uid is not required
+  string object_name = 3 [(google.api.field_behavior) = OPTIONAL];
+  // expiration time in minutes for url with default value to 1440 minutes (1 day).
+  // minimum is 60 minutes (1 hour) and maximum is 20160 minutes (14 days)
+  int32 expiration_time = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// GetObjectDownloadURLResponse
+message GetObjectDownloadURLResponse {
+  // download url
+  string download_url = 1;
+  // expire at in UTC (UTC+0)
+  google.protobuf.Timestamp url_expire_at = 2;
+  // object
+  Object object = 4;
+}

--- a/artifact/artifact/v1alpha/openapi.proto.templ
+++ b/artifact/artifact/v1alpha/openapi.proto.templ
@@ -15,6 +15,10 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     {
       name: "Catalog"
       description: "Catalog endpoints"
+    },
+    {
+      name: "Object"
+      description: "Object endpoints"
     }
   ]
 {{$conf}}

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -13,6 +13,8 @@ info:
 tags:
   - name: Catalog
     description: Catalog endpoints
+  - name: Object
+    description: Object endpoints
 host: api.instill.tech
 schemes:
   - https
@@ -550,6 +552,106 @@ paths:
           type: string
       tags:
         - Catalog
+  /v1alpha/namespaces/{namespaceId}/object-upload-url:
+    get:
+      summary: Get Object Upload URL
+      operationId: ArtifactPublicService_GetObjectUploadURL
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetObjectUploadURLResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: namespaceId
+          description: id of the namespace
+          in: path
+          required: true
+          type: string
+        - name: objectName
+          description: |-
+            name of the object with length limit to 1024 characters.
+            this is the unique identifier of the object in the namespace
+          in: query
+          required: true
+          type: string
+        - name: expirationTime
+          description: |-
+            expiration time in minutes for the URL with a default value of 1440 minutes (1 day).
+            minimum is 60 minutes (1 hour) and maximum is 20160 minutes (14 days)
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: lastModifiedTime
+          description: last modified time this value is provided by the client when the object url is created
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: objectExpireDays
+          description: |-
+            object live time in days
+            minimum is 1 day. if not set, the object will not be deleted automatically
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - Object
+  /v1alpha/namespaces/{namespaceId}/object-download-url:
+    get:
+      summary: Get Object Download URL
+      operationId: ArtifactPublicService_GetObjectDownloadURL
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1alphaGetObjectDownloadURLResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: namespaceId
+          description: id of the namespace
+          in: path
+          required: true
+          type: string
+        - name: objectUid
+          description: |-
+            uid of the object
+            if provided, object name is not required
+            uid has priority over name
+          in: query
+          required: false
+          type: string
+        - name: objectName
+          description: |-
+            object name
+            if provided, object uid is not required
+          in: query
+          required: false
+          type: string
+        - name: expirationTime
+          description: |-
+            expiration time in minutes for url with default value to 1440 minutes (1 day).
+            minimum is 60 minutes (1 hour) and maximum is 20160 minutes (14 days)
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - Object
 definitions:
   ArtifactPublicServiceCreateCatalogBody:
     type: object
@@ -1096,6 +1198,36 @@ definitions:
         type: boolean
         title: chunk retrievable
     title: chunk message
+  v1alphaGetObjectDownloadURLResponse:
+    type: object
+    properties:
+      downloadUrl:
+        type: string
+        title: download url
+      urlExpireAt:
+        type: string
+        format: date-time
+        title: expire at in UTC (UTC+0)
+      object:
+        title: object
+        allOf:
+          - $ref: '#/definitions/v1alphaObject'
+    title: GetObjectDownloadURLResponse
+  v1alphaGetObjectUploadURLResponse:
+    type: object
+    properties:
+      uploadUrl:
+        type: string
+        title: upload url
+      urlExpireAt:
+        type: string
+        format: date-time
+        title: expire at in UTC (UTC+0)
+      object:
+        title: object
+        allOf:
+          - $ref: '#/definitions/v1alphaObject'
+    title: GetObjectUploadURLResponse
   v1alphaGetRepositoryTagResponse:
     type: object
     properties:
@@ -1216,6 +1348,51 @@ definitions:
         format: int32
         description: The requested page offset.
     description: ListRepositoryTagsResponse contains a list of container image tags.
+  v1alphaObject:
+    type: object
+    properties:
+      uid:
+        type: string
+        title: uid
+      name:
+        type: string
+        title: name of the object
+      size:
+        type: string
+        format: int64
+        title: size in bytes
+      contentType:
+        type: string
+        title: |-
+          content type
+          this is from content-type header of http request
+      namespaceUid:
+        type: string
+        title: namespace uid
+      creator:
+        type: string
+        title: creator
+      isUploaded:
+        type: boolean
+        title: if file is uploaded
+      path:
+        type: string
+        title: object path(optional)
+      objectExpireDays:
+        type: integer
+        format: int32
+        title: |-
+          object live time in days
+          minimum is 1 day. if not set, the object will not be deleted automatically
+      createdTime:
+        type: string
+        format: date-time
+        title: created time
+      updatedTime:
+        type: string
+        format: date-time
+        title: updated time
+    title: Object
   v1alphaProcessCatalogFilesRequest:
     type: object
     properties:


### PR DESCRIPTION
Because

artifact will support object management on behalf of minIO

This commit

1. provide get upload url API
2. provide get download url API
