### PR TITLE
feat(run): add requester id in list pipeline/model run response

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1770,11 +1770,9 @@ message ModelRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
-  // Requester ID. It will return null if it's already deleted.
-  optional string requester_id = 16 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    (google.api.field_behavior) = OPTIONAL
-  ];
+  // Requester ID. This field might be empty if the model run belongs to a
+  // deleted namespace.
+  string requester_id = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListModelRunsRequest represents a request to list of model runs.
@@ -1831,8 +1829,8 @@ message ListModelRunsByRequesterRequest {
   // End of the time range from which the records will be fetched.
   // The default value is the current timestamp.
   optional google.protobuf.Timestamp stop = 6;
-  // Namespace ID.
-  string namespace_id = 7 [(google.api.field_behavior) = REQUIRED];
+  // Requester ID.
+  string requester_id = 7 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListModelRunsResponse contains a list of model runs.

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1770,7 +1770,7 @@ message ModelRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
-  // Requester ID. If current viewing requester does not have enough permission, it will return null.
+  // Requester ID. It will return null if it's already deleted.
   optional string requester_id = 16 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
@@ -1831,6 +1831,8 @@ message ListModelRunsByRequesterRequest {
   // End of the time range from which the records will be fetched.
   // The default value is the current timestamp.
   optional google.protobuf.Timestamp stop = 6;
+  // Namespace ID.
+  string namespace_id = 7 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListModelRunsResponse contains a list of model runs.

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1770,6 +1770,11 @@ message ModelRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
+  // Requester ID. If current viewing requester does not have enough permission, it will return null.
+  optional string requester_id = 16 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 // ListModelRunsRequest represents a request to list of model runs.
@@ -1800,8 +1805,8 @@ message ListModelRunsRequest {
   optional string filter = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// ListModelRunsByCreditOwnerRequest is the request message for ListModelRunsByCreditOwner.
-message ListModelRunsByCreditOwnerRequest {
+// ListModelRunsByRequesterRequest is the request message for ListModelRunsByRequester.
+message ListModelRunsByRequesterRequest {
   // The maximum number of runs to return. The default and cap values are 10
   // and 100, respectively.
   optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
@@ -1815,9 +1820,10 @@ message ListModelRunsByCreditOwnerRequest {
   optional string order_by = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  // - Example: `status="RUN_STATUS_COMPLETED"`.
   // The filter can be applied to the following fields:
-  // - `create_time`
+  // - `status`
+  // - `source`
   optional string filter = 4 [(google.api.field_behavior) = OPTIONAL];
   // Beginning of the time range from which the records will be fetched.
   // The default value is the beginning of the current day, in UTC.
@@ -1839,8 +1845,8 @@ message ListModelRunsResponse {
   int32 page = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ListModelRunsByCreditOwnerResponse is the request message for ListModelRunsByCreditOwner.
-message ListModelRunsByCreditOwnerResponse {
+// ListModelRunsByRequesterResponse is the request message for ListModelRunsByRequester.
+message ListModelRunsByRequesterResponse {
   // A list of runs resources.
   repeated ModelRun runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Total number of runs.

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -737,7 +737,7 @@ service ModelPublicService {
   //
   // Returns a paginated list of runs for 1 or more models. This is mainly used by credit dashboard.
   // The requester can view all the runs that consumed their credits across different models.
-  rpc ListModelRunsByCreditOwner(ListModelRunsByCreditOwnerRequest) returns (ListModelRunsByCreditOwnerResponse) {
+  rpc ListModelRunsByRequester(ListModelRunsByRequesterRequest) returns (ListModelRunsByRequesterResponse) {
     option (google.api.http) = {get: "/v1alpha/dashboard/models/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger"

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -735,8 +735,8 @@ service ModelPublicService {
 
   // List Model Runs of a Namespace (user or organization)
   //
-  // Returns a paginated list of runs for 1 or more models. This is mainly used by credit dashboard.
-  // The requester can view all the runs that consumed their credits across different models.
+  // Returns a paginated list of runs for 1 or more models. This is mainly used by dashboard.
+  // The requester can view all the runs by the requester across different models.
   rpc ListModelRunsByRequester(ListModelRunsByRequesterRequest) returns (ListModelRunsByRequesterResponse) {
     option (google.api.http) = {get: "/v1alpha/dashboard/models/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {

--- a/openapiv2/model/service.swagger.yaml
+++ b/openapiv2/model/service.swagger.yaml
@@ -1021,14 +1021,14 @@ paths:
     get:
       summary: List Model Runs of a Namespace (user or organization)
       description: |-
-        Returns a paginated list of runs for 1 or more models. This is mainly used by credit dashboard.
-        The requester can view all the runs that consumed their credits across different models.
-      operationId: ModelPublicService_ListModelRunsByCreditOwner
+        Returns a paginated list of runs for 1 or more models. This is mainly used by dashboard.
+        The requester can view all the runs by the requester across different models.
+      operationId: ModelPublicService_ListModelRunsByRequester
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1alphaListModelRunsByCreditOwnerResponse'
+            $ref: '#/definitions/v1alphaListModelRunsByRequesterResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -1065,9 +1065,10 @@ paths:
           description: |-
             Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
             expression.
-            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+            - Example: `status="RUN_STATUS_COMPLETED"`.
             The filter can be applied to the following fields:
-            - `create_time`
+            - `status`
+            - `source`
           in: query
           required: false
           type: string
@@ -1087,6 +1088,11 @@ paths:
           required: false
           type: string
           format: date-time
+        - name: requesterId
+          description: Requester ID.
+          in: query
+          required: true
+          type: string
         - name: Instill-Requester-Uid
           description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
           in: header
@@ -1527,7 +1533,7 @@ definitions:
         format: int32
         description: Total number of model definitions.
     description: ListModelDefinitionsResponse contains a list of model definitions.
-  v1alphaListModelRunsByCreditOwnerResponse:
+  v1alphaListModelRunsByRequesterResponse:
     type: object
     properties:
       runs:
@@ -1552,7 +1558,7 @@ definitions:
         format: int32
         description: The requested page offset.
         readOnly: true
-    description: ListModelRunsByCreditOwnerResponse is the request message for ListModelRunsByCreditOwner.
+    description: ListModelRunsByRequesterResponse is the request message for ListModelRunsByRequester.
   v1alphaListModelRunsResponse:
     type: object
     properties:
@@ -1927,6 +1933,12 @@ definitions:
       modelId:
         type: string
         description: Model ID.
+        readOnly: true
+      requesterId:
+        type: string
+        description: |-
+          Requester ID. This field might be empty if the model run belongs to a
+          deleted namespace.
         readOnly: true
     description: ModelRun contains information about a run of models.
   v1alphaModelVersion:

--- a/openapiv2/vdp/service.swagger.yaml
+++ b/openapiv2/vdp/service.swagger.yaml
@@ -1428,14 +1428,14 @@ paths:
     get:
       summary: List Pipeline Runs of a Namespace (user or organization)
       description: |-
-        Returns a paginated list of runs for 1 or more pipelines. This is mainly used by credit dashboard.
-        The requester can view all the runs that consumed their credits across different pipelines.
-      operationId: PipelinePublicService_ListPipelineRunsByCreditOwner
+        Returns a paginated list of runs for 1 or more pipelines. This is mainly used by dashboard.
+        The requester can view all the runs by the requester across different pipelines.
+      operationId: PipelinePublicService_ListPipelineRunsByRequester
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1betaListPipelineRunsByCreditOwnerResponse'
+            $ref: '#/definitions/v1betaListPipelineRunsByRequesterResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -1462,7 +1462,11 @@ paths:
           description: |-
             Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
             expression.
-            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+            The following filters are supported:
+            - `status`
+            - `source`
+
+            **Example**: `status="RUN_STATUS_COMPLETED"`.
           in: query
           required: false
           type: string
@@ -1489,6 +1493,11 @@ paths:
           required: false
           type: string
           format: date-time
+        - name: requesterId
+          description: Requester ID.
+          in: query
+          required: true
+          type: string
         - name: Instill-Requester-Uid
           description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
           in: header
@@ -3343,7 +3352,7 @@ definitions:
       requested by an admin user.
       For the moment, the pipeline recipes will be UID-based (permalink) instead
       of name-based. This is a temporary solution.
-  v1betaListPipelineRunsByCreditOwnerResponse:
+  v1betaListPipelineRunsByRequesterResponse:
     type: object
     properties:
       pipelineRuns:
@@ -3368,7 +3377,7 @@ definitions:
         format: int32
         description: The number of items per page.
         readOnly: true
-    description: ListPipelineRunsByCreditOwnerResponse is the response message for ListPipelineRunsByCreditOwner.
+    description: ListPipelineRunsByRequesterResponse is the response message for ListPipelineRunsByRequester.
   v1betaListPipelineRunsResponse:
     type: object
     properties:
@@ -3801,6 +3810,12 @@ definitions:
       pipelineId:
         type: string
         title: The ID of the pipeline
+        readOnly: true
+      requesterId:
+        type: string
+        description: |-
+          Requester ID. This field might be empty if the pipeline run belongs to a
+          deleted namespace.
         readOnly: true
     description: PipelineRun represents a single execution of a pipeline.
   v1betaPipelineView:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1906,6 +1906,8 @@ message ListPipelineRunsByRequesterRequest {
   // End of the time range from which the records will be fetched.
   // The default value is the current timestamp.
   optional google.protobuf.Timestamp stop = 6;
+  // Namespace ID.
+  string namespace_id = 7 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListPipelineRunsResponse is the response message for ListPipelineRuns.
@@ -2070,7 +2072,7 @@ message PipelineRun {
     (google.api.field_behavior) = OPTIONAL
   ];
 
-  // Requester ID. If current viewing requester does not have enough permission, it will return null.
+  // Requester ID. It will return null if it's already deleted.
   optional string requester_id = 20 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1906,8 +1906,8 @@ message ListPipelineRunsByRequesterRequest {
   // End of the time range from which the records will be fetched.
   // The default value is the current timestamp.
   optional google.protobuf.Timestamp stop = 6;
-  // Namespace ID.
-  string namespace_id = 7 [(google.api.field_behavior) = REQUIRED];
+  // Requester ID.
+  string requester_id = 7 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListPipelineRunsResponse is the response message for ListPipelineRuns.
@@ -2072,11 +2072,9 @@ message PipelineRun {
     (google.api.field_behavior) = OPTIONAL
   ];
 
-  // Requester ID. It will return null if it's already deleted.
-  optional string requester_id = 20 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    (google.api.field_behavior) = OPTIONAL
-  ];
+  // Requester ID. This field might be empty if the pipeline run belongs to a
+  // deleted namespace.
+  string requester_id = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1880,8 +1880,8 @@ message ListPipelineRunsRequest {
   optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// ListPipelineRunsByCreditOwnerRequest is the request message for ListPipelineRunsByCreditOwner.
-message ListPipelineRunsByCreditOwnerRequest {
+// ListPipelineRunsByRequesterRequest is the request message for ListPipelineRunsByRequester.
+message ListPipelineRunsByRequesterRequest {
   // The page number to retrieve.
   int32 page = 1 [(google.api.field_behavior) = OPTIONAL];
 
@@ -1891,7 +1891,11 @@ message ListPipelineRunsByCreditOwnerRequest {
 
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+  // The following filters are supported:
+  // - `status`
+  // - `source`
+  //
+  // **Example**: `status="RUN_STATUS_COMPLETED"`.
   optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
   // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
   // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
@@ -1919,8 +1923,8 @@ message ListPipelineRunsResponse {
   int32 page_size = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ListPipelineRunsByCreditOwnerResponse is the response message for ListPipelineRunsByCreditOwner.
-message ListPipelineRunsByCreditOwnerResponse {
+// ListPipelineRunsByRequesterResponse is the response message for ListPipelineRunsByRequester.
+message ListPipelineRunsByRequesterResponse {
   // The list of pipeline runs.
   repeated PipelineRun pipeline_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
@@ -2062,6 +2066,12 @@ message PipelineRun {
 
   // The ID of the pipeline
   optional string pipeline_id = 19 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Requester ID. If current viewing requester does not have enough permission, it will return null.
+  optional string requester_id = 20 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -1236,8 +1236,8 @@ service PipelinePublicService {
 
   // List Pipeline Runs of a Namespace (user or organization)
   //
-  // Returns a paginated list of runs for 1 or more pipelines. This is mainly used by credit dashboard.
-  // The requester can view all the runs that consumed their credits across different pipelines.
+  // Returns a paginated list of runs for 1 or more pipelines. This is mainly used by dashboard.
+  // The requester can view all the runs by the requester across different pipelines.
   rpc ListPipelineRunsByRequester(ListPipelineRunsByRequesterRequest) returns (ListPipelineRunsByRequesterResponse) {
     option (google.api.http) = {get: "/v1beta/dashboard/pipelines/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -1238,7 +1238,7 @@ service PipelinePublicService {
   //
   // Returns a paginated list of runs for 1 or more pipelines. This is mainly used by credit dashboard.
   // The requester can view all the runs that consumed their credits across different pipelines.
-  rpc ListPipelineRunsByCreditOwner(ListPipelineRunsByCreditOwnerRequest) returns (ListPipelineRunsByCreditOwnerResponse) {
+  rpc ListPipelineRunsByRequester(ListPipelineRunsByRequesterRequest) returns (ListPipelineRunsByRequesterResponse) {
     option (google.api.http) = {get: "/v1beta/dashboard/pipelines/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Trigger"


### PR DESCRIPTION
Because

- runs pages need to display credit owner field

This commit

- expose requester id in response
- rename rpc name and add documentations (from previous TODOs in https://github.com/instill-ai/protobufs/pull/472)