### PR TITLE
feat(blob): add internal object url method

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -163,6 +163,42 @@ message DeleteRepositoryTagRequest {
 // DeleteRepositoryTagResponse represent an empty response.
 message DeleteRepositoryTagResponse {}
 
+// ObjectUploadURL
+message ObjectURL {
+  // The unique identifier of the ObjectURL
+  string uid = 1;
+  // The namespace UID associated with this ObjectURL
+  string namespace_uid = 2;
+  // The object UID associated with this ObjectURL
+  string object_uid = 3;
+  // The expiration time of the URL
+  google.protobuf.Timestamp url_expire_at = 4;
+  // The MinIO URL path
+  string minio_url_path = 5;
+  // The encoded URL path
+  string encoded_url_path = 6;
+  // The type of URL (download or upload)
+  string type = 7;
+  // The creation time of the ObjectURL
+  google.protobuf.Timestamp create_time = 8;
+  // The last update time of the ObjectURL
+  google.protobuf.Timestamp update_time = 9;
+  // The deletion time of the ObjectURL, if applicable
+  optional google.protobuf.Timestamp delete_time = 10;
+}
+
+// GetObjectURLRequest
+message GetObjectURLRequest {
+  // object url uid
+  string uid = 1;
+}
+
+// GetObjectURLResponse
+message GetObjectURLResponse {
+  // object upload url
+  ObjectURL object_url = 1;
+}
+
 // Catalog represents a catalog.
 message Catalog {
   // The catalog uid.

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -27,4 +27,7 @@ service ArtifactPrivateService {
 
   // Delete a repository tag.
   rpc DeleteRepositoryTag(DeleteRepositoryTagRequest) returns (DeleteRepositoryTagResponse);
+
+  // Get Object Upload URL
+  rpc GetObjectURL(GetObjectURLRequest) returns (GetObjectURLResponse);
 }

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -1215,6 +1215,14 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1alphaObject'
     title: GetObjectDownloadURLResponse
+  v1alphaGetObjectURLResponse:
+    type: object
+    properties:
+      objectUrl:
+        title: object upload url
+        allOf:
+          - $ref: '#/definitions/v1alphaObjectURL'
+    title: GetObjectURLResponse
   v1alphaGetObjectUploadURLResponse:
     type: object
     properties:
@@ -1399,6 +1407,44 @@ definitions:
         format: date-time
         title: updated time
     title: Object
+  v1alphaObjectURL:
+    type: object
+    properties:
+      uid:
+        type: string
+        title: The unique identifier of the ObjectURL
+      namespaceUid:
+        type: string
+        title: The namespace UID associated with this ObjectURL
+      objectUid:
+        type: string
+        title: The object UID associated with this ObjectURL
+      urlExpireAt:
+        type: string
+        format: date-time
+        title: The expiration time of the URL
+      minioUrlPath:
+        type: string
+        title: The MinIO URL path
+      encodedUrlPath:
+        type: string
+        title: The encoded URL path
+      type:
+        type: string
+        title: The type of URL (download or upload)
+      createTime:
+        type: string
+        format: date-time
+        title: The creation time of the ObjectURL
+      updateTime:
+        type: string
+        format: date-time
+        title: The last update time of the ObjectURL
+      deleteTime:
+        type: string
+        format: date-time
+        title: The deletion time of the ObjectURL, if applicable
+    title: ObjectUploadURL
   v1alphaProcessCatalogFilesRequest:
     type: object
     properties:


### PR DESCRIPTION
Because

blob plugin needs to get the object url information

This commit

adds internal method `GetObjectURL ` in `artifact`