### PR TITLE
feat(blob): add get object method

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -4,6 +4,7 @@ package artifact.artifact.v1alpha;
 
 import "common/healthcheck/v1beta/healthcheck.proto";
 import "common/run/v1alpha/run.proto";
+import "artifact/artifact/v1alpha/object.proto";
 // Google API
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
@@ -186,6 +187,17 @@ message ObjectURL {
   // The deletion time of the ObjectURL, if applicable
   optional google.protobuf.Timestamp delete_time = 10;
 }
+// GetObjectRequest
+message GetObjectRequest {
+  // object uid
+  string uid = 1;
+}
+
+// GetObjectResponse
+message GetObjectResponse {
+  // object
+  Object object = 1;
+}
 
 // GetObjectURLRequest
 message GetObjectURLRequest {
@@ -195,7 +207,7 @@ message GetObjectURLRequest {
 
 // GetObjectURLResponse
 message GetObjectURLResponse {
-  // object upload url
+  // object url
   ObjectURL object_url = 1;
 }
 

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 
 package artifact.artifact.v1alpha;
 
+import "artifact/artifact/v1alpha/object.proto";
 import "common/healthcheck/v1beta/healthcheck.proto";
 import "common/run/v1alpha/run.proto";
-import "artifact/artifact/v1alpha/object.proto";
 // Google API
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
@@ -187,6 +187,7 @@ message ObjectURL {
   // The deletion time of the ObjectURL, if applicable
   optional google.protobuf.Timestamp delete_time = 10;
 }
+
 // GetObjectRequest
 message GetObjectRequest {
   // object uid

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -30,8 +30,7 @@ service ArtifactPrivateService {
 
   // Get Object
   rpc GetObject(GetObjectRequest) returns (GetObjectResponse);
-  
+
   // Get Object URL
   rpc GetObjectURL(GetObjectURLRequest) returns (GetObjectURLResponse);
-
 }

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -28,6 +28,10 @@ service ArtifactPrivateService {
   // Delete a repository tag.
   rpc DeleteRepositoryTag(DeleteRepositoryTagRequest) returns (DeleteRepositoryTagResponse);
 
-  // Get Object Upload URL
+  // Get Object
+  rpc GetObject(GetObjectRequest) returns (GetObjectResponse);
+  
+  // Get Object URL
   rpc GetObjectURL(GetObjectURLRequest) returns (GetObjectURLResponse);
+
 }

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -1215,11 +1215,19 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1alphaObject'
     title: GetObjectDownloadURLResponse
+  v1alphaGetObjectResponse:
+    type: object
+    properties:
+      object:
+        title: object
+        allOf:
+          - $ref: '#/definitions/v1alphaObject'
+    title: GetObjectResponse
   v1alphaGetObjectURLResponse:
     type: object
     properties:
       objectUrl:
-        title: object upload url
+        title: object url
         allOf:
           - $ref: '#/definitions/v1alphaObjectURL'
     title: GetObjectURLResponse


### PR DESCRIPTION
Because 

another service needs to get the info of the object stored in the blob, 

Commit 

adds the get object method