### PR TITLE
feat(blob): add encoded_url_path to retrieve object

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -188,7 +188,6 @@ message ObjectURL {
   optional google.protobuf.Timestamp delete_time = 10;
 }
 
-
 // GetObjectRequest
 message GetObjectRequest {
   // object uid

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -188,6 +188,7 @@ message ObjectURL {
   optional google.protobuf.Timestamp delete_time = 10;
 }
 
+
 // GetObjectRequest
 message GetObjectRequest {
   // object uid
@@ -204,6 +205,9 @@ message GetObjectResponse {
 message GetObjectURLRequest {
   // object url uid
   string uid = 1;
+  // encoded url path. artifact first use uid to get object url,
+  // if not exist, then use encoded url path to get object url
+  optional string encoded_url_path = 2;
 }
 
 // GetObjectURLResponse


### PR DESCRIPTION
Because

some service may only maintain the object url in their service

This commit

add encode path filed to get back the object url
