### PR TITLE
feat(artifact): provide update object metadata method

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -215,6 +215,26 @@ message GetObjectURLResponse {
   ObjectURL object_url = 1;
 }
 
+// UpdateObjectRequest
+message UpdateObjectRequest {
+  // object uid
+  string uid = 1;
+  // size
+  optional int64 size = 2;
+  // type
+  optional string type = 3;
+  // is upload
+  optional bool is_uploaded = 4;
+  // last modified time
+  optional google.protobuf.Timestamp last_modified_time = 5;
+}
+
+// UpdateObjectResponse
+message UpdateObjectResponse {
+  // object
+  Object object = 1;
+}
+
 // Catalog represents a catalog.
 message Catalog {
   // The catalog uid.

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -33,4 +33,7 @@ service ArtifactPrivateService {
 
   // Get Object URL
   rpc GetObjectURL(GetObjectURLRequest) returns (GetObjectURLResponse);
+
+  // Update Object
+  rpc UpdateObject(UpdateObjectRequest) returns (UpdateObjectResponse);
 }

--- a/artifact/artifact/v1alpha/object.proto
+++ b/artifact/artifact/v1alpha/object.proto
@@ -70,15 +70,10 @@ message GetObjectDownloadURLRequest {
   // id of the namespace
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // uid of the object
-  // if provided, object name is not required
-  // uid has priority over name
-  string object_uid = 2 [(google.api.field_behavior) = OPTIONAL];
-  // object name
-  // if provided, object uid is not required
-  string object_name = 3 [(google.api.field_behavior) = OPTIONAL];
-  // Expiration time in days for the URL.
-  // Minimum is 1 day and maximum is 7 days. If not set or set to 0, defaults to 1 day.
-  int32 url_expire_days = 4 [(google.api.field_behavior) = OPTIONAL];
+  string object_uid = 2 [(google.api.field_behavior) = REQUIRED];
+  // expiration time in days for the URL.
+  // minimum is 1 day. if not set or set to 0, defaults to 1 day.
+  int32 url_expire_days = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetObjectDownloadURLResponse
@@ -88,5 +83,5 @@ message GetObjectDownloadURLResponse {
   // expire at in UTC (UTC+0)
   google.protobuf.Timestamp url_expire_at = 2;
   // object
-  Object object = 4;
+  Object object = 3;
 }

--- a/openapiv2/artifact/service.swagger.yaml
+++ b/openapiv2/artifact/service.swagger.yaml
@@ -630,24 +630,14 @@ paths:
           required: true
           type: string
         - name: objectUid
-          description: |-
-            uid of the object
-            if provided, object name is not required
-            uid has priority over name
+          description: uid of the object
           in: query
-          required: false
-          type: string
-        - name: objectName
-          description: |-
-            object name
-            if provided, object uid is not required
-          in: query
-          required: false
+          required: true
           type: string
         - name: urlExpireDays
           description: |-
-            Expiration time in days for the URL.
-            Minimum is 1 day and maximum is 7 days. If not set or set to 0, defaults to 1 day.
+            expiration time in days for the URL.
+            minimum is 1 day. if not set or set to 0, defaults to 1 day.
           in: query
           required: false
           type: integer
@@ -1598,6 +1588,14 @@ definitions:
         allOf:
           - $ref: '#/definitions/artifactv1alphaChunk'
     title: update chunk response
+  v1alphaUpdateObjectResponse:
+    type: object
+    properties:
+      object:
+        title: object
+        allOf:
+          - $ref: '#/definitions/v1alphaObject'
+    title: UpdateObjectResponse
   v1alphaUploadCatalogFileResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

when API Gateway succeeds in uploading a file, it will update the object info. 

This commit 

adds an internal method for API Gateway to use.