### PR TITLE
feat(metric): model trigger chart records api

### DIFF
--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -229,11 +229,39 @@ message ListPipelineTriggerChartRecordsRequest {
   optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
+// ListModelTriggerChartRecordsRequest represents a request to list model
+// trigger metrics, aggregated by model ID and time frame.
+message ListModelTriggerChartRecordsRequest {
+  // The ID of the namespace that requested the model triggers.
+  string requester_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 4;
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 5;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 6;
+}
+
 // ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
 // chart records.
 message ListPipelineTriggerChartRecordsResponse {
   // A list of pipeline trigger records.
   repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
+}
+
+// ListModelTriggerChartRecordsResponse contains a list of model trigger
+// chart records.
+message ListModelTriggerChartRecordsResponse {
+  // Model trigger counts. Until we allow filtering or grouping by fields
+  // like model ID, this list will contain only one element with the
+  // timeline of trigger counts for a given requester, regardless the model
+  // ID, trigger mode, final status or other fields.
+  repeated ModelTriggerChartRecord model_trigger_chart_records = 1;
 }
 
 // PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
@@ -304,4 +332,18 @@ message ListPipelineTriggerRecordsResponse {
   string next_page_token = 2;
   // Total number of pipeline triggers.
   int32 total_size = 3;
+}
+
+// ModelTriggerChartRecord represents a timeline of model triggers. It
+// contains a collection of (timestamp, count) pairs that represent the total
+// model triggers in a given time bucket.
+message ModelTriggerChartRecord {
+  // This field will be present present when the information is grouped by model.
+  optional string model_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Time buckets.
+  repeated google.protobuf.Timestamp time_buckets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Aggregated trigger count in each time bucket.
+  repeated int32 trigger_counts = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The ID of the namespace that requested the model triggers.
+  string requester_id = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -324,6 +324,16 @@ service MgmtPublicService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "📊 Metrics"};
   }
 
+  // List model trigger time charts
+  //
+  // Returns a timeline of model trigger counts for a given requester. The
+  // response will contain one set of records (datapoints), representing the
+  // amount of triggers in a time bucket.
+  rpc ListModelTriggerChartRecords(ListModelTriggerChartRecordsRequest) returns (ListModelTriggerChartRecordsResponse) {
+    option (google.api.http) = {get: "/v1beta/model-runs:query-charts"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "📊 Metrics"};
+  }
+
   // List Instill Credit consumption time charts
   //
   // Returns a timeline of Instill Credit consumption for a given owner. The

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -2157,6 +2157,59 @@ paths:
           type: string
       tags:
         - "\U0001F4CA Metrics"
+  /v1beta/model-runs:query-charts:
+    get:
+      summary: List model trigger time charts
+      description: |-
+        Returns a timeline of model trigger counts for a given requester. The
+        response will contain one set of records (datapoints), representing the
+        amount of triggers in a time bucket.
+      operationId: MgmtPublicService_ListModelTriggerChartRecords
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/ListModelTriggerChartRecordsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: requesterId
+          description: The ID of the namespace that requested the model triggers.
+          in: query
+          required: true
+          type: string
+        - name: aggregationWindow
+          description: |-
+            Aggregation window. The value is a positive duration string, i.e. a
+            sequence of decimal numbers, each with optional fraction and a unit
+            suffix, such as "300ms", "1.5h" or "2h45m".
+            The minimum (and default) window is 1h.
+          in: query
+          required: false
+          type: string
+        - name: start
+          description: |-
+            Beginning of the time range from which the records will be fetched.
+            The default value is the beginning of the current day, in UTC.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: stop
+          description: |-
+            End of the time range from which the records will be fetched.
+            The default value is the current timestamp.
+          in: query
+          required: false
+          type: string
+          format: date-time
+      tags:
+        - "\U0001F4CA Metrics"
   /v1beta/metrics/credit/charts:
     get:
       summary: List Instill Credit consumption time charts
@@ -7403,6 +7456,22 @@ definitions:
         description: The requested page offset.
         readOnly: true
     description: ListModelRunsResponse contains a list of model runs.
+  ListModelTriggerChartRecordsResponse:
+    type: object
+    properties:
+      modelTriggerChartRecords:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/ModelTriggerChartRecord'
+        description: |-
+          Model trigger counts. Until we allow filtering or grouping by fields
+          like model ID, this list will contain only one element with the
+          timeline of trigger counts for a given requester, regardless the model
+          ID, trigger mode, final status or other fields.
+    description: |-
+      ListModelTriggerChartRecordsResponse contains a list of model trigger
+      chart records.
   ListModelsAdminResponse:
     type: object
     properties:
@@ -8272,6 +8341,35 @@ definitions:
           deleted namespace.
         readOnly: true
     description: ModelRun contains information about a run of models.
+  ModelTriggerChartRecord:
+    type: object
+    properties:
+      modelId:
+        type: string
+        description: This field will be present present when the information is grouped by model.
+        readOnly: true
+      timeBuckets:
+        type: array
+        items:
+          type: string
+          format: date-time
+        description: Time buckets.
+        readOnly: true
+      triggerCounts:
+        type: array
+        items:
+          type: integer
+          format: int32
+        description: Aggregated trigger count in each time bucket.
+        readOnly: true
+      requesterId:
+        type: string
+        description: The ID of the namespace that requested the model triggers.
+        readOnly: true
+    description: |-
+      ModelTriggerChartRecord represents a timeline of model triggers. It
+      contains a collection of (timestamp, count) pairs that represent the total
+      model triggers in a given time bucket.
   ModelVersion:
     type: object
     properties:


### PR DESCRIPTION
Because

- dashboard needs API for model trigger count

This commit

- add new metrics API
