### PR TITLE
chore(integration): mark connection.namespace_id as output-only

### DIFF
--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6081,6 +6081,7 @@ definitions:
       namespaceId:
         type: string
         description: ID of the namespace owning the connection.
+        readOnly: true
       integrationId:
         type: string
         description: |-
@@ -6151,7 +6152,6 @@ definitions:
       used by several components and pipelines.
     required:
       - id
-      - namespaceId
       - integrationId
       - method
       - setup

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -30,10 +30,7 @@ message Connection {
   // ID.
   string id = 2 [(google.api.field_behavior) = REQUIRED];
   // ID of the namespace owning the connection.
-  string namespace_id = 3 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.field_behavior) = IMMUTABLE
-  ];
+  string namespace_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Integration ID. It determines for which type of components can reference
   // this connection.
   string integration_id = 4 [


### PR DESCRIPTION
Because

- The creation / update requests use an explicit parameter for this info
  (instead of the value in the nested object), so this field has become
  output-only.


This commit

- Updates the field behaviour of `connection.namespace_id`
