### PR TITLE
feat(openapi): add x-stage extension to public endpoints

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Buffers](https://protobuf.dev/). The proto files are the source from which
 different code is auto-generated (e.g., language SDKs, OpenAPI
 specification of the contracts).
 
-### OpenAPI contracts
+### OpenAPI Contracts
 
 All the public endpoints are exposed in a single service
 ([`api-gateway`](https://github.com/instill-ai/api-gateway)]). These
@@ -29,7 +29,7 @@ format](../openapi/v2/service.swagger.yaml) and publicly available at
 auto-generated via [`grpc-gateway`](https://grpc-ecosystem.github.io/grpc-gateway/)
 and it only reflects the protobuf specification.
 
-## Codebase contribution
+## Codebase Contribution
 
 The Instill AI contracts follow most of the guidelines provided by [Google
 AIP](https://google.aip.dev/) but have made adjustments in certain areas
@@ -99,13 +99,39 @@ rpc UpdateNamespacePipeline(UpdateNamespacePipelineRequest) returns (UpdateNames
         patch: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"
         body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
 }
 ```
 
 [openapi.instill.tech](https://openapi.instill.tech) will render each part
 as the endpoint title (which can also used in the search engine) and the
 description in the endpoint's view.
+
+### Swagger Extensions
+
+The [Swagger
+Extension](https://swagger.io/docs/specification/2-0/swagger-extensions/)
+`x-stage` **MUST** be present in every **public** method for endpoints in
+_alpha_ or _beta_ stage. This extension can be added with the
+`openapiv2_operation` option:
+
+```proto
+// Get a pipeline
+//
+// Returns the details of a pipeline.
+rpc GetNamespacePipeline(GetNamespacePipelineRequest) returns (GetNamespacePipelineResponse) {
+    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+    tags: "💧 VDP"
+    extensions: {
+        key: "x-stage"
+            value {string_value: "beta"}
+        }
+    };
+}
+```
+
+This is used in the C# SDK generator to warn about the stage of the
+endpoints
 
 ## Sending PRs
 

--- a/app/app/v1alpha/app_public_service.proto
+++ b/app/app/v1alpha/app_public_service.proto
@@ -48,7 +48,13 @@ service AppPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/apps"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // List all apps info
@@ -56,7 +62,13 @@ service AppPublicService {
   // Returns a paginated list of apps.
   rpc ListApps(ListAppsRequest) returns (ListAppsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/apps"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Update a app info
@@ -67,7 +79,13 @@ service AppPublicService {
       put: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Delete a app
@@ -75,7 +93,13 @@ service AppPublicService {
   // Deletes an app.
   rpc DeleteApp(DeleteAppRequest) returns (DeleteAppResponse) {
     option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Create a conversation
@@ -86,7 +110,13 @@ service AppPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // List conversations
@@ -94,7 +124,13 @@ service AppPublicService {
   // Returns a paginated list of conversations.
   rpc ListConversations(ListConversationsRequest) returns (ListConversationsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Update a conversation
@@ -105,7 +141,13 @@ service AppPublicService {
       put: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Delete a conversation
@@ -113,7 +155,13 @@ service AppPublicService {
   // Deletes a conversation.
   rpc DeleteConversation(DeleteConversationRequest) returns (DeleteConversationResponse) {
     option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Create a message
@@ -124,7 +172,13 @@ service AppPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}/messages"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // List messages
@@ -132,7 +186,13 @@ service AppPublicService {
   // Returns a paginated list of messages.
   rpc ListMessages(ListMessagesRequest) returns (ListMessagesResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}/messages"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Update a message
@@ -143,7 +203,13 @@ service AppPublicService {
       put: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}/messages/{message_uid}"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Delete a message
@@ -151,7 +217,13 @@ service AppPublicService {
   // Deletes a message.
   rpc DeleteMessage(DeleteMessageRequest) returns (DeleteMessageResponse) {
     option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/conversations/{conversation_id}/messages/{message_uid}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Get Playground Conversation
@@ -159,7 +231,13 @@ service AppPublicService {
   // Returns the latest conversation of auth user(e.g. login user and api key user).
   rpc GetPlaygroundConversation(GetPlaygroundConversationRequest) returns (GetPlaygroundConversationResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/ai_assistant_playground/conversation"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Restart Playground Conversation
@@ -168,7 +246,13 @@ service AppPublicService {
   // auto-generates a new conversation ID on the behalf of auth user.
   rpc RestartPlaygroundConversation(RestartPlaygroundConversationRequest) returns (RestartPlaygroundConversationResponse) {
     option (google.api.http) = {post: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/ai_assistant_playground/restart"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Chat
@@ -181,6 +265,12 @@ service AppPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/apps/{app_id}/chat"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🍎 App"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 App"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 }

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -51,7 +51,13 @@ service ArtifactPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/catalogs"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get all catalogs info
@@ -59,7 +65,13 @@ service ArtifactPublicService {
   // Returns a paginated list of catalogs.
   rpc ListCatalogs(ListCatalogsRequest) returns (ListCatalogsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a catalog info
@@ -70,7 +82,13 @@ service ArtifactPublicService {
       put: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a catalog
@@ -78,7 +96,13 @@ service ArtifactPublicService {
   // Deletes a catalog.
   rpc DeleteCatalog(DeleteCatalogRequest) returns (DeleteCatalogResponse) {
     option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Create a file
@@ -89,7 +113,13 @@ service ArtifactPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files"
       body: "file"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a file
@@ -97,7 +127,13 @@ service ArtifactPublicService {
   // Deletes a file.
   rpc DeleteCatalogFile(DeleteCatalogFileRequest) returns (DeleteCatalogFileResponse) {
     option (google.api.http) = {delete: "/v1alpha/catalogs/files"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Process catalog files
@@ -125,7 +161,13 @@ service ArtifactPublicService {
   // Returns a paginated list of catalog files.
   rpc ListCatalogFiles(ListCatalogFilesRequest) returns (ListCatalogFilesResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List catalog chunks
@@ -133,7 +175,13 @@ service ArtifactPublicService {
   // Returns a paginated list of catalog chunks.
   rpc ListChunks(ListChunksRequest) returns (ListChunksResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/chunks"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get catalog single-source-of-truth file
@@ -141,7 +189,13 @@ service ArtifactPublicService {
   // Gets the single-source-of-truth file of a catalog.
   rpc GetSourceFile(GetSourceFileRequest) returns (GetSourceFileResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files/{file_uid}/source"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update catalog chunk
@@ -152,7 +206,13 @@ service ArtifactPublicService {
       post: "/v1alpha/chunks/{chunk_uid}"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Retrieve similar chunks
@@ -200,7 +260,13 @@ service ArtifactPublicService {
   // Get the catalog file.
   rpc GetFileCatalog(GetFileCatalogRequest) returns (GetFileCatalogResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List Catalog Runs
@@ -208,7 +274,13 @@ service ArtifactPublicService {
   // Returns a paginated list of catalog runs.
   rpc ListCatalogRuns(ListCatalogRunsRequest) returns (ListCatalogRunsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/catalogs/{catalog_id}/runs"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get Object Upload URL
@@ -216,7 +288,13 @@ service ArtifactPublicService {
   // Returns the upload URL of an object.
   rpc GetObjectUploadURL(GetObjectUploadURLRequest) returns (GetObjectUploadURLResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/object-upload-url"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get Object Download URL
@@ -224,6 +302,12 @@ service ArtifactPublicService {
   // Returns the download URL of an object.
   rpc GetObjectDownloadURL(GetObjectDownloadURLRequest) returns (GetObjectDownloadURLResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/object-download-url"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💾 Artifact"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 }

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -47,7 +47,13 @@ service MgmtPublicService {
   // Returns the details of the authenticated user.
   rpc GetAuthenticatedUser(GetAuthenticatedUserRequest) returns (GetAuthenticatedUserResponse) {
     option (google.api.http) = {get: "/v1beta/user"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update the authenticated user
@@ -61,7 +67,13 @@ service MgmtPublicService {
       patch: "/v1beta/user"
       body: "user"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List users
@@ -69,7 +81,13 @@ service MgmtPublicService {
   // Returns a paginated list of users.
   rpc ListUsers(ListUsersRequest) returns (ListUsersResponse) {
     option (google.api.http) = {get: "/v1beta/users"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a user
@@ -77,7 +95,13 @@ service MgmtPublicService {
   // Returns the details of a user by their ID.
   rpc GetUser(GetUserRequest) returns (GetUserResponse) {
     option (google.api.http) = {get: "/v1beta/users/{user_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Create an organization
@@ -88,7 +112,13 @@ service MgmtPublicService {
       post: "/v1beta/organizations"
       body: "organization"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List organizations
@@ -96,7 +126,13 @@ service MgmtPublicService {
   // Returns a paginated list of organizations.
   rpc ListOrganizations(ListOrganizationsRequest) returns (ListOrganizationsResponse) {
     option (google.api.http) = {get: "/v1beta/organizations"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get an organization
@@ -104,7 +140,13 @@ service MgmtPublicService {
   // Returns the organization details by its ID.
   rpc GetOrganization(GetOrganizationRequest) returns (GetOrganizationResponse) {
     option (google.api.http) = {get: "/v1beta/organizations/{organization_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update an organization
@@ -118,7 +160,13 @@ service MgmtPublicService {
       patch: "/v1beta/organizations/{organization_id}"
       body: "organization"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete an organization
@@ -126,7 +174,13 @@ service MgmtPublicService {
   // Accesses and deletes an organization by ID.
   rpc DeleteOrganization(DeleteOrganizationRequest) returns (DeleteOrganizationResponse) {
     option (google.api.http) = {delete: "/v1beta/organizations/{organization_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List user memberships
@@ -134,7 +188,13 @@ service MgmtPublicService {
   // Returns the memberships of a user.
   rpc ListUserMemberships(ListUserMembershipsRequest) returns (ListUserMembershipsResponse) {
     option (google.api.http) = {get: "/v1beta/users/{user_id}/memberships"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a user membership
@@ -143,7 +203,13 @@ service MgmtPublicService {
   // organization. The authenticated must match the membership parent.
   rpc GetUserMembership(GetUserMembershipRequest) returns (GetUserMembershipResponse) {
     option (google.api.http) = {get: "/v1beta/users/{user_id}/memberships/{organization_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a user membership
@@ -154,7 +220,13 @@ service MgmtPublicService {
       put: "/v1beta/users/{user_id}/memberships/{organization_id}"
       body: "membership"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a user membership
@@ -162,7 +234,13 @@ service MgmtPublicService {
   // Accesses and deletes a user membership by parent and membership IDs.
   rpc DeleteUserMembership(DeleteUserMembershipRequest) returns (DeleteUserMembershipResponse) {
     option (google.api.http) = {delete: "/v1beta/users/{user_id}/memberships/{organization_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List organization memberships
@@ -170,7 +248,13 @@ service MgmtPublicService {
   // Returns a paginated list of the user memberships in an organization.
   rpc ListOrganizationMemberships(ListOrganizationMembershipsRequest) returns (ListOrganizationMembershipsResponse) {
     option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/memberships"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a an organization membership
@@ -178,7 +262,13 @@ service MgmtPublicService {
   // Returns the details of a user membership within an organization.
   rpc GetOrganizationMembership(GetOrganizationMembershipRequest) returns (GetOrganizationMembershipResponse) {
     option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/memberships/{user_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Uppdate an organization membership
@@ -189,7 +279,13 @@ service MgmtPublicService {
       put: "/v1beta/organizations/{organization_id}/memberships/{user_id}"
       body: "membership"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete an organization membership
@@ -197,7 +293,13 @@ service MgmtPublicService {
   // Deletes a user membership within an organization.
   rpc DeleteOrganizationMembership(DeleteOrganizationMembershipRequest) returns (DeleteOrganizationMembershipResponse) {
     option (google.api.http) = {delete: "/v1beta/organizations/{organization_id}/memberships/{user_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get the subscription of the authenticated user
@@ -205,7 +307,13 @@ service MgmtPublicService {
   // Returns the subscription details of the authenticated user.
   rpc GetAuthenticatedUserSubscription(GetAuthenticatedUserSubscriptionRequest) returns (GetAuthenticatedUserSubscriptionResponse) {
     option (google.api.http) = {get: "/v1beta/user/subscription"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🤝 Subscription"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🤝 Subscription"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get the subscription of an organization
@@ -213,7 +321,13 @@ service MgmtPublicService {
   // Returns the subscription details of an organization.
   rpc GetOrganizationSubscription(GetOrganizationSubscriptionRequest) returns (GetOrganizationSubscriptionResponse) {
     option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/subscription"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🤝 Subscription"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🤝 Subscription"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Create an API token
@@ -224,7 +338,13 @@ service MgmtPublicService {
       post: "/v1beta/tokens"
       body: "token"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List API tokens
@@ -232,7 +352,13 @@ service MgmtPublicService {
   // Returns a paginated list of the API tokens of the authenticated user.
   rpc ListTokens(ListTokensRequest) returns (ListTokensResponse) {
     option (google.api.http) = {get: "/v1beta/tokens"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get an API token
@@ -240,7 +366,13 @@ service MgmtPublicService {
   // Returns the details of an API token.
   rpc GetToken(GetTokenRequest) returns (GetTokenResponse) {
     option (google.api.http) = {get: "/v1beta/tokens/{token_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete an API token
@@ -248,7 +380,13 @@ service MgmtPublicService {
   // Deletes an API token.
   rpc DeleteToken(DeleteTokenRequest) returns (DeleteTokenResponse) {
     option (google.api.http) = {delete: "/v1beta/tokens/{token_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Validate an API token
@@ -256,7 +394,13 @@ service MgmtPublicService {
   // Validates an API token.
   rpc ValidateToken(ValidateTokenRequest) returns (ValidateTokenResponse) {
     option (google.api.http) = {post: "/v1beta/validate_token"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get the remaining Instill Credit
@@ -268,7 +412,13 @@ service MgmtPublicService {
   // On Instill Core, this endpoint will return a 404 Not Found status.
   rpc GetRemainingCredit(GetRemainingCreditRequest) returns (GetRemainingCreditResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/credit"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🤝 Subscription"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🤝 Subscription"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Check if a namespace is in use
@@ -280,7 +430,13 @@ service MgmtPublicService {
       post: "/v1beta/check-namespace"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "🪆 Namespace"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🪆 Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List pipeline triggers
@@ -288,7 +444,13 @@ service MgmtPublicService {
   // Returns a paginated list of pipeline executions.
   rpc ListPipelineTriggerRecords(ListPipelineTriggerRecordsRequest) returns (ListPipelineTriggerRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/triggers"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "📊 Metrics"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get pipeline trigger count
@@ -297,7 +459,13 @@ service MgmtPublicService {
   // Results are grouped by trigger status.
   rpc GetPipelineTriggerCount(GetPipelineTriggerCountRequest) returns (GetPipelineTriggerCountResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/trigger-count"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "📊 Metrics"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
     // This endpoint will remain hidden until the new dashboard is implemented
     // in the frontend. Until then, the server might return empty data.
     option (google.api.method_visibility).restriction = "INTERNAL";
@@ -309,7 +477,13 @@ service MgmtPublicService {
   // NOTE: This method is deprecated and will be retired soon.
   rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "📊 Metrics"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
     option deprecated = true;
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
@@ -321,7 +495,13 @@ service MgmtPublicService {
   // NOTE: This method will soon return the trigger counts of a given requester.
   rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "📊 Metrics"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List model trigger time charts
@@ -331,7 +511,13 @@ service MgmtPublicService {
   // amount of triggers in a time bucket.
   rpc ListModelTriggerChartRecords(ListModelTriggerChartRecordsRequest) returns (ListModelTriggerChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/model-runs:query-charts"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "📊 Metrics"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List Instill Credit consumption time charts
@@ -342,7 +528,13 @@ service MgmtPublicService {
   // consumed in a time bucket.
   rpc ListCreditConsumptionChartRecords(ListCreditConsumptionChartRecordsRequest) returns (ListCreditConsumptionChartRecordsResponse) {
     option (google.api.http) = {get: "/v1beta/metrics/credit/charts"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "📊 Metrics"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "📊 Metrics"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Auth endpoints are only used in the community edition and the OpenAPI

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -47,7 +47,13 @@ service ModelPublicService {
   // Returns a paginated list of model definitions.
   rpc ListModelDefinitions(ListModelDefinitionsRequest) returns (ListModelDefinitionsResponse) {
     option (google.api.http) = {get: "/v1alpha/model-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // List available regions
@@ -55,7 +61,13 @@ service ModelPublicService {
   // Returns a paginated list of available regions.
   rpc ListAvailableRegions(ListAvailableRegionsRequest) returns (ListAvailableRegionsResponse) {
     option (google.api.http) = {get: "/v1alpha/available-regions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Get a model definition
@@ -63,7 +75,13 @@ service ModelPublicService {
   // Returns the details of a model definition.
   rpc GetModelDefinition(GetModelDefinitionRequest) returns (GetModelDefinitionResponse) {
     option (google.api.http) = {get: "/v1alpha/model-definitions/{model_definition_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // List models
@@ -71,7 +89,13 @@ service ModelPublicService {
   // Returns a paginated list of models.
   rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/models"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Get a model by UID
@@ -79,7 +103,13 @@ service ModelPublicService {
   // Returns the details of a model by a permalink defined by the resource UID.
   rpc LookUpModel(LookUpModelRequest) returns (LookUpModelResponse) {
     option (google.api.http) = {get: "/v1alpha/{permalink=models/*}/lookUp"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
@@ -88,7 +118,13 @@ service ModelPublicService {
   // Returns a paginated list of models.
   rpc ListNamespaceModels(ListNamespaceModelsRequest) returns (ListNamespaceModelsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Create a new model
@@ -103,7 +139,13 @@ service ModelPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/models"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Get a model
@@ -111,7 +153,13 @@ service ModelPublicService {
   // Returns the detail of a model, accessing it by the model ID and its parent namespace.
   rpc GetNamespaceModel(GetNamespaceModelRequest) returns (GetNamespaceModelResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Update a model
@@ -126,7 +174,13 @@ service ModelPublicService {
       patch: "/v1alpha/namespaces/{namespace_id}/models/{model_id}"
       body: "model"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Delete a model
@@ -135,7 +189,13 @@ service ModelPublicService {
   // parent namespace and the ID of the model.
   rpc DeleteNamespaceModel(DeleteNamespaceModelRequest) returns (DeleteNamespaceModelResponse) {
     option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/models/{model_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Rename a model
@@ -147,7 +207,13 @@ service ModelPublicService {
       post: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Watch the state of a model version
@@ -157,7 +223,13 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchNamespaceModel(WatchNamespaceModelRequest) returns (WatchNamespaceModelResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Watch the state of the latest model version
@@ -167,7 +239,13 @@ service ModelPublicService {
   // allows clients to track the state.
   rpc WatchNamespaceLatestModel(WatchNamespaceLatestModelRequest) returns (WatchNamespaceLatestModelResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/watch"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // List namespace model versions
@@ -176,7 +254,13 @@ service ModelPublicService {
   // Contains model version and digest.
   rpc ListNamespaceModelVersions(ListNamespaceModelVersionsRequest) returns (ListNamespaceModelVersionsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Delete a model version
@@ -185,7 +269,13 @@ service ModelPublicService {
   // parent namespace and the ID of the model, and version.
   rpc DeleteNamespaceModelVersion(DeleteNamespaceModelVersionRequest) returns (DeleteNamespaceModelVersionResponse) {
     option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Trigger model inference
@@ -313,7 +403,13 @@ service ModelPublicService {
   // long-running operations in a model, such as trigger.
   rpc GetNamespaceModelOperation(GetNamespaceModelOperationRequest) returns (GetNamespaceModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/versions/{version}/operation"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Get the details of the latest long-running operation from a namespace model
@@ -322,7 +418,13 @@ service ModelPublicService {
   // long-running operations in a model, such as trigger.
   rpc GetNamespaceLatestModelOperation(GetNamespaceLatestModelOperationRequest) returns (GetNamespaceLatestModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/operation"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // Get the details of a long-running operation
@@ -331,7 +433,13 @@ service ModelPublicService {
   // long-running operations in a model, such as trigger.
   rpc GetModelOperation(GetModelOperationRequest) returns (GetModelOperationResponse) {
     option (google.api.http) = {get: "/v1alpha/operations/{operation_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "⚗️ Model"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
   }
 
   // The following endpoints are all deprecated

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -60,6 +60,7 @@ paths:
           type: string
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
     post:
       summary: Create an app
       description: Creates an app.
@@ -89,6 +90,7 @@ paths:
             $ref: '#/definitions/CreateAppBody'
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/apps/{appId}:
     delete:
       summary: Delete a app
@@ -119,6 +121,7 @@ paths:
           type: string
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
     put:
       summary: Update a app info
       description: Updates the information of an app.
@@ -153,6 +156,7 @@ paths:
             $ref: '#/definitions/UpdateAppBody'
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/conversations:
     get:
       summary: List conversations
@@ -211,6 +215,7 @@ paths:
           type: boolean
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
     post:
       summary: Create a conversation
       description: Creates a conversation.
@@ -245,6 +250,7 @@ paths:
             $ref: '#/definitions/CreateConversationBody'
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/conversations/{conversationId}:
     delete:
       summary: Delete a conversation
@@ -280,6 +286,7 @@ paths:
           type: string
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
     put:
       summary: Update a conversation
       description: Updates a conversation.
@@ -319,6 +326,7 @@ paths:
             $ref: '#/definitions/UpdateConversationBody'
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/conversations/{conversationId}/messages:
     get:
       summary: List messages
@@ -386,6 +394,7 @@ paths:
           type: string
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
     post:
       summary: Create a message
       description: Creates a message.
@@ -425,6 +434,7 @@ paths:
             $ref: '#/definitions/CreateMessageBody'
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/conversations/{conversationId}/messages/{messageUid}:
     delete:
       summary: Delete a message
@@ -465,6 +475,7 @@ paths:
           type: string
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
     put:
       summary: Update a message
       description: Updates a message.
@@ -509,6 +520,7 @@ paths:
             $ref: '#/definitions/UpdateMessageBody'
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/ai_assistant_playground/conversation:
     get:
       summary: Get Playground Conversation
@@ -539,6 +551,7 @@ paths:
           type: string
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/ai_assistant_playground/restart:
     post:
       summary: Restart Playground Conversation
@@ -571,6 +584,7 @@ paths:
           type: string
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/apps/{appId}/chat:
     post:
       summary: Chat
@@ -609,6 +623,7 @@ paths:
             $ref: '#/definitions/ChatBody'
       tags:
         - "\U0001F34E App"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs:
     get:
       summary: Get all catalogs info
@@ -634,6 +649,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
     post:
       summary: Create a catalog
       description: Creates a catalog.
@@ -663,6 +679,7 @@ paths:
             $ref: '#/definitions/CreateCatalogBody'
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}:
     get:
       summary: Get file catalog
@@ -703,6 +720,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
     delete:
       summary: Delete a catalog
       description: Deletes a catalog.
@@ -732,6 +750,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
     put:
       summary: Update a catalog info
       description: Updates the information of a catalog.
@@ -766,6 +785,7 @@ paths:
             $ref: '#/definitions/UpdateCatalogBody'
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/files:
     get:
       summary: List catalog files
@@ -815,6 +835,7 @@ paths:
           collectionFormat: multi
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
     post:
       summary: Create a file
       description: Creates a file.
@@ -850,6 +871,7 @@ paths:
             $ref: '#/definitions/File'
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1alpha/catalogs/files:
     delete:
       summary: Delete a file
@@ -875,6 +897,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1alpha/catalogs/files/processAsync:
     post:
       summary: Process catalog files
@@ -948,6 +971,7 @@ paths:
           collectionFormat: multi
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/files/{fileUid}/source:
     get:
       summary: Get catalog single-source-of-truth file
@@ -983,6 +1007,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1alpha/chunks/{chunkUid}:
     post:
       summary: Update catalog chunk
@@ -1013,6 +1038,7 @@ paths:
             $ref: '#/definitions/UpdateChunkBody'
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/chunks/retrieve:
     post:
       summary: Retrieve similar chunks
@@ -1152,6 +1178,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1alpha/namespaces/{namespaceId}/object-upload-url:
     get:
       summary: Get Object Upload URL
@@ -1208,6 +1235,7 @@ paths:
           format: int32
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1alpha/namespaces/{namespaceId}/object-download-url:
     get:
       summary: Get Object Download URL
@@ -1246,6 +1274,7 @@ paths:
           format: int32
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: beta
   /v1beta/user:
     get:
       summary: Get the authenticated user
@@ -1265,6 +1294,7 @@ paths:
             $ref: '#/definitions/rpc.Status'
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     patch:
       summary: Update the authenticated user
       description: |-
@@ -1296,6 +1326,7 @@ paths:
               - user
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/users:
     get:
       summary: List users
@@ -1350,6 +1381,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/users/{userId}:
     get:
       summary: Get a user
@@ -1387,6 +1419,7 @@ paths:
             - VIEW_FULL
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/organizations:
     get:
       summary: List organizations
@@ -1441,6 +1474,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     post:
       summary: Create an organization
       description: Creates an organization.
@@ -1466,6 +1500,7 @@ paths:
             $ref: '#/definitions/Organization'
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/organizations/{organizationId}:
     get:
       summary: Get an organization
@@ -1503,6 +1538,7 @@ paths:
             - VIEW_FULL
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     delete:
       summary: Delete an organization
       description: Accesses and deletes an organization by ID.
@@ -1527,6 +1563,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     patch:
       summary: Update an organization
       description: |-
@@ -1561,6 +1598,7 @@ paths:
             $ref: '#/definitions/Organization'
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/users/{userId}/memberships:
     get:
       summary: List user memberships
@@ -1586,6 +1624,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/users/{userId}/memberships/{organizationId}:
     get:
       summary: Get a user membership
@@ -1630,6 +1669,7 @@ paths:
             - VIEW_FULL
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     delete:
       summary: Delete a user membership
       description: Accesses and deletes a user membership by parent and membership IDs.
@@ -1659,6 +1699,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     put:
       summary: Update a user membership
       description: Accesses and updates a user membership by parent and membership IDs.
@@ -1705,6 +1746,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/organizations/{organizationId}/memberships:
     get:
       summary: List organization memberships
@@ -1730,6 +1772,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/organizations/{organizationId}/memberships/{userId}:
     get:
       summary: Get a an organization membership
@@ -1772,6 +1815,7 @@ paths:
             - VIEW_FULL
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     delete:
       summary: Delete an organization membership
       description: Deletes a user membership within an organization.
@@ -1801,6 +1845,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     put:
       summary: Uppdate an organization membership
       description: Updates a user membership within an organization.
@@ -1847,6 +1892,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/user/subscription:
     get:
       summary: Get the subscription of the authenticated user
@@ -1866,6 +1912,7 @@ paths:
             $ref: '#/definitions/rpc.Status'
       tags:
         - "\U0001F91D Subscription"
+      x-stage: beta
   /v1beta/organizations/{organizationId}/subscription:
     get:
       summary: Get the subscription of an organization
@@ -1891,6 +1938,7 @@ paths:
           type: string
       tags:
         - "\U0001F91D Subscription"
+      x-stage: beta
   /v1beta/tokens:
     get:
       summary: List API tokens
@@ -1925,6 +1973,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     post:
       summary: Create an API token
       description: Creates an API token for the authenticated user.
@@ -1950,6 +1999,7 @@ paths:
             $ref: '#/definitions/ApiToken'
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/tokens/{tokenId}:
     get:
       summary: Get an API token
@@ -1975,6 +2025,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
     delete:
       summary: Delete an API token
       description: Deletes an API token.
@@ -1999,6 +2050,7 @@ paths:
           type: string
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/validate_token:
     post:
       summary: Validate an API token
@@ -2018,6 +2070,7 @@ paths:
             $ref: '#/definitions/rpc.Status'
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/credit:
     get:
       summary: Get the remaining Instill Credit
@@ -2048,6 +2101,7 @@ paths:
           type: string
       tags:
         - "\U0001F91D Subscription"
+      x-stage: beta
   /v1beta/check-namespace:
     post:
       summary: Check if a namespace is in use
@@ -2078,6 +2132,7 @@ paths:
             $ref: '#/definitions/CheckNamespaceRequest'
       tags:
         - "\U0001FA86 Namespace"
+      x-stage: beta
   /v1beta/metrics/vdp/pipeline/triggers:
     get:
       summary: List pipeline triggers
@@ -2120,6 +2175,7 @@ paths:
           type: string
       tags:
         - "\U0001F4CA Metrics"
+      x-stage: beta
   /v1beta/metrics/vdp/pipeline/charts:
     get:
       summary: List pipeline trigger time charts
@@ -2157,6 +2213,7 @@ paths:
           type: string
       tags:
         - "\U0001F4CA Metrics"
+      x-stage: beta
   /v1beta/model-runs:query-charts:
     get:
       summary: List model trigger time charts
@@ -2210,6 +2267,7 @@ paths:
           format: date-time
       tags:
         - "\U0001F4CA Metrics"
+      x-stage: beta
   /v1beta/metrics/credit/charts:
     get:
       summary: List Instill Credit consumption time charts
@@ -2264,6 +2322,7 @@ paths:
           format: date-time
       tags:
         - "\U0001F4CA Metrics"
+      x-stage: beta
   /v1alpha/model-definitions:
     get:
       summary: List model definitions
@@ -2310,6 +2369,7 @@ paths:
             - VIEW_FULL
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/available-regions:
     get:
       summary: List available regions
@@ -2329,6 +2389,7 @@ paths:
             $ref: '#/definitions/rpc.Status'
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/model-definitions/{modelDefinitionId}:
     get:
       summary: Get a model definition
@@ -2368,6 +2429,7 @@ paths:
             - VIEW_FULL
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/models:
     get:
       summary: List models
@@ -2446,6 +2508,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models:
     get:
       summary: List namespace models
@@ -2529,6 +2592,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
     post:
       summary: Create a new model
       description: |-
@@ -2564,6 +2628,7 @@ paths:
             $ref: '#/definitions/Model'
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}:
     get:
       summary: Get a model
@@ -2606,6 +2671,7 @@ paths:
             - VIEW_FULL
       tags:
         - ⚗️ Model
+      x-stage: alpha
     delete:
       summary: Delete a model
       description: |-
@@ -2637,6 +2703,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
     patch:
       summary: Update a model
       description: |-
@@ -2679,6 +2746,7 @@ paths:
               - model
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/rename:
     post:
       summary: Rename a model
@@ -2716,6 +2784,7 @@ paths:
             $ref: '#/definitions/RenameNamespaceModelBody'
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}/watch:
     get:
       summary: Watch the state of a model version
@@ -2754,6 +2823,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/watch:
     get:
       summary: Watch the state of the latest model version
@@ -2787,6 +2857,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions:
     get:
       summary: List namespace model versions
@@ -2833,6 +2904,7 @@ paths:
           format: int32
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}:
     delete:
       summary: Delete a model version
@@ -2870,6 +2942,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}/trigger:
     post:
       summary: Trigger model inference
@@ -3099,6 +3172,7 @@ paths:
             - VIEW_FULL
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/operation:
     get:
       summary: Get the details of the latest long-running operation from a namespace model
@@ -3143,6 +3217,7 @@ paths:
             - VIEW_FULL
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/operations/{operationId}:
     get:
       summary: Get the details of a long-running operation
@@ -3182,6 +3257,7 @@ paths:
             - VIEW_FULL
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/runs:
     get:
       summary: List model runs
@@ -3416,6 +3492,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines:
     get:
       summary: List namespace pipelines
@@ -3503,6 +3580,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     post:
       summary: Create a new pipeline
       description: Creates a new pipeline under a namespace.
@@ -3533,6 +3611,7 @@ paths:
             $ref: '#/definitions/Pipeline'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}:
     get:
       summary: Get a pipeline
@@ -3577,6 +3656,7 @@ paths:
             - VIEW_RECIPE
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     delete:
       summary: Delete a pipeline
       description: |-
@@ -3609,6 +3689,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     patch:
       summary: Update a pipeline
       description: |-
@@ -3650,6 +3731,7 @@ paths:
             $ref: '#/definitions/Pipeline'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/validate:
     post:
       summary: Validate a pipeline
@@ -3689,6 +3771,7 @@ paths:
             $ref: '#/definitions/ValidateNamespacePipelineBody'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/rename:
     post:
       summary: Rename a pipeline
@@ -3733,6 +3816,7 @@ paths:
             $ref: '#/definitions/RenameNamespacePipelineBody'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/clone:
     post:
       summary: Clone a pipeline
@@ -3770,6 +3854,7 @@ paths:
             $ref: '#/definitions/CloneNamespacePipelineBody'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/trigger:
     post:
       summary: Trigger a pipeline
@@ -3992,6 +4077,7 @@ paths:
           type: boolean
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     post:
       summary: Create a pipeline release
       description: |-
@@ -4032,6 +4118,7 @@ paths:
             $ref: '#/definitions/PipelineRelease'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}:
     get:
       summary: Get a pipeline release
@@ -4083,6 +4170,7 @@ paths:
             - VIEW_RECIPE
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     delete:
       summary: Delete a pipeline release
       description: |-
@@ -4122,6 +4210,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     patch:
       summary: Update a pipeline release
       description: |-
@@ -4169,6 +4258,7 @@ paths:
             $ref: '#/definitions/PipelineRelease'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}/clone:
     post:
       summary: Clone a pipeline release
@@ -4211,6 +4301,7 @@ paths:
             $ref: '#/definitions/CloneNamespacePipelineReleaseBody'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}/trigger:
     post:
       summary: Trigger a pipeline release
@@ -4356,6 +4447,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     post:
       summary: Create a secret
       description: Creates a new secret under the parenthood of an namespace.
@@ -4386,6 +4478,7 @@ paths:
             $ref: '#/definitions/Secret'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/secrets/{secretId}:
     get:
       summary: Get a secret
@@ -4418,6 +4511,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     delete:
       summary: Delete a secret
       description: |-
@@ -4449,6 +4543,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     patch:
       summary: Update a secret
       description: |-
@@ -4488,6 +4583,7 @@ paths:
             $ref: '#/definitions/Secret'
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/component-definitions:
     get:
       summary: List component definitions
@@ -4548,6 +4644,7 @@ paths:
           format: int32
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/operations/{operationId}:
     get:
       summary: Get the details of a long-running operation
@@ -4854,6 +4951,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     post:
       summary: Create a connection
       description: Creates a connection under the ownership of a namespace.
@@ -4886,6 +4984,7 @@ paths:
               - connection
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/connections/{connectionId}:
     get:
       summary: Get a namespace connection
@@ -4928,6 +5027,7 @@ paths:
             - VIEW_FULL
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     delete:
       summary: Delete a connection
       description: Deletes a connection.
@@ -4957,6 +5057,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
     patch:
       summary: Update a connection
       description: Updates a connection with the supplied connection fields.
@@ -4997,6 +5098,7 @@ paths:
               - connection
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/connections/{connectionId}/test:
     post:
       summary: Test a connection
@@ -5034,6 +5136,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/connections/{connectionId}/referenced-pipelines:
     get:
       summary: List pipelines that reference a connection
@@ -5086,6 +5189,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/integrations:
     get:
       summary: List integrations
@@ -5128,6 +5232,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/integrations/{integrationId}:
     get:
       summary: Get an integration
@@ -5165,6 +5270,7 @@ paths:
             - VIEW_FULL
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
 definitions:
   AIAssistantAppMetadata:
     type: object

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -46,7 +46,13 @@ service PipelinePublicService {
   // Return the stats of the hub
   rpc GetHubStats(GetHubStatsRequest) returns (GetHubStatsResponse) {
     option (google.api.http) = {get: "/v1beta/hub-stats"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
@@ -55,7 +61,13 @@ service PipelinePublicService {
   // Returns a paginated list of pipelines that are visible to the requester.
   rpc ListPipelines(ListPipelinesRequest) returns (ListPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a pipeline by UID
@@ -64,7 +76,13 @@ service PipelinePublicService {
   // UID.
   rpc LookUpPipeline(LookUpPipelineRequest) returns (LookUpPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{permalink=pipelines/*}/lookUp"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
@@ -73,7 +91,13 @@ service PipelinePublicService {
   // Returns a paginated list of pipelines of a namespace
   rpc ListNamespacePipelines(ListNamespacePipelinesRequest) returns (ListNamespacePipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Create a new pipeline
@@ -84,7 +108,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a pipeline
@@ -92,7 +122,13 @@ service PipelinePublicService {
   // Returns the details of a pipeline.
   rpc GetNamespacePipeline(GetNamespacePipelineRequest) returns (GetNamespacePipelineResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a pipeline
@@ -108,7 +144,13 @@ service PipelinePublicService {
       patch: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"
       body: "pipeline"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a pipeline
@@ -118,7 +160,13 @@ service PipelinePublicService {
   // the parent of the pipeline in order to delete it.
   rpc DeleteNamespacePipeline(DeleteNamespacePipelineRequest) returns (DeleteNamespacePipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Validate a pipeline
@@ -132,7 +180,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/validate"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Rename a pipeline
@@ -151,7 +205,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/rename"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Clone a pipeline
@@ -163,7 +223,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // SendNamespacePipelineEvent
@@ -278,7 +344,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List the releases in a pipeline
@@ -287,7 +359,13 @@ service PipelinePublicService {
   // name, which is formed by the parent namespace and ID of the pipeline.
   rpc ListNamespacePipelineReleases(ListNamespacePipelineReleasesRequest) returns (ListNamespacePipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a pipeline release
@@ -296,7 +374,13 @@ service PipelinePublicService {
   // by its resource name, formed by its parent namespace and ID.
   rpc GetNamespacePipelineRelease(GetNamespacePipelineReleaseRequest) returns (GetNamespacePipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a pipeline release
@@ -311,7 +395,13 @@ service PipelinePublicService {
       patch: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"
       body: "release"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a pipeline release
@@ -323,7 +413,13 @@ service PipelinePublicService {
   // perform this action.
   rpc DeleteNamespacePipelineRelease(DeleteNamespacePipelineReleaseRequest) returns (DeleteNamespacePipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Clone a pipeline release
@@ -335,7 +431,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/clone"
       body: "*"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Trigger a pipeline release
@@ -398,7 +500,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/secrets"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List secrets
@@ -407,7 +515,13 @@ service PipelinePublicService {
   // namespace.
   rpc ListNamespaceSecrets(ListNamespaceSecretsRequest) returns (ListNamespaceSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a secret
@@ -416,7 +530,13 @@ service PipelinePublicService {
   // which is defined by the parent namespace and the ID of the secret.
   rpc GetNamespaceSecret(GetNamespaceSecretRequest) returns (GetNamespaceSecretResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a secret
@@ -430,7 +550,13 @@ service PipelinePublicService {
       patch: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"
       body: "secret"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a secret
@@ -439,7 +565,13 @@ service PipelinePublicService {
   // the parent namespace and the ID of the secret.
   rpc DeleteNamespaceSecret(DeleteNamespaceSecretRequest) returns (DeleteNamespaceSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List component definitions
@@ -449,7 +581,13 @@ service PipelinePublicService {
   // capabilities, for the components that might be used in a VDP pipeline.
   rpc ListComponentDefinitions(ListComponentDefinitionsRequest) returns (ListComponentDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/component-definitions"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get the details of a long-running operation
@@ -1257,7 +1395,13 @@ service PipelinePublicService {
   // Returns a paginated list of connections created by a namespace.
   rpc ListNamespaceConnections(ListNamespaceConnectionsRequest) returns (ListNamespaceConnectionsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/connections"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get a namespace connection
@@ -1265,7 +1409,13 @@ service PipelinePublicService {
   // Returns the details of a connection.
   rpc GetNamespaceConnection(GetNamespaceConnectionRequest) returns (GetNamespaceConnectionResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Create a connection
@@ -1276,7 +1426,13 @@ service PipelinePublicService {
       post: "/v1beta/namespaces/{namespace_id}/connections"
       body: "connection"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Update a connection
@@ -1287,7 +1443,13 @@ service PipelinePublicService {
       patch: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}"
       body: "connection"
     };
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Delete a connection
@@ -1295,7 +1457,13 @@ service PipelinePublicService {
   // Deletes a connection.
   rpc DeleteNamespaceConnection(DeleteNamespaceConnectionRequest) returns (DeleteNamespaceConnectionResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Test a connection
@@ -1309,7 +1477,13 @@ service PipelinePublicService {
   // account in the 3rd party app.
   rpc TestNamespaceConnection(TestNamespaceConnectionRequest) returns (TestNamespaceConnectionResponse) {
     option (google.api.http) = {post: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}/test"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List pipelines that reference a connection
@@ -1319,7 +1493,13 @@ service PipelinePublicService {
   // the connection.
   rpc ListPipelineIDsByConnectionID(ListPipelineIDsByConnectionIDRequest) returns (ListPipelineIDsByConnectionIDResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}/referenced-pipelines"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // List integrations
@@ -1327,7 +1507,13 @@ service PipelinePublicService {
   // Returns a paginated list of available integrations.
   rpc ListIntegrations(ListIntegrationsRequest) returns (ListIntegrationsResponse) {
     option (google.api.http) = {get: "/v1beta/integrations"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 
   // Get an integration
@@ -1335,6 +1521,12 @@ service PipelinePublicService {
   // Returns the details of an integration.
   rpc GetIntegration(GetIntegrationRequest) returns (GetIntegrationResponse) {
     option (google.api.http) = {get: "/v1beta/integrations/{integration_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
   }
 }


### PR DESCRIPTION
Because

- This feature was recommended in order to build the C# SDK from the
  OpenAPI docs. This will warn SDK users about the stage of the endpoint.

This commit

- Adds extension and documents the convention.
