### PR TITLE
feat(blob,catalog): add external_metadata field and correct the comment

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -419,7 +419,7 @@ message File {
   int32 total_chunks = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
   // total tokens
   int32 total_tokens = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
-  
+
   // Custom metadata provided by the user during file upload
   optional google.protobuf.Struct external_metadata = 17 [(google.api.field_behavior) = OPTIONAL];
 }

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -419,6 +419,9 @@ message File {
   int32 total_chunks = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
   // total tokens
   int32 total_tokens = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
+  
+  // Custom metadata provided by the user during file upload
+  optional google.protobuf.Struct external_metadata = 17 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // upload file request

--- a/artifact/artifact/v1alpha/object.proto
+++ b/artifact/artifact/v1alpha/object.proto
@@ -44,8 +44,8 @@ message GetObjectUploadURLRequest {
   // name of the object with length limit to 1024 characters.
   // this is the unique identifier of the object in the namespace
   string object_name = 2 [(google.api.field_behavior) = REQUIRED];
-  // Expiration time in days for the URL.
-  // Minimum is 1 day and maximum is 7 days. If not set or set to 0, defaults to 1 day.
+  // expiration time in days for the URL.
+  // maximum is 7 days. if set to 0, URL will not expire.
   int32 url_expire_days = 3 [(google.api.field_behavior) = OPTIONAL];
   // last modified time this value is provided by the client when the object url is created
   // it must be in RFC3339 formatted date-time string
@@ -72,7 +72,7 @@ message GetObjectDownloadURLRequest {
   // uid of the object
   string object_uid = 2 [(google.api.field_behavior) = REQUIRED];
   // expiration time in days for the URL.
-  // minimum is 1 day. if not set or set to 0, defaults to 1 day.
+  // maximum is 7 days. if set to 0, URL will not expire.
   int32 url_expire_days = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -1184,8 +1184,8 @@ paths:
           type: string
         - name: urlExpireDays
           description: |-
-            Expiration time in days for the URL.
-            Minimum is 1 day and maximum is 7 days. If not set or set to 0, defaults to 1 day.
+            expiration time in days for the URL.
+            maximum is 7 days. if set to 0, URL will not expire.
           in: query
           required: false
           type: integer
@@ -1239,7 +1239,7 @@ paths:
         - name: urlExpireDays
           description: |-
             expiration time in days for the URL.
-            minimum is 1 day. if not set or set to 0, defaults to 1 day.
+            maximum is 7 days. if set to 0, URL will not expire.
           in: query
           required: false
           type: integer
@@ -6615,6 +6615,9 @@ definitions:
         format: int32
         title: total tokens
         readOnly: true
+      externalMetadata:
+        type: object
+        title: Custom metadata provided by the user during file upload
     title: file
     required:
       - name


### PR DESCRIPTION
Because:

1. We will support users attaching metadata to uploaded files.
2. The URL should support a non-expiring mode.

This commit:

1. Adds external_metadata in the file message.
2. Allows url_expire to be set to 0, meaning it does not expire.

ref: ins-6685