### PR TITLE
fix(run): change total size type to int32

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -592,7 +592,7 @@ message ListCatalogRunsResponse {
   repeated CatalogRun catalog_runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The total number of runs matching the request.
-  int64 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  int32 total_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The current page number.
   int32 page = 3 [(google.api.field_behavior) = OUTPUT_ONLY];

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7334,8 +7334,8 @@ definitions:
         description: The list of runs.
         readOnly: true
       totalSize:
-        type: string
-        format: int64
+        type: integer
+        format: int32
         description: The total number of runs matching the request.
         readOnly: true
       page:


### PR DESCRIPTION
Because

- int type usage should align with others

This commit

- change total size type to int32
