### PR TITLE
fix(metric): fix path conflicts with existing wildcard in gin

### DIFF
--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -476,7 +476,7 @@ service MgmtPublicService {
   // Returns the model trigger count of a given requester within a timespan.
   // Results are grouped by trigger status.
   rpc GetModelTriggerCount(GetModelTriggerCountRequest) returns (GetModelTriggerCountResponse) {
-    option (google.api.http) = {get: "/v1beta/model-runs:count"};
+    option (google.api.http) = {get: "/v1beta/model-runs/count"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "📊 Metrics"
       extensions: {
@@ -528,7 +528,7 @@ service MgmtPublicService {
   // response will contain one set of records (datapoints), representing the
   // amount of triggers in a time bucket.
   rpc ListModelTriggerChartRecords(ListModelTriggerChartRecordsRequest) returns (ListModelTriggerChartRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/model-runs:query-charts"};
+    option (google.api.http) = {get: "/v1beta/model-runs/query-charts"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "📊 Metrics"
       extensions: {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -2214,7 +2214,7 @@ paths:
       tags:
         - "\U0001F4CA Metrics"
       x-stage: beta
-  /v1beta/model-runs:query-charts:
+  /v1beta/model-runs/query-charts:
     get:
       summary: List model trigger time charts
       description: |-


### PR DESCRIPTION
Because

- using colons in url paths will cause conflicts either in krakend or gin

This commit

- replace colons with `/`
