### PR TITLE
fix(run): add namespace id in response

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1773,6 +1773,8 @@ message ModelRun {
   // Requester ID. This field might be empty if the model run belongs to a
   // deleted namespace.
   string requester_id = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Namespace ID.
+  string namespace_id = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListModelRunsRequest represents a request to list of model runs.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -8449,6 +8449,10 @@ definitions:
           Requester ID. This field might be empty if the model run belongs to a
           deleted namespace.
         readOnly: true
+      namespaceId:
+        type: string
+        description: Namespace ID.
+        readOnly: true
     description: ModelRun contains information about a run of models.
   ModelTriggerChartRecord:
     type: object
@@ -9119,6 +9123,10 @@ definitions:
         description: |-
           Requester ID. This field might be empty if the pipeline run belongs to a
           deleted namespace.
+        readOnly: true
+      namespaceId:
+        type: string
+        title: Namespace ID
         readOnly: true
     description: PipelineRun represents a single execution of a pipeline.
   PipelineTriggerChartRecord:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -2075,6 +2075,9 @@ message PipelineRun {
   // Requester ID. This field might be empty if the pipeline run belongs to a
   // deleted namespace.
   string requester_id = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Namespace ID
+  string namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.


### PR DESCRIPTION
Because

- dashboard needs pipeline/model namespace id to redirect

This commit

- add namespace id in response
