### PR TITLE
feat(mgmt): update metrics endpoints to serve new dashboard design

### DIFF
--- a/core/mgmt/v1beta/metric.proto
+++ b/core/mgmt/v1beta/metric.proto
@@ -38,39 +38,6 @@ message TriggerCount {
   optional Status status = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-/*
-   // PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
-   // contains a collection of (timestamp, count) pairs that represent the total
-   // pipeline triggers in a given time bucket.
-   // pipeline ID and time frame.
-   message PipelineTriggerChartRecord {
-     // This field will be present present when the information is grouped by pipeline.
-     optional string pipeline_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-     // 2 is reserved for the pipeline UUID.
-     reserved 2;
-     // 3 is reserved for the trigger mode. The server wasn't grouping results by this
-     // field.
-     reserved 3;
-     // 4 is reserved for the trigger status. The server wasn't grouping results
-     // by this field.
-     reserved 4;
-     // Time buckets.
-     repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-     // Aggregated trigger count in each time bucket.
-     repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-     // 7 is reserved for the trigger execution duration.
-     reserved 7;
-     // 8 is reserved for the pipeline release ID. The server wasn't grouping
-     // results by this field.
-     reserved 8;
-     // 9 is reserved for the pipeline release UUID. The server wasn't grouping
-     // results by this field.
-     reserved 9;
-     // The ID of the namespace that requested the pipeline triggers.
-     string namespace_id = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-   }
-*/
-
 // GetPipelineTriggerCountRequest represents a request to fetch the trigger
 // count of a requester over a time period.
 message GetPipelineTriggerCountRequest {
@@ -111,44 +78,42 @@ message GetModelTriggerCountResponse {
   repeated TriggerCount model_trigger_counts = 1;
 }
 
-/*
-   // ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
-   // trigger chart records for a given requester, grouped by time buckets.
-   message ListPipelineTriggerChartRecordsRequest {
-     // 1 is reserved for the aggregation window in nanoseconds. This is
-     // deprecated in favour of an aggregation window string that represents a
-     // duration.
-     reserved 1;
-     // 2 is reserved for the filter. For now, this endpoint won't allow filtering
-     // but in the future we might implement a filter to show the trigger count of
-     // only certain pipelines and to group by the pipeline ID.
-     reserved 2;
+// ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
+// trigger chart records for a given requester, grouped by time buckets.
+message ListPipelineTriggerChartRecordsRequest {
+  // 1 is reserved for the aggregation window in nanoseconds. This is
+  // deprecated in favour of an aggregation window string that represents a
+  // duration.
+  reserved 1;
+  // 2 is reserved for the filter. For now, this endpoint won't allow filtering
+  // but in the future we might implement a filter to show the trigger count of
+  // only certain pipelines and to group by the pipeline ID.
+  reserved 2;
 
-     // The ID of the namespace that requested the pipeline triggers.
-     string namespace_id = 3 [(google.api.field_behavior) = REQUIRED];
-     // Aggregation window. The value is a positive duration string, i.e. a
-     // sequence of decimal numbers, each with optional fraction and a unit
-     // suffix, such as "300ms", "1.5h" or "2h45m".
-     // The minimum (and default) window is 1h.
-     optional string aggregation_window = 4;
-     // Beginning of the time range from which the records will be fetched.
-     // The default value is the beginning of the current day, in UTC.
-     optional google.protobuf.Timestamp start = 5;
-     // End of the time range from which the records will be fetched.
-     // The default value is the current timestamp.
-     optional google.protobuf.Timestamp stop = 6;
-   }
+  // The ID of the namespace that requested the pipeline triggers.
+  string requester_id = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Aggregation window. The value is a positive duration string, i.e. a
+  // sequence of decimal numbers, each with optional fraction and a unit
+  // suffix, such as "300ms", "1.5h" or "2h45m".
+  // The minimum (and default) window is 1h.
+  optional string aggregation_window = 4;
+  // Beginning of the time range from which the records will be fetched.
+  // The default value is the beginning of the current day, in UTC.
+  optional google.protobuf.Timestamp start = 5;
+  // End of the time range from which the records will be fetched.
+  // The default value is the current timestamp.
+  optional google.protobuf.Timestamp stop = 6;
+}
 
-   // ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
-   // chart records.
-   message ListPipelineTriggerChartRecordsResponse {
-     // Pipeline trigger counts. Until we allow filtering or grouping by fields
-     // like pipeline ID, this list will contain only one element with the
-     // timeline of trigger counts for a given requester, regardless the pipeline
-     // ID, trigger mode, final status or other fields.
-     repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
-   }
-*/
+// ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
+// chart records.
+message ListPipelineTriggerChartRecordsResponse {
+  // Pipeline trigger counts. Until we allow filtering or grouping by fields
+  // like pipeline ID, this list will contain only one element with the
+  // timeline of trigger counts for a given requester, regardless the pipeline
+  // ID, trigger mode, final status or other fields.
+  repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
+}
 
 // CreditConsumptionChartRecord represents a timeline of Instill Credit
 // consumption. It contains a collection of (timestamp, amount) pairs that
@@ -194,61 +159,6 @@ message ListCreditConsumptionChartRecordsResponse {
   reserved 2;
 }
 
-// Deprecated messages, to be removed with the new dashboard implementation.
-
-// PipelineTriggerTableRecord contains pipeline trigger metrics, aggregated by
-// pipeline ID.
-message PipelineTriggerTableRecord {
-  // Pipeline ID.
-  string pipeline_id = 1;
-  // Pipeline UUID.
-  string pipeline_uid = 2;
-  // Number of triggers with `STATUS_COMPLETED`.
-  int32 trigger_count_completed = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Number of triggers with `STATUS_ERRORED`.
-  int32 trigger_count_errored = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Version for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Release UUID for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
-// ListPipelineTriggerTableRecordsRequest represents a request to list the
-// pipeline triggers metrics, aggregated by pipeline ID.
-message ListPipelineTriggerTableRecordsRequest {
-  // The maximum number of results to return. If this parameter is unspecified,
-  // at most 100 pipelines will be returned. The cap value for this parameter
-  // is 1000 (i.e. any value above that will be coerced to 1000).
-  optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
-  // Page token.
-  optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 3 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// ListPipelineTriggerTableRecordsResponse contains the pipeline metrics.
-message ListPipelineTriggerTableRecordsResponse {
-  // A list of pipeline trigger tables.
-  repeated PipelineTriggerTableRecord pipeline_trigger_table_records = 1;
-  // Next page token.
-  string next_page_token = 2;
-  // Total number of pipeline trigger records
-  int32 total_size = 3;
-}
-
-// ListPipelineTriggerChartRecordsRequest represents a request to list pipeline
-// trigger metrics, aggregated by pipeline ID and time frame.
-message ListPipelineTriggerChartRecordsRequest {
-  // Aggregation window in nanoseconds.
-  int32 aggregation_window = 1;
-  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-  // expression.
-  // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
-  optional string filter = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
 // ListModelTriggerChartRecordsRequest represents a request to list model
 // trigger metrics, aggregated by model ID and time frame.
 message ListModelTriggerChartRecordsRequest {
@@ -267,13 +177,6 @@ message ListModelTriggerChartRecordsRequest {
   optional google.protobuf.Timestamp stop = 6;
 }
 
-// ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
-// chart records.
-message ListPipelineTriggerChartRecordsResponse {
-  // A list of pipeline trigger records.
-  repeated PipelineTriggerChartRecord pipeline_trigger_chart_records = 1;
-}
-
 // ListModelTriggerChartRecordsResponse contains a list of model trigger
 // chart records.
 message ListModelTriggerChartRecordsResponse {
@@ -284,27 +187,35 @@ message ListModelTriggerChartRecordsResponse {
   repeated ModelTriggerChartRecord model_trigger_chart_records = 1;
 }
 
-// PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
+// PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
+// contains a collection of (timestamp, count) pairs that represent the total
+// pipeline triggers in a given time bucket.
 // pipeline ID and time frame.
 message PipelineTriggerChartRecord {
-  // Pipeline ID.
-  string pipeline_id = 1;
-  // Pipeline UUID.
-  string pipeline_uid = 2;
-  // Trigger mode.
-  Mode trigger_mode = 3;
-  // Final status.
-  Status status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // This field will be present present when the information is grouped by pipeline.
+  optional string pipeline_id = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // 2 is reserved for the pipeline UUID.
+  reserved 2;
+  // 3 is reserved for the trigger mode. The server wasn't grouping results by this
+  // field.
+  reserved 3;
+  // 4 is reserved for the trigger status. The server wasn't grouping results
+  // by this field.
+  reserved 4;
   // Time buckets.
   repeated google.protobuf.Timestamp time_buckets = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Aggregated trigger count in each time bucket.
   repeated int32 trigger_counts = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Total computation time duration in each time bucket.
-  repeated float compute_time_duration = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Version for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Release UUID for the triggered pipeline if it is a release pipeline.
-  string pipeline_release_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // 7 is reserved for the trigger execution duration.
+  reserved 7;
+  // 8 is reserved for the pipeline release ID. The server wasn't grouping
+  // results by this field.
+  reserved 8;
+  // 9 is reserved for the pipeline release UUID. The server wasn't grouping
+  // results by this field.
+  reserved 9;
+  // The ID of the namespace that requested the model triggers.
+  string requester_id = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // PipelineTriggerRecord represents a pipeline execution event.

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -481,9 +481,6 @@ service MgmtPublicService {
         value: {string_value: "beta"}
       }
     };
-    // This endpoint will remain hidden until the new dashboard is implemented
-    // in the frontend. Until then, the server might return empty data.
-    option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
   // List pipeline trigger time charts

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -458,7 +458,7 @@ service MgmtPublicService {
   // Returns the pipeline trigger count of a given requester within a timespan.
   // Results are grouped by trigger status.
   rpc GetPipelineTriggerCount(GetPipelineTriggerCountRequest) returns (GetPipelineTriggerCountResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/trigger-count"};
+    option (google.api.http) = {get: "/v1beta/pipeline-runs/count"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "📊 Metrics"
       extensions: {
@@ -466,9 +466,6 @@ service MgmtPublicService {
         value: {string_value: "beta"}
       }
     };
-    // This endpoint will remain hidden until the new dashboard is implemented
-    // in the frontend. Until then, the server might return empty data.
-    option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
   // Get model trigger count
@@ -489,30 +486,13 @@ service MgmtPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // List pipeline trigger metrics
-  //
-  // Returns a paginated list of pipeline executions aggregated by pipeline ID.
-  // NOTE: This method is deprecated and will be retired soon.
-  rpc ListPipelineTriggerTableRecords(ListPipelineTriggerTableRecordsRequest) returns (ListPipelineTriggerTableRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/tables"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "📊 Metrics"
-      extensions: {
-        key: "x-stage"
-        value: {string_value: "beta"}
-      }
-    };
-    option deprecated = true;
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
   // List pipeline trigger time charts
   //
-  // Returns a timeline of pipline trigger counts for the pipelines of a given
-  // owner.
-  // NOTE: This method will soon return the trigger counts of a given requester.
+  // Returns a timeline of pipline trigger counts for a given requester. The
+  // response will contain one set of records (datapoints), representing the
+  // amount of triggers in a time bucket.
   rpc ListPipelineTriggerChartRecords(ListPipelineTriggerChartRecordsRequest) returns (ListPipelineTriggerChartRecordsResponse) {
-    option (google.api.http) = {get: "/v1beta/metrics/vdp/pipeline/charts"};
+    option (google.api.http) = {get: "/v1beta/pipeline-runs/query-charts"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "📊 Metrics"
       extensions: {

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1724,7 +1724,8 @@ message UndeployOrganizationModelAdminResponse {}
 message ModelRun {
   // Model Run UUID.
   string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Reversed for `model_uid`
+  // 2 is reserved for the model UUID. Public resources should be identified by
+  // their ID and parent resource.
   reserved 2;
   // Model run status.
   common.run.v1alpha.RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -1740,7 +1741,8 @@ message ModelRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
-  // Runner ID. If current viewing requester does not have enough permission, it will return null.
+  // Runner ID. The user triggered the run. If current viewing requester does not
+  // have enough permission, it will return null.
   optional string runner_id = 7 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
@@ -1770,10 +1772,10 @@ message ModelRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
-  // Requester ID. This field might be empty if the model run belongs to a
-  // deleted namespace.
+  // Requester ID. The namespace used to trigger the run. This field might be
+  // empty if the model run belongs to a deleted namespace.
   string requester_id = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Model Namespace ID. The owner namespace id of the model.
+  // ID of the namespace that owns the model.
   string model_namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1724,8 +1724,8 @@ message UndeployOrganizationModelAdminResponse {}
 message ModelRun {
   // Model Run UUID.
   string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Model UUID.
-  string model_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reversed for `model_uid`
+  reserved 2;
   // Model run status.
   common.run.v1alpha.RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Run source.
@@ -1773,8 +1773,8 @@ message ModelRun {
   // Requester ID. This field might be empty if the model run belongs to a
   // deleted namespace.
   string requester_id = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Namespace ID.
-  string namespace_id = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Model Namespace ID. The owner namespace id of the model.
+  string model_namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListModelRunsRequest represents a request to list of model runs.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -2176,13 +2176,101 @@ paths:
       tags:
         - "\U0001F4CA Metrics"
       x-stage: beta
-  /v1beta/metrics/vdp/pipeline/charts:
+  /v1beta/pipeline-runs/count:
+    get:
+      summary: Get pipeline trigger count
+      description: |-
+        Returns the pipeline trigger count of a given requester within a timespan.
+        Results are grouped by trigger status.
+      operationId: MgmtPublicService_GetPipelineTriggerCount
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/GetPipelineTriggerCountResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that requested the pipeline triggers.
+          in: query
+          required: true
+          type: string
+        - name: start
+          description: |-
+            Beginning of the time range from which the records will be fetched.
+            The default value is the beginning of the current day, in UTC.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: stop
+          description: |-
+            End of the time range from which the records will be fetched.
+            The default value is the current timestamp.
+          in: query
+          required: false
+          type: string
+          format: date-time
+      tags:
+        - "\U0001F4CA Metrics"
+      x-stage: beta
+  /v1beta/model-runs/count:
+    get:
+      summary: Get model trigger count
+      description: |-
+        Returns the model trigger count of a given requester within a timespan.
+        Results are grouped by trigger status.
+      operationId: MgmtPublicService_GetModelTriggerCount
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/GetModelTriggerCountResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: requesterId
+          description: The ID of the requester that triggered the model.
+          in: query
+          required: true
+          type: string
+        - name: start
+          description: |-
+            Beginning of the time range from which the records will be fetched.
+            The default value is the beginning of the current day, in UTC.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: stop
+          description: |-
+            End of the time range from which the records will be fetched.
+            The default value is the current timestamp.
+          in: query
+          required: false
+          type: string
+          format: date-time
+      tags:
+        - "\U0001F4CA Metrics"
+      x-stage: beta
+  /v1beta/pipeline-runs/query-charts:
     get:
       summary: List pipeline trigger time charts
       description: |-
-        Returns a timeline of pipline trigger counts for the pipelines of a given
-        owner.
-        NOTE: This method will soon return the trigger counts of a given requester.
+        Returns a timeline of pipline trigger counts for a given requester. The
+        response will contain one set of records (datapoints), representing the
+        amount of triggers in a time bucket.
       operationId: MgmtPublicService_ListPipelineTriggerChartRecords
       responses:
         "200":
@@ -2197,20 +2285,36 @@ paths:
           schema:
             $ref: '#/definitions/rpc.Status'
       parameters:
-        - name: aggregationWindow
-          description: Aggregation window in nanoseconds.
-          in: query
-          required: false
-          type: integer
-          format: int32
-        - name: filter
-          description: |-
-            Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
-            expression.
-            - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
+        - name: requesterId
+          description: The ID of the namespace that requested the pipeline triggers.
           in: query
           required: false
           type: string
+        - name: aggregationWindow
+          description: |-
+            Aggregation window. The value is a positive duration string, i.e. a
+            sequence of decimal numbers, each with optional fraction and a unit
+            suffix, such as "300ms", "1.5h" or "2h45m".
+            The minimum (and default) window is 1h.
+          in: query
+          required: false
+          type: string
+        - name: start
+          description: |-
+            Beginning of the time range from which the records will be fetched.
+            The default value is the beginning of the current day, in UTC.
+          in: query
+          required: false
+          type: string
+          format: date-time
+        - name: stop
+          description: |-
+            End of the time range from which the records will be fetched.
+            The default value is the current timestamp.
+          in: query
+          required: false
+          type: string
+          format: date-time
       tags:
         - "\U0001F4CA Metrics"
       x-stage: beta
@@ -6909,6 +7013,18 @@ definitions:
     description: |-
       GetModelOperationRequest represents a request to query a long-running
       operation.
+  GetModelTriggerCountResponse:
+    type: object
+    properties:
+      modelTriggerCounts:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/TriggerCount'
+        description: The trigger counts, grouped by status.
+    description: |-
+      GetModelTriggerCountResponse contains the trigger count, grouped by
+      trigger status.
   GetNamespaceConnectionResponse:
     type: object
     properties:
@@ -7072,6 +7188,18 @@ definitions:
         allOf:
           - $ref: '#/definitions/OrganizationSubscription'
     description: GetOrganizationSubscriptionResponse contains the requested subscription.
+  GetPipelineTriggerCountResponse:
+    type: object
+    properties:
+      pipelineTriggerCounts:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/TriggerCount'
+        description: The trigger counts, grouped by status.
+    description: |-
+      GetPipelineTriggerCountResponse contains the trigger count, grouped by
+      trigger status.
   GetPlaygroundConversationResponse:
     type: object
     properties:
@@ -7894,7 +8022,11 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/PipelineTriggerChartRecord'
-        description: A list of pipeline trigger records.
+        description: |-
+          Pipeline trigger counts. Until we allow filtering or grouping by fields
+          like pipeline ID, this list will contain only one element with the
+          timeline of trigger counts for a given requester, regardless the pipeline
+          ID, trigger mode, final status or other fields.
     description: |-
       ListPipelineTriggerChartRecordsResponse contains a list of pipeline trigger
       chart records.
@@ -8376,10 +8508,6 @@ definitions:
         type: string
         description: Model Run UUID.
         readOnly: true
-      modelUid:
-        type: string
-        description: Model UUID.
-        readOnly: true
       status:
         description: Model run status.
         readOnly: true
@@ -8402,7 +8530,9 @@ definitions:
         readOnly: true
       runnerId:
         type: string
-        description: Runner ID. If current viewing requester does not have enough permission, it will return null.
+        description: |-
+          Runner ID. The user triggered the run. If current viewing requester does not
+          have enough permission, it will return null.
         readOnly: true
       creditAmount:
         type: number
@@ -8446,12 +8576,12 @@ definitions:
       requesterId:
         type: string
         description: |-
-          Requester ID. This field might be empty if the model run belongs to a
-          deleted namespace.
+          Requester ID. The namespace used to trigger the run. This field might be
+          empty if the model run belongs to a deleted namespace.
         readOnly: true
-      namespaceId:
+      modelNamespaceId:
         type: string
-        description: Namespace ID.
+        description: ID of the namespace that owns the model.
         readOnly: true
     description: ModelRun contains information about a run of models.
   ModelTriggerChartRecord:
@@ -9043,10 +9173,6 @@ definitions:
   PipelineRun:
     type: object
     properties:
-      pipelineUid:
-        type: string
-        description: Unique identifier for the pipeline.
-        readOnly: true
       pipelineRunUid:
         type: string
         description: Unique identifier for each run.
@@ -9072,7 +9198,9 @@ definitions:
         readOnly: true
       runnerId:
         type: string
-        description: Runner ID. If current viewing requester does not have enough permission, it will return null.
+        description: |-
+          Runner ID. The user triggered the run. If current viewing requester does not
+          have enough permission, it will return null.
         readOnly: true
       inputs:
         type: array
@@ -9121,12 +9249,12 @@ definitions:
       requesterId:
         type: string
         description: |-
-          Requester ID. This field might be empty if the pipeline run belongs to a
-          deleted namespace.
+          Requester ID. The namespace used to trigger the run. This field might be
+          empty if the pipeline run belongs to a deleted namespace.
         readOnly: true
-      namespaceId:
+      pipelineNamespaceId:
         type: string
-        title: Namespace ID
+        description: ID of the namespace that owns the pipeline.
         readOnly: true
     description: PipelineRun represents a single execution of a pipeline.
   PipelineTriggerChartRecord:
@@ -9134,19 +9262,8 @@ definitions:
     properties:
       pipelineId:
         type: string
-        description: Pipeline ID.
-      pipelineUid:
-        type: string
-        description: Pipeline UUID.
-      triggerMode:
-        description: Trigger mode.
-        allOf:
-          - $ref: '#/definitions/Mode'
-      status:
-        description: Final status.
+        description: This field will be present present when the information is grouped by pipeline.
         readOnly: true
-        allOf:
-          - $ref: '#/definitions/v1beta.Status'
       timeBuckets:
         type: array
         items:
@@ -9161,23 +9278,14 @@ definitions:
           format: int32
         description: Aggregated trigger count in each time bucket.
         readOnly: true
-      computeTimeDuration:
-        type: array
-        items:
-          type: number
-          format: float
-        description: Total computation time duration in each time bucket.
-        readOnly: true
-      pipelineReleaseId:
+      requesterId:
         type: string
-        description: Version for the triggered pipeline if it is a release pipeline.
-        readOnly: true
-      pipelineReleaseUid:
-        type: string
-        description: Release UUID for the triggered pipeline if it is a release pipeline.
+        description: The ID of the namespace that requested the model triggers.
         readOnly: true
     description: |-
-      PipelineTriggerChartRecord contains pipeline trigger metrics, aggregated by
+      PipelineTriggerChartRecord represents a timeline of pipeline triggers. It
+      contains a collection of (timestamp, count) pairs that represent the total
+      pipeline triggers in a given time bucket.
       pipeline ID and time frame.
   PipelineTriggerRecord:
     type: object
@@ -9849,6 +9957,22 @@ definitions:
     description: |-
       TriggerAsyncNamespacePipelineResponse contains the information to access the
       status of an asynchronous pipeline execution.
+  TriggerCount:
+    type: object
+    properties:
+      triggerCount:
+        type: integer
+        format: int32
+        description: Number of triggers.
+        readOnly: true
+      status:
+        description: This field will be present when results are grouped by trigger status.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1beta.Status'
+    description: |-
+      TriggerCount represents a execution count with some
+      aggregation params (e.g. trigger status).
   TriggerData:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1996,8 +1996,8 @@ message FileReference {
 
 // PipelineRun represents a single execution of a pipeline.
 message PipelineRun {
-  // Unique identifier for the pipeline.
-  string pipeline_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reversed for `pipeline_uid`
+  reserved 1;
 
   // Unique identifier for each run.
   string pipeline_run_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -2076,8 +2076,8 @@ message PipelineRun {
   // deleted namespace.
   string requester_id = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Namespace ID
-  string namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Pipeline Namespace ID. The owner namespace id of the pipeline.
+  string pipeline_namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -1996,7 +1996,8 @@ message FileReference {
 
 // PipelineRun represents a single execution of a pipeline.
 message PipelineRun {
-  // Reversed for `pipeline_uid`
+  // 1 is reserved for the pipeline UUID. Public resources should be identified by
+  // their ID and parent resource.
   reserved 1;
 
   // Unique identifier for each run.
@@ -2017,7 +2018,8 @@ message PipelineRun {
     (google.api.field_behavior) = OPTIONAL
   ];
 
-  // Runner ID. If current viewing requester does not have enough permission, it will return null.
+  // Runner ID. The user triggered the run. If current viewing requester does not
+  // have enough permission, it will return null.
   optional string runner_id = 7 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
@@ -2072,11 +2074,11 @@ message PipelineRun {
     (google.api.field_behavior) = OPTIONAL
   ];
 
-  // Requester ID. This field might be empty if the pipeline run belongs to a
-  // deleted namespace.
+  // Requester ID. The namespace used to trigger the run. This field might be
+  // empty if the pipeline run belongs to a deleted namespace.
   string requester_id = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Pipeline Namespace ID. The owner namespace id of the pipeline.
+  // ID of the namespace that owns the pipeline.
   string pipeline_namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 


### PR DESCRIPTION
Because

- Pipeline and credit endpoints have different params and schemas.
- Some of the information served by the existing endpoints will be handled by the pipeline run feature.

This commit

- Removes unused endpoints and updates metrics contracts to serve the new dashboard.