### PR TITLE
feat(vdp): introduce `DispatchPipelineWebhookEvent` endpoint

### DIFF
--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -495,8 +495,8 @@ message CloneNamespacePipelineReleaseRequest {
 // CloneNamespacePipelineReleaseResponse contains a cloned pipeline.
 message CloneNamespacePipelineReleaseResponse {}
 
-//SendNamespacePipelineEventRequest
-message SendNamespacePipelineEventRequest {
+//HandleNamespacePipelineWebhookEventRequest
+message HandleNamespacePipelineWebhookEventRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Pipeline ID
@@ -509,14 +509,14 @@ message SendNamespacePipelineEventRequest {
   google.protobuf.Struct data = 5;
 }
 
-//SendNamespacePipelineEventResponse
-message SendNamespacePipelineEventResponse {
+//HandleNamespacePipelineWebhookEventResponse
+message HandleNamespacePipelineWebhookEventResponse {
   // data
   google.protobuf.Struct data = 1;
 }
 
-//SendNamespacePipelineReleaseEventRequest
-message SendNamespacePipelineReleaseEventRequest {
+//HandleNamespacePipelineReleaseWebhookEventRequest
+message HandleNamespacePipelineReleaseWebhookEventRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Pipeline ID
@@ -531,10 +531,30 @@ message SendNamespacePipelineReleaseEventRequest {
   google.protobuf.Struct data = 6;
 }
 
-//SendNamespacePipelineReleaseEventResponse
-message SendNamespacePipelineReleaseEventResponse {
+//HandleNamespacePipelineReleaseWebhookEventResponse
+message HandleNamespacePipelineReleaseWebhookEventResponse {
   // data
   google.protobuf.Struct data = 1;
+}
+
+// DispatchPipelineWebhookEventRequest represents a request to dispatch webhook events
+// for a pipeline. The request contains the webhook type and event message that
+// will be processed by the event router and dispatched to the appropriate pipeline
+// based on the webhook type and message. The event message contains the payload
+// data that will be used to trigger pipeline execution.
+message DispatchPipelineWebhookEventRequest {
+  // Webhook Type
+  string webhook_type = 1 [(google.api.field_behavior) = REQUIRED];
+  // Event
+  google.protobuf.Struct message = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DispatchPipelineWebhookEventResponse represents a response to dispatch webhook events
+// for a pipeline. The response contains the response message that will be sent
+// back to the webhook sender.
+message DispatchPipelineWebhookEventResponse {
+  // Response
+  google.protobuf.Struct response = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // TriggerNamespacePipelineRequest represents a request to trigger a user-owned

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -232,22 +232,37 @@ service PipelinePublicService {
     };
   }
 
-  // SendNamespacePipelineEvent
-  rpc SendNamespacePipelineEvent(SendNamespacePipelineEventRequest) returns (SendNamespacePipelineEventResponse) {
+  // HandleNamespacePipelineWebhookEvent
+  rpc HandleNamespacePipelineWebhookEvent(HandleNamespacePipelineWebhookEventRequest) returns (HandleNamespacePipelineWebhookEventResponse) {
     option (google.api.http) = {
-      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/events"
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/webhooks"
       body: "data"
       response_body: "data"
     };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // SendNamespacePipelineReleaseEvent
-  rpc SendNamespacePipelineReleaseEvent(SendNamespacePipelineReleaseEventRequest) returns (SendNamespacePipelineReleaseEventResponse) {
+  // HandleNamespacePipelineReleaseWebhookEvent
+  rpc HandleNamespacePipelineReleaseWebhookEvent(HandleNamespacePipelineReleaseWebhookEventRequest) returns (HandleNamespacePipelineReleaseWebhookEventResponse) {
     option (google.api.http) = {
-      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/events"
+      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/webhooks"
       body: "data"
       response_body: "data"
+    };
+    option (google.api.method_visibility).restriction = "INTERNAL";
+  }
+
+  // Dispatch Pipeline Webhook Event
+  //
+  // Handles webhook events by routing them to the appropriate pipeline based on the webhook type and message.
+  // The webhook type determines which component processes the event, while the message payload contains data
+  // that triggers pipeline execution. The pipeline processes the event using configured handlers and returns
+  // a response to the webhook sender.
+  rpc DispatchPipelineWebhookEvent(DispatchPipelineWebhookEventRequest) returns (DispatchPipelineWebhookEventResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/pipeline-webhooks/{webhook_type}"
+      body: "message"
+      response_body: "response"
     };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }


### PR DESCRIPTION
Because

- We’re introducing the run-on-event feature. For some applications, we can only register a single webhook URL rather than a unique URL per pipeline. In this case, we need an event router to route and dispatch events to the appropriate pipelines.

This commit

- introduces `DispatchPipelineWebhookEvent` endpoint.
