### PR TITLE
chore(vdp): adjust EventSpecification message

### DIFF
--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6679,9 +6679,17 @@ definitions:
   EventSpecification:
     type: object
     properties:
-      setupSchema:
+      title:
+        type: string
+        description: Event title.
+        readOnly: true
+      description:
+        type: string
+        description: Event description.
+        readOnly: true
+      configSchema:
         type: object
-        description: JSON schema describing the component event setup data.
+        description: JSON schema describing the component event config data.
         readOnly: true
       messageSchema:
         type: object

--- a/vdp/pipeline/v1beta/component_definition.proto
+++ b/vdp/pipeline/v1beta/component_definition.proto
@@ -142,12 +142,16 @@ message DataSpecification {
 
 // EventSpecification describes the JSON schema of component event setup and examples.
 message EventSpecification {
-  // JSON schema describing the component event setup data.
-  google.protobuf.Struct setup_schema = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Event title.
+  string title = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Event description.
+  string description = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // JSON schema describing the component event config data.
+  google.protobuf.Struct config_schema = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // JSON schema describing the component event message data.
-  google.protobuf.Struct message_schema = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Struct message_schema = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // JSON schema describing the component event examples.
-  repeated google.protobuf.Struct message_examples = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated google.protobuf.Struct message_examples = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Because

 - We want to include title and description information in the message.

This commit
 - Updates the EventSpecification message structure.