### PR TITLE
chore(app): add optional parameters

### DIFF
--- a/app/app/v1alpha/conversation.proto
+++ b/app/app/v1alpha/conversation.proto
@@ -258,6 +258,10 @@ message ChatRequest {
   string message = 5 [(google.api.field_behavior) = REQUIRED];
   // top k, defaults to 5
   optional uint32 top_k = 6;
+  // LLM model name, defaults to `gpt-4o`
+  optional string llm_model = 7;
+  // Instruction for the model to follow, defaults to `Please answer user question accurately and in the same language as the Follow-up Question.`
+  optional string user_instruction = 8;
 }
 
 // ChatResponse contains the chatbot response.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -5782,6 +5782,12 @@ definitions:
         type: integer
         format: int64
         title: top k, defaults to 5
+      llmModel:
+        type: string
+        title: LLM model name, defaults to `gpt-4o`
+      userInstruction:
+        type: string
+        title: Instruction for the model to follow, defaults to `Please answer user question accurately and in the same language as the Follow-up Question.`
     description: |-
       ChatRequest represents a request to send a message
       to a chatbot synchronously and streams back the results.


### PR DESCRIPTION
Because

- support choosing LLM model and providing instruction

This commit

- add optional `llm_model` and `user_instructions`
