### PR TITLE
fix(pipeline-run,model-run): clarify actors in Run objects

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -47,6 +47,8 @@ jobs:
           git_tag_gpgsign: true
           workdir: ./protogen-go
       - name: Generate Go/gRPC/gRPC-Gateway client and server stubs, and commit to protogen-go repository
+        env:
+          BUF_TOKEN: ${{ secrets.botBufToken }}
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
@@ -86,6 +88,8 @@ jobs:
           git_tag_gpgsign: true
           workdir: ./protogen-python
       - name: Generate Go/gRPC client and server stubs, and commit to protogen-python repository
+        env:
+          BUF_TOKEN: ${{ secrets.botBufToken }}
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest

--- a/.github/workflows/buf-gen-openapi.yaml
+++ b/.github/workflows/buf-gen-openapi.yaml
@@ -25,6 +25,8 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
       - name: Generate OpenAPI definitions
+        env:
+          BUF_TOKEN: ${{ secrets.botBufToken }}
         run: |
           make openapi
       - name: Lint generated OpenAPI definitions

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -55,7 +55,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -69,7 +69,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -86,7 +86,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -100,7 +100,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -117,7 +117,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -131,7 +131,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -146,6 +146,10 @@ service ArtifactPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -165,7 +169,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -179,7 +183,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -207,7 +211,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -238,7 +242,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -253,6 +257,10 @@ service ArtifactPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -273,6 +281,10 @@ service ArtifactPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -292,7 +304,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -301,12 +313,12 @@ service ArtifactPublicService {
   //
   // Returns a paginated list of catalog runs.
   rpc ListCatalogRuns(ListCatalogRunsRequest) returns (ListCatalogRunsResponse) {
-    option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/catalogs/{catalog_id}/runs"};
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -320,7 +332,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }
@@ -334,7 +346,7 @@ service ArtifactPublicService {
       tags: "💾 Artifact"
       extensions: {
         key: "x-stage"
-        value: {string_value: "beta"}
+        value: {string_value: "alpha"}
       }
     };
   }

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -1724,8 +1724,9 @@ message UndeployOrganizationModelAdminResponse {}
 message ModelRun {
   // Model Run UUID.
   string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Model UUID.
-  string model_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // 2 is reserved for the model UUID. Public resources should be identified by
+  // their ID and parent resource.
+  reserved 2;
   // Model run status.
   common.run.v1alpha.RunStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Run source.
@@ -1770,11 +1771,11 @@ message ModelRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
-  // Requester ID. This field might be empty if the model run belongs to a
-  // deleted namespace.
+  // Requester ID. The namespace used to trigger the run. This field might be
+  // empty if the model run belongs to a deleted namespace.
   string requester_id = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Namespace ID.
-  string namespace_id = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // ID of the namespace that owns the model.
+  string model_namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListModelRunsRequest represents a request to list of model runs.

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -289,6 +289,10 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -310,6 +314,10 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -331,6 +339,10 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -352,6 +364,10 @@ service ModelPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -369,6 +385,10 @@ service ModelPublicService {
   rpc TriggerNamespaceModelBinaryFileUpload(stream TriggerNamespaceModelBinaryFileUploadRequest) returns (TriggerNamespaceModelBinaryFileUploadResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -386,6 +406,10 @@ service ModelPublicService {
   rpc TriggerNamespaceLatestModelBinaryFileUpload(stream TriggerNamespaceLatestModelBinaryFileUploadRequest) returns (TriggerNamespaceLatestModelBinaryFileUploadResponse) {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "⚗️ Model"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -838,6 +862,10 @@ service ModelPublicService {
           type: STRING
         }
       }
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
     };
   }
 
@@ -855,6 +883,10 @@ service ModelPublicService {
           description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
           type: STRING
         }
+      }
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
       }
     };
   }

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -852,8 +852,9 @@ service ModelPublicService {
   //
   // Returns a paginated list of runs for a given model. When the requester is
   // the owner of the model, they will be able to all the model runs,
-  // regardless who requested the trigger. Other requesters will only be able
-  // to see the runs requested by themselves.
+  // regardless who requested the trigger (the view will be partial to hide
+  // sensitive data like e.g. the trigger input and output). Other requesters
+  // will only be able to see the runs requested by themselves.
   rpc ListModelRuns(ListModelRunsRequest) returns (ListModelRunsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -880,13 +881,6 @@ service ModelPublicService {
     option (google.api.http) = {get: "/v1alpha/dashboard/models/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "⚗️ Model"
-      parameters: {
-        headers: {
-          name: "Instill-Requester-Uid"
-          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
-          type: STRING
-        }
-      }
       extensions: {
         key: "x-stage"
         value: {string_value: "alpha"}

--- a/model/model/v1alpha/model_public_service.proto
+++ b/model/model/v1alpha/model_public_service.proto
@@ -848,9 +848,12 @@ service ModelPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
-  // List model runs
+  // List Model Runs
   //
-  // Returns a paginated list of model runs.
+  // Returns a paginated list of runs for a given model. When the requester is
+  // the owner of the model, they will be able to all the model runs,
+  // regardless who requested the trigger. Other requesters will only be able
+  // to see the runs requested by themselves.
   rpc ListModelRuns(ListModelRunsRequest) returns (ListModelRunsResponse) {
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/models/{model_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -869,10 +872,10 @@ service ModelPublicService {
     };
   }
 
-  // List Model Runs of a Namespace (user or organization)
+  // List Model Runs By Requester
   //
-  // Returns a paginated list of runs for 1 or more models. This is mainly used by dashboard.
-  // The requester can view all the runs by the requester across different models.
+  // Returns a paginated list of runs requested by a namespace. The response
+  // may contain runs from several models.
   rpc ListModelRunsByRequester(ListModelRunsByRequesterRequest) returns (ListModelRunsByRequesterResponse) {
     option (google.api.http) = {get: "/v1alpha/dashboard/models/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -1001,7 +1001,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
     post:
       summary: Create a catalog
       description: Creates a catalog.
@@ -1031,7 +1031,7 @@ paths:
             $ref: '#/definitions/CreateCatalogBody'
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}:
     get:
       summary: Get file catalog
@@ -1072,7 +1072,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
     delete:
       summary: Delete a catalog
       description: Deletes a catalog.
@@ -1102,7 +1102,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
     put:
       summary: Update a catalog info
       description: Updates the information of a catalog.
@@ -1137,7 +1137,7 @@ paths:
             $ref: '#/definitions/UpdateCatalogBody'
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/files:
     get:
       summary: List catalog files
@@ -1187,7 +1187,7 @@ paths:
           collectionFormat: multi
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
     post:
       summary: Create a file
       description: Creates a file.
@@ -1223,7 +1223,7 @@ paths:
             $ref: '#/definitions/File'
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1alpha/catalogs/files:
     delete:
       summary: Delete a file
@@ -1249,7 +1249,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1alpha/catalogs/files/processAsync:
     post:
       summary: Process catalog files
@@ -1280,6 +1280,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/chunks:
     get:
       summary: List catalog chunks
@@ -1315,7 +1316,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/chunks:
     get:
       summary: Search catalog chunks
@@ -1385,7 +1386,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/source-files:
     get:
       summary: Search single-source-of-truth files
@@ -1450,7 +1451,7 @@ paths:
             $ref: '#/definitions/UpdateChunkBody'
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/chunks/retrieve:
     post:
       summary: Retrieve similar chunks
@@ -1491,6 +1492,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/ask:
     post:
       summary: Ask a question
@@ -1531,7 +1533,8 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
-  /v1beta/namespaces/{namespaceId}/catalogs/{catalogId}/runs:
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/runs:
     get:
       summary: List Catalog Runs
       description: Returns a paginated list of catalog runs.
@@ -1590,7 +1593,7 @@ paths:
           type: string
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/object-upload-url:
     get:
       summary: Get Object Upload URL
@@ -1647,7 +1650,7 @@ paths:
           format: int32
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/object-download-url:
     get:
       summary: Get Object Download URL
@@ -1686,7 +1689,7 @@ paths:
           format: int32
       tags:
         - "\U0001F4BE Artifact"
-      x-stage: beta
+      x-stage: alpha
   /v1beta/user:
     get:
       summary: Get the authenticated user
@@ -3377,6 +3380,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}/trigger-async:
     post:
       summary: Trigger model inference asynchronously
@@ -3424,6 +3428,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/trigger:
     post:
       summary: Trigger model inference
@@ -3466,6 +3471,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/trigger-async:
     post:
       summary: Trigger model inference asynchronously
@@ -3508,6 +3514,7 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/versions/{version}/operation:
     get:
       summary: |-
@@ -3647,8 +3654,13 @@ paths:
       x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/models/{modelId}/runs:
     get:
-      summary: List model runs
-      description: Returns a paginated list of model runs.
+      summary: List Model Runs
+      description: |-
+        Returns a paginated list of runs for a given model. When the requester is
+        the owner of the model, they will be able to all the model runs,
+        regardless who requested the trigger (the view will be partial to hide
+        sensitive data like e.g. the trigger input and output). Other requesters
+        will only be able to see the runs requested by themselves.
       operationId: ModelPublicService_ListModelRuns
       responses:
         "200":
@@ -3714,12 +3726,13 @@ paths:
           type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1alpha/dashboard/models/runs:
     get:
-      summary: List Model Runs of a Namespace (user or organization)
+      summary: List Model Runs By Requester
       description: |-
-        Returns a paginated list of runs for 1 or more models. This is mainly used by dashboard.
-        The requester can view all the runs by the requester across different models.
+        Returns a paginated list of runs requested by a namespace. The response
+        may contain runs from several models.
       operationId: ModelPublicService_ListModelRunsByRequester
       responses:
         "200":
@@ -3790,13 +3803,9 @@ paths:
           in: query
           required: true
           type: string
-        - name: Instill-Requester-Uid
-          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
-          in: header
-          required: false
-          type: string
       tags:
         - ⚗️ Model
+      x-stage: alpha
   /v1beta/pipelines:
     get:
       summary: List accessible pipelines
@@ -4290,6 +4299,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/trigger-stream:
     post:
       summary: Trigger a pipeline via streaming
@@ -4342,6 +4352,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/trigger-async:
     post:
       summary: Trigger a pipeline asynchronously
@@ -4391,6 +4402,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases:
     get:
       summary: List the releases in a pipeline
@@ -4741,6 +4753,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}/trigger-async:
     post:
       summary: Trigger a pipeline release asynchronously
@@ -4793,6 +4806,7 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/secrets:
     get:
       summary: List secrets
@@ -5066,14 +5080,16 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/runs:
     get:
       summary: List Pipeline Runs
       description: |-
         Returns a paginated list of runs for a given pipeline. When the requester
         is the owner of the pipeline, they will be able to all the pipeline runs,
-        regardless the requester. Other requesters will only be able to see the
-        runs requested by themselves.
+        regardless who requested the trigger (the view will be partial to hide
+        sensitive data like e.g. the trigger input and output). Other requesters
+        will only be able to see the runs requested by themselves.
       operationId: PipelinePublicService_ListPipelineRuns
       responses:
         "200":
@@ -5134,9 +5150,10 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/pipeline-runs/{pipelineRunId}/component-runs:
     get:
-      summary: List Component runs
+      summary: List Component Runs
       description: Returns the information of each component execution within a pipeline run.
       operationId: PipelinePublicService_ListComponentRuns
       responses:
@@ -5208,12 +5225,13 @@ paths:
           type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/dashboard/pipelines/runs:
     get:
-      summary: List Pipeline Runs of a Namespace (user or organization)
+      summary: List Pipeline Runs By Requester
       description: |-
-        Returns a paginated list of runs for 1 or more pipelines. This is mainly used by dashboard.
-        The requester can view all the runs by the requester across different pipelines.
+        Returns a paginated list of runs for requested by a namespace. The
+        response may contain runs from several pipelines.
       operationId: PipelinePublicService_ListPipelineRunsByRequester
       responses:
         "200":
@@ -5282,13 +5300,9 @@ paths:
           in: query
           required: true
           type: string
-        - name: Instill-Requester-Uid
-          description: Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to
-          in: header
-          required: false
-          type: string
       tags:
         - "\U0001F4A7 VDP"
+      x-stage: beta
   /v1beta/namespaces/{namespaceId}/connections:
     get:
       summary: List namespace connections
@@ -9051,10 +9065,6 @@ definitions:
         type: string
         description: Model Run UUID.
         readOnly: true
-      modelUid:
-        type: string
-        description: Model UUID.
-        readOnly: true
       status:
         description: Model run status.
         readOnly: true
@@ -9121,12 +9131,12 @@ definitions:
       requesterId:
         type: string
         description: |-
-          Requester ID. This field might be empty if the model run belongs to a
-          deleted namespace.
+          Requester ID. The namespace used to trigger the run. This field might be
+          empty if the model run belongs to a deleted namespace.
         readOnly: true
-      namespaceId:
+      modelNamespaceId:
         type: string
-        description: Namespace ID.
+        description: ID of the namespace that owns the model.
         readOnly: true
     description: ModelRun contains information about a run of models.
   ModelTriggerChartRecord:
@@ -9718,10 +9728,6 @@ definitions:
   PipelineRun:
     type: object
     properties:
-      pipelineUid:
-        type: string
-        description: Unique identifier for the pipeline.
-        readOnly: true
       pipelineRunUid:
         type: string
         description: Unique identifier for each run.
@@ -9747,7 +9753,9 @@ definitions:
         readOnly: true
       runnerId:
         type: string
-        description: Runner ID. If current viewing requester does not have enough permission, it will return null.
+        description: |-
+          Runner ID. The authenticated user that triggered the run. If current
+          viewing requester does not have enough permission, it will return null.
         readOnly: true
       inputs:
         type: array
@@ -9796,12 +9804,12 @@ definitions:
       requesterId:
         type: string
         description: |-
-          Requester ID. This field might be empty if the pipeline run belongs to a
-          deleted namespace.
+          Requester ID. The namespace used to trigger the run. This field might be
+          empty if the pipeline run belongs to a deleted namespace.
         readOnly: true
-      namespaceId:
+      pipelineNamespaceId:
         type: string
-        title: Namespace ID
+        description: ID of the namespace that owns the pipeline.
         readOnly: true
     description: PipelineRun represents a single execution of a pipeline.
   PipelineTriggerChartRecord:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -2034,8 +2034,9 @@ message FileReference {
 
 // PipelineRun represents a single execution of a pipeline.
 message PipelineRun {
-  // Unique identifier for the pipeline.
-  string pipeline_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // 1 is reserved for the pipeline UUID. Public resources should be identified by
+  // their ID and parent resource.
+  reserved 1;
 
   // Unique identifier for each run.
   string pipeline_run_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -2055,7 +2056,8 @@ message PipelineRun {
     (google.api.field_behavior) = OPTIONAL
   ];
 
-  // Runner ID. If current viewing requester does not have enough permission, it will return null.
+  // Runner ID. The authenticated user that triggered the run. If current
+  // viewing requester does not have enough permission, it will return null.
   optional string runner_id = 7 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
@@ -2110,12 +2112,12 @@ message PipelineRun {
     (google.api.field_behavior) = OPTIONAL
   ];
 
-  // Requester ID. This field might be empty if the pipeline run belongs to a
-  // deleted namespace.
+  // Requester ID. The namespace used to trigger the run. This field might be
+  // empty if the pipeline run belongs to a deleted namespace.
   string requester_id = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Namespace ID
-  string namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // ID of the namespace that owns the pipeline.
+  string pipeline_namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -1322,8 +1322,9 @@ service PipelinePublicService {
   //
   // Returns a paginated list of runs for a given pipeline. When the requester
   // is the owner of the pipeline, they will be able to all the pipeline runs,
-  // regardless who requested the trigger. Other requesters will only be able
-  // to see the runs requested by themselves.
+  // regardless who requested the trigger (the view will be partial to hide
+  // sensitive data like e.g. the trigger input and output). Other requesters
+  // will only be able to see the runs requested by themselves.
   rpc ListPipelineRuns(ListPipelineRunsRequest) returns (ListPipelineRunsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -1374,13 +1375,6 @@ service PipelinePublicService {
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
-      }
-      parameters: {
-        headers: {
-          name: "Instill-Requester-Uid"
-          description: "Indicates the authenticated namespace is making the request on behalf of another entity, typically an organization they belong to"
-          type: STRING
-        }
       }
     };
   }

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -1322,8 +1322,8 @@ service PipelinePublicService {
   //
   // Returns a paginated list of runs for a given pipeline. When the requester
   // is the owner of the pipeline, they will be able to all the pipeline runs,
-  // regardless the requester. Other requesters will only be able to see the
-  // runs requested by themselves.
+  // regardless who requested the trigger. Other requesters will only be able
+  // to see the runs requested by themselves.
   rpc ListPipelineRuns(ListPipelineRunsRequest) returns (ListPipelineRunsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -1342,7 +1342,7 @@ service PipelinePublicService {
     };
   }
 
-  // List Component runs
+  // List Component Runs
   //
   // Returns the information of each component execution within a pipeline run.
   rpc ListComponentRuns(ListComponentRunsRequest) returns (ListComponentRunsResponse) {
@@ -1363,10 +1363,10 @@ service PipelinePublicService {
     };
   }
 
-  // List Pipeline Runs of a Namespace (user or organization)
+  // List Pipeline Runs By Requester
   //
-  // Returns a paginated list of runs for 1 or more pipelines. This is mainly used by dashboard.
-  // The requester can view all the runs by the requester across different pipelines.
+  // Returns a paginated list of runs for requested by a namespace. The
+  // response may contain runs from several pipelines.
   rpc ListPipelineRunsByRequester(ListPipelineRunsByRequesterRequest) returns (ListPipelineRunsByRequesterResponse) {
     option (google.api.http) = {get: "/v1beta/dashboard/pipelines/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {

--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -264,6 +264,10 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -289,6 +293,10 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -317,6 +325,10 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -451,6 +463,10 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -477,6 +493,10 @@ service PipelinePublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -593,6 +613,10 @@ service PipelinePublicService {
     option (google.api.http) = {get: "/v1beta/operations/{operation_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -1304,6 +1328,10 @@ service PipelinePublicService {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -1321,6 +1349,10 @@ service PipelinePublicService {
     option (google.api.http) = {get: "/v1beta/pipeline-runs/{pipeline_run_id}/component-runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"
@@ -1339,6 +1371,10 @@ service PipelinePublicService {
     option (google.api.http) = {get: "/v1beta/dashboard/pipelines/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "💧 VDP"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
       parameters: {
         headers: {
           name: "Instill-Requester-Uid"


### PR DESCRIPTION
Because

- The `PipelineRun` and `ModelRun` objects have confusing documentation for
  the requester, runner and owner of a pipeline/model run.

This commit

- Recovers changes in #513 improving the object naming and documentation.
