### PR TITLE
chore(integration): remove deprecated `schemas` field

### DIFF
--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7556,24 +7556,11 @@ definitions:
         title: |-
           View defines how the integration is presented. The following fields are
           only shown in the FULL view:
-          - schemas
           - setupSchema
           - oAuthConfig
         readOnly: true
         allOf:
           - $ref: '#/definitions/pipeline.v1beta.View'
-      schemas:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/SetupSchema'
-        description: |-
-          Schemas defines the supported schemas for the connection setup.
-          We haven't found a case for a schema that changes on the connection method
-          (components don't care about how the connection was built), so the schema
-          will be provided in the setupSchema field and the OAuth support and
-          configuration will be provided in oAuthConfig.
-        readOnly: true
     description: |-
       Integration contains the parameters to create a connection between
       components and 3rd party apps.
@@ -9705,23 +9692,6 @@ definitions:
         type: string
         title: Description
     description: API secrets allow users to make requests to the Instill AI API.
-  SetupSchema:
-    type: object
-    properties:
-      method:
-        description: The connection method, which will define the fields in the schema.
-        readOnly: true
-        allOf:
-          - $ref: '#/definitions/Method'
-      schema:
-        type: object
-        description: |-
-          The connection setup field definitions. Each integration will require
-          different data to connect to the 3rd party app.
-        readOnly: true
-    description: |-
-      SetupSchema defines the schema for a connection setup.
-      This message is deprecated.
   ShareCode:
     type: object
     properties:

--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -234,36 +234,9 @@ message Integration {
   optional OAuthConfig o_auth_config = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
   // View defines how the integration is presented. The following fields are
   // only shown in the FULL view:
-  // - schemas
   // - setupSchema
   // - oAuthConfig
   View view = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // SetupSchema defines the schema for a connection setup.
-  // This message is deprecated.
-  message SetupSchema {
-    // The connection method, which will define the fields in the schema.
-    Connection.Method method = 1 [
-      deprecated = true,
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-    // The connection setup field definitions. Each integration will require
-    // different data to connect to the 3rd party app.
-    google.protobuf.Struct schema = 2 [
-      deprecated = true,
-      (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-  }
-
-  // Schemas defines the supported schemas for the connection setup.
-  // We haven't found a case for a schema that changes on the connection method
-  // (components don't care about how the connection was built), so the schema
-  // will be provided in the setupSchema field and the OAuth support and
-  // configuration will be provided in oAuthConfig.
-  repeated SetupSchema schemas = 8 [
-    deprecated = true,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
 }
 
 // ListPipelineIDsByConnectionIDRequest represents a request to list the


### PR DESCRIPTION
Because

- The `schemas` field was added under the wrong assumption that the
  integration schemas would differ across connection methods (OAuth vs
  key-value).
- After deprecating this field and providing an alternative `setupSchema`
  field, all the clients for the deprecated one have been removed.
  Therefore, removing the deprecated field won't break any client.

This commit

- Removes the deprecated `schemas` field.
