### PR TITLE
chore(vdp): remove old webhook endpoints

### DIFF
--- a/vdp/pipeline/v1beta/pipeline_public_service.proto
+++ b/vdp/pipeline/v1beta/pipeline_public_service.proto
@@ -232,26 +232,6 @@ service PipelinePublicService {
     };
   }
 
-  // HandleNamespacePipelineWebhookEvent
-  rpc HandleNamespacePipelineWebhookEvent(HandleNamespacePipelineWebhookEventRequest) returns (HandleNamespacePipelineWebhookEventResponse) {
-    option (google.api.http) = {
-      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/webhooks"
-      body: "data"
-      response_body: "data"
-    };
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
-  // HandleNamespacePipelineReleaseWebhookEvent
-  rpc HandleNamespacePipelineReleaseWebhookEvent(HandleNamespacePipelineReleaseWebhookEventRequest) returns (HandleNamespacePipelineReleaseWebhookEventResponse) {
-    option (google.api.http) = {
-      post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}/webhooks"
-      body: "data"
-      response_body: "data"
-    };
-    option (google.api.method_visibility).restriction = "INTERNAL";
-  }
-
   // Dispatch Pipeline Webhook Event
   //
   // Handles webhook events by routing them to the appropriate pipeline based on the webhook type and message.


### PR DESCRIPTION
Because

- The old webhook endpoints are deprecated and no longer in use.

This commit

- Removes the outdated webhook endpoints.