### PR TITLE
fix(connection): correct param in lookup endpoint

### DIFF
--- a/vdp/pipeline/v1beta/integration.proto
+++ b/vdp/pipeline/v1beta/integration.proto
@@ -311,7 +311,7 @@ message GetIntegrationResponse {
 // connection by UID.
 message LookUpConnectionAdminRequest {
   // Connection UID.
-  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  string uid = 1 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired view in the response. It
   // defaults to `VIEW_BASIC`.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];


### PR DESCRIPTION
Because

- `LookUpConnectionAdminRequest` should contain the connection UID, not the namespace ID.

This commit

- Update the object with the right field name.
