### PR TITLE
feat(agent): support breakpoint and connection

### DIFF
--- a/app/app/v1alpha/agent.proto
+++ b/app/app/v1alpha/agent.proto
@@ -40,6 +40,8 @@ message AIAgentAppMetadata {
   int32 chunk_top_k = 4 [(google.api.field_behavior) = OPTIONAL];
   // AI agent chunk weight
   float chunk_weight = 5 [(google.api.field_behavior) = OPTIONAL];
+  // connection key(used connection id in recipe) and value(connection uid from namespace).
+  map<string, string> connections = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // tool definitions
@@ -48,8 +50,8 @@ message Tool {
   string pipeline_id = 1 [(google.api.field_behavior) = OPTIONAL];
   // The tool name.
   optional string name = 2 [(google.api.field_behavior) = OPTIONAL];
-  // The tool connection key(variable) and value(id).
-  map<string, string> config = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The tool connection key(used connection id in recipe) and value(connection uid from namespace).
+  map<string, string> connections = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // CreateAgentRequest represents a request to create a agent.

--- a/app/app/v1alpha/conversation.proto
+++ b/app/app/v1alpha/conversation.proto
@@ -52,6 +52,8 @@ message Chat {
   optional string temp_catalog_id = 9 [(google.api.field_behavior) = OPTIONAL];
   // conversation display name
   string chat_display_name = 10 [(google.api.field_behavior) = OPTIONAL];
+  // breakpoint id
+  string breakpoint_id = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ChatWith enum

--- a/app/app/v1alpha/conversation.proto
+++ b/app/app/v1alpha/conversation.proto
@@ -52,8 +52,8 @@ message Chat {
   optional string temp_catalog_id = 9 [(google.api.field_behavior) = OPTIONAL];
   // conversation display name
   string chat_display_name = 10 [(google.api.field_behavior) = OPTIONAL];
-  // breakpoint id
-  string breakpoint_id = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // breakpoint. allow to continue the chat from breakpoint
+  string breakpoint = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ChatWith enum

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -5698,6 +5698,11 @@ definitions:
         type: number
         format: float
         title: AI agent chunk weight
+      connections:
+        type: object
+        additionalProperties:
+          type: string
+        description: connection key(used connection id in recipe) and value(connection uid from namespace).
     description: AIAgentAppMetadata represents the metadata for the AI agent app.
   AIAssistantAppMetadata:
     type: object
@@ -10349,11 +10354,11 @@ definitions:
       name:
         type: string
         description: The tool name.
-      config:
+      connections:
         type: object
         additionalProperties:
           type: string
-        description: The tool connection key(variable) and value(id).
+        description: The tool connection key(used connection id in recipe) and value(connection uid from namespace).
     title: tool definitions
   Trace:
     type: object
@@ -11373,6 +11378,10 @@ definitions:
       chatDisplayName:
         type: string
         title: conversation display name
+      breakpoint:
+        type: string
+        title: breakpoint. allow to continue the chat from breakpoint
+        readOnly: true
     title: Chat represents a chat
     required:
       - namespaceId


### PR DESCRIPTION
Because

1. FE will set the connection in chat level
2. FE will use breakpoint to continue the chat after setting up the connection

This commit

add this two fields
