### PR TITLE
fix(agent): add description for tool

### DIFF
--- a/app/app/v1alpha/agent.proto
+++ b/app/app/v1alpha/agent.proto
@@ -52,6 +52,8 @@ message Tool {
   optional string name = 2 [(google.api.field_behavior) = OPTIONAL];
   // The tool connection key(used connection id in recipe) and value(connection uid from namespace).
   map<string, string> connections = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The tool description.
+  string description = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateAgentRequest represents a request to create a agent.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -10359,6 +10359,10 @@ definitions:
         additionalProperties:
           type: string
         description: The tool connection key(used connection id in recipe) and value(connection uid from namespace).
+      description:
+        type: string
+        description: The tool description.
+        readOnly: true
     title: tool definitions
   Trace:
     type: object


### PR DESCRIPTION
Because

tools have description 

This commit

retrun tool description for FE
