### PR TITLE
feat(artifact): add move file method

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -644,8 +644,8 @@ message MoveFileToCatalogRequest {
   string file_uid = 1 [(google.api.field_behavior) = REQUIRED];
   // namespace id
   string namespace_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // The source catalog id.
-  string from_catalog_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // catalog id
+  string catalog_id = 3 [(google.api.field_behavior) = REQUIRED];
   // The target catalog id.
   string to_catalog_id = 4 [(google.api.field_behavior) = REQUIRED];
 }

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -637,3 +637,21 @@ message ListCatalogRunsRequest {
   // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
   optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
+
+// MoveFileToCatalogRequest represents a request to move a file to another catalog.
+message MoveFileToCatalogRequest {
+  // The file uid.
+  string file_uid = 1 [(google.api.field_behavior) = REQUIRED];
+  // namespace id
+  string namespace_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The source catalog id.
+  string from_catalog_id = 3 [(google.api.field_behavior) = REQUIRED];
+  // The target catalog id.
+  string to_catalog_id = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// MoveFileToCatalogResponse represents a response for moving a file to another catalog.
+message MoveFileToCatalogResponse {
+  // The file uid.
+  string file_uid = 1;
+}

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -350,4 +350,21 @@ service ArtifactPublicService {
       }
     };
   }
+
+  // Move file to another catalog
+  //
+  // Moves a file to another catalog.
+  rpc MoveFileToCatalog(MoveFileToCatalogRequest) returns (MoveFileToCatalogResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files:move"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
 }

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -1690,6 +1690,42 @@ paths:
       tags:
         - "\U0001F4BE Artifact"
       x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/files:move:
+    post:
+      summary: Move file to another catalog
+      description: Moves a file to another catalog.
+      operationId: ArtifactPublicService_MoveFileToCatalog
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/MoveFileToCatalogResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: namespace id
+          in: path
+          required: true
+          type: string
+        - name: catalogId
+          description: catalog id
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/MoveFileToCatalogBody'
+      tags:
+        - "\U0001F4BE Artifact"
+      x-stage: alpha
   /v1beta/user:
     get:
       summary: Get the authenticated user
@@ -9225,6 +9261,26 @@ definitions:
         description: Version update time, i.e. timestamp of the last push.
         readOnly: true
     description: ModelVersion contains information about the version of a model.
+  MoveFileToCatalogBody:
+    type: object
+    properties:
+      fileUid:
+        type: string
+        description: The file uid.
+      toCatalogId:
+        type: string
+        description: The target catalog id.
+    description: MoveFileToCatalogRequest represents a request to move a file to another catalog.
+    required:
+      - fileUid
+      - toCatalogId
+  MoveFileToCatalogResponse:
+    type: object
+    properties:
+      fileUid:
+        type: string
+        description: The file uid.
+    description: MoveFileToCatalogResponse represents a response for moving a file to another catalog.
   NullValue:
     type: string
     description: |-


### PR DESCRIPTION
Because

in chat ui, user can move file from temporal catalog to persistent one

This commit

add contract

ref: INS-7085