### PR TITLE
chore(model): update hardware message type

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -52,7 +52,15 @@ message Region {
   // Concate name of provider and region
   string region_name = 1;
   // Hardware describes the available hardware types in this region
-  repeated string hardware = 2;
+  repeated Hardware hardware = 2;
+}
+
+// Hardware describes the hardware title and string value that backend consumes.
+message Hardware {
+  // Hardware display title
+  string title = 1;
+  // Hardware name value
+  string value = 2;
 }
 
 // State describes the state of a model. See [Deploy

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7892,6 +7892,16 @@ definitions:
         allOf:
           - $ref: '#/definitions/UserSubscription'
     title: GetUserSubscriptionAdminResponse
+  Hardware:
+    type: object
+    properties:
+      title:
+        type: string
+        title: Hardware title
+      value:
+        type: string
+        title: Hardware name value
+    description: Hardware describes the hardware title and string value that backend consumes.
   Integration:
     type: object
     properties:
@@ -9979,7 +9989,8 @@ definitions:
       hardware:
         type: array
         items:
-          type: string
+          type: object
+          $ref: '#/definitions/Hardware'
         title: Hardware describes the available hardware types in this region
     description: |-
       Region describes the supported cloud provider and regions, with

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7897,7 +7897,7 @@ definitions:
     properties:
       title:
         type: string
-        title: Hardware title
+        title: Hardware display title
       value:
         type: string
         title: Hardware name value


### PR DESCRIPTION
Because

- provide display name for each hardware type

This commit

- update hardware message
