### PR TITLE
chore(model): Revert "chore(model): update model hardware prop type (#536)"

### DIFF
--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -200,8 +200,8 @@ message Model {
     (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];
-  // Deleted Fields.
-  reserved 19;
+  // Hardware of choice to serve the model.
+  string hardware = 19 [(google.api.field_behavior) = REQUIRED];
   // README holds the model documentation.
   optional string readme = 20 [(google.api.field_behavior) = OPTIONAL];
   // A link to the source code of the model (e.g. to a GitHub repository).
@@ -228,8 +228,6 @@ message Model {
   repeated string versions = 31 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Statistic data.
   Stats stats = 32 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Hardware of choice to serve the model.
-  Hardware hardware = 33 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListModelsRequest represents a request to list  models.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -8990,6 +8990,9 @@ definitions:
       region:
         type: string
         description: Region of choice for the particular provider to host the model.
+      hardware:
+        type: string
+        description: Hardware of choice to serve the model.
       readme:
         type: string
         description: README holds the model documentation.
@@ -9035,10 +9038,6 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/Model.Stats'
-      hardware:
-        description: Hardware of choice to serve the model.
-        allOf:
-          - $ref: '#/definitions/Hardware'
     title: |-
       Model represents an AI model, i.e. a program that performs tasks as decision
       making or or pattern recognition based on its training data
@@ -9986,7 +9985,7 @@ definitions:
     properties:
       regionName:
         type: string
-        title: Concatenate name of provider and region
+        title: Concate name of provider and region
       hardware:
         type: array
         items:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -9985,7 +9985,7 @@ definitions:
     properties:
       regionName:
         type: string
-        title: Concate name of provider and region
+        title: Concatenate name of provider and region
       hardware:
         type: array
         items:


### PR DESCRIPTION
Because

- hardware should stay as string

This commit

- reverts commit 99c515cd3e003401e5ba92abf9a53ce1b21f8ffa.
