### PR TITLE
feat(pipeline): add blob expiration time to run logs

### DIFF
--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6806,6 +6806,15 @@ definitions:
         format: float
         description: Credits used of internal accounting metric.
         readOnly: true
+      blobDataExpirationTime:
+        type: string
+        format: date-time
+        description: |-
+          Expiration time for the blob data associated with the component run (e.g.
+          input / output data). When the run is accessed after the expiration, that
+          information will be empty, but this field will allow the user identify
+          that the data isn't there because it has expired.
+        readOnly: true
     description: ComponentRun represents the execution details of a single component within a pipeline run.
   ComponentTask:
     type: object
@@ -9903,6 +9912,15 @@ definitions:
       pipelineNamespaceId:
         type: string
         description: ID of the namespace that owns the pipeline.
+        readOnly: true
+      blobDataExpirationTime:
+        type: string
+        format: date-time
+        description: |-
+          Expiration time for the blob data associated with the pipeline run (e.g.
+          input data, recipe). When the run is accessed after the expiration, that
+          information will be empty, but this field will allow the user identify
+          that the data isn't there because it has expired.
         readOnly: true
     description: PipelineRun represents a single execution of a pipeline.
   PipelineTriggerChartRecord:

--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -2118,6 +2118,15 @@ message PipelineRun {
 
   // ID of the namespace that owns the pipeline.
   string pipeline_namespace_id = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Expiration time for the blob data associated with the pipeline run (e.g.
+  // input data, recipe). When the run is accessed after the expiration, that
+  // information will be empty, but this field will allow the user identify
+  // that the data isn't there because it has expired.
+  optional google.protobuf.Timestamp blob_data_expiration_time = 22 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 // ComponentRun represents the execution details of a single component within a pipeline run.
@@ -2169,6 +2178,15 @@ message ComponentRun {
 
   // Credits used of internal accounting metric.
   optional float credit_amount = 12 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Expiration time for the blob data associated with the component run (e.g.
+  // input / output data). When the run is accessed after the expiration, that
+  // information will be empty, but this field will allow the user identify
+  // that the data isn't there because it has expired.
+  optional google.protobuf.Timestamp blob_data_expiration_time = 22 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];


### PR DESCRIPTION
Because

- When the blob data associated to a pipeline / component run expires, the backend will stop serving it. It will be useful to both backend and clients to know that the data isn't there because it expired (instead of because an error occurred).

This commit

- Adds a field with the blob data expiration data to the run entities.
