### PR TITLE
feat(table): add move-rows API

### DIFF
--- a/app/app/v1alpha/app_public_service.proto
+++ b/app/app/v1alpha/app_public_service.proto
@@ -555,7 +555,7 @@ service AppPublicService {
   rpc InsertRow(InsertRowRequest) returns (InsertRowResponse) {
     option (google.api.http) = {
       post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows"
-      body: "row"
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Table"
@@ -572,7 +572,7 @@ service AppPublicService {
   rpc UpdateRow(UpdateRowRequest) returns (UpdateRowResponse) {
     option (google.api.http) = {
       patch: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}"
-      body: "row"
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Table"
@@ -589,7 +589,7 @@ service AppPublicService {
   rpc UpdateRows(UpdateRowsRequest) returns (UpdateRowsResponse) {
     option (google.api.http) = {
       patch: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows"
-      body: "rows"
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Table"
@@ -619,6 +619,23 @@ service AppPublicService {
   // Deletes multiple rows from a table.
   rpc DeleteRows(DeleteRowsRequest) returns (DeleteRowsResponse) {
     option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Move row
+  //
+  // Moves a row to a new position in a table.
+  rpc MoveRows(MoveRowsRequest) returns (MoveRowsResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/move-rows"
+      body: "*"
+    };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Table"
       extensions: {

--- a/app/app/v1alpha/table.proto
+++ b/app/app/v1alpha/table.proto
@@ -272,6 +272,9 @@ message Row {
 
   // The timestamp when the row was created.
   google.protobuf.Timestamp create_time = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when the row was last updated.
+  google.protobuf.Timestamp update_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListRowsRequest represents a request to fetch rows from a table.
@@ -317,6 +320,9 @@ message InsertRowRequest {
 
   // The rows to insert.
   Row row = 3;
+
+  // The unique identifier of the row to insert after.
+  optional string after_row_uid = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // InsertRowResponse contains the inserted row.
@@ -393,6 +399,24 @@ message DeleteRowsRequest {
 
 // DeleteRowsResponse is an empty response for deleting multiple rows.
 message DeleteRowsResponse {}
+
+// MoveRowsRequest represents a request to move multiple rows.
+message MoveRowsRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table containing the row.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifiers of the rows to be moved.
+  repeated string row_uids = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the row to move after.
+  optional string after_row_uid = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// MoveRowsResponse is an empty response for moving multiple rows.
+message MoveRowsResponse {}
 
 // ExportRequest represents a request to export table data.
 message ExportRequest {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -1321,12 +1321,11 @@ paths:
           in: path
           required: true
           type: string
-        - name: row
-          description: The rows to insert.
+        - name: body
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Row'
+            $ref: '#/definitions/InsertRowBody'
       tags:
         - Table
       x-stage: alpha
@@ -1357,15 +1356,11 @@ paths:
           in: path
           required: true
           type: string
-        - name: rows
-          description: The rows to update.
+        - name: body
           in: body
           required: true
           schema:
-            type: array
-            items:
-              type: object
-              $ref: '#/definitions/Row'
+            $ref: '#/definitions/UpdateRowsBody'
       tags:
         - Table
       x-stage: alpha
@@ -1437,12 +1432,47 @@ paths:
           in: path
           required: true
           type: string
-        - name: row
-          description: The new row data.
+        - name: body
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Row'
+            $ref: '#/definitions/UpdateRowBody'
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/move-rows:
+    post:
+      summary: Move row
+      description: Moves a row to a new position in a table.
+      operationId: AppPublicService_MoveRows
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/MoveRowsResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table containing the row.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/MoveRowsBody'
       tags:
         - Table
       x-stage: alpha
@@ -8588,6 +8618,17 @@ definitions:
     description: ImageCell represents a cell with a url of an image resource.
     required:
       - url
+  InsertRowBody:
+    type: object
+    properties:
+      row:
+        description: The rows to insert.
+        allOf:
+          - $ref: '#/definitions/Row'
+      afterRowUid:
+        type: string
+        description: The unique identifier of the row to insert after.
+    description: InsertRowRequest represents a request to insert a row into a table.
   InsertRowResponse:
     type: object
     properties:
@@ -10026,6 +10067,23 @@ definitions:
         type: string
         description: The file uid.
     description: MoveFileToCatalogResponse represents a response for moving a file to another catalog.
+  MoveRowsBody:
+    type: object
+    properties:
+      rowUids:
+        type: array
+        items:
+          type: string
+        description: The unique identifiers of the rows to be moved.
+      afterRowUid:
+        type: string
+        description: The unique identifier of the row to move after.
+    description: MoveRowsRequest represents a request to move multiple rows.
+    required:
+      - rowUids
+  MoveRowsResponse:
+    type: object
+    description: MoveRowsResponse is an empty response for moving multiple rows.
   NullValue:
     type: string
     description: |-
@@ -10848,6 +10906,11 @@ definitions:
         type: string
         format: date-time
         description: The timestamp when the row was created.
+        readOnly: true
+      updateTime:
+        type: string
+        format: date-time
+        description: The timestamp when the row was last updated.
         readOnly: true
     description: Row represents a row in a table.
     required:
@@ -11918,6 +11981,14 @@ definitions:
         allOf:
           - $ref: '#/definitions/Organization'
     description: UpdateOrganizationResponse contains the updated organization.
+  UpdateRowBody:
+    type: object
+    properties:
+      row:
+        description: The new row data.
+        allOf:
+          - $ref: '#/definitions/Row'
+    description: UpdateRowRequest represents a request to update a row.
   UpdateRowResponse:
     type: object
     properties:
@@ -11927,6 +11998,16 @@ definitions:
         allOf:
           - $ref: '#/definitions/Row'
     description: UpdateRowResponse contains the updated row.
+  UpdateRowsBody:
+    type: object
+    properties:
+      rows:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/Row'
+        description: The rows to update.
+    description: UpdateRowsRequest represents a request to update multiple rows.
   UpdateRowsResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- we need to allow users to move rows.

This commit

- adds the move-rows API.