### PR TITLE
chore(table): use beforeRowUID when inserting or moving rows

### DIFF
--- a/app/app/v1alpha/table.proto
+++ b/app/app/v1alpha/table.proto
@@ -321,8 +321,8 @@ message InsertRowRequest {
   // The rows to insert.
   Row row = 3;
 
-  // The unique identifier of the row to insert after.
-  optional string after_row_uid = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The unique identifier of the row to insert before.
+  optional string before_row_uid = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // InsertRowResponse contains the inserted row.
@@ -411,8 +411,8 @@ message MoveRowsRequest {
   // The unique identifiers of the rows to be moved.
   repeated string row_uids = 3 [(google.api.field_behavior) = REQUIRED];
 
-  // The unique identifier of the row to move after.
-  optional string after_row_uid = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The unique identifier of the row to move before.
+  optional string before_row_uid = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // MoveRowsResponse is an empty response for moving multiple rows.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -8625,9 +8625,9 @@ definitions:
         description: The rows to insert.
         allOf:
           - $ref: '#/definitions/Row'
-      afterRowUid:
+      beforeRowUid:
         type: string
-        description: The unique identifier of the row to insert after.
+        description: The unique identifier of the row to insert before.
     description: InsertRowRequest represents a request to insert a row into a table.
   InsertRowResponse:
     type: object
@@ -10075,9 +10075,9 @@ definitions:
         items:
           type: string
         description: The unique identifiers of the rows to be moved.
-      afterRowUid:
+      beforeRowUid:
         type: string
-        description: The unique identifier of the row to move after.
+        description: The unique identifier of the row to move before.
     description: MoveRowsRequest represents a request to move multiple rows.
     required:
       - rowUids


### PR DESCRIPTION
Because

- The original default behavior when `afterRowUID` is nil differs between inserting and moving rows.

This commit

- Uses `beforeRowUID` instead of `afterRowUID` when inserting or moving rows.