### PR TITLE
feat(pipeline): add supports for clone with template

### DIFF
--- a/vdp/pipeline/v1beta/pipeline.proto
+++ b/vdp/pipeline/v1beta/pipeline.proto
@@ -445,51 +445,84 @@ message RenameNamespacePipelineResponse {
   Pipeline pipeline = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// TemplateOverrides allows customizing values when cloning a pipeline
+// as a template.
+message TemplateOverrides {
+  // A collection of connection references. By default, connection references
+  // (`${connection.<id>}`) in a pipeline will be resolved by fetching the
+  // value from the requester's connections. Connections contain sensitive data
+  // and can't be shared across namespaces, so this means that, in order to
+  // successfully run a pipeline owned by another namespace, the requester will
+  // need to have a connection with the same ID.
+  // This object provides a way to override the connection references with
+  // connections that the requester owns. Each element in the object maps a
+  // connection ID present in the pipeline (key) to the ID of a connection
+  // owned by the requester (value).
+  // Note that, since only references are accepted (this object shouldn't
+  // contain connection **values**), the reference syntax shouldn't be used
+  // here.
+  map<string, string> connection_references = 1 [(google.api.field_behavior) = OPTIONAL];
+}
+
 // CloneNamespacePipelineRequest represents a request to clone a pipeline owned by a
-// user.
+// namespace into another namespace. The cloned pipeline can either be an exact copy
+// or a template-based copy with overridden values.
 message CloneNamespacePipelineRequest {
-  // Namespace ID
+  // Source namespace ID containing the pipeline to clone
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline ID
+  // Source pipeline ID to clone
   string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
 
   // Deprecated `target` field
   reserved 3;
 
-  // Pipeline description.
+  // Description for the cloned pipeline
   string description = 4 [(google.api.field_behavior) = OPTIONAL];
-  // Pipeline sharing information.
+  // Sharing settings for the cloned pipeline
   Sharing sharing = 5 [(google.api.field_behavior) = OPTIONAL];
-  // Target Namespace ID.
+  // Target namespace ID where the pipeline will be cloned to
   string target_namespace_id = 6 [(google.api.field_behavior) = REQUIRED];
-  // Target Pipeline ID.
+  // Target pipeline ID for the cloned pipeline
   string target_pipeline_id = 7 [(google.api.field_behavior) = REQUIRED];
+
+  // When true, treats the source pipeline as a template and allows overriding
+  // sensitive values through template_overrides
+  bool as_template = 8 [(google.api.field_behavior) = OPTIONAL];
+  // Template overrides for sensitive values, only used when as_template is true
+  TemplateOverrides template_overrides = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // CloneNamespacePipelineResponse contains a cloned pipeline.
 message CloneNamespacePipelineResponse {}
 
-// CloneNamespacePipelineReleaseRequest represents a request to clone a pipeline
-// release owned by a user.
+// CloneNamespacePipelineReleaseRequest represents a request to clone a pipeline release owned by a
+// namespace into another namespace. The cloned pipeline can either be an exact copy
+// or a template-based copy with overridden values.
 message CloneNamespacePipelineReleaseRequest {
-  // Namespace ID
+  // Source namespace ID containing the pipeline to clone
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Pipeline ID
+  // Source pipeline ID to clone
   string pipeline_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // Release ID
+  // Source release ID to clone
   string release_id = 3 [(google.api.field_behavior) = REQUIRED];
 
   // Deprecated `target` field
   reserved 4;
 
-  // Pipeline description.
+  // Description for the cloned pipeline
   string description = 5 [(google.api.field_behavior) = OPTIONAL];
-  // Pipeline sharing information.
+  // Sharing settings for the cloned pipeline
   Sharing sharing = 6 [(google.api.field_behavior) = OPTIONAL];
-  // Target Namespace ID.
+  // Target namespace ID where the pipeline will be cloned to
   string target_namespace_id = 7 [(google.api.field_behavior) = REQUIRED];
-  // Target Pipeline ID.
+  // Target pipeline ID for the cloned pipeline
   string target_pipeline_id = 8 [(google.api.field_behavior) = REQUIRED];
+
+  // When true, treats the source pipeline as a template and allows overriding
+  // sensitive values through template_overrides
+  bool as_template = 9 [(google.api.field_behavior) = OPTIONAL];
+  // Template overrides for sensitive values, only used when as_template is true
+  TemplateOverrides template_overrides = 10 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // CloneNamespacePipelineReleaseResponse contains a cloned pipeline.


### PR DESCRIPTION
Because

- we want to enable users to clone pipelines using templates.

This commit

- adds parameters to allow user cloning pipelines with templates.
