### PR TITLE
chore(table): add NullCell for table

### DIFF
--- a/app/app/v1alpha/table.proto
+++ b/app/app/v1alpha/table.proto
@@ -208,11 +208,17 @@ message Cell {
 
     // The value of the cell as a url of an audio resource.
     AudioCell audio_value = 12;
+
+    // The value of the cell as a null cell.
+    NullCell null_value = 13;
   }
 
   // Additional metadata for the cell.
-  google.protobuf.Struct metadata = 13 [(google.api.field_behavior) = OPTIONAL];
+  google.protobuf.Struct metadata = 15 [(google.api.field_behavior) = OPTIONAL];
 }
+
+// NullCell represents a null cell.
+message NullCell {}
 
 // StringCell represents a cell with a string value.
 message StringCell {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6171,6 +6171,10 @@ definitions:
         description: The value of the cell as a url of an audio resource.
         allOf:
           - $ref: '#/definitions/AudioCell'
+      nullValue:
+        description: The value of the cell as a null cell.
+        allOf:
+          - $ref: '#/definitions/NullCell'
       metadata:
         type: object
         description: Additional metadata for the cell.
@@ -9085,6 +9089,9 @@ definitions:
   MoveRowsResponse:
     type: object
     description: MoveRowsResponse is an empty response for moving multiple rows.
+  NullCell:
+    type: object
+    description: NullCell represents a null cell.
   NullValue:
     type: string
     description: |-


### PR DESCRIPTION
Because

- users might want to clear cells with no value.

This commit

- adds support for NullCell in the table.
