### PR TITLE
feat(table): add table streaming endpoints

### DIFF
--- a/app/app/v1alpha/app_public_service.proto
+++ b/app/app/v1alpha/app_public_service.proto
@@ -401,6 +401,20 @@ service AppPublicService {
     };
   }
 
+  // Get table events
+  //
+  // Returns a list of events for a table.
+  rpc GetTableEvents(GetTableEventsRequest) returns (stream GetTableEventsResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/events"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // Export table
   //
   // Exports table data.
@@ -413,5 +427,15 @@ service AppPublicService {
         value: {string_value: "alpha"}
       }
     };
+  }
+
+  // Generate mock table
+  //
+  // Generates mock table data.
+  // This API is only available for internal use to generate mock row data for testing purposes.
+  // It should not be used in production environments.
+  rpc GenerateMockTable(GenerateMockTableRequest) returns (GenerateMockTableResponse) {
+    option (google.api.http) = {post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/generate-mock"};
+    option (google.api.method_visibility).restriction = "INTERNAL";
   }
 }

--- a/app/app/v1alpha/table.proto
+++ b/app/app/v1alpha/table.proto
@@ -169,6 +169,27 @@ message UpdateColumnDefinitionsResponse {
   map<string, ColumnDefinition> column_definitions = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// CellStatus represents the status of a cell.
+enum CellStatus {
+  // The cell status is not specified.
+  CELL_STATUS_UNSPECIFIED = 0;
+
+  // The cell is idle.
+  CELL_STATUS_IDLE = 1;
+
+  // The cell is pending.
+  CELL_STATUS_PENDING = 2;
+
+  // The cell is processing.
+  CELL_STATUS_PROCESSING = 3;
+
+  // The cell is failed.
+  CELL_STATUS_FAILED = 4;
+
+  // The cell is completed.
+  CELL_STATUS_COMPLETED = 5;
+}
+
 // Cell represents a cell in a table.
 message Cell {
   // The unique identifier of the cell.
@@ -177,44 +198,50 @@ message Cell {
   // The unique identifier of the column this cell belongs to.
   string column_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
+  // The row that this cell belongs to.
+  string row_uid = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
   // The timestamp when the cell was last updated.
-  google.protobuf.Timestamp update_time = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Timestamp update_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The type of the cell's value.
-  string type = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string type = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The value of the cell as a string.
   oneof value {
     // The value of the cell as a string.
-    StringCell string_value = 5;
+    StringCell string_value = 6;
 
     // The value of the cell as a number.
-    NumberCell number_value = 6;
+    NumberCell number_value = 7;
 
     // The value of the cell as a boolean.
-    BooleanCell boolean_value = 7;
+    BooleanCell boolean_value = 8;
 
     // The value of the cell as a url of a file resource.
-    FileCell file_value = 8;
+    FileCell file_value = 9;
 
     // The value of the cell as a url of a document resource.
-    DocumentCell document_value = 9;
+    DocumentCell document_value = 10;
 
     // The value of the cell as a url of an image resource.
-    ImageCell image_value = 10;
+    ImageCell image_value = 11;
 
     // The value of the cell as a url of a video resource.
-    VideoCell video_value = 11;
+    VideoCell video_value = 12;
 
     // The value of the cell as a url of an audio resource.
-    AudioCell audio_value = 12;
+    AudioCell audio_value = 13;
 
     // The value of the cell as a null cell.
-    NullCell null_value = 13;
+    NullCell null_value = 14;
   }
 
   // Additional metadata for the cell.
   google.protobuf.Struct metadata = 15 [(google.api.field_behavior) = OPTIONAL];
+
+  // The status of the cell.
+  CellStatus status = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // NullCell represents a null cell.
@@ -441,3 +468,127 @@ message ExportResponse {
   // The exported data.
   bytes data = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
+
+// GetTableEventsRequest represents a request to fetch events for a table.
+message GetTableEventsRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table to fetch events for.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetTableEventsResponse contains the events for a table.
+message GetTableEventsResponse {
+  // The events for the table.
+  TableEvent event = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TableEvent represents an event for a table.
+message TableEvent {
+  // The event type.
+  // In text/event-stream format, this maps to the `event` field.
+  string event = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The ID of the event.
+  // In text/event-stream format, this maps to the `id` field.
+  string id = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The data of the event.
+  // In text/event-stream format, this maps to the `data` field.
+  oneof data {
+    // The table that was updated.
+    TableUpdatedEvent table_updated_event = 3;
+
+    // The table that was deleted.
+    TableDeletedEvent table_deleted_event = 4;
+
+    // The column definitions that were updated.
+    ColumnDefinitionsUpdatedEvent column_definitions_updated_event = 5;
+
+    // The row that was inserted.
+    RowInsertedEvent row_inserted_event = 6;
+
+    // The row that was updated.
+    RowUpdatedEvent row_updated_event = 7;
+
+    // The row that was deleted.
+    RowDeletedEvent row_deleted_event = 8;
+
+    // The rows that were moved.
+    RowsMovedEvent rows_moved_event = 9;
+
+    // The cell that was updated.
+    CellUpdatedEvent cell_updated_event = 10;
+  }
+}
+
+// TableUpdatedEvent represents an event for a table being updated.
+message TableUpdatedEvent {
+  // The table that was updated.
+  Table table = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// TableDeletedEvent represents an event for a table being deleted.
+message TableDeletedEvent {}
+
+// ColumnDefinitionsUpdatedEvent represents an event for column definitions being updated.
+message ColumnDefinitionsUpdatedEvent {
+  // The column definitions that were updated.
+  map<string, ColumnDefinition> column_definitions = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// RowInsertedEvent represents an event for a row being inserted.
+message RowInsertedEvent {
+  // The row that was inserted.
+  // Note: Only the row metadata is returned, not the cell data.
+  Row row = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The unique identifier of the row that was inserted before.
+  string before_row_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// RowUpdatedEvent represents an event for a row being updated.
+message RowUpdatedEvent {
+  // The row that was updated.
+  // Note: Only the row metadata is returned, not the cell data.
+  Row row = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// RowDeletedEvent represents an event for a row being deleted.
+message RowDeletedEvent {
+  // The unique identifier of the row that was deleted.
+  string row_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// RowsMovedEvent represents an event for multiple rows being moved.
+message RowsMovedEvent {
+  // The unique identifiers of the rows that were moved.
+  repeated string row_uids = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The unique identifier of the row that was moved before.
+  optional string before_row_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CellUpdatedEvent represents an event for a cell being updated.
+message CellUpdatedEvent {
+  // The cell that was updated.
+  Cell cell = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Whether the event is a delta update.
+  // Only cells with string type can be returned in delta mode. Delta mode returns
+  // only the changes made to the cell value rather than the full value.
+  bool delta_mode = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GenerateMockTableRequest represents a request to generate mock table data.
+message GenerateMockTableRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table to generate mock data for.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GenerateMockTableResponse is an empty response for generating mock table data.
+message GenerateMockTableResponse {}

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -877,6 +877,43 @@ paths:
       tags:
         - Table
       x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/events:
+    get:
+      summary: Get table events
+      description: Returns a list of events for a table.
+      operationId: AppPublicService_GetTableEvents
+      responses:
+        "200":
+          description: A successful response.(streaming responses)
+          schema:
+            type: object
+            properties:
+              result:
+                $ref: '#/definitions/GetTableEventsResponse'
+              error:
+                $ref: '#/definitions/rpc.Status'
+            title: Stream result of GetTableEventsResponse
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table to fetch events for.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Table
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/export:
     get:
       summary: Export table
@@ -6130,6 +6167,10 @@ definitions:
         type: string
         description: The unique identifier of the column this cell belongs to.
         readOnly: true
+      rowUid:
+        type: string
+        description: The row that this cell belongs to.
+        readOnly: true
       updateTime:
         type: string
         format: date-time
@@ -6178,7 +6219,44 @@ definitions:
       metadata:
         type: object
         description: Additional metadata for the cell.
+      status:
+        description: The status of the cell.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/CellStatus'
     description: Cell represents a cell in a table.
+  CellStatus:
+    type: string
+    enum:
+      - CELL_STATUS_IDLE
+      - CELL_STATUS_PENDING
+      - CELL_STATUS_PROCESSING
+      - CELL_STATUS_FAILED
+      - CELL_STATUS_COMPLETED
+    description: |-
+      CellStatus represents the status of a cell.
+
+       - CELL_STATUS_IDLE: The cell is idle.
+       - CELL_STATUS_PENDING: The cell is pending.
+       - CELL_STATUS_PROCESSING: The cell is processing.
+       - CELL_STATUS_FAILED: The cell is failed.
+       - CELL_STATUS_COMPLETED: The cell is completed.
+  CellUpdatedEvent:
+    type: object
+    properties:
+      cell:
+        description: The cell that was updated.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Cell'
+      deltaMode:
+        type: boolean
+        description: |-
+          Whether the event is a delta update.
+          Only cells with string type can be returned in delta mode. Delta mode returns
+          only the changes made to the cell value rather than the full value.
+        readOnly: true
+    description: CellUpdatedEvent represents an event for a cell being updated.
   ChatResponse:
     type: object
     properties:
@@ -6414,6 +6492,16 @@ definitions:
     required:
       - type
       - order
+  ColumnDefinitionsUpdatedEvent:
+    type: object
+    properties:
+      columnDefinitions:
+        type: object
+        additionalProperties:
+          $ref: '#/definitions/ColumnDefinition'
+        description: The column definitions that were updated.
+        readOnly: true
+    description: ColumnDefinitionsUpdatedEvent represents an event for column definitions being updated.
   ComponentDefinition:
     type: object
     properties:
@@ -7623,6 +7711,15 @@ definitions:
         allOf:
           - $ref: '#/definitions/SourceFile'
     title: get source file response
+  GetTableEventsResponse:
+    type: object
+    properties:
+      event:
+        description: The events for the table.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/TableEvent'
+    description: GetTableEventsResponse contains the events for a table.
   GetTableResponse:
     type: object
     properties:
@@ -9914,6 +10011,54 @@ definitions:
     description: Row represents a row in a table.
     required:
       - cells
+  RowDeletedEvent:
+    type: object
+    properties:
+      rowUid:
+        type: string
+        description: The unique identifier of the row that was deleted.
+        readOnly: true
+    description: RowDeletedEvent represents an event for a row being deleted.
+  RowInsertedEvent:
+    type: object
+    properties:
+      row:
+        description: |-
+          The row that was inserted.
+          Note: Only the row metadata is returned, not the cell data.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Row'
+      beforeRowUid:
+        type: string
+        description: The unique identifier of the row that was inserted before.
+        readOnly: true
+    description: RowInsertedEvent represents an event for a row being inserted.
+  RowUpdatedEvent:
+    type: object
+    properties:
+      row:
+        description: |-
+          The row that was updated.
+          Note: Only the row metadata is returned, not the cell data.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Row'
+    description: RowUpdatedEvent represents an event for a row being updated.
+  RowsMovedEvent:
+    type: object
+    properties:
+      rowUids:
+        type: array
+        items:
+          type: string
+        description: The unique identifiers of the rows that were moved.
+        readOnly: true
+      beforeRowUid:
+        type: string
+        description: The unique identifier of the row that was moved before.
+        readOnly: true
+    description: RowsMovedEvent represents an event for multiple rows being moved.
   RunSource:
     type: string
     enum:
@@ -10253,6 +10398,66 @@ definitions:
     required:
       - id
       - title
+  TableDeletedEvent:
+    type: object
+    description: TableDeletedEvent represents an event for a table being deleted.
+  TableEvent:
+    type: object
+    properties:
+      event:
+        type: string
+        description: |-
+          The event type.
+          In text/event-stream format, this maps to the `event` field.
+        readOnly: true
+      id:
+        type: string
+        description: |-
+          The ID of the event.
+          In text/event-stream format, this maps to the `id` field.
+        readOnly: true
+      tableUpdatedEvent:
+        description: The table that was updated.
+        allOf:
+          - $ref: '#/definitions/TableUpdatedEvent'
+      tableDeletedEvent:
+        description: The table that was deleted.
+        allOf:
+          - $ref: '#/definitions/TableDeletedEvent'
+      columnDefinitionsUpdatedEvent:
+        description: The column definitions that were updated.
+        allOf:
+          - $ref: '#/definitions/ColumnDefinitionsUpdatedEvent'
+      rowInsertedEvent:
+        description: The row that was inserted.
+        allOf:
+          - $ref: '#/definitions/RowInsertedEvent'
+      rowUpdatedEvent:
+        description: The row that was updated.
+        allOf:
+          - $ref: '#/definitions/RowUpdatedEvent'
+      rowDeletedEvent:
+        description: The row that was deleted.
+        allOf:
+          - $ref: '#/definitions/RowDeletedEvent'
+      rowsMovedEvent:
+        description: The rows that were moved.
+        allOf:
+          - $ref: '#/definitions/RowsMovedEvent'
+      cellUpdatedEvent:
+        description: The cell that was updated.
+        allOf:
+          - $ref: '#/definitions/CellUpdatedEvent'
+    description: TableEvent represents an event for a table.
+  TableUpdatedEvent:
+    type: object
+    properties:
+      table:
+        description: The table that was updated.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Table'
+    description: TableUpdatedEvent represents an event for a table being updated.
   Task:
     type: string
     enum:


### PR DESCRIPTION
Because

- we need to provide streaming endpoints for the Console to receive data change events.

This commit

- adds table streaming endpoints
