### PR TITLE
chore(table): add order field for row

### DIFF
--- a/app/app/v1alpha/table.proto
+++ b/app/app/v1alpha/table.proto
@@ -132,7 +132,8 @@ message ColumnDefinition {
   // The type of the column.
   string type = 3 [(google.api.field_behavior) = REQUIRED];
 
-  // The order of the column in the table.
+  // The order of the column in the table, starting at 1. This determines the column's position
+  // when displaying or processing table data.
   int32 order = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
@@ -303,11 +304,15 @@ message Row {
   // Map of column names to their cell values.
   map<string, Cell> cells = 2 [(google.api.field_behavior) = REQUIRED];
 
+  // The order of the row in the table, starting at 1. This determines the row's position
+  // when displaying or processing table data.
+  int32 order = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
   // The timestamp when the row was created.
-  google.protobuf.Timestamp create_time = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Timestamp create_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The timestamp when the row was last updated.
-  google.protobuf.Timestamp update_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListRowsRequest represents a request to fetch rows from a table.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6487,7 +6487,9 @@ definitions:
       order:
         type: integer
         format: int32
-        description: The order of the column in the table.
+        description: |-
+          The order of the column in the table, starting at 1. This determines the column's position
+          when displaying or processing table data.
     description: ColumnDefinition represents a column definition in a table.
     required:
       - type
@@ -9998,6 +10000,13 @@ definitions:
         additionalProperties:
           $ref: '#/definitions/Cell'
         description: Map of column names to their cell values.
+      order:
+        type: integer
+        format: int32
+        description: |-
+          The order of the row in the table, starting at 1. This determines the row's position
+          when displaying or processing table data.
+        readOnly: true
       createTime:
         type: string
         format: date-time


### PR DESCRIPTION
Because

- we'd like to return the actual order of the rows in the API response.

This commit

- adds an order field for rows, starting from 1.
