### PR TITLE
chore(table): add num_rows for mock api

### DIFF
--- a/app/app/v1alpha/app_public_service.proto
+++ b/app/app/v1alpha/app_public_service.proto
@@ -435,7 +435,10 @@ service AppPublicService {
   // This API is only available for internal use to generate mock row data for testing purposes.
   // It should not be used in production environments.
   rpc GenerateMockTable(GenerateMockTableRequest) returns (GenerateMockTableResponse) {
-    option (google.api.http) = {post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/generate-mock"};
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/generate-mock"
+      body: "*"
+    };
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 }

--- a/app/app/v1alpha/table.proto
+++ b/app/app/v1alpha/table.proto
@@ -593,6 +593,9 @@ message GenerateMockTableRequest {
 
   // The UID of the table to generate mock data for.
   string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The number of rows to generate.
+  optional int32 num_rows = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GenerateMockTableResponse is an empty response for generating mock table data.


### PR DESCRIPTION
This commit

- adds num_rows for mock api
