### PR TITLE
chore(table): adjust table export endpoint

### DIFF
--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -418,8 +418,11 @@ service AgentPublicService {
   // Export table
   //
   // Exports table data.
-  rpc Export(ExportRequest) returns (ExportResponse) {
-    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/export"};
+  rpc ExportTable(ExportTableRequest) returns (ExportTableResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/export"
+      body: "*"
+    };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Table"
       extensions: {

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -456,20 +456,32 @@ message MoveRowsRequest {
 // MoveRowsResponse is an empty response for moving multiple rows.
 message MoveRowsResponse {}
 
-// ExportRequest represents a request to export table data.
-message ExportRequest {
+// ExportFormat represents the format to export the data in.
+enum ExportFormat {
+  // The format is not specified.
+  EXPORT_FORMAT_UNSPECIFIED = 0;
+
+  // The format is CSV.
+  EXPORT_FORMAT_CSV = 1;
+
+  // The format is Parquet.
+  EXPORT_FORMAT_PARQUET = 2;
+}
+
+// ExportTableRequest represents a request to export table data.
+message ExportTableRequest {
   // The ID of the namespace that owns the table.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The UID of the table to export.
   string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // The format to export the data in (csv, parquet).
-  string type = 3 [(google.api.field_behavior) = REQUIRED];
+  // The format to export the data in.
+  ExportFormat format = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
-// ExportResponse is an empty response for exporting table data.
-message ExportResponse {
+// ExportTableResponse is an empty response for exporting table data.
+message ExportTableResponse {
   // The exported data.
   bytes data = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -456,16 +456,16 @@ message MoveRowsRequest {
 // MoveRowsResponse is an empty response for moving multiple rows.
 message MoveRowsResponse {}
 
-// ExportFormat represents the format to export the data in.
-enum ExportFormat {
-  // The format is not specified.
-  EXPORT_FORMAT_UNSPECIFIED = 0;
+// ExportType represents the type to export the data in.
+enum ExportType {
+  // The type is not specified.
+  EXPORT_TYPE_UNSPECIFIED = 0;
 
-  // The format is CSV.
-  EXPORT_FORMAT_CSV = 1;
+  // The type is CSV.
+  EXPORT_TYPE_CSV = 1;
 
-  // The format is Parquet.
-  EXPORT_FORMAT_PARQUET = 2;
+  // The type is Parquet.
+  EXPORT_TYPE_PARQUET = 2;
 }
 
 // ExportTableRequest represents a request to export table data.
@@ -476,8 +476,8 @@ message ExportTableRequest {
   // The UID of the table to export.
   string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // The format to export the data in.
-  ExportFormat format = 3 [(google.api.field_behavior) = REQUIRED];
+  // The type to export the data in.
+  ExportType type = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ExportTableResponse is an empty response for exporting table data.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7207,26 +7207,16 @@ definitions:
         description: JSON schema describing the component event examples.
         readOnly: true
     description: EventSpecification describes the JSON schema of component event setup and examples.
-  ExportFormat:
-    type: string
-    enum:
-      - EXPORT_FORMAT_CSV
-      - EXPORT_FORMAT_PARQUET
-    description: |-
-      ExportFormat represents the format to export the data in.
-
-       - EXPORT_FORMAT_CSV: The format is CSV.
-       - EXPORT_FORMAT_PARQUET: The format is Parquet.
   ExportTableBody:
     type: object
     properties:
-      format:
-        description: The format to export the data in.
+      type:
+        description: The type to export the data in.
         allOf:
-          - $ref: '#/definitions/ExportFormat'
+          - $ref: '#/definitions/ExportType'
     description: ExportTableRequest represents a request to export table data.
     required:
-      - format
+      - type
   ExportTableResponse:
     type: object
     properties:
@@ -7236,6 +7226,16 @@ definitions:
         description: The exported data.
         readOnly: true
     description: ExportTableResponse is an empty response for exporting table data.
+  ExportType:
+    type: string
+    enum:
+      - EXPORT_TYPE_CSV
+      - EXPORT_TYPE_PARQUET
+    description: |-
+      ExportType represents the type to export the data in.
+
+       - EXPORT_TYPE_CSV: The type is CSV.
+       - EXPORT_TYPE_PARQUET: The type is Parquet.
   File:
     type: object
     properties:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -915,15 +915,15 @@ paths:
         - Table
       x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/export:
-    get:
+    post:
       summary: Export table
       description: Exports table data.
-      operationId: AgentPublicService_Export
+      operationId: AgentPublicService_ExportTable
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/ExportResponse'
+            $ref: '#/definitions/ExportTableResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -942,11 +942,11 @@ paths:
           in: path
           required: true
           type: string
-        - name: type
-          description: The format to export the data in (csv, parquet).
-          in: query
+        - name: body
+          in: body
           required: true
-          type: string
+          schema:
+            $ref: '#/definitions/ExportTableBody'
       tags:
         - Table
       x-stage: alpha
@@ -7207,7 +7207,27 @@ definitions:
         description: JSON schema describing the component event examples.
         readOnly: true
     description: EventSpecification describes the JSON schema of component event setup and examples.
-  ExportResponse:
+  ExportFormat:
+    type: string
+    enum:
+      - EXPORT_FORMAT_CSV
+      - EXPORT_FORMAT_PARQUET
+    description: |-
+      ExportFormat represents the format to export the data in.
+
+       - EXPORT_FORMAT_CSV: The format is CSV.
+       - EXPORT_FORMAT_PARQUET: The format is Parquet.
+  ExportTableBody:
+    type: object
+    properties:
+      format:
+        description: The format to export the data in.
+        allOf:
+          - $ref: '#/definitions/ExportFormat'
+    description: ExportTableRequest represents a request to export table data.
+    required:
+      - format
+  ExportTableResponse:
     type: object
     properties:
       data:
@@ -7215,7 +7235,7 @@ definitions:
         format: byte
         description: The exported data.
         readOnly: true
-    description: ExportResponse is an empty response for exporting table data.
+    description: ExportTableResponse is an empty response for exporting table data.
   File:
     type: object
     properties:


### PR DESCRIPTION
Because:

- We need to allow users to export the table in a specified type.

This commit:

- Updates the table export endpoint accordingly.