### PR TITLE
ci(buf): upgrade Golang version

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.23
       - name: Checkout protobuf repository
         uses: actions/checkout@v3
       - name: Checkout protogen-go repository
@@ -69,7 +69,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.23
       - name: Checkout protobuf repository
         uses: actions/checkout@v3
       - name: Checkout protogen-python repository


### PR DESCRIPTION
Because

- the `buf` actions are broken.

This commit

- upgrades Golang version for `buf`.
