### PR TITLE
chore(table): use `format` instead of `type` in export API

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -456,16 +456,16 @@ message MoveRowsRequest {
 // MoveRowsResponse is an empty response for moving multiple rows.
 message MoveRowsResponse {}
 
-// ExportType represents the type to export the data in.
-enum ExportType {
-  // The type is not specified.
-  EXPORT_TYPE_UNSPECIFIED = 0;
+// ExportFormat represents the format to export the data in.
+enum ExportFormat {
+  // The format is not specified.
+  EXPORT_FORMAT_UNSPECIFIED = 0;
 
-  // The type is CSV.
-  EXPORT_TYPE_CSV = 1;
+  // The format is CSV.
+  EXPORT_FORMAT_CSV = 1;
 
-  // The type is Parquet.
-  EXPORT_TYPE_PARQUET = 2;
+  // The format is Parquet.
+  EXPORT_FORMAT_PARQUET = 2;
 }
 
 // ExportTableRequest represents a request to export table data.
@@ -476,8 +476,8 @@ message ExportTableRequest {
   // The UID of the table to export.
   string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // The type to export the data in.
-  ExportType type = 3 [(google.api.field_behavior) = REQUIRED];
+  // The format to export the data in.
+  ExportFormat format = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ExportTableResponse is an empty response for exporting table data.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7207,16 +7207,26 @@ definitions:
         description: JSON schema describing the component event examples.
         readOnly: true
     description: EventSpecification describes the JSON schema of component event setup and examples.
+  ExportFormat:
+    type: string
+    enum:
+      - EXPORT_FORMAT_CSV
+      - EXPORT_FORMAT_PARQUET
+    description: |-
+      ExportFormat represents the format to export the data in.
+
+       - EXPORT_FORMAT_CSV: The format is CSV.
+       - EXPORT_FORMAT_PARQUET: The format is Parquet.
   ExportTableBody:
     type: object
     properties:
-      type:
-        description: The type to export the data in.
+      format:
+        description: The format to export the data in.
         allOf:
-          - $ref: '#/definitions/ExportType'
+          - $ref: '#/definitions/ExportFormat'
     description: ExportTableRequest represents a request to export table data.
     required:
-      - type
+      - format
   ExportTableResponse:
     type: object
     properties:
@@ -7226,16 +7236,6 @@ definitions:
         description: The exported data.
         readOnly: true
     description: ExportTableResponse is an empty response for exporting table data.
-  ExportType:
-    type: string
-    enum:
-      - EXPORT_TYPE_CSV
-      - EXPORT_TYPE_PARQUET
-    description: |-
-      ExportType represents the type to export the data in.
-
-       - EXPORT_TYPE_CSV: The type is CSV.
-       - EXPORT_TYPE_PARQUET: The type is Parquet.
   File:
     type: object
     properties:


### PR DESCRIPTION
This commit

- uses `format` instead of `type` in export API
