### PR TITLE
feat(pipeline): rename VDP to pipeline

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ tag can be added with `grpc-gateway`'s `tags` operation option:
 // Returns the details of a pipeline.
 rpc GetNamespacePipeline(GetNamespacePipelineRequest) returns (GetNamespacePipelineResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 VDP"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {tags: "💧 Pipeline"};
 }
 ```
 
@@ -121,7 +121,7 @@ _alpha_ or _beta_ stage. This extension can be added with the
 rpc GetNamespacePipeline(GetNamespacePipelineRequest) returns (GetNamespacePipelineResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-    tags: "💧 VDP"
+    tags: "💧 Pipeline"
     extensions: {
         key: "x-stage"
             value {string_value: "beta"}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository is the interface definitions of the APIs of [Instill
 Core](https://github.com/instill-ai/mgmt-backend), [Instill
 Model](https://github.com/instill-ai/model-backend) and [Instill
-VDP](https://github.com/instill-ai/pipeline-backend) and [Instill
+Pipeline](https://github.com/instill-ai/pipeline-backend) and [Instill
 Artifact](https://github.com/instill-ai/artifact-backend) that support both REST
 and gRPC protocols. You can also use these definitions with open source tools to
 generate client libraries, documentation, and other artifacts.

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -56,7 +56,7 @@ message ReadinessResponse {
 
    An implementation of the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec?tab=readme-ov-file)
    is used to manage versioned content. The main use for repositories is storing
-   container images that can be used to deploy AI models or VDP pipelines.
+   container images that can be used to deploy AI models or pipelines.
 
    The ID of a repository has 2 segments, the owner (an Instill user or
    organization) and the content ID (the AI model or pipeline ID), e.g.

--- a/buf.md
+++ b/buf.md
@@ -3,7 +3,7 @@
 This repository is the interface definitions of the APIs of [Instill
 Core](https://github.com/instill-ai/mgmt-backend), [Instill
 Model](https://github.com/instill-ai/model-backend) and [Instill
-VDP](https://github.com/instill-ai/pipeline-backend) and [Instill
+Pipeline](https://github.com/instill-ai/pipeline-backend) and [Instill
 Artifact](https://github.com/instill-ai/artifact-backend) that support both REST
 and gRPC protocols. You can also use these definitions with open source tools to
 generate client libraries, documentation, and other artifacts.

--- a/core/metric/v1beta/metric.proto
+++ b/core/metric/v1beta/metric.proto
@@ -403,9 +403,9 @@ message PipelineData {
 
 // Pipeline trigger usage record definition
 message PipelineUsageRecord {
-  // A unique request id given by vdp when trigger the pipeline.
+  // A unique request id given by Instill Core when trigger the pipeline.
   string request_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // A unique operation id given by vdp
+  // A unique operation id given by Instill Core
   string operation_id = 2 [(google.api.field_behavior) = REQUIRED];
   // The HTTP status received when user trigger the pipeline
   string status = 3 [(google.api.field_behavior) = REQUIRED];

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -405,7 +405,7 @@ service MgmtPublicService {
 
   // Get the remaining Instill Credit
   //
-  // This endpoint returns the remaining [Instill Credit](https://www.instill.tech/docs/vdp/credit) of a given user or
+  // This endpoint returns the remaining [Instill Credit](https://www.instill.tech/docs/cloud/credit) of a given user or
   // organization. The requested credit owner must be either the authenticated
   // user or an organization they belong to.
   //

--- a/core/usage/v1beta/usage.proto
+++ b/core/usage/v1beta/usage.proto
@@ -36,7 +36,7 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
-// Session represents a unique session whenever a new instance of VDP service
+// Session represents a unique session whenever a new instance of Instill Core service
 // gets started. The usage server returns a token that should be used as part of
 // the challenge when sending a report with data collected from this session
 message Session {

--- a/openapi/v2/conf.proto
+++ b/openapi/v2/conf.proto
@@ -25,8 +25,8 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       description: "Namespaces (e.g. User, Organization) that structure the resource hierarchy."
     },
     {
-      name: "💧 VDP"
-      description: "Pipeline orchestration in VDP (Versatile Data Pipeline)."
+      name: "💧 Pipeline"
+      description: "Pipeline orchestration in Instill Core."
     },
     {
       name: "⚗️ Model"

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -14,8 +14,8 @@ info:
 tags:
   - name: "\U0001FA86 Namespace"
     description: Namespaces (e.g. User, Organization) that structure the resource hierarchy.
-  - name: "\U0001F4A7 VDP"
-    description: Pipeline orchestration in VDP (Versatile Data Pipeline).
+  - name: "\U0001F4A7 Pipeline"
+    description: Pipeline orchestration in Instill Core.
   - name: ⚗️ Model
     description: AI Model resources for MLOps/LLMOps.
   - name: "\U0001F4BE Artifact"
@@ -2500,7 +2500,7 @@ paths:
     get:
       summary: Get the remaining Instill Credit
       description: |-
-        This endpoint returns the remaining [Instill Credit](https://www.instill.tech/docs/vdp/credit) of a given user or
+        This endpoint returns the remaining [Instill Credit](https://www.instill.tech/docs/cloud/credit) of a given user or
         organization. The requested credit owner must be either the authenticated
         user or an organization they belong to.
 
@@ -3897,7 +3897,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines:
     get:
@@ -3985,7 +3985,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     post:
       summary: Create a new pipeline
@@ -4016,7 +4016,7 @@ paths:
           schema:
             $ref: '#/definitions/Pipeline'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}:
     get:
@@ -4061,7 +4061,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     delete:
       summary: Delete a pipeline
@@ -4094,7 +4094,7 @@ paths:
           required: true
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     patch:
       summary: Update a pipeline
@@ -4136,7 +4136,7 @@ paths:
           schema:
             $ref: '#/definitions/Pipeline'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/validate:
     post:
@@ -4176,7 +4176,7 @@ paths:
           schema:
             $ref: '#/definitions/ValidateNamespacePipelineBody'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/rename:
     post:
@@ -4221,7 +4221,7 @@ paths:
           schema:
             $ref: '#/definitions/RenameNamespacePipelineBody'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/clone:
     post:
@@ -4259,7 +4259,7 @@ paths:
           schema:
             $ref: '#/definitions/CloneNamespacePipelineBody'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/trigger:
     post:
@@ -4272,7 +4272,7 @@ paths:
         The pipeline is identified by its resource name, formed by the parent namespace
         and ID of the pipeline.
 
-        For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+        For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/pipeline/run-pipeline).
       operationId: PipelinePublicService_TriggerNamespacePipeline
       responses:
         "200":
@@ -4308,7 +4308,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/trigger-stream:
     post:
@@ -4361,7 +4361,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/trigger-async:
     post:
@@ -4375,7 +4375,7 @@ paths:
         The pipeline is identified by its resource name, formed by the parent namespace
         and ID of the pipeline.
 
-        For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+        For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/pipeline/run-pipeline).
       operationId: PipelinePublicService_TriggerAsyncNamespacePipeline
       responses:
         "200":
@@ -4411,7 +4411,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases:
     get:
@@ -4485,7 +4485,7 @@ paths:
           required: false
           type: boolean
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     post:
       summary: Create a pipeline release
@@ -4526,7 +4526,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelineRelease'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}:
     get:
@@ -4578,7 +4578,7 @@ paths:
             - VIEW_FULL
             - VIEW_RECIPE
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     delete:
       summary: Delete a pipeline release
@@ -4618,7 +4618,7 @@ paths:
           required: true
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     patch:
       summary: Update a pipeline release
@@ -4666,7 +4666,7 @@ paths:
           schema:
             $ref: '#/definitions/PipelineRelease'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}/clone:
     post:
@@ -4709,7 +4709,7 @@ paths:
           schema:
             $ref: '#/definitions/CloneNamespacePipelineReleaseBody'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}/trigger:
     post:
@@ -4762,7 +4762,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/releases/{releaseId}/trigger-async:
     post:
@@ -4815,7 +4815,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/secrets:
     get:
@@ -4857,7 +4857,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     post:
       summary: Create a secret
@@ -4888,7 +4888,7 @@ paths:
           schema:
             $ref: '#/definitions/Secret'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/secrets/{secretId}:
     get:
@@ -4921,7 +4921,7 @@ paths:
           required: true
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     delete:
       summary: Delete a secret
@@ -4953,7 +4953,7 @@ paths:
           required: true
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     patch:
       summary: Update a secret
@@ -4993,7 +4993,7 @@ paths:
           schema:
             $ref: '#/definitions/Secret'
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/component-definitions:
     get:
@@ -5001,7 +5001,7 @@ paths:
       description: |-
         Returns a paginated list of component definitions, regardless their type.
         This offers a single source of truth, with pagination and filter
-        capabilities, for the components that might be used in a VDP pipeline.
+        capabilities, for the components that might be used in a pipeline.
       operationId: PipelinePublicService_ListComponentDefinitions
       responses:
         "200":
@@ -5054,7 +5054,7 @@ paths:
           type: integer
           format: int32
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/operations/{operationId}:
     get:
@@ -5089,7 +5089,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/pipelines/{pipelineId}/runs:
     get:
@@ -5159,7 +5159,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/pipeline-runs/{pipelineRunId}/component-runs:
     get:
@@ -5234,7 +5234,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/dashboard/pipelines/runs:
     get:
@@ -5311,7 +5311,7 @@ paths:
           required: true
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/connections:
     get:
@@ -5361,7 +5361,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     post:
       summary: Create a connection
@@ -5394,7 +5394,7 @@ paths:
             required:
               - connection
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/connections/{connectionId}:
     get:
@@ -5437,7 +5437,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     delete:
       summary: Delete a connection
@@ -5467,7 +5467,7 @@ paths:
           required: true
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
     patch:
       summary: Update a connection
@@ -5508,7 +5508,7 @@ paths:
             required:
               - connection
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/connections/{connectionId}/test:
     post:
@@ -5546,7 +5546,7 @@ paths:
           required: true
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/namespaces/{namespaceId}/connections/{connectionId}/referenced-pipelines:
     get:
@@ -5599,7 +5599,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/integrations:
     get:
@@ -5642,7 +5642,7 @@ paths:
           required: false
           type: string
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
   /v1beta/integrations/{integrationId}:
     get:
@@ -5680,7 +5680,7 @@ paths:
             - VIEW_BASIC
             - VIEW_FULL
       tags:
-        - "\U0001F4A7 VDP"
+        - "\U0001F4A7 Pipeline"
       x-stage: beta
 definitions:
   AgentConfig:
@@ -9633,7 +9633,7 @@ definitions:
       A Pipeline is an end-to-end workflow that automates a sequence of components
       to process data.
 
-      For more information, see [Pipeline](https://www.instill.tech/docs/vdp/introduction) in
+      For more information, see [Pipeline](https://www.instill.tech/docs/pipeline/introduction) in
       the official documentation.
     required:
       - recipe
@@ -10213,7 +10213,7 @@ definitions:
     description: |-
       Sharing contains the information to share a resource with other users.
 
-      For more information, see [Share Pipelines](https://www.instill.tech/docs/vdp/share).
+      For more information, see [Share Pipelines](https://www.instill.tech/docs/pipeline/share-pipeline).
   Sharing.User:
     type: object
     properties:

--- a/pipeline/pipeline/v1beta/common.proto
+++ b/pipeline/pipeline/v1beta/common.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package vdp.pipeline.v1beta;
+package pipeline.pipeline.v1beta;
 
 import "google/api/field_behavior.proto";
 
@@ -16,7 +16,7 @@ enum Role {
 
 // Sharing contains the information to share a resource with other users.
 //
-// For more information, see [Share Pipelines](https://www.instill.tech/docs/vdp/share).
+// For more information, see [Share Pipelines](https://www.instill.tech/docs/pipeline/share-pipeline).
 message Sharing {
   // Describes the sharing configuration with a given user.
   message User {

--- a/pipeline/pipeline/v1beta/component_definition.proto
+++ b/pipeline/pipeline/v1beta/component_definition.proto
@@ -1,13 +1,13 @@
 syntax = "proto3";
 
-package vdp.pipeline.v1beta;
+package pipeline.pipeline.v1beta;
 
 // Google API
 import "google/api/field_behavior.proto";
 // Protocol Buffers Well-Known Types
 import "google/protobuf/struct.proto";
-// VDP definitions
-import "vdp/pipeline/v1beta/common.proto";
+// Pipeline definitions
+import "pipeline/pipeline/v1beta/common.proto";
 
 ///////////////////////////////////////////////////////////////////////
 // Domain types

--- a/pipeline/pipeline/v1beta/integration.proto
+++ b/pipeline/pipeline/v1beta/integration.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package vdp.pipeline.v1beta;
+package pipeline.pipeline.v1beta;
 
 // Google API
 import "google/api/field_behavior.proto";
@@ -8,8 +8,8 @@ import "google/api/field_behavior.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-// VDP definitions
-import "vdp/pipeline/v1beta/common.proto";
+// Pipeline definitions
+import "pipeline/pipeline/v1beta/common.proto";
 
 // Connection contains the parameters to communicate with a 3rd party app. A
 // component may reference a connection in their setup. One connection may be

--- a/pipeline/pipeline/v1beta/pipeline.proto
+++ b/pipeline/pipeline/v1beta/pipeline.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package vdp.pipeline.v1beta;
+package pipeline.pipeline.v1beta;
 
 import "common/healthcheck/v1beta/healthcheck.proto";
 import "common/run/v1alpha/run.proto";
@@ -14,11 +14,11 @@ import "google/longrunning/operations.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+// Pipeline definitions
+import "pipeline/pipeline/v1beta/common.proto";
+import "pipeline/pipeline/v1beta/component_definition.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
-// VDP definitions
-import "vdp/pipeline/v1beta/common.proto";
-import "vdp/pipeline/v1beta/component_definition.proto";
 
 // LivenessRequest represents a request to check a service liveness status
 message LivenessRequest {
@@ -73,7 +73,7 @@ message Endpoints {
 // A Pipeline is an end-to-end workflow that automates a sequence of components
 // to process data.
 //
-// For more information, see [Pipeline](https://www.instill.tech/docs/vdp/introduction) in
+// For more information, see [Pipeline](https://www.instill.tech/docs/pipeline/introduction) in
 // the official documentation.
 message Pipeline {
   // View defines how a Pipeline is presented.

--- a/pipeline/pipeline/v1beta/pipeline_private_service.proto
+++ b/pipeline/pipeline/v1beta/pipeline_private_service.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
 
-package vdp.pipeline.v1beta;
+package pipeline.pipeline.v1beta;
 
+import "pipeline/pipeline/v1beta/integration.proto";
+import "pipeline/pipeline/v1beta/pipeline.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
-import "vdp/pipeline/v1beta/integration.proto";
-import "vdp/pipeline/v1beta/pipeline.proto";
 
 // PipelinePrivateService defines private methods to interact with Pipeline
 // resources.

--- a/pipeline/pipeline/v1beta/pipeline_public_service.proto
+++ b/pipeline/pipeline/v1beta/pipeline_public_service.proto
@@ -1,25 +1,25 @@
 syntax = "proto3";
 
-package vdp.pipeline.v1beta;
+package pipeline.pipeline.v1beta;
 
 // Google API
 import "google/api/annotations.proto";
 import "google/api/visibility.proto";
+// Pipeline definitions
+import "pipeline/pipeline/v1beta/common.proto";
+import "pipeline/pipeline/v1beta/component_definition.proto";
+import "pipeline/pipeline/v1beta/integration.proto";
+import "pipeline/pipeline/v1beta/pipeline.proto";
+import "pipeline/pipeline/v1beta/secret.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
-// VDP definitions
-import "vdp/pipeline/v1beta/common.proto";
-import "vdp/pipeline/v1beta/component_definition.proto";
-import "vdp/pipeline/v1beta/integration.proto";
-import "vdp/pipeline/v1beta/pipeline.proto";
-import "vdp/pipeline/v1beta/secret.proto";
 
-// VDP
+// Pipeline
 //
-// PipelinePublicService exposes the public VDP endpoints that allow clients to
+// PipelinePublicService exposes the public endpoints that allow clients to
 // manage pipelines.
 service PipelinePublicService {
-  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {description: "Public VDP endpoints"};
+  option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_tag) = {description: "Public Pipeline endpoints"};
 
   // Check if the pipeline server is alive
   //
@@ -47,7 +47,7 @@ service PipelinePublicService {
   rpc GetHubStats(GetHubStatsRequest) returns (GetHubStatsResponse) {
     option (google.api.http) = {get: "/v1beta/hub-stats"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -62,7 +62,7 @@ service PipelinePublicService {
   rpc ListPipelines(ListPipelinesRequest) returns (ListPipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/pipelines"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -77,7 +77,7 @@ service PipelinePublicService {
   rpc LookUpPipeline(LookUpPipelineRequest) returns (LookUpPipelineResponse) {
     option (google.api.http) = {get: "/v1beta/{permalink=pipelines/*}/lookUp"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -92,7 +92,7 @@ service PipelinePublicService {
   rpc ListNamespacePipelines(ListNamespacePipelinesRequest) returns (ListNamespacePipelinesResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -109,7 +109,7 @@ service PipelinePublicService {
       body: "pipeline"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -123,7 +123,7 @@ service PipelinePublicService {
   rpc GetNamespacePipeline(GetNamespacePipelineRequest) returns (GetNamespacePipelineResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -145,7 +145,7 @@ service PipelinePublicService {
       body: "pipeline"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -161,7 +161,7 @@ service PipelinePublicService {
   rpc DeleteNamespacePipeline(DeleteNamespacePipelineRequest) returns (DeleteNamespacePipelineResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -181,7 +181,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -206,7 +206,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -224,7 +224,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -256,14 +256,14 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent namespace
   // and ID of the pipeline.
   //
-  // For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+  // For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/pipeline/run-pipeline).
   rpc TriggerNamespacePipeline(TriggerNamespacePipelineRequest) returns (TriggerNamespacePipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/trigger"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -292,7 +292,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -317,14 +317,14 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent namespace
   // and ID of the pipeline.
   //
-  // For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/vdp/run).
+  // For more information, see [Run NamespacePipeline](https://www.instill.tech/docs/pipeline/run-pipeline).
   rpc TriggerAsyncNamespacePipeline(TriggerAsyncNamespacePipelineRequest) returns (TriggerAsyncNamespacePipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/trigger-async"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -352,7 +352,7 @@ service PipelinePublicService {
       body: "release"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -367,7 +367,7 @@ service PipelinePublicService {
   rpc ListNamespacePipelineReleases(ListNamespacePipelineReleasesRequest) returns (ListNamespacePipelineReleasesResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -382,7 +382,7 @@ service PipelinePublicService {
   rpc GetNamespacePipelineRelease(GetNamespacePipelineReleaseRequest) returns (GetNamespacePipelineReleaseResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -403,7 +403,7 @@ service PipelinePublicService {
       body: "release"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -421,7 +421,7 @@ service PipelinePublicService {
   rpc DeleteNamespacePipelineRelease(DeleteNamespacePipelineReleaseRequest) returns (DeleteNamespacePipelineReleaseResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/releases/{release_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -439,7 +439,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -462,7 +462,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -492,7 +492,7 @@ service PipelinePublicService {
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -516,7 +516,7 @@ service PipelinePublicService {
       body: "secret"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -531,7 +531,7 @@ service PipelinePublicService {
   rpc ListNamespaceSecrets(ListNamespaceSecretsRequest) returns (ListNamespaceSecretsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -546,7 +546,7 @@ service PipelinePublicService {
   rpc GetNamespaceSecret(GetNamespaceSecretRequest) returns (GetNamespaceSecretResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -566,7 +566,7 @@ service PipelinePublicService {
       body: "secret"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -581,7 +581,7 @@ service PipelinePublicService {
   rpc DeleteNamespaceSecret(DeleteNamespaceSecretRequest) returns (DeleteNamespaceSecretResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/secrets/{secret_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -593,11 +593,11 @@ service PipelinePublicService {
   //
   // Returns a paginated list of component definitions, regardless their type.
   // This offers a single source of truth, with pagination and filter
-  // capabilities, for the components that might be used in a VDP pipeline.
+  // capabilities, for the components that might be used in a pipeline.
   rpc ListComponentDefinitions(ListComponentDefinitionsRequest) returns (ListComponentDefinitionsResponse) {
     option (google.api.http) = {get: "/v1beta/component-definitions"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -612,7 +612,7 @@ service PipelinePublicService {
   rpc GetOperation(GetOperationRequest) returns (GetOperationResponse) {
     option (google.api.http) = {get: "/v1beta/operations/{operation_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -737,7 +737,7 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent user
   // and ID of the pipeline.
   //
-  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/pipeline/run-pipeline).
   rpc TriggerUserPipeline(TriggerUserPipelineRequest) returns (TriggerUserPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=users/*/pipelines/*}/trigger"
@@ -774,7 +774,7 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent user
   // and ID of the pipeline.
   //
-  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/pipeline/run-pipeline).
   rpc TriggerAsyncUserPipeline(TriggerAsyncUserPipelineRequest) returns (TriggerAsyncUserPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=users/*/pipelines/*}/triggerAsync"
@@ -1020,7 +1020,7 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent
   // organization and ID of the pipeline.
   //
-  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/pipeline/run-pipeline).
   rpc TriggerOrganizationPipelineStream(TriggerOrganizationPipelineStreamRequest) returns (stream TriggerOrganizationPipelineStreamResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/trigger-stream"
@@ -1039,7 +1039,7 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent
   // organization and ID of the pipeline.
   //
-  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/pipeline/run-pipeline).
   rpc TriggerOrganizationPipeline(TriggerOrganizationPipelineRequest) returns (TriggerOrganizationPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/trigger"
@@ -1059,7 +1059,7 @@ service PipelinePublicService {
   // The pipeline is identified by its resource name, formed by the parent
   // organization and ID of the pipeline.
   //
-  // For more information, see [Run Pipeline](https://www.instill.tech/docs/vdp/run).
+  // For more information, see [Run Pipeline](https://www.instill.tech/docs/pipeline/run-pipeline).
   rpc TriggerAsyncOrganizationPipeline(TriggerAsyncOrganizationPipelineRequest) returns (TriggerAsyncOrganizationPipelineResponse) {
     option (google.api.http) = {
       post: "/v1beta/{name=organizations/*/pipelines/*}/triggerAsync"
@@ -1328,7 +1328,7 @@ service PipelinePublicService {
   rpc ListPipelineRuns(ListPipelineRunsRequest) returns (ListPipelineRunsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/pipelines/{pipeline_id}/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1349,7 +1349,7 @@ service PipelinePublicService {
   rpc ListComponentRuns(ListComponentRunsRequest) returns (ListComponentRunsResponse) {
     option (google.api.http) = {get: "/v1beta/pipeline-runs/{pipeline_run_id}/component-runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1371,7 +1371,7 @@ service PipelinePublicService {
   rpc ListPipelineRunsByRequester(ListPipelineRunsByRequesterRequest) returns (ListPipelineRunsByRequesterResponse) {
     option (google.api.http) = {get: "/v1beta/dashboard/pipelines/runs"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1385,7 +1385,7 @@ service PipelinePublicService {
   rpc ListNamespaceConnections(ListNamespaceConnectionsRequest) returns (ListNamespaceConnectionsResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/connections"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1399,7 +1399,7 @@ service PipelinePublicService {
   rpc GetNamespaceConnection(GetNamespaceConnectionRequest) returns (GetNamespaceConnectionResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1416,7 +1416,7 @@ service PipelinePublicService {
       body: "connection"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1433,7 +1433,7 @@ service PipelinePublicService {
       body: "connection"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1447,7 +1447,7 @@ service PipelinePublicService {
   rpc DeleteNamespaceConnection(DeleteNamespaceConnectionRequest) returns (DeleteNamespaceConnectionResponse) {
     option (google.api.http) = {delete: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1467,7 +1467,7 @@ service PipelinePublicService {
   rpc TestNamespaceConnection(TestNamespaceConnectionRequest) returns (TestNamespaceConnectionResponse) {
     option (google.api.http) = {post: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}/test"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1483,7 +1483,7 @@ service PipelinePublicService {
   rpc ListPipelineIDsByConnectionID(ListPipelineIDsByConnectionIDRequest) returns (ListPipelineIDsByConnectionIDResponse) {
     option (google.api.http) = {get: "/v1beta/namespaces/{namespace_id}/connections/{connection_id}/referenced-pipelines"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1497,7 +1497,7 @@ service PipelinePublicService {
   rpc ListIntegrations(ListIntegrationsRequest) returns (ListIntegrationsResponse) {
     option (google.api.http) = {get: "/v1beta/integrations"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}
@@ -1511,7 +1511,7 @@ service PipelinePublicService {
   rpc GetIntegration(GetIntegrationRequest) returns (GetIntegrationResponse) {
     option (google.api.http) = {get: "/v1beta/integrations/{integration_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "💧 VDP"
+      tags: "💧 Pipeline"
       extensions: {
         key: "x-stage"
         value: {string_value: "beta"}

--- a/pipeline/pipeline/v1beta/secret.proto
+++ b/pipeline/pipeline/v1beta/secret.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package vdp.pipeline.v1beta;
+package pipeline.pipeline.v1beta;
 
 // Google API
 import "google/api/field_behavior.proto";


### PR DESCRIPTION
This commit

- renames `vdp` to `pipeline`.