### PR TITLE
chore(artifact): add summarizing status

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -361,6 +361,8 @@ enum FileProcessStatus {
   FILE_PROCESS_STATUS_COMPLETED = 6;
   // failed
   FILE_PROCESS_STATUS_FAILED = 7;
+  // file is summarizing
+  FILE_PROCESS_STATUS_SUMMARIZING = 8;
 }
 
 // file type

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7479,6 +7479,7 @@ definitions:
       - FILE_PROCESS_STATUS_EMBEDDING
       - FILE_PROCESS_STATUS_COMPLETED
       - FILE_PROCESS_STATUS_FAILED
+      - FILE_PROCESS_STATUS_SUMMARIZING
     description: |-
       - FILE_PROCESS_STATUS_NOTSTARTED: NOTSTARTED
        - FILE_PROCESS_STATUS_WAITING: file is waiting for embedding process
@@ -7487,6 +7488,7 @@ definitions:
        - FILE_PROCESS_STATUS_EMBEDDING: file is embedding
        - FILE_PROCESS_STATUS_COMPLETED: completed
        - FILE_PROCESS_STATUS_FAILED: failed
+       - FILE_PROCESS_STATUS_SUMMARIZING: file is summarizing
     title: file embedding process status
   FileReference:
     type: object


### PR DESCRIPTION
Because

- additional summarizing stage is introduced in document parsing

This commit

- add summarizing status
