### PR TITLE
feat(table): adjust table proto

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -128,6 +128,24 @@ message DeleteTableRequest {
 // DeleteTableResponse is an empty response for deleting a table.
 message DeleteTableResponse {}
 
+// The type of the column.
+enum Type {
+  // The type is not specified.
+  TYPE_UNSPECIFIED = 0;
+
+  // The type is a string.
+  TYPE_STRING = 1;
+
+  // The type is a number.
+  TYPE_NUMBER = 2;
+
+  // The type is a boolean.
+  TYPE_BOOLEAN = 3;
+
+  // The type is a url of a file resource.
+  TYPE_FILE = 4;
+}
+
 // ColumnDefinition represents a column definition in a table.
 message ColumnDefinition {
   // The unique identifier of the column.
@@ -139,7 +157,7 @@ message ColumnDefinition {
   string name = 2 [(google.api.field_behavior) = OPTIONAL];
 
   // The type of the column.
-  string type = 3 [(google.api.field_behavior) = REQUIRED];
+  Type type = 3 [(google.api.field_behavior) = REQUIRED];
 
   // The order of the column in the table, starting at 1. This determines the column's position
   // when displaying or processing table data.
@@ -149,9 +167,6 @@ message ColumnDefinition {
   message AgentConfig {
     // The instructions for the agent.
     string instructions = 1;
-
-    // Whether to enable web search for the agent.
-    bool enable_web_search = 2;
   }
 
   // The configuration for the agent.
@@ -214,17 +229,20 @@ enum CellStatus {
   // The cell is idle.
   CELL_STATUS_IDLE = 1;
 
+  // The cell is uploading (only for file cells).
+  CELL_STATUS_UPLOADING = 2;
+
   // The cell is pending.
-  CELL_STATUS_PENDING = 2;
+  CELL_STATUS_PENDING = 3;
 
   // The cell is processing.
-  CELL_STATUS_PROCESSING = 3;
+  CELL_STATUS_PROCESSING = 4;
 
   // The cell is failed.
-  CELL_STATUS_FAILED = 4;
+  CELL_STATUS_FAILED = 5;
 
   // The cell is completed.
-  CELL_STATUS_COMPLETED = 5;
+  CELL_STATUS_COMPLETED = 6;
 }
 
 // Cell represents a cell in a table.
@@ -242,7 +260,7 @@ message Cell {
   google.protobuf.Timestamp update_time = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The type of the cell's value.
-  string type = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  Type type = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The value of the cell as a string.
   oneof value {
@@ -257,40 +275,55 @@ message Cell {
 
     // The value of the cell as a url of a file resource.
     FileCell file_value = 9;
-
-    // The value of the cell as a url of a document resource.
-    DocumentCell document_value = 10;
-
-    // The value of the cell as a url of an image resource.
-    ImageCell image_value = 11;
-
-    // The value of the cell as a url of a video resource.
-    VideoCell video_value = 12;
-
-    // The value of the cell as a url of an audio resource.
-    AudioCell audio_value = 13;
-
-    // The value of the cell as a null cell.
-    NullCell null_value = 14;
   }
 
   // Additional metadata for the cell.
-  google.protobuf.Struct metadata = 15 [(google.api.field_behavior) = OPTIONAL];
+  google.protobuf.Struct metadata = 11 [(google.api.field_behavior) = OPTIONAL];
 
   // The status of the cell.
-  CellStatus status = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
+  CellStatus status = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // The faithfulness checking result for the cell.
-  message FaithfulnessCheckingResult {
-    // The text of the faithfulness checking result.
-    string result = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-    // The confidence score for the faithfulness checking result.
-    double confidence_score = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The transparency of the cell.
+  message Transparency {
+    // The text of the transparency.
+    string text = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
 
-  // The faithfulness checking result for the cell.
-  FaithfulnessCheckingResult faithfulness_checking_result = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The citations for the cell.
+  message Citation {
+    // The type of the citation.
+    enum Type {
+      // The type is not specified.
+      TYPE_UNSPECIFIED = 0;
+
+      // The type is a url of a web page.
+      TYPE_WEB = 1;
+
+      // The type is a url of a file resource.
+      TYPE_FILE = 2;
+
+      // The type is a url of a table resource.
+      TYPE_TABLE = 3;
+    }
+
+    // The type of the citation.
+    Type type = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+    // The url of the citation.
+    string url = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+    // The title of the citation.
+    string title = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+    // The summary of the citation.
+    string summary = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+
+  // The citations for the cell.
+  repeated Citation citations = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The transparency of the cell.
+  Transparency transparency = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // NullCell represents a null cell.
@@ -318,30 +351,12 @@ message BooleanCell {
 message FileCell {
   // The URL of the file resource.
   string url = 1 [(google.api.field_behavior) = REQUIRED];
-}
 
-// DocumentCell represents a cell with a url of a document resource.
-message DocumentCell {
-  // The URL of the document resource.
-  string url = 1 [(google.api.field_behavior) = REQUIRED];
-}
+  // File Name
+  string name = 2 [(google.api.field_behavior) = REQUIRED];
 
-// ImageCell represents a cell with a url of an image resource.
-message ImageCell {
-  // The URL of the image resource.
-  string url = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-// VideoCell represents a cell with a url of a video resource.
-message VideoCell {
-  // The URL of the video resource.
-  string url = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-// AudioCell represents a cell with a url of an audio resource.
-message AudioCell {
-  // The URL of the audio resource.
-  string url = 1 [(google.api.field_behavior) = REQUIRED];
+  // MIME type of the file.
+  string mime_type = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Row represents a row in a table.

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -33,8 +33,8 @@ message Table {
 
   // The configuration for the agent.
   message AgentConfig {
-    // Whether to enable faithfulness checking for the table.
-    bool enable_faithfulness_checking = 1;
+    // Whether to enable transparency for the table.
+    bool enable_transparency = 1;
   }
 
   // The configuration for the agent.
@@ -672,8 +672,8 @@ message GenerateMockTableRequest {
   // The number of rows to generate.
   optional int32 num_rows = 3 [(google.api.field_behavior) = OPTIONAL];
 
-  // Whether to enable faithfulness checking for the mock data.
-  optional bool enable_faithfulness_checking = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Whether to enable transparency for the mock data.
+  optional bool enable_transparency = 4 [(google.api.field_behavior) = OPTIONAL];
 
   // The mode to generate mock data.
   enum Mode {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -5995,15 +5995,6 @@ definitions:
        - STATE_INACTIVE: Inactive.
        - STATE_ACTIVE: Active.
        - STATE_EXPIRED: Expired.
-  AudioCell:
-    type: object
-    properties:
-      url:
-        type: string
-        description: The URL of the audio resource.
-    description: AudioCell represents a cell with a url of an audio resource.
-    required:
-      - url
   AuthenticatedUser:
     type: object
     properties:
@@ -6285,9 +6276,10 @@ definitions:
         description: The timestamp when the cell was last updated.
         readOnly: true
       type:
-        type: string
         description: The type of the cell's value.
         readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alpha.Type'
       stringValue:
         description: The value of the cell as a string.
         allOf:
@@ -6304,26 +6296,6 @@ definitions:
         description: The value of the cell as a url of a file resource.
         allOf:
           - $ref: '#/definitions/FileCell'
-      documentValue:
-        description: The value of the cell as a url of a document resource.
-        allOf:
-          - $ref: '#/definitions/DocumentCell'
-      imageValue:
-        description: The value of the cell as a url of an image resource.
-        allOf:
-          - $ref: '#/definitions/ImageCell'
-      videoValue:
-        description: The value of the cell as a url of a video resource.
-        allOf:
-          - $ref: '#/definitions/VideoCell'
-      audioValue:
-        description: The value of the cell as a url of an audio resource.
-        allOf:
-          - $ref: '#/definitions/AudioCell'
-      nullValue:
-        description: The value of the cell as a null cell.
-        allOf:
-          - $ref: '#/definitions/NullCell'
       metadata:
         type: object
         description: Additional metadata for the cell.
@@ -6332,16 +6304,45 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/CellStatus'
-      faithfulnessCheckingResult:
-        description: The faithfulness checking result for the cell.
+      citations:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/Cell.Citation'
+        description: The citations for the cell.
+        readOnly: true
+      transparency:
+        description: The transparency of the cell.
         readOnly: true
         allOf:
-          - $ref: '#/definitions/FaithfulnessCheckingResult'
+          - $ref: '#/definitions/Transparency'
     description: Cell represents a cell in a table.
+  Cell.Citation:
+    type: object
+    properties:
+      type:
+        description: The type of the citation.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Citation.Type'
+      url:
+        type: string
+        description: The url of the citation.
+        readOnly: true
+      title:
+        type: string
+        description: The title of the citation.
+        readOnly: true
+      summary:
+        type: string
+        description: The summary of the citation.
+        readOnly: true
+    description: The citations for the cell.
   CellStatus:
     type: string
     enum:
       - CELL_STATUS_IDLE
+      - CELL_STATUS_UPLOADING
       - CELL_STATUS_PENDING
       - CELL_STATUS_PROCESSING
       - CELL_STATUS_FAILED
@@ -6350,6 +6351,7 @@ definitions:
       CellStatus represents the status of a cell.
 
        - CELL_STATUS_IDLE: The cell is idle.
+       - CELL_STATUS_UPLOADING: The cell is uploading (only for file cells).
        - CELL_STATUS_PENDING: The cell is pending.
        - CELL_STATUS_PROCESSING: The cell is processing.
        - CELL_STATUS_FAILED: The cell is failed.
@@ -6498,30 +6500,18 @@ definitions:
        - CHUNK_TYPE_AUDIO: audio
        - CHUNK_TYPE_VIDEO: video
     title: chunk type
-  Citation:
-    type: object
-    properties:
-      type:
-        title: Type of citation
-        allOf:
-          - $ref: '#/definitions/CitationType'
-      name:
-        type: string
-        title: Name of the citation
-        readOnly: true
-      url:
-        type: string
-        title: URL of the citation (only applicable for URL-type citations)
-        readOnly: true
-      chunkUid:
-        type: string
-        title: Chunk UID (only applicable for chunk-type citations)
-        readOnly: true
-      fileUid:
-        type: string
-        title: File UID (only applicable for chunk-type citations)
-        readOnly: true
-    title: Citation message
+  Citation.Type:
+    type: string
+    enum:
+      - TYPE_WEB
+      - TYPE_FILE
+      - TYPE_TABLE
+    description: |-
+      The type of the citation.
+
+       - TYPE_WEB: The type is a url of a web page.
+       - TYPE_FILE: The type is a url of a file resource.
+       - TYPE_TABLE: The type is a url of a table resource.
   CitationType:
     type: string
     enum:
@@ -6595,8 +6585,9 @@ definitions:
           The name of the column. If this differs from the key in the ColumnDefinitions map,
           the key will be updated to match this value.
       type:
-        type: string
         description: The type of the column.
+        allOf:
+          - $ref: '#/definitions/v1alpha.Type'
       order:
         type: integer
         format: int32
@@ -6621,9 +6612,6 @@ definitions:
       instructions:
         type: string
         description: The instructions for the agent.
-      enableWebSearch:
-        type: boolean
-        description: Whether to enable web search for the agent.
     description: The configuration for the agent.
   ColumnDefinitionsUpdatedEvent:
     type: object
@@ -7293,15 +7281,6 @@ definitions:
   DeployUserModelAdminResponse:
     type: object
     title: DeployUserModelAdminResponse represents a response for a deployed model
-  DocumentCell:
-    type: object
-    properties:
-      url:
-        type: string
-        description: The URL of the document resource.
-    description: DocumentCell represents a cell with a url of a document resource.
-    required:
-      - url
   Endpoints:
     type: object
     properties:
@@ -7379,19 +7358,6 @@ definitions:
         description: The exported data.
         readOnly: true
     description: ExportTableResponse is an empty response for exporting table data.
-  FaithfulnessCheckingResult:
-    type: object
-    properties:
-      result:
-        type: string
-        description: The text of the faithfulness checking result.
-        readOnly: true
-      confidenceScore:
-        type: number
-        format: double
-        description: The confidence score for the faithfulness checking result.
-        readOnly: true
-    description: The faithfulness checking result for the cell.
   File:
     type: object
     properties:
@@ -7479,9 +7445,17 @@ definitions:
       url:
         type: string
         description: The URL of the file resource.
+      name:
+        type: string
+        title: File Name
+      mimeType:
+        type: string
+        description: MIME type of the file.
     description: FileCell represents a cell with a url of a file resource.
     required:
       - url
+      - name
+      - mimeType
   FileMediaType:
     type: string
     enum:
@@ -7973,15 +7947,6 @@ definitions:
         type: string
         title: Hardware name value
     description: Hardware describes the hardware title and string value that backend consumes.
-  ImageCell:
-    type: object
-    properties:
-      url:
-        type: string
-        description: The URL of the image resource.
-    description: ImageCell represents a cell with a url of an image resource.
-    required:
-      - url
   InsertRowBody:
     type: object
     properties:
@@ -9389,9 +9354,6 @@ definitions:
   MoveRowsResponse:
     type: object
     description: MoveRowsResponse is an empty response for moving multiple rows.
-  NullCell:
-    type: object
-    description: NullCell represents a null cell.
   NullValue:
     type: string
     description: |-
@@ -10817,6 +10779,14 @@ definitions:
        - STATUS_COMPLETED: Successfully completed.
        - STATUS_SKIPPED: Skipped.
        - STATUS_ERROR: Aborted with error.
+  Transparency:
+    type: object
+    properties:
+      text:
+        type: string
+        description: The text of the transparency.
+        readOnly: true
+    description: The transparency of the cell.
   TriggerAsyncNamespaceLatestModelBody:
     type: object
     properties:
@@ -11513,15 +11483,6 @@ definitions:
         description: If token is valid, UUID of the user that owns it.
         readOnly: true
     description: ValidateTokenResponse contains the validation of a token.
-  VideoCell:
-    type: object
-    properties:
-      url:
-        type: string
-        description: The URL of the video resource.
-    description: VideoCell represents a cell with a url of a video resource.
-    required:
-      - url
   WatchNamespaceLatestModelResponse:
     type: object
     properties:
@@ -11599,7 +11560,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/Citation'
+          $ref: '#/definitions/v1alpha.Citation'
         title: citations(only for agent messages)
         readOnly: true
     title: Message represents a single message in a conversation
@@ -11816,6 +11777,30 @@ definitions:
         allOf:
           - $ref: '#/definitions/ContentType'
     description: The Chunk message represents a chunk of data in the artifact system.
+  v1alpha.Citation:
+    type: object
+    properties:
+      type:
+        title: Type of citation
+        allOf:
+          - $ref: '#/definitions/CitationType'
+      name:
+        type: string
+        title: Name of the citation
+        readOnly: true
+      url:
+        type: string
+        title: URL of the citation (only applicable for URL-type citations)
+        readOnly: true
+      chunkUid:
+        type: string
+        title: Chunk UID (only applicable for chunk-type citations)
+        readOnly: true
+      fileUid:
+        type: string
+        title: File UID (only applicable for chunk-type citations)
+        readOnly: true
+    title: Citation message
   v1alpha.Permission:
     type: object
     properties:
@@ -11863,6 +11848,20 @@ definitions:
       resources for the model
        - STATE_SCALING_UP: Scaling Up is the transition state when the system is provisioning compute resource for this model instance.
        - STATE_SCALING_DOWN: Scaling is the transition state when the system is releasing compute resource for this model instance.
+  v1alpha.Type:
+    type: string
+    enum:
+      - TYPE_STRING
+      - TYPE_NUMBER
+      - TYPE_BOOLEAN
+      - TYPE_FILE
+    description: |-
+      The type of the column.
+
+       - TYPE_STRING: The type is a string.
+       - TYPE_NUMBER: The type is a number.
+       - TYPE_BOOLEAN: The type is a boolean.
+       - TYPE_FILE: The type is a url of a file resource.
   v1alpha.View:
     type: string
     enum:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -10613,9 +10613,9 @@ definitions:
   Table.AgentConfig:
     type: object
     properties:
-      enableFaithfulnessChecking:
+      enableTransparency:
         type: boolean
-        description: Whether to enable faithfulness checking for the table.
+        description: Whether to enable transparency for the table.
     description: The configuration for the agent.
   TableDeletedEvent:
     type: object


### PR DESCRIPTION
Because

- Some protos need to be redefined for the new design.

This commit:

- Adjusts the table proto and adds enums for column types.
- Removes document, image, audio, and video types.
- Replaces faithfulness check with transparency.