### PR TITLE
chore(chat): support get chat and catalog id when create chat

### DIFF
--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -89,6 +89,20 @@ service AgentPublicService {
     };
   }
 
+  // Get a chat
+  //
+  // Gets a chat.
+  rpc GetChat(GetChatRequest) returns (GetChatResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/chats/{chat_uid}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "🍎 Agent"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // Delete a chat
   //
   // Deletes a chat.

--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -146,6 +146,20 @@ message UpdateChatResponse {
   Chat chat = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// GetChatRequest is used to get a chat
+message GetChatRequest {
+  // namespace id
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // chat uid
+  string chat_uid = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetChatResponse returns the chat
+message GetChatResponse {
+  // chat
+  Chat chat = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // DeleteChatRequest is used to delete a chat
 message DeleteChatRequest {
   // namespace id

--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -32,6 +32,8 @@ message Chat {
   google.protobuf.Timestamp update_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // chat delete time.
   google.protobuf.Timestamp delete_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // catalog id
+  string catalog_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // type of the citations message
@@ -95,6 +97,8 @@ message CreateChatRequest {
   string chat_display_name = 2 [(google.api.field_behavior) = OPTIONAL];
   // agent config
   AgentConfig agent_config = 3 [(google.api.field_behavior) = OPTIONAL];
+  // catalog id
+  string catalog_id = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // CreateChatResponse returns the created chat

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -117,6 +117,36 @@ paths:
         - "\U0001F34E Agent"
       x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/chats/{chatUid}:
+    get:
+      summary: Get a chat
+      description: Gets a chat.
+      operationId: AgentPublicService_GetChat
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/GetChatResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: namespace id
+          in: path
+          required: true
+          type: string
+        - name: chatUid
+          description: chat uid
+          in: path
+          required: true
+          type: string
+      tags:
+        - "\U0001F34E Agent"
+      x-stage: alpha
     delete:
       summary: Delete a chat
       description: Deletes a chat.
@@ -7046,6 +7076,9 @@ definitions:
         title: agent config
         allOf:
           - $ref: '#/definitions/v1alpha.AgentConfig'
+      catalogId:
+        type: string
+        title: catalog id
     title: CreateChatRequest is used to create a new chat
   CreateChatResponse:
     type: object
@@ -7564,6 +7597,15 @@ definitions:
         allOf:
           - $ref: '#/definitions/UserSubscription'
     description: GetAuthenticatedUserSubscriptionResponse contains the requested subscription.
+  GetChatResponse:
+    type: object
+    properties:
+      chat:
+        title: chat
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/v1alpha.Chat'
+    title: GetChatResponse returns the chat
   GetColumnDefinitionsResponse:
     type: object
     properties:
@@ -11732,6 +11774,10 @@ definitions:
         type: string
         format: date-time
         description: chat delete time.
+        readOnly: true
+      catalogId:
+        type: string
+        title: catalog id
         readOnly: true
     title: Chat represents a chat
     required:


### PR DESCRIPTION
Because

- support get chat
- support optional catalog id when create chat

This commit

- support get chat
- support optional catalog id when create chat
