### PR TITLE
feat(artifact): add get summary for catalog file

### DIFF
--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -216,6 +216,20 @@ service ArtifactPublicService {
     };
   }
 
+  // Get summary from a catalog file
+  //
+  // Gets summary from a catalog file
+  rpc GetFileSummary(GetFileSummaryRequest) returns (GetFileSummaryResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files/{file_uid}/summary"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // Search single-source-of-truth files
   //
   // Searches the single-source-of-truth files of a catalog.

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -114,6 +114,22 @@ message GetSourceFileResponse {
   SourceFile source_file = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// get file summary request
+message GetFileSummaryRequest {
+  // owner/namespace id
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // catalog id
+  string catalog_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // unique identifier of the original uploaded file
+  string file_uid = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// get file summary response
+message GetFileSummaryResponse {
+  // summary of the file
+  string summary = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // search source file request
 message SearchSourceFilesRequest {
   // owner/namespace id


### PR DESCRIPTION
Because

- Agent needs summary for RAG/high-recall

This commit

- add get summary for catalog file
