### PR TITLE
chore(agent): add citation message type

### DIFF
--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -68,6 +68,8 @@ message Message {
     MESSAGE_TYPE_UNSPECIFIED = 0;
     // text
     MESSAGE_TYPE_TEXT = 1;
+    // citation
+    MESSAGE_TYPE_CITATION = 2;
   }
   // message uid
   string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];

--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -40,10 +40,12 @@ message Chat {
 enum CitationType {
   // Unspecified citation type
   CITATION_TYPE_UNSPECIFIED = 0;
-  // Chunk-based citation
-  CITATION_TYPE_CHUNK = 1;
+  // file citation
+  CITATION_TYPE_FILE = 1;
   // URL-based citation
   CITATION_TYPE_URL = 2;
+  // cell-based citation
+  CITATION_TYPE_CELL = 3;
 }
 
 // Citation message
@@ -52,12 +54,16 @@ message Citation {
   CitationType type = 1;
   // Name of the citation
   string name = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // URL of the citation (only applicable for URL-type citations)
+  // URL of the citation (only applicable for URL and cell type citations)
   optional string url = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // Chunk UID (only applicable for chunk-type citations)
-  optional string chunk_uid = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // File UID (only applicable for chunk-type citations)
+  // Chunk UID (only applicable for file type citations)
+  repeated string chunk_uid = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // File UID (only applicable for file type citations)
   optional string file_uid = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Object UID for download (only applicable for file type citations)
+  optional string object_uid = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // File summary (only applicable for file type citations)
+  optional string summary = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Message represents a single message in a conversation
@@ -68,8 +74,6 @@ message Message {
     MESSAGE_TYPE_UNSPECIFIED = 0;
     // text
     MESSAGE_TYPE_TEXT = 1;
-    // citation
-    MESSAGE_TYPE_CITATION = 2;
   }
   // message uid
   string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6581,11 +6581,13 @@ definitions:
   CitationType:
     type: string
     enum:
-      - CITATION_TYPE_CHUNK
+      - CITATION_TYPE_FILE
       - CITATION_TYPE_URL
+      - CITATION_TYPE_CELL
     description: |-
-      - CITATION_TYPE_CHUNK: Chunk-based citation
+      - CITATION_TYPE_FILE: file citation
        - CITATION_TYPE_URL: URL-based citation
+       - CITATION_TYPE_CELL: cell-based citation
     title: type of the citations message
   CloneNamespacePipelineBody:
     type: object
@@ -11880,15 +11882,25 @@ definitions:
         readOnly: true
       url:
         type: string
-        title: URL of the citation (only applicable for URL-type citations)
+        title: URL of the citation (only applicable for URL and cell type citations)
         readOnly: true
       chunkUid:
-        type: string
-        title: Chunk UID (only applicable for chunk-type citations)
+        type: array
+        items:
+          type: string
+        title: Chunk UID (only applicable for file type citations)
         readOnly: true
       fileUid:
         type: string
-        title: File UID (only applicable for chunk-type citations)
+        title: File UID (only applicable for file type citations)
+        readOnly: true
+      objectUid:
+        type: string
+        title: Object UID for download (only applicable for file type citations)
+        readOnly: true
+      summary:
+        type: string
+        title: File summary (only applicable for file type citations)
         readOnly: true
     title: Citation message
   v1alpha.Permission:


### PR DESCRIPTION
Because

- FE needs to render all citations in each round of conversation

This commit

- add citation message type
