### PR TITLE
chore(chat): add file uids in send message

### DIFF
--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -278,6 +278,8 @@ message ChatRequest {
   string chat_uid = 2 [(google.api.field_behavior) = REQUIRED];
   // User message
   string message = 3 [(google.api.field_behavior) = REQUIRED];
+  // file UIDs
+  repeated string file_uids = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ChatResponse contains the chatbot response.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -5858,6 +5858,11 @@ definitions:
       message:
         type: string
         title: User message
+      fileUids:
+        type: array
+        items:
+          type: string
+        title: file UIDs
     description: |-
       ChatRequest represents a request to send a message
       to a chatbot synchronously and streams back the results.


### PR DESCRIPTION
Because

- retrieve file status when sending message

This commit

- add file uids in send message
