### PR TITLE
chore(agent): share the same citation structure between the chat and the table

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package agent.agent.v1alpha;
 
+import "agent/agent/v1alpha/chat.proto";
 // Google API
 import "google/api/field_behavior.proto";
 import "google/protobuf/field_mask.proto";
@@ -287,36 +288,6 @@ message Cell {
   message Transparency {
     // The text of the transparency.
     string text = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  }
-
-  // The citations for the cell.
-  message Citation {
-    // The type of the citation.
-    enum Type {
-      // The type is not specified.
-      TYPE_UNSPECIFIED = 0;
-
-      // The type is a url of a web page.
-      TYPE_WEB = 1;
-
-      // The type is a url of a file resource.
-      TYPE_FILE = 2;
-
-      // The type is a url of a table resource.
-      TYPE_TABLE = 3;
-    }
-
-    // The type of the citation.
-    Type type = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-    // The url of the citation.
-    string url = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-    // The title of the citation.
-    string title = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-    // The summary of the citation.
-    string summary = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
 
   // The citations for the cell.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6379,7 +6379,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/Cell.Citation'
+          $ref: '#/definitions/Citation'
         description: The citations for the cell.
         readOnly: true
       transparency:
@@ -6388,27 +6388,6 @@ definitions:
         allOf:
           - $ref: '#/definitions/Transparency'
     description: Cell represents a cell in a table.
-  Cell.Citation:
-    type: object
-    properties:
-      type:
-        description: The type of the citation.
-        readOnly: true
-        allOf:
-          - $ref: '#/definitions/Citation.Type'
-      url:
-        type: string
-        description: The url of the citation.
-        readOnly: true
-      title:
-        type: string
-        description: The title of the citation.
-        readOnly: true
-      summary:
-        type: string
-        description: The summary of the citation.
-        readOnly: true
-    description: The citations for the cell.
   CellStatus:
     type: string
     enum:
@@ -6571,18 +6550,31 @@ definitions:
        - CHUNK_TYPE_AUDIO: audio
        - CHUNK_TYPE_VIDEO: video
     title: chunk type
-  Citation.Type:
-    type: string
-    enum:
-      - TYPE_WEB
-      - TYPE_FILE
-      - TYPE_TABLE
-    description: |-
-      The type of the citation.
-
-       - TYPE_WEB: The type is a url of a web page.
-       - TYPE_FILE: The type is a url of a file resource.
-       - TYPE_TABLE: The type is a url of a table resource.
+  Citation:
+    type: object
+    properties:
+      type:
+        title: Type of citation
+        allOf:
+          - $ref: '#/definitions/CitationType'
+      name:
+        type: string
+        title: Name of the citation
+        readOnly: true
+      url:
+        type: string
+        title: URL of the citation, can be web url, cell url or object-uid
+        readOnly: true
+      number:
+        type: integer
+        format: int64
+        title: Citation number
+        readOnly: true
+      summary:
+        type: string
+        title: File summary (only applicable for file type citations)
+        readOnly: true
+    title: Citation message
   CitationType:
     type: string
     enum:
@@ -11653,7 +11645,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1alpha.Citation'
+          $ref: '#/definitions/Citation'
         title: citations(only for agent messages)
         readOnly: true
     title: Message represents a single message in a conversation
@@ -11874,31 +11866,6 @@ definitions:
         allOf:
           - $ref: '#/definitions/ContentType'
     description: The Chunk message represents a chunk of data in the artifact system.
-  v1alpha.Citation:
-    type: object
-    properties:
-      type:
-        title: Type of citation
-        allOf:
-          - $ref: '#/definitions/CitationType'
-      name:
-        type: string
-        title: Name of the citation
-        readOnly: true
-      url:
-        type: string
-        title: URL of the citation, can be web url, cell url or object-uid
-        readOnly: true
-      number:
-        type: integer
-        format: int64
-        title: Citation number
-        readOnly: true
-      summary:
-        type: string
-        title: File summary (only applicable for file type citations)
-        readOnly: true
-    title: Citation message
   v1alpha.Permission:
     type: object
     properties:


### PR DESCRIPTION
This commit

- shares the same citation structure between the chat and the table