### PR TITLE
chore(table): adjust file cell format

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -320,8 +320,8 @@ message BooleanCell {
 
 // FileCell represents a cell with a url of a file resource.
 message FileCell {
-  // The URL of the file resource.
-  string url = 1 [(google.api.field_behavior) = REQUIRED];
+  // The UID of the file resource.
+  string file_uid = 1 [(google.api.field_behavior) = REQUIRED];
 
   // File Name
   string name = 2 [(google.api.field_behavior) = REQUIRED];

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7510,9 +7510,9 @@ definitions:
   FileCell:
     type: object
     properties:
-      url:
+      fileUid:
         type: string
-        description: The URL of the file resource.
+        description: The UID of the file resource.
       name:
         type: string
         title: File Name
@@ -7521,7 +7521,7 @@ definitions:
         description: MIME type of the file.
     description: FileCell represents a cell with a url of a file resource.
     required:
-      - url
+      - fileUid
       - name
       - mimeType
   FileMediaType:


### PR DESCRIPTION
This commit

- adjusts file cell format to use file uid instead of file url
