### PR TITLE
chore(agent): add extract method

### DIFF
--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -48,6 +48,20 @@ enum CitationType {
   CITATION_TYPE_TABLE = 3;
 }
 
+// type of the citations message extract method
+enum CitationExtractMethodType {
+  // Unspecified citation extract method
+  CITATION_EXTRACT_METHOD_TYPE_UNSPECIFIED = 0;
+  // self generated
+  CITATION_EXTRACT_METHOD_TYPE_SELF = 1;
+  // extract from web search tool
+  CITATION_EXTRACT_METHOD_TYPE_WEB = 2;
+  // extract from RAG tool
+  CITATION_EXTRACT_METHOD_TYPE_RAG = 3;
+  // extract from deep analysis tool
+  CITATION_EXTRACT_METHOD_TYPE_DEEP_ANALYSIS = 4;
+}
+
 // Citation message
 message Citation {
   // Type of citation
@@ -60,6 +74,8 @@ message Citation {
   uint32 number = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // File summary (only applicable for file type citations)
   optional string summary = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Citation extract method type
+  CitationExtractMethodType extract_method = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Message represents a single message in a conversation

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6579,7 +6579,25 @@ definitions:
         type: string
         title: File summary (only applicable for file type citations)
         readOnly: true
+      extractMethod:
+        title: Citation extract method type
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/CitationExtractMethodType'
     title: Citation message
+  CitationExtractMethodType:
+    type: string
+    enum:
+      - CITATION_EXTRACT_METHOD_TYPE_SELF
+      - CITATION_EXTRACT_METHOD_TYPE_WEB
+      - CITATION_EXTRACT_METHOD_TYPE_RAG
+      - CITATION_EXTRACT_METHOD_TYPE_DEEP_ANALYSIS
+    description: |-
+      - CITATION_EXTRACT_METHOD_TYPE_SELF: self generated
+       - CITATION_EXTRACT_METHOD_TYPE_WEB: extract from web search tool
+       - CITATION_EXTRACT_METHOD_TYPE_RAG: extract from RAG tool
+       - CITATION_EXTRACT_METHOD_TYPE_DEEP_ANALYSIS: extract from deep analysis tool
+    title: type of the citations message extract method
   CitationType:
     type: string
     enum:


### PR DESCRIPTION
Because

- transparency pipeline requires extract method

This commit

- add extract method
