### PR TITLE
chore(artifact): add get chat file

### DIFF
--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package artifact.artifact.v1alpha;
 
 import "artifact/artifact/v1alpha/artifact.proto";
+import "artifact/artifact/v1alpha/file_catalog.proto";
 
 // ArtifactPrivateService exposes the private endpoints that allow clients to
 // manage artifacts.
@@ -36,4 +37,7 @@ service ArtifactPrivateService {
 
   // Update Object
   rpc UpdateObject(UpdateObjectRequest) returns (UpdateObjectResponse);
+
+  // Get Chat file
+  rpc GetChatFile(GetChatFileRequest) returns (GetChatFileResponse);
 }

--- a/artifact/artifact/v1alpha/file_catalog.proto
+++ b/artifact/artifact/v1alpha/file_catalog.proto
@@ -92,3 +92,19 @@ message GetFileCatalogResponse {
   // chunks
   repeated Chunk chunks = 4;
 }
+
+// GetChatFileRequest
+message GetChatFileRequest {
+  // id of the namespace
+  string namespace_id = 1;
+  // id of the catalog
+  string catalog_id = 2;
+  // id of the file(i.e. file name)
+  string file_id = 3;
+}
+
+// GetChatFileResponse
+message GetChatFileResponse {
+  // converted markdown content
+  string markdown = 1;
+}

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7663,6 +7663,13 @@ definitions:
         allOf:
           - $ref: '#/definitions/UserSubscription'
     description: GetAuthenticatedUserSubscriptionResponse contains the requested subscription.
+  GetChatFileResponse:
+    type: object
+    properties:
+      markdown:
+        type: string
+        title: converted markdown content
+    title: GetChatFileResponse
   GetChatResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- Support transparency for deep analysis content

This commit

- add get chat file
