### PR TITLE
chore(artifact): use bytes for markdown content

### DIFF
--- a/artifact/artifact/v1alpha/file_catalog.proto
+++ b/artifact/artifact/v1alpha/file_catalog.proto
@@ -106,5 +106,5 @@ message GetChatFileRequest {
 // GetChatFileResponse
 message GetChatFileResponse {
   // converted markdown content
-  string markdown = 1;
+  bytes markdown = 1;
 }

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7668,6 +7668,7 @@ definitions:
     properties:
       markdown:
         type: string
+        format: byte
         title: converted markdown content
     title: GetChatFileResponse
   GetChatResponse:


### PR DESCRIPTION
Because

- use bytes for markdown content

This commit

- use bytes for markdown content
