### PR TITLE
chore(artifact): add GetCatalogFile API

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -436,6 +436,10 @@ message File {
   // objectUid in blob storage. user can upload to blob storage directly, then put objectUid here.
   // then no need the base64 encoding for the file content.
   string object_uid = 18 [(google.api.field_behavior) = OPTIONAL];
+  // summary of the file
+  string summary = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // download url of the file
+  string download_url = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // upload file request
@@ -511,6 +515,22 @@ message ListCatalogFilesResponse {
   string next_page_token = 4;
   // The filter.
   ListCatalogFilesFilter filter = 5;
+}
+
+// GetCatalogFileRequest represents a request to get a catalog file.
+message GetCatalogFileRequest {
+  // The namespace id.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The catalog id.
+  string catalog_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // The file uid.
+  string file_uid = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetCatalogFileResponse represents a response for getting a catalog file.
+message GetCatalogFileResponse {
+  // The file.
+  File file = 1;
 }
 
 // CatalogRunAction describes the actions a user has over a catalog.

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -174,6 +174,20 @@ service ArtifactPublicService {
     };
   }
 
+  // Get catalog file
+  //
+  // Gets the file of a catalog.
+  rpc GetCatalogFile(GetCatalogFileRequest) returns (GetCatalogFileResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}/files/{file_uid}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "💾 Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // List catalog chunks
   //
   // Returns a paginated list of catalog chunks.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -1388,6 +1388,42 @@ paths:
       tags:
         - "\U0001F4BE Artifact"
       x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/files/{fileUid}:
+    get:
+      summary: Get catalog file
+      description: Gets the file of a catalog.
+      operationId: ArtifactPublicService_GetCatalogFile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/GetCatalogFileResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The namespace id.
+          in: path
+          required: true
+          type: string
+        - name: catalogId
+          description: The catalog id.
+          in: path
+          required: true
+          type: string
+        - name: fileUid
+          description: The file uid.
+          in: path
+          required: true
+          type: string
+      tags:
+        - "\U0001F4BE Artifact"
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/chunks:
     get:
       summary: List catalog chunks
@@ -7535,6 +7571,14 @@ definitions:
         description: |-
           objectUid in blob storage. user can upload to blob storage directly, then put objectUid here.
           then no need the base64 encoding for the file content.
+      summary:
+        type: string
+        title: summary of the file
+        readOnly: true
+      downloadUrl:
+        type: string
+        title: download url of the file
+        readOnly: true
     title: file
   FileCell:
     type: object
@@ -7669,6 +7713,14 @@ definitions:
         allOf:
           - $ref: '#/definitions/UserSubscription'
     description: GetAuthenticatedUserSubscriptionResponse contains the requested subscription.
+  GetCatalogFileResponse:
+    type: object
+    properties:
+      file:
+        description: The file.
+        allOf:
+          - $ref: '#/definitions/File'
+    description: GetCatalogFileResponse represents a response for getting a catalog file.
   GetChatFileResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- We need a new endpoint to return file information with summary and download_url

This commit

- adds GetCatalogFile API
- adds summary and download_url for File
