### PR TITLE
feat(ray): add protobuf for model and ray

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -16,9 +16,11 @@ lint:
     - PACKAGE_NO_IMPORT_CYCLE
   except:
     - FIELD_NOT_REQUIRED
+  ignore:
+    - model/model/v1alpha/model_ray_serve.proto # protobuf file copied from ray repo
   enum_zero_value_suffix: _UNSPECIFIED
   service_suffix: Service
-  disallow_comment_ignores: true
+  disallow_comment_ignores: false
 breaking:
   use:
     - FILE

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -82,9 +82,11 @@ enum State {
   // Starting is the state when the system is provisioning the necessary
   // resources for the model
   STATE_STARTING = 6;
-  // Scaling Up is the transition state when the system is provisioning compute resource for this model instance.
+  // Scaling Up is the transition state when the system is provisioning compute
+  // resource for this model instance.
   STATE_SCALING_UP = 7;
-  // Scaling is the transition state when the system is releasing compute resource for this model instance.
+  // Scaling is the transition state when the system is releasing compute
+  // resource for this model instance.
   STATE_SCALING_DOWN = 8;
 }
 
@@ -246,8 +248,9 @@ message ListModelsRequest {
   optional string filter = 5 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Model.Visibility visibility = 6 [(google.api.field_behavior) = OPTIONAL];
-  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
-  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+  // Order by field, with options for ordering by `id`, `create_time` or
+  // `update_time`. Format: `order_by=id` or `order_by=create_time desc`,
+  // default is `asc`.
   optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -296,8 +299,9 @@ message ListNamespaceModelsRequest {
   optional string filter = 6 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Model.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
-  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
-  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+  // Order by field, with options for ordering by `id`, `create_time` or
+  // `update_time`. Format: `order_by=id` or `order_by=create_time desc`,
+  // default is `asc`.
   optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -311,7 +315,8 @@ message ListNamespaceModelsResponse {
   int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// CreateNamespaceModelRequest represents a request from a namespace to create a model.
+// CreateNamespaceModelRequest represents a request from a namespace to create a
+// model.
 message CreateNamespaceModelRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -393,7 +398,8 @@ message RenameNamespaceModelResponse {
   Model model = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// WatchNamespaceModelRequest represents a request to fetch current state of a model
+// WatchNamespaceModelRequest represents a request to fetch current state of a
+// model
 message WatchNamespaceModelRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -413,8 +419,8 @@ message WatchNamespaceModelResponse {
   string message = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// WatchNamespaceNamespaceLatestModelRequest represents a request to fetch current state of
-// the latest model version.
+// WatchNamespaceNamespaceLatestModelRequest represents a request to fetch
+// current state of the latest model version.
 message WatchNamespaceLatestModelRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -422,7 +428,8 @@ message WatchNamespaceLatestModelRequest {
   string model_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
-// WatchNamespaceLatestModelResponse contains the state of the latest model version.
+// WatchNamespaceLatestModelResponse contains the state of the latest model
+// version.
 message WatchNamespaceLatestModelResponse {
   // State.
   State state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -432,8 +439,8 @@ message WatchNamespaceLatestModelResponse {
   string message = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ListNamespaceModelVersionsRequest represents a request to list all the versions
-// of a model namespace of a namespace.
+// ListNamespaceModelVersionsRequest represents a request to list all the
+// versions of a model namespace of a namespace.
 message ListNamespaceModelVersionsRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -458,7 +465,8 @@ message ListNamespaceModelVersionsResponse {
   int32 page = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// DeleteNamespaceModelVersionRequest represents a request to delete a model version
+// DeleteNamespaceModelVersionRequest represents a request to delete a model
+// version
 //  owned by a namespace.
 message DeleteNamespaceModelVersionRequest {
   // Namespace ID
@@ -472,7 +480,8 @@ message DeleteNamespaceModelVersionRequest {
 // DeleteNamespaceModelVersionResponse is an empty response.
 message DeleteNamespaceModelVersionResponse {}
 
-// TriggerNamespaceModelRequest represents a request to trigger a model inference.
+// TriggerNamespaceModelRequest represents a request to trigger a model
+// inference.
 message TriggerNamespaceModelRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -496,8 +505,8 @@ message TriggerNamespaceModelResponse {
   repeated google.protobuf.Struct task_outputs = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerAsyncNamespaceModelRequest represents a request to trigger a model inference
-// asynchronously.
+// TriggerAsyncNamespaceModelRequest represents a request to trigger a model
+// inference asynchronously.
 message TriggerAsyncNamespaceModelRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -518,8 +527,8 @@ message TriggerAsyncNamespaceModelResponse {
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerNamespaceLatestModelRequest represents a request to trigger a model inference
-// with the latest uploaded version.
+// TriggerNamespaceLatestModelRequest represents a request to trigger a model
+// inference with the latest uploaded version.
 message TriggerNamespaceLatestModelRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -541,8 +550,8 @@ message TriggerNamespaceLatestModelResponse {
   repeated google.protobuf.Struct task_outputs = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerAsyncNamespaceLatestModelRequest represents a request to trigger a model inference
-// asynchronously with the latest uploaded version.
+// TriggerAsyncNamespaceLatestModelRequest represents a request to trigger a
+// model inference asynchronously with the latest uploaded version.
 message TriggerAsyncNamespaceLatestModelRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -554,15 +563,15 @@ message TriggerAsyncNamespaceLatestModelRequest {
   repeated google.protobuf.Struct task_inputs = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerAsyncNamespaceLatestModelResponse contains the information to access the
-// status of an asynchronous model inference.
+// TriggerAsyncNamespaceLatestModelResponse contains the information to access
+// the status of an asynchronous model inference.
 message TriggerAsyncNamespaceLatestModelResponse {
   // Long-running operation information.
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerNamespaceModelBinaryFileUploadRequest represents a request trigger a model
-// inference by uploading a binary file as the input.
+// TriggerNamespaceModelBinaryFileUploadRequest represents a request trigger a
+// model inference by uploading a binary file as the input.
 message TriggerNamespaceModelBinaryFileUploadRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -576,7 +585,8 @@ message TriggerNamespaceModelBinaryFileUploadRequest {
   repeated google.protobuf.Struct task_input = 5 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerNamespaceModelBinaryFileUploadResponse contains the model inference results.
+// TriggerNamespaceModelBinaryFileUploadResponse contains the model inference
+// results.
 message TriggerNamespaceModelBinaryFileUploadResponse {
   // Task type.
   common.task.v1alpha.Task task = 1 [(google.api.field_behavior) = REQUIRED];
@@ -588,8 +598,8 @@ message TriggerNamespaceModelBinaryFileUploadResponse {
   repeated google.protobuf.Struct task_outputs = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerNamespaceModelLatestBinaryFileUploadRequest represents a request trigger a model
-// inference by uploading a binary file as the input.
+// TriggerNamespaceModelLatestBinaryFileUploadRequest represents a request
+// trigger a model inference by uploading a binary file as the input.
 message TriggerNamespaceLatestModelBinaryFileUploadRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -601,7 +611,8 @@ message TriggerNamespaceLatestModelBinaryFileUploadRequest {
   repeated google.protobuf.Struct task_input = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerNamespaceLatestModelBinaryFileUploadResponse contains the model inference results.
+// TriggerNamespaceLatestModelBinaryFileUploadResponse contains the model
+// inference results.
 message TriggerNamespaceLatestModelBinaryFileUploadResponse {
   // Task type.
   common.task.v1alpha.Task task = 1 [(google.api.field_behavior) = REQUIRED];
@@ -611,26 +622,28 @@ message TriggerNamespaceLatestModelBinaryFileUploadResponse {
   repeated google.protobuf.Struct task_outputs = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetNamespaceLatestModelOperationRequest represents a request to fetch the latest long-running
-// operation performed on a model for a namespace.
+// GetNamespaceLatestModelOperationRequest represents a request to fetch the
+// latest long-running operation performed on a model for a namespace.
 message GetNamespaceLatestModelOperationRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // Model ID
   string model_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // View allows clients to specify the desired operation result in the response.
+  // View allows clients to specify the desired operation result in the
+  // response.
   optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetNamespaceLatestModelOperationResponse represents a response to query a long-running
-// operation.
+// GetNamespaceLatestModelOperationResponse represents a response to query a
+// long-running operation.
 message GetNamespaceLatestModelOperationResponse {
   // The long-running operation.
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetNamespaceModelOperationRequest represents a request to fetch the long-running
-// operation performed on a particular model version for a namespace.
+// GetNamespaceModelOperationRequest represents a request to fetch the
+// long-running operation performed on a particular model version for a
+// namespace.
 message GetNamespaceModelOperationRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -638,18 +651,20 @@ message GetNamespaceModelOperationRequest {
   string model_id = 2 [(google.api.field_behavior) = REQUIRED];
   // Model version
   string version = 3 [(google.api.field_behavior) = REQUIRED];
-  // View allows clients to specify the desired operation result in the response.
+  // View allows clients to specify the desired operation result in the
+  // response.
   optional View view = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetNamespaceModelOperationResponse represents a response to query a long-running
-// operation.
+// GetNamespaceModelOperationResponse represents a response to query a
+// long-running operation.
 message GetNamespaceModelOperationResponse {
   // The long-running operation.
   google.longrunning.Operation operation = 1;
 }
 
-// DeployNamespaceModelAdminRequest represents a request to deploy a model to online state
+// DeployNamespaceModelAdminRequest represents a request to deploy a model to
+// online state
 message DeployNamespaceModelAdminRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -667,8 +682,8 @@ message DeployNamespaceModelAdminResponse {
   reserved 1;
 }
 
-// UndeployNamespaceModelAdminRequest represents a request to undeploy a model to offline
-// state
+// UndeployNamespaceModelAdminRequest represents a request to undeploy a model
+// to offline state
 message UndeployNamespaceModelAdminRequest {
   // Namespace ID
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -680,7 +695,8 @@ message UndeployNamespaceModelAdminRequest {
   string digest = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// UndeployNamespaceModelAdminResponse represents a response for a undeployed model
+// UndeployNamespaceModelAdminResponse represents a response for a undeployed
+// model
 message UndeployNamespaceModelAdminResponse {
   // Deprecated operation
   reserved 1;
@@ -732,8 +748,9 @@ message ListUserModelsRequest {
   optional string filter = 6 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Model.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
-  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
-  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+  // Order by field, with options for ordering by `id`, `create_time` or
+  // `update_time`. Format: `order_by=id` or `order_by=create_time desc`,
+  // default is `asc`.
   optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -969,8 +986,8 @@ message TriggerUserModelResponse {
   repeated google.protobuf.Struct task_outputs = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerAsyncUserModelRequest represents a request to trigger a model inference
-// asynchronously.
+// TriggerAsyncUserModelRequest represents a request to trigger a model
+// inference asynchronously.
 message TriggerAsyncUserModelRequest {
   // The resource name of the model , which allows its access by parent user
   // and ID.
@@ -997,8 +1014,8 @@ message TriggerAsyncUserModelResponse {
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerUserLatestModelRequest represents a request to trigger a model inference
-// with the latest uploaded version.
+// TriggerUserLatestModelRequest represents a request to trigger a model
+// inference with the latest uploaded version.
 message TriggerUserLatestModelRequest {
   // The resource name of the model , which allows its access by parent user
   // and ID.
@@ -1026,8 +1043,8 @@ message TriggerUserLatestModelResponse {
   repeated google.protobuf.Struct task_outputs = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerAsyncUserLatestModelRequest represents a request to trigger a model inference
-// asynchronously with the latest uploaded version.
+// TriggerAsyncUserLatestModelRequest represents a request to trigger a model
+// inference asynchronously with the latest uploaded version.
 message TriggerAsyncUserLatestModelRequest {
   // The resource name of the model , which allows its access by parent user
   // and ID.
@@ -1073,7 +1090,8 @@ message TriggerUserModelBinaryFileUploadRequest {
   repeated google.protobuf.Struct task_inputs = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerUserModelBinaryFileUploadResponse contains the model inference results.
+// TriggerUserModelBinaryFileUploadResponse contains the model inference
+// results.
 message TriggerUserModelBinaryFileUploadResponse {
   // Task type.
   common.task.v1alpha.Task task = 1 [(google.api.field_behavior) = REQUIRED];
@@ -1089,7 +1107,8 @@ message TriggerUserModelBinaryFileUploadResponse {
 //  Organization methods
 ////////////////////////////////////
 
-// CreateOrganizationModelRequest represents a request from an organization to create a model.
+// CreateOrganizationModelRequest represents a request from an organization to
+// create a model.
 message CreateOrganizationModelRequest {
   // The properties of the model to be created.
   Model model = 1;
@@ -1138,8 +1157,9 @@ message ListOrganizationModelsRequest {
   optional string filter = 6 [(google.api.field_behavior) = OPTIONAL];
   // Limit results to pipelines with the specified visibility.
   optional Model.Visibility visibility = 7 [(google.api.field_behavior) = OPTIONAL];
-  // Order by field, with options for ordering by `id`, `create_time` or `update_time`.
-  // Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+  // Order by field, with options for ordering by `id`, `create_time` or
+  // `update_time`. Format: `order_by=id` or `order_by=create_time desc`,
+  // default is `asc`.
   optional string order_by = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -1153,11 +1173,11 @@ message ListOrganizationModelsResponse {
   int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetOrganizationModelRequest represents a request to fetch the details of a model
-// owned by an organization.
+// GetOrganizationModelRequest represents a request to fetch the details of a
+// model owned by an organization.
 message GetOrganizationModelRequest {
-  // The resource name of the model, which allows its access by parent organization
-  // and ID.
+  // The resource name of the model, which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1176,8 +1196,8 @@ message GetOrganizationModelResponse {
   Model model = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// UpdateOrganizationModelRequest represents a request to update a model owned by an
-// organization.
+// UpdateOrganizationModelRequest represents a request to update a model owned
+// by an organization.
 message UpdateOrganizationModelRequest {
   // The model to update
   Model model = 1 [(google.api.field_behavior) = REQUIRED];
@@ -1194,11 +1214,11 @@ message UpdateOrganizationModelResponse {
   Model model = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// DeleteOrganizationModelRequest represents a request to delete a model owned by an
-// organization.
+// DeleteOrganizationModelRequest represents a request to delete a model owned
+// by an organization.
 message DeleteOrganizationModelRequest {
-  // The resource name of the model, which allows its access by parent organization
-  // and ID.
+  // The resource name of the model, which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1214,8 +1234,8 @@ message DeleteOrganizationModelResponse {}
 
 // RenameOrganizationModelRequest represents a request to rename a model
 message RenameOrganizationModelRequest {
-  // The resource name of the model, which allows its access by parent organization
-  // and ID.
+  // The resource name of the model, which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1236,10 +1256,11 @@ message RenameOrganizationModelResponse {
   Model model = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// WatchOrganizationModelRequest represents a request to fetch current state of a model.
+// WatchOrganizationModelRequest represents a request to fetch current state of
+// a model.
 message WatchOrganizationModelRequest {
-  // The resource name of the model, which allows its access by parent organization
-  // and ID.
+  // The resource name of the model, which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1262,11 +1283,11 @@ message WatchOrganizationModelResponse {
   string message = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// WatchOrganizationLatestModelRequest represents a request to fetch current state of
-// the latest model version
+// WatchOrganizationLatestModelRequest represents a request to fetch current
+// state of the latest model version
 message WatchOrganizationLatestModelRequest {
-  // The resource name of the model, which allows its access by parent organization
-  // and ID.
+  // The resource name of the model, which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1277,7 +1298,8 @@ message WatchOrganizationLatestModelRequest {
   ];
 }
 
-// WatchOrganizationLatestModelResponse contains the state of the latest model version.
+// WatchOrganizationLatestModelResponse contains the state of the latest model
+// version.
 message WatchOrganizationLatestModelResponse {
   // State.
   State state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -1287,8 +1309,8 @@ message WatchOrganizationLatestModelResponse {
   string message = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ListOrganizationModelVersionsRequest represents a request to list all the versions
-// of a model namespace of an organization.
+// ListOrganizationModelVersionsRequest represents a request to list all the
+// versions of a model namespace of an organization.
 message ListOrganizationModelVersionsRequest {
   // The maximum number of versions to return. The default and cap values are 10
   // and 100, respectively.
@@ -1321,7 +1343,8 @@ message ListOrganizationModelVersionsResponse {
   int32 page = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// DeleteOrganizationModelVersionRequest represents a request to delete a model version
+// DeleteOrganizationModelVersionRequest represents a request to delete a model
+// version
 //  owned by an organization.
 message DeleteOrganizationModelVersionRequest {
   // The parent resource, i.e., the user that created the models.
@@ -1343,10 +1366,11 @@ message DeleteOrganizationModelVersionRequest {
 // DeleteOrganizationModelVersionResponse is an empty response.
 message DeleteOrganizationModelVersionResponse {}
 
-// TriggerOrganizationModelRequest represents a request to trigger a model inference.
+// TriggerOrganizationModelRequest represents a request to trigger a model
+// inference.
 message TriggerOrganizationModelRequest {
-  // The resource name of the model , which allows its access by parent organization
-  // and ID.
+  // The resource name of the model , which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1373,11 +1397,11 @@ message TriggerOrganizationModelResponse {
   repeated google.protobuf.Struct task_outputs = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerAsyncOrganizationModelRequest represents a request to trigger a model inference
-// asynchronously
+// TriggerAsyncOrganizationModelRequest represents a request to trigger a model
+// inference asynchronously
 message TriggerAsyncOrganizationModelRequest {
-  // The resource name of the model , which allows its access by parent organization
-  // and ID.
+  // The resource name of the model , which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1401,10 +1425,11 @@ message TriggerAsyncOrganizationModelResponse {
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerOrganizationLatestModelRequest represents a request to trigger a model inference.
+// TriggerOrganizationLatestModelRequest represents a request to trigger a model
+// inference.
 message TriggerOrganizationLatestModelRequest {
-  // The resource name of the model , which allows its access by parent organization
-  // and ID.
+  // The resource name of the model , which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1429,11 +1454,11 @@ message TriggerOrganizationLatestModelResponse {
   repeated google.protobuf.Struct task_outputs = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerAsyncOrganizationLatestModelRequest represents a request to trigger a model inference
-// asynchronously
+// TriggerAsyncOrganizationLatestModelRequest represents a request to trigger a
+// model inference asynchronously
 message TriggerAsyncOrganizationLatestModelRequest {
-  // The resource name of the model , which allows its access by parent organization
-  // and ID.
+  // The resource name of the model , which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1448,18 +1473,18 @@ message TriggerAsyncOrganizationLatestModelRequest {
   repeated google.protobuf.Struct task_inputs = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerAsyncOrganizationLatestModelResponse contains the information to access the
-// status of an asynchronous model inference.
+// TriggerAsyncOrganizationLatestModelResponse contains the information to
+// access the status of an asynchronous model inference.
 message TriggerAsyncOrganizationLatestModelResponse {
   // Long-running operation information.
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// TriggerOrganizationModelBinaryFileUploadRequest represents a request trigger a model
-// inference by uploading a binary file as the input.
+// TriggerOrganizationModelBinaryFileUploadRequest represents a request trigger
+// a model inference by uploading a binary file as the input.
 message TriggerOrganizationModelBinaryFileUploadRequest {
-  // The resource name of the model , which allows its access by parent organization
-  // and ID.
+  // The resource name of the model , which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1476,7 +1501,8 @@ message TriggerOrganizationModelBinaryFileUploadRequest {
   repeated google.protobuf.Struct task_inputs = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
-// TriggerOrganizationModelBinaryFileUploadResponse contains the model inference results.
+// TriggerOrganizationModelBinaryFileUploadResponse contains the model inference
+// results.
 message TriggerOrganizationModelBinaryFileUploadResponse {
   // Task type.
   common.task.v1alpha.Task task = 1 [(google.api.field_behavior) = REQUIRED];
@@ -1505,7 +1531,8 @@ message GetModelOperationResponse {
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// LatestOperation represents an internal message for GetLatestModelOperation Response
+// LatestOperation represents an internal message for GetLatestModelOperation
+// Response
 message LatestOperation {
   // Deprecated input request type
   reserved 1;
@@ -1517,8 +1544,8 @@ message LatestOperation {
   TriggerNamespaceModelResponse response = 4;
 }
 
-// GetUserLatestModelOperationRequest represents a request to fetch the latest long-running
-// operation performed on a model for a user.
+// GetUserLatestModelOperationRequest represents a request to fetch the latest
+// long-running operation performed on a model for a user.
 message GetUserLatestModelOperationRequest {
   // The resource name of the model, which allows its access by parent user
   // and ID.
@@ -1530,22 +1557,23 @@ message GetUserLatestModelOperationRequest {
       field_configuration: {path_param_name: "user_model_name"}
     }
   ];
-  // View allows clients to specify the desired operation result in the response.
+  // View allows clients to specify the desired operation result in the
+  // response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetUserLatestModelOperationRequest represents a request to query a long-running
-// operation.
+// GetUserLatestModelOperationRequest represents a request to query a
+// long-running operation.
 message GetUserLatestModelOperationResponse {
   // The long-running operation.
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetOrganizationLatestModelOperationRequest represents a request to fetch the latest long-running
-// operation performed on a model for a user.
+// GetOrganizationLatestModelOperationRequest represents a request to fetch the
+// latest long-running operation performed on a model for a user.
 message GetOrganizationLatestModelOperationRequest {
-  // The resource name of the model, which allows its access by parent organization
-  // and ID.
+  // The resource name of the model, which allows its access by parent
+  // organization and ID.
   // - Format: `organizations/{organization.id}/models/{model.id}`.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
@@ -1554,12 +1582,13 @@ message GetOrganizationLatestModelOperationRequest {
       field_configuration: {path_param_name: "organization_model_name"}
     }
   ];
-  // View allows clients to specify the desired operation result in the response.
+  // View allows clients to specify the desired operation result in the
+  // response.
   optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// GetOrganizationLatestModelOperationRequest represents a request to query a long-running
-// operation.
+// GetOrganizationLatestModelOperationRequest represents a request to query a
+// long-running operation.
 message GetOrganizationLatestModelOperationResponse {
   // The long-running operation.
   google.longrunning.Operation operation = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -1628,7 +1657,8 @@ message LookUpModelAdminResponse {
   Model model = 1;
 }
 
-// DeployUserModelAdminRequest represents a request to deploy a model to online state
+// DeployUserModelAdminRequest represents a request to deploy a model to online
+// state
 message DeployUserModelAdminRequest {
   reserved 1;
   // The resource name of the model, which allows its access by parent user
@@ -1653,7 +1683,8 @@ message DeployUserModelAdminResponse {
   reserved 1;
 }
 
-// DeployOrganizationModelAdminRequest represents a request to deploy a model to online state
+// DeployOrganizationModelAdminRequest represents a request to deploy a model to
+// online state
 message DeployOrganizationModelAdminRequest {
   reserved 1;
   // The resource name of the model, which allows its access by parent user
@@ -1672,11 +1703,12 @@ message DeployOrganizationModelAdminRequest {
   string digest = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// DeployOrganizationModelAdminResponse represents a response for a deployed model
+// DeployOrganizationModelAdminResponse represents a response for a deployed
+// model
 message DeployOrganizationModelAdminResponse {}
 
-// UndeployUserModelAdminRequest represents a request to undeploy a model to offline
-// state
+// UndeployUserModelAdminRequest represents a request to undeploy a model to
+// offline state
 message UndeployUserModelAdminRequest {
   reserved 1;
   // The resource name of the model, which allows its access by parent user
@@ -1701,8 +1733,8 @@ message UndeployUserModelAdminResponse {
   reserved 1;
 }
 
-// UndeployOrganizationModelAdminRequest represents a request to undeploy a model to offline
-// state
+// UndeployOrganizationModelAdminRequest represents a request to undeploy a
+// model to offline state
 message UndeployOrganizationModelAdminRequest {
   reserved 1;
   // The resource name of the model, which allows its access by parent user
@@ -1721,7 +1753,8 @@ message UndeployOrganizationModelAdminRequest {
   string digest = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// UndeployOrganizationModelAdminResponse represents a response for a undeployed model
+// UndeployOrganizationModelAdminResponse represents a response for a undeployed
+// model
 message UndeployOrganizationModelAdminResponse {}
 
 // ModelRun contains information about a run of models.
@@ -1745,12 +1778,14 @@ message ModelRun {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
-  // Runner ID. If current viewing requester does not have enough permission, it will return null.
+  // Runner ID. If current viewing requester does not have enough permission, it
+  // will return null.
   optional string runner_id = 7 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
   ];
-  // The amount of Instill Credit consumed by the run. This field will only be present on Instill Cloud.
+  // The amount of Instill Credit consumed by the run. This field will only be
+  // present on Instill Cloud.
   optional float credit_amount = 8 [
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = OPTIONAL
@@ -1789,8 +1824,8 @@ message ListModelRunsRequest {
   optional int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
   // Page number.
   optional int32 page = 2 [(google.api.field_behavior) = OPTIONAL];
-  // Deprecated: View allows clients to specify the desired run view in the response.
-  // The basic view excludes input / output data.
+  // Deprecated: View allows clients to specify the desired run view in the
+  // response. The basic view excludes input / output data.
   reserved 3;
   // Sort the results by the given expression.
   // Format: `field [ASC | DESC], where `field` can be:
@@ -1810,7 +1845,8 @@ message ListModelRunsRequest {
   optional string filter = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// ListModelRunsByRequesterRequest is the request message for ListModelRunsByRequester.
+// ListModelRunsByRequesterRequest is the request message for
+// ListModelRunsByRequester.
 message ListModelRunsByRequesterRequest {
   // The maximum number of runs to return. The default and cap values are 10
   // and 100, respectively.
@@ -1852,7 +1888,8 @@ message ListModelRunsResponse {
   int32 page = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// ListModelRunsByRequesterResponse is the request message for ListModelRunsByRequester.
+// ListModelRunsByRequesterResponse is the request message for
+// ListModelRunsByRequester.
 message ListModelRunsByRequesterResponse {
   // A list of runs resources.
   repeated ModelRun runs = 1 [(google.api.field_behavior) = OUTPUT_ONLY];

--- a/model/model/v1alpha/model_ray_serve.proto
+++ b/model/model/v1alpha/model_ray_serve.proto
@@ -1,0 +1,309 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package model.model.v1alpha;
+
+option cc_enable_arenas = true;
+
+// Configuration options for Serve's replica autoscaler.
+message AutoscalingConfig {
+  // Minimal number of replicas, must be a non-negative integer.
+  uint32 min_replicas = 1;
+
+  // Maximal number of replicas, must be a non-negative integer and greater or
+  // equals to min_replicas.
+  uint32 max_replicas = 2;
+
+  // Target number of in flight requests per replicas. This is the primary
+  // configuration knob for replica autoscaler. Lower the number, the more
+  // rapidly will the replicas being scaled up. Must be a non-negative integer.
+  double target_num_ongoing_requests_per_replica = 3;
+
+  // The frequency of how long does each replica sending metrics to autoscaler.
+  double metrics_interval_s = 4;
+
+  // The window (in seconds) for autoscaler to calculate rolling average of
+  // metrics on.
+  double look_back_period_s = 5;
+
+  // The multiplicative "gain" factor to limit scaling decisions.
+  double smoothing_factor = 6;
+
+  // How long to wait before scaling down replicas.
+  double downscale_delay_s = 7;
+
+  // How long to wait before scaling up replicas.
+  double upscale_delay_s = 8;
+
+  // Initial number of replicas deployment should start with. Must be
+  // non-negative.
+  optional uint32 initial_replicas = 9;
+
+  // The multiplicative "gain" factor to limit upscale.
+  optional double upscale_smoothing_factor = 10;
+
+  // The multiplicative "gain" factor to limit downscale.
+  optional double downscale_smoothing_factor = 11;
+
+  // The cloudpickled policy definition.
+  bytes serialized_policy_def = 12;
+
+  // The import path of the policy if user passed a string. Will be the
+  // concatenation of the policy module and the policy name if user passed a
+  // callable.
+  string policy = 13;
+}
+
+//[Begin] LOGGING CONFIG
+// Encoding type
+enum EncodingType {
+  TEXT = 0;
+  JSON = 1;
+}
+
+message LoggingConfig {
+  EncodingType encoding = 1;
+  string log_level = 2;
+  string logs_dir = 3;
+  bool enable_access_log = 4;
+}
+
+//[End] Logging Config
+
+// Configuration options for a deployment, to be set by the user.
+message DeploymentConfig {
+  // The number of processes to start up that will handle requests to this
+  // deployment. Defaults to 1.
+  int32 num_replicas = 1;
+
+  // The maximum number of queries that will be sent to a replica of this
+  // deployment without receiving a response. Defaults to 100.
+  int32 max_concurrent_queries = 2;
+
+  // Arguments to pass to the reconfigure method of the deployment. The
+  // reconfigure method is called if user_config is not None.
+  bytes user_config = 3;
+
+  // Duration that deployment replicas will wait until there is no more work to
+  // be done before shutting down.
+  double graceful_shutdown_wait_loop_s = 4;
+
+  // Controller waits for this duration to forcefully kill the replica for
+  // shutdown.
+  double graceful_shutdown_timeout_s = 5;
+
+  // Frequency at which the controller health checks replicas.
+  double health_check_period_s = 6;
+
+  // Timeout after which a replica is marked unhealthy without a response.
+  double health_check_timeout_s = 7;
+
+  // Is the construction of deployment is cross language?
+  bool is_cross_language = 8;
+
+  // The deployment's programming language.
+  DeploymentLanguage deployment_language = 9;
+
+  // The deployment's autoscaling configuration.
+  AutoscalingConfig autoscaling_config = 10;
+
+  string version = 11;
+
+  repeated string user_configured_option_names = 12;
+
+  LoggingConfig logging_config = 13;
+}
+
+// Deployment language.
+enum DeploymentLanguage {
+  PYTHON = 0;
+  JAVA = 1;
+}
+
+message RequestMetadata {
+  string request_id = 1;
+
+  string endpoint = 2;
+
+  string call_method = 3;
+
+  map<string, string> context = 4;
+
+  string multiplexed_model_id = 5;
+
+  string route = 6;
+}
+
+message RequestWrapper {
+  bytes body = 1;
+}
+
+message UpdatedObject {
+  bytes object_snapshot = 1;
+  int32 snapshot_id = 2;
+}
+
+message LongPollRequest {
+  map<string, int32> keys_to_snapshot_ids = 1;
+}
+
+message LongPollResult {
+  map<string, UpdatedObject> updated_objects = 1;
+}
+
+message EndpointInfo {
+  string endpoint_name = 1;
+  string route = 2;
+  map<string, string> config = 3;
+}
+
+message EndpointSet {
+  map<string, EndpointInfo> endpoints = 1;
+}
+
+// Now Actor handle can be transfered across language through ray call, but the
+// list of Actor handles can't. So we use this message wrapped a Actor name list
+// to pass actor list across language. When Actor handle list supports across
+// language, this message can be replaced.
+message ActorNameList {
+  repeated string names = 1;
+}
+
+message DeploymentVersion {
+  string code_version = 1;
+  DeploymentConfig deployment_config = 2;
+  string ray_actor_options = 3;
+  string placement_group_bundles = 4;
+  string placement_group_strategy = 5;
+  int32 max_replicas_per_node = 6;
+}
+
+message ReplicaConfig {
+  string deployment_def_name = 1;
+  bytes deployment_def = 2;
+  bytes init_args = 3;
+  bytes init_kwargs = 4;
+  string ray_actor_options = 5;
+  string placement_group_bundles = 6;
+  string placement_group_strategy = 7;
+  int32 max_replicas_per_node = 8;
+}
+
+enum TargetCapacityDirection {
+  UNSET = 0;
+  UP = 1;
+  DOWN = 2;
+}
+
+message DeploymentInfo {
+  string name = 1;
+  DeploymentConfig deployment_config = 2;
+  ReplicaConfig replica_config = 3;
+  int64 start_time_ms = 4;
+  string actor_name = 5;
+  string version = 6;
+  int64 end_time_ms = 7;
+  double target_capacity = 8;
+  TargetCapacityDirection target_capacity_direction = 9;
+}
+
+// Wrap DeploymentInfo and route. The "" route value need to be convert to
+// None/null.
+message DeploymentRoute {
+  DeploymentInfo deployment_info = 1;
+  string route = 2;
+}
+
+// Wrap a list for DeploymentRoute.
+message DeploymentRouteList {
+  repeated DeploymentRoute deployment_routes = 1;
+}
+
+enum DeploymentStatus {
+  // Keep frontend code of ServeDeploymentStatus in
+  // dashboard/client/src/type/serve.ts in sync with this enum
+  DEPLOYMENT_STATUS_UPDATING = 0;
+  DEPLOYMENT_STATUS_HEALTHY = 1;
+  DEPLOYMENT_STATUS_UNHEALTHY = 2;
+  DEPLOYMENT_STATUS_UPSCALING = 3;
+  DEPLOYMENT_STATUS_DOWNSCALING = 4;
+}
+
+enum DeploymentStatusTrigger {
+  DEPLOYMENT_STATUS_TRIGGER_UNSPECIFIED = 0;
+  DEPLOYMENT_STATUS_TRIGGER_CONFIG_UPDATE_STARTED = 1;
+  DEPLOYMENT_STATUS_TRIGGER_CONFIG_UPDATE_COMPLETED = 2;
+  DEPLOYMENT_STATUS_TRIGGER_UPSCALE_COMPLETED = 3;
+  DEPLOYMENT_STATUS_TRIGGER_DOWNSCALE_COMPLETED = 4;
+  DEPLOYMENT_STATUS_TRIGGER_AUTOSCALING = 5;
+  DEPLOYMENT_STATUS_TRIGGER_REPLICA_STARTUP_FAILED = 6;
+  DEPLOYMENT_STATUS_TRIGGER_HEALTH_CHECK_FAILED = 7;
+  DEPLOYMENT_STATUS_TRIGGER_INTERNAL_ERROR = 8;
+  DEPLOYMENT_STATUS_TRIGGER_DELETING = 9;
+}
+
+message DeploymentStatusInfo {
+  string name = 1;
+  DeploymentStatus status = 2;
+  string message = 3;
+  DeploymentStatusTrigger status_trigger = 4;
+}
+
+// Wrap a list for DeploymentStatusInfo.
+message DeploymentStatusInfoList {
+  repeated DeploymentStatusInfo deployment_status_infos = 1;
+}
+
+enum ApplicationStatus {
+  // Keep frontend code of ServeApplicationStatus in
+  // dashboard/client/src/type/serve.ts in sync with this enum
+  APPLICATION_STATUS_DEPLOYING = 0;
+  APPLICATION_STATUS_RUNNING = 1;
+  APPLICATION_STATUS_DEPLOY_FAILED = 2;
+  APPLICATION_STATUS_DELETING = 3;
+  APPLICATION_STATUS_NOT_STARTED = 5;
+  APPLICATION_STATUS_UNHEALTHY = 6;
+}
+
+message ApplicationStatusInfo {
+  ApplicationStatus status = 1;
+  string message = 2;
+  double deployment_timestamp = 3;
+}
+
+message StatusOverview {
+  ApplicationStatusInfo app_status = 1;
+  DeploymentStatusInfoList deployment_statuses = 2;
+  string name = 3;
+}
+
+// Used for gRPC proxy health check
+message ListApplicationsRequest {}
+
+message ListApplicationsResponse {
+  repeated string application_names = 1;
+}
+
+message HealthzRequest {}
+
+message HealthzResponse {
+  string message = 1;
+}
+
+service RayServeAPIService {
+  rpc ListApplications(ListApplicationsRequest) returns (ListApplicationsResponse);
+  rpc Healthz(HealthzRequest) returns (HealthzResponse);
+}

--- a/model/model/v1alpha/model_ray_user_defined.proto
+++ b/model/model/v1alpha/model_ray_user_defined.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package model.model.v1alpha;
+
+// Protobuf standard
+import "google/protobuf/struct.proto";
+
+// CallRequest represents a request for model inference
+message CallRequest {
+  // Inference input parameters.
+  repeated google.protobuf.Struct task_inputs = 1;
+}
+
+// CallResponse represents a response for model inference
+message CallResponse {
+  // Model inference outputs.
+  repeated google.protobuf.Struct task_outputs = 1;
+}
+
+// Ray user defined service for internal process
+service RayUserDefinedService {
+  // Trigger method is the default trigger entry for ray deployment
+  // Ray doesn't comply with the naming convention of protobuf, so we need to
+  // buf:lint:ignore RPC_PASCAL_CASE
+  rpc __call__(CallRequest) returns (CallResponse);
+}

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -3106,8 +3106,9 @@ paths:
             - VISIBILITY_PUBLIC
         - name: orderBy
           description: |-
-            Order by field, with options for ordering by `id`, `create_time` or `update_time`.
-            Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+            Order by field, with options for ordering by `id`, `create_time` or
+            `update_time`. Format: `order_by=id` or `order_by=create_time desc`,
+            default is `asc`.
           in: query
           required: false
           type: string
@@ -3190,8 +3191,9 @@ paths:
             - VISIBILITY_PUBLIC
         - name: orderBy
           description: |-
-            Order by field, with options for ordering by `id`, `create_time` or `update_time`.
-            Format: `order_by=id` or `order_by=create_time desc`, default is `asc`.
+            Order by field, with options for ordering by `id`, `create_time` or
+            `update_time`. Format: `order_by=id` or `order_by=create_time desc`,
+            default is `asc`.
           in: query
           required: false
           type: string
@@ -3769,7 +3771,8 @@ paths:
           type: string
         - name: view
           description: |-
-            View allows clients to specify the desired operation result in the response.
+            View allows clients to specify the desired operation result in the
+            response.
 
              - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
              - VIEW_FULL: Full representation.
@@ -3814,7 +3817,8 @@ paths:
           type: string
         - name: view
           description: |-
-            View allows clients to specify the desired operation result in the response.
+            View allows clients to specify the desired operation result in the
+            response.
 
              - VIEW_BASIC: Default view, only includes basic information (omits `model_spec`).
              - VIEW_FULL: Full representation.
@@ -6202,6 +6206,15 @@ definitions:
     description: BooleanCell represents a cell with a boolean value.
     required:
       - value
+  CallResponse:
+    type: object
+    properties:
+      taskOutputs:
+        type: array
+        items:
+          type: object
+        description: Model inference outputs.
+    title: CallResponse represents a response for model inference
   Catalog:
     type: object
     properties:
@@ -7410,7 +7423,9 @@ definitions:
     title: DeployNamespaceModelAdminResponse represents a response for a deployed model
   DeployOrganizationModelAdminResponse:
     type: object
-    title: DeployOrganizationModelAdminResponse represents a response for a deployed model
+    title: |-
+      DeployOrganizationModelAdminResponse represents a response for a deployed
+      model
   DeployUserModelAdminResponse:
     type: object
     title: DeployUserModelAdminResponse represents a response for a deployed model
@@ -7863,8 +7878,8 @@ definitions:
         allOf:
           - $ref: '#/definitions/longrunning.Operation'
     description: |-
-      GetNamespaceLatestModelOperationResponse represents a response to query a long-running
-      operation.
+      GetNamespaceLatestModelOperationResponse represents a response to query a
+      long-running operation.
   GetNamespaceModelOperationResponse:
     type: object
     properties:
@@ -7873,8 +7888,8 @@ definitions:
         allOf:
           - $ref: '#/definitions/longrunning.Operation'
     description: |-
-      GetNamespaceModelOperationResponse represents a response to query a long-running
-      operation.
+      GetNamespaceModelOperationResponse represents a response to query a
+      long-running operation.
   GetNamespaceModelResponse:
     type: object
     properties:
@@ -8129,6 +8144,11 @@ definitions:
         type: string
         title: Hardware name value
     description: Hardware describes the hardware title and string value that backend consumes.
+  HealthzResponse:
+    type: object
+    properties:
+      message:
+        type: string
   InsertRowBody:
     type: object
     properties:
@@ -8226,6 +8246,13 @@ definitions:
         description: URL contains the reference the link will redirect to.
         readOnly: true
     description: Link contains the information to display an reference to an external URL.
+  ListApplicationsResponse:
+    type: object
+    properties:
+      applicationNames:
+        type: array
+        items:
+          type: string
   ListAvailableRegionsResponse:
     type: object
     properties:
@@ -8502,7 +8529,9 @@ definitions:
         format: int32
         description: The requested page offset.
         readOnly: true
-    description: ListModelRunsByRequesterResponse is the request message for ListModelRunsByRequester.
+    description: |-
+      ListModelRunsByRequesterResponse is the request message for
+      ListModelRunsByRequester.
   ListModelRunsResponse:
     type: object
     properties:
@@ -9388,12 +9417,16 @@ definitions:
         readOnly: true
       runnerId:
         type: string
-        description: Runner ID. If current viewing requester does not have enough permission, it will return null.
+        description: |-
+          Runner ID. If current viewing requester does not have enough permission, it
+          will return null.
         readOnly: true
       creditAmount:
         type: number
         format: float
-        description: The amount of Instill Credit consumed by the run. This field will only be present on Instill Cloud.
+        description: |-
+          The amount of Instill Credit consumed by the run. This field will only be
+          present on Instill Cloud.
         readOnly: true
       error:
         type: string
@@ -10978,8 +11011,8 @@ definitions:
           type: object
         description: Model inference inputs.
     description: |-
-      TriggerAsyncNamespaceLatestModelRequest represents a request to trigger a model inference
-      asynchronously with the latest uploaded version.
+      TriggerAsyncNamespaceLatestModelRequest represents a request to trigger a
+      model inference asynchronously with the latest uploaded version.
     required:
       - taskInputs
   TriggerAsyncNamespaceLatestModelResponse:
@@ -10991,8 +11024,8 @@ definitions:
         allOf:
           - $ref: '#/definitions/longrunning.Operation'
     description: |-
-      TriggerAsyncNamespaceLatestModelResponse contains the information to access the
-      status of an asynchronous model inference.
+      TriggerAsyncNamespaceLatestModelResponse contains the information to access
+      the status of an asynchronous model inference.
   TriggerAsyncNamespaceModelBody:
     type: object
     properties:
@@ -11002,8 +11035,8 @@ definitions:
           type: object
         description: Model inference inputs.
     description: |-
-      TriggerAsyncNamespaceModelRequest represents a request to trigger a model inference
-      asynchronously.
+      TriggerAsyncNamespaceModelRequest represents a request to trigger a model
+      inference asynchronously.
     required:
       - taskInputs
   TriggerAsyncNamespaceModelResponse:
@@ -11135,7 +11168,9 @@ definitions:
           Deleteted field.
           Model inference outputs.
         readOnly: true
-    description: TriggerNamespaceLatestModelBinaryFileUploadResponse contains the model inference results.
+    description: |-
+      TriggerNamespaceLatestModelBinaryFileUploadResponse contains the model
+      inference results.
     required:
       - task
   TriggerNamespaceLatestModelBody:
@@ -11147,8 +11182,8 @@ definitions:
           type: object
         description: Model inference inputs.
     description: |-
-      TriggerNamespaceLatestModelRequest represents a request to trigger a model inference
-      with the latest uploaded version.
+      TriggerNamespaceLatestModelRequest represents a request to trigger a model
+      inference with the latest uploaded version.
     required:
       - taskInputs
   TriggerNamespaceLatestModelResponse:
@@ -11179,7 +11214,9 @@ definitions:
           type: object
         description: Model inference outputs.
         readOnly: true
-    description: TriggerNamespaceModelBinaryFileUploadResponse contains the model inference results.
+    description: |-
+      TriggerNamespaceModelBinaryFileUploadResponse contains the model inference
+      results.
     required:
       - task
   TriggerNamespaceModelBody:
@@ -11190,7 +11227,9 @@ definitions:
         items:
           type: object
         description: Model inference inputs.
-    description: TriggerNamespaceModelRequest represents a request to trigger a model inference.
+    description: |-
+      TriggerNamespaceModelRequest represents a request to trigger a model
+      inference.
     required:
       - taskInputs
   TriggerNamespaceModelResponse:
@@ -11327,10 +11366,14 @@ definitions:
     description: UnbindChatTableResponse is an empty response for unbinding a table from a chat.
   UndeployNamespaceModelAdminResponse:
     type: object
-    title: UndeployNamespaceModelAdminResponse represents a response for a undeployed model
+    title: |-
+      UndeployNamespaceModelAdminResponse represents a response for a undeployed
+      model
   UndeployOrganizationModelAdminResponse:
     type: object
-    title: UndeployOrganizationModelAdminResponse represents a response for a undeployed model
+    title: |-
+      UndeployOrganizationModelAdminResponse represents a response for a undeployed
+      model
   UndeployUserModelAdminResponse:
     type: object
     title: UndeployUserModelAdminResponse represents a response for a undeployed model
@@ -11677,7 +11720,9 @@ definitions:
         type: string
         title: Detail description of the state
         readOnly: true
-    description: WatchNamespaceLatestModelResponse contains the state of the latest model version.
+    description: |-
+      WatchNamespaceLatestModelResponse contains the state of the latest model
+      version.
   WatchNamespaceModelResponse:
     type: object
     properties:
@@ -12008,8 +12053,10 @@ definitions:
        - STATE_ERROR: Error is the state when the model is undeployable.
        - STATE_STARTING: Starting is the state when the system is provisioning the necessary
       resources for the model
-       - STATE_SCALING_UP: Scaling Up is the transition state when the system is provisioning compute resource for this model instance.
-       - STATE_SCALING_DOWN: Scaling is the transition state when the system is releasing compute resource for this model instance.
+       - STATE_SCALING_UP: Scaling Up is the transition state when the system is provisioning compute
+      resource for this model instance.
+       - STATE_SCALING_DOWN: Scaling is the transition state when the system is releasing compute
+      resource for this model instance.
   v1alpha.Type:
     type: string
     enum:


### PR DESCRIPTION
Because
- We need to support Ray integration for our model service
- Ray uses specific protobuf definitions that need to be incorporated
- Some Ray protobuf files don't follow our standard naming conventions

This commit
- Adds protobuf definitions for Ray model service
- Configures `buf.yaml` to ignore Ray-specific protobuf files
- Enables comment-based lint ignores to handle Ray's non-standard naming conventions