### PR TITLE
fix(model): fix package ray.serve

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -17,7 +17,7 @@ lint:
   except:
     - FIELD_NOT_REQUIRED
   ignore:
-    - model/model/v1alpha/model_ray_serve.proto # protobuf file copied from ray repo
+    - model/ray/serve.proto # protobuf file copied from ray repo
   enum_zero_value_suffix: _UNSPECIFIED
   service_suffix: Service
   disallow_comment_ignores: false

--- a/model/ray/serve.proto
+++ b/model/ray/serve.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package model.model.v1alpha;
+package ray.serve;
 
 option cc_enable_arenas = true;
 


### PR DESCRIPTION
Because

- Ray protobuf has the package name `ray.serve`

This commit

- move Ray `serve.proto` under an independent `ray` folder