### PR TITLE
chore(ray): update ray.serve and ray user defined type

### DIFF
--- a/buf.gen.openapi.yaml
+++ b/buf.gen.openapi.yaml
@@ -10,7 +10,7 @@ managed:
     - file_option: go_package_prefix
       value: github.com/instill-ai/protogen-go
 plugins:
-  - remote: buf.build/grpc-ecosystem/openapiv2:v2.22.0
+  - remote: buf.build/grpc-ecosystem/openapiv2:v2.26.3
     out: .
     opt:
       - output_format=yaml

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,10 +2,8 @@ version: v2
 managed:
   enabled: true
   disable:
-    - file_option: go_package
-      module: buf.build/googleapis/googleapis
-    - file_option: go_package
-      module: buf.build/grpc-ecosystem/grpc-gateway
+    - module: buf.build/googleapis/googleapis
+    - module: buf.build/grpc-ecosystem/grpc-gateway
   override:
     - file_option: go_package_prefix
       value: github.com/instill-ai/protogen-go
@@ -18,15 +16,15 @@ plugins:
     out: gen/python
   - remote: buf.build/community/nipunn1313-mypy-grpc:v3.5.0
     out: gen/python
-  - remote: buf.build/protocolbuffers/go:v1.30.0
+  - remote: buf.build/protocolbuffers/go:v1.36.6
     out: gen/go
     opt: paths=source_relative
-  - remote: buf.build/grpc/go:v1.3.0
+  - remote: buf.build/grpc/go:v1.5.1
     out: gen/go
     opt:
       - paths=source_relative
       - require_unimplemented_servers=false
-  - remote: buf.build/grpc-ecosystem/gateway:v2.15.2
+  - remote: buf.build/grpc-ecosystem/gateway:v2.26.3
     out: gen/go
     opt:
       - paths=source_relative

--- a/model/ray/serve.proto
+++ b/model/ray/serve.proto
@@ -16,7 +16,9 @@ syntax = "proto3";
 
 package ray.serve;
 
-option cc_enable_arenas = true;
+option java_multiple_files = true;
+option java_outer_classname = "ServeProtos";
+option java_package = "io.ray.serve.generated";
 
 // Configuration options for Serve's replica autoscaler.
 message AutoscalingConfig {
@@ -27,44 +29,50 @@ message AutoscalingConfig {
   // equals to min_replicas.
   uint32 max_replicas = 2;
 
-  // Target number of in flight requests per replicas. This is the primary
-  // configuration knob for replica autoscaler. Lower the number, the more
-  // rapidly will the replicas being scaled up. Must be a non-negative integer.
-  double target_num_ongoing_requests_per_replica = 3;
-
   // The frequency of how long does each replica sending metrics to autoscaler.
-  double metrics_interval_s = 4;
+  double metrics_interval_s = 3;
 
   // The window (in seconds) for autoscaler to calculate rolling average of
   // metrics on.
-  double look_back_period_s = 5;
+  double look_back_period_s = 4;
 
-  // The multiplicative "gain" factor to limit scaling decisions.
-  double smoothing_factor = 6;
+  // [DEPRECATED] Use `upscaling_factor` and/or `downscaling_factor` instead.
+  double smoothing_factor = 5;
 
   // How long to wait before scaling down replicas.
-  double downscale_delay_s = 7;
+  double downscale_delay_s = 6;
 
   // How long to wait before scaling up replicas.
-  double upscale_delay_s = 8;
+  double upscale_delay_s = 7;
 
   // Initial number of replicas deployment should start with. Must be
   // non-negative.
-  optional uint32 initial_replicas = 9;
+  optional uint32 initial_replicas = 8;
 
-  // The multiplicative "gain" factor to limit upscale.
-  optional double upscale_smoothing_factor = 10;
+  // [DEPRECATED] Use `upscaling_factor` instead.
+  optional double upscale_smoothing_factor = 9;
 
-  // The multiplicative "gain" factor to limit downscale.
-  optional double downscale_smoothing_factor = 11;
+  // [DEPRECATED] Use `downscaling_factor` instead.
+  optional double downscale_smoothing_factor = 10;
 
   // The cloudpickled policy definition.
-  bytes serialized_policy_def = 12;
+  bytes _serialized_policy_def = 11;
 
   // The import path of the policy if user passed a string. Will be the
   // concatenation of the policy module and the policy name if user passed a
   // callable.
-  string policy = 13;
+  string _policy = 12;
+
+  // Target number of in flight requests per replica. This is the primary
+  // configuration knob for replica autoscaler. Lower the number, the more
+  // rapidly the replicas scales up. Must be a non-negative integer.
+  double target_ongoing_requests = 13;
+
+  // The multiplicative "gain" factor to limit upscale.
+  optional double upscaling_factor = 14;
+
+  // The multiplicative "gain" factor to limit downscale.
+  optional double downscaling_factor = 15;
 }
 
 //[Begin] LOGGING CONFIG
@@ -79,6 +87,7 @@ message LoggingConfig {
   string log_level = 2;
   string logs_dir = 3;
   bool enable_access_log = 4;
+  repeated string additional_log_standard_attrs = 5;
 }
 
 //[End] Logging Config
@@ -86,45 +95,48 @@ message LoggingConfig {
 // Configuration options for a deployment, to be set by the user.
 message DeploymentConfig {
   // The number of processes to start up that will handle requests to this
-  // deployment. Defaults to 1.
+  // deployment.
   int32 num_replicas = 1;
 
   // The maximum number of queries that will be sent to a replica of this
-  // deployment without receiving a response. Defaults to 100.
-  int32 max_concurrent_queries = 2;
+  // deployment without receiving a response.
+  int32 max_ongoing_requests = 2;
+
+  // The maximum number of requests that will be queued in deployment handles.
+  int32 max_queued_requests = 3;
 
   // Arguments to pass to the reconfigure method of the deployment. The
   // reconfigure method is called if user_config is not None.
-  bytes user_config = 3;
+  bytes user_config = 4;
 
   // Duration that deployment replicas will wait until there is no more work to
   // be done before shutting down.
-  double graceful_shutdown_wait_loop_s = 4;
+  double graceful_shutdown_wait_loop_s = 5;
 
   // Controller waits for this duration to forcefully kill the replica for
   // shutdown.
-  double graceful_shutdown_timeout_s = 5;
+  double graceful_shutdown_timeout_s = 6;
 
   // Frequency at which the controller health checks replicas.
-  double health_check_period_s = 6;
+  double health_check_period_s = 7;
 
   // Timeout after which a replica is marked unhealthy without a response.
-  double health_check_timeout_s = 7;
+  double health_check_timeout_s = 8;
 
   // Is the construction of deployment is cross language?
-  bool is_cross_language = 8;
+  bool is_cross_language = 9;
 
   // The deployment's programming language.
-  DeploymentLanguage deployment_language = 9;
+  DeploymentLanguage deployment_language = 10;
 
   // The deployment's autoscaling configuration.
-  AutoscalingConfig autoscaling_config = 10;
+  AutoscalingConfig autoscaling_config = 11;
 
-  string version = 11;
+  string version = 12;
 
-  repeated string user_configured_option_names = 12;
+  repeated string user_configured_option_names = 13;
 
-  LoggingConfig logging_config = 13;
+  LoggingConfig logging_config = 14;
 }
 
 // Deployment language.
@@ -136,7 +148,7 @@ enum DeploymentLanguage {
 message RequestMetadata {
   string request_id = 1;
 
-  string endpoint = 2;
+  string internal_request_id = 2;
 
   string call_method = 3;
 
@@ -180,6 +192,11 @@ message EndpointSet {
 // language, this message can be replaced.
 message ActorNameList {
   repeated string names = 1;
+}
+
+message DeploymentTargetInfo {
+  repeated string replica_names = 1;
+  bool is_available = 2;
 }
 
 message DeploymentVersion {
@@ -238,8 +255,9 @@ enum DeploymentStatus {
   DEPLOYMENT_STATUS_UPDATING = 0;
   DEPLOYMENT_STATUS_HEALTHY = 1;
   DEPLOYMENT_STATUS_UNHEALTHY = 2;
-  DEPLOYMENT_STATUS_UPSCALING = 3;
-  DEPLOYMENT_STATUS_DOWNSCALING = 4;
+  DEPLOYMENT_STATUS_DEPLOY_FAILED = 3;
+  DEPLOYMENT_STATUS_UPSCALING = 4;
+  DEPLOYMENT_STATUS_DOWNSCALING = 5;
 }
 
 enum DeploymentStatusTrigger {
@@ -306,4 +324,72 @@ message HealthzResponse {
 service RayServeAPIService {
   rpc ListApplications(ListApplicationsRequest) returns (ListApplicationsResponse);
   rpc Healthz(HealthzRequest) returns (HealthzResponse);
+}
+
+// Used for gRPC related tests
+message UserDefinedMessage {
+  string name = 1;
+  string foo = 2;
+  int64 num = 3;
+}
+
+message UserDefinedResponse {
+  string greeting = 1;
+  int64 num_x2 = 2;
+}
+
+message UserDefinedMessage2 {}
+
+message UserDefinedResponse2 {
+  string greeting = 1;
+}
+
+message FruitAmounts {
+  int64 orange = 1;
+  int64 apple = 2;
+  int64 banana = 3;
+}
+
+message FruitCosts {
+  float costs = 1;
+}
+
+service UserDefinedService {
+  rpc __call__(UserDefinedMessage) returns (UserDefinedResponse);
+  rpc Method1(UserDefinedMessage) returns (UserDefinedResponse);
+  rpc Method2(UserDefinedMessage2) returns (UserDefinedResponse2);
+  rpc Streaming(UserDefinedMessage) returns (stream UserDefinedResponse);
+}
+
+service FruitService {
+  rpc FruitStand(FruitAmounts) returns (FruitCosts);
+}
+
+// Used for gRPC benchmark
+message ArrayData {
+  repeated float nums = 1;
+}
+
+message StringData {
+  string data = 1;
+}
+
+message ModelOutput {
+  float output = 1;
+}
+
+service RayServeBenchmarkService {
+  rpc grpc_call(ArrayData) returns (ModelOutput);
+  rpc call_with_string(StringData) returns (ModelOutput);
+}
+
+// The required deployment parameters when deploying an application.
+message DeploymentArgs {
+  string deployment_name = 1;
+  bytes deployment_config = 2;
+  bytes replica_config = 3;
+  string deployer_job_id = 4;
+  optional string route_prefix = 5;
+  bool ingress = 6;
+  optional string docs_path = 7;
 }

--- a/model/ray/v1alpha/user_defined.proto
+++ b/model/ray/v1alpha/user_defined.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package model.model.v1alpha;
+package model.ray.v1alpha;
 
 // Protobuf standard
 import "google/protobuf/struct.proto";

--- a/openapi/v2/conf.proto
+++ b/openapi/v2/conf.proto
@@ -55,7 +55,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   ]
   host: "api.instill-ai.com"
   external_docs: {
-    url: "https://instill-ai.dev/docs"
+    url: "https://www.instill-ai.dev/docs"
     description: "More about Instill AI"
   }
   schemes: HTTPS

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7710,6 +7710,12 @@ definitions:
        - FILE_TYPE_XLSX: XLSX
        - FILE_TYPE_CSV: CSV
     title: file type
+  FruitCosts:
+    type: object
+    properties:
+      costs:
+        type: number
+        format: float
   GetAuthenticatedUserResponse:
     type: object
     properties:
@@ -9388,6 +9394,12 @@ definitions:
         description: Update time.
         readOnly: true
     description: ModelDefinition defines how to configure and import a model.
+  ModelOutput:
+    type: object
+    properties:
+      output:
+        type: number
+        format: float
   ModelRun:
     type: object
     properties:
@@ -11597,6 +11609,19 @@ definitions:
         allOf:
           - $ref: '#/definitions/File'
     title: upload file response
+  UserDefinedResponse:
+    type: object
+    properties:
+      greeting:
+        type: string
+      numX2:
+        type: string
+        format: int64
+  UserDefinedResponse2:
+    type: object
+    properties:
+      greeting:
+        type: string
   UserMembership:
     type: object
     properties:
@@ -12133,4 +12158,4 @@ security:
   - Bearer: []
 externalDocs:
   description: More about Instill AI
-  url: https://instill-ai.dev/docs
+  url: https://www.instill-ai.dev/docs


### PR DESCRIPTION
Because:
- The previous proto files were outdated and didn't match the upstream Ray project
- User-defined services need to be separated for better code organization and maintainability
- Updated plugin versions provide better compatibility and bug fixes

This commit:
- Updates `model/ray/serve.proto` with the latest Ray Serve protocol buffers
- Creates a new `user_defined.proto` file for custom service definitions
- Updates plugin versions in both build configuration files

Note:
- The `buf breaking` CI failure is due to the update of `ray.serve`