### PR TITLE
feat(table): optimize table endpoints

### DIFF
--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -338,12 +338,43 @@ service AgentPublicService {
 
   // Update column definitions
   //
-  // Updates column definitions for a table.
+  // Updates column definitions for a table. When updating the column
+  // definitions, if the column's agent instructions are updated, the existing
+  // cells in that column will be cleared and recomputed. This ensures that all
+  // data reflects the latest instructions.
   rpc UpdateColumnDefinitions(UpdateColumnDefinitionsRequest) returns (UpdateColumnDefinitionsResponse) {
     option (google.api.http) = {
       put: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/column-definitions"
       body: "column_definitions"
     };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Get column definition
+  //
+  // Gets a column definition for a table.
+  rpc GetColumnDefinition(GetColumnDefinitionRequest) returns (GetColumnDefinitionResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/column-definitions/{column_name}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Recompute column
+  //
+  // Recomputes all the cells in a column.
+  rpc RecomputeColumn(RecomputeColumnRequest) returns (RecomputeColumnResponse) {
+    option (google.api.http) = {post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/column-definitions/{column_name}/recompute"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Table"
       extensions: {
@@ -452,6 +483,76 @@ service AgentPublicService {
   rpc MoveRows(MoveRowsRequest) returns (MoveRowsResponse) {
     option (google.api.http) = {
       post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/move-rows"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Update cell
+  //
+  // Updates a cell in a table.
+  rpc UpdateCell(UpdateCellRequest) returns (UpdateCellResponse) {
+    option (google.api.http) = {
+      patch: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}/cells/{cell_uid}"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Reset cell
+  //
+  // Resets a cell in a table. Resetting a cell clears its user input and
+  // reverts to using the computed value if available. This operation only
+  // affects cells that have a user input set.
+  rpc ResetCell(ResetCellRequest) returns (ResetCellResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}/cells/{cell_uid}/reset"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Recompute cell
+  //
+  // Recomputes a cell in a table.
+  rpc RecomputeCell(RecomputeCellRequest) returns (RecomputeCellResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}/cells/{cell_uid}/recompute"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Set cell lock state
+  //
+  // Sets the lock state of a cell in a table.
+  rpc SetCellLockState(SetCellLockStateRequest) returns (SetCellLockStateResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}/cells/{cell_uid}/lock-state"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {

--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -360,7 +360,7 @@ service AgentPublicService {
   //
   // Gets a column definition for a table.
   rpc GetColumnDefinition(GetColumnDefinitionRequest) returns (GetColumnDefinitionResponse) {
-    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/column-definitions/{column_name}"};
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/column-definitions/{column_uid}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Table"
       extensions: {
@@ -374,7 +374,7 @@ service AgentPublicService {
   //
   // Recomputes all the cells in a column.
   rpc RecomputeColumn(RecomputeColumnRequest) returns (RecomputeColumnResponse) {
-    option (google.api.http) = {post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/column-definitions/{column_name}/recompute"};
+    option (google.api.http) = {post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/column-definitions/{column_uid}/recompute"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Table"
       extensions: {

--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -398,6 +398,20 @@ service AgentPublicService {
     };
   }
 
+  // Get row
+  //
+  // Gets a row from a table.
+  rpc GetRow(GetRowRequest) returns (GetRowResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // Insert row
   //
   // Inserts a row into a table.
@@ -494,6 +508,20 @@ service AgentPublicService {
     };
   }
 
+  // Get cell
+  //
+  // Gets a cell from a table.
+  rpc GetCell(GetCellRequest) returns (GetCellResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}/cells/{cell_uid}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // Update cell
   //
   // Updates a cell in a table.
@@ -547,12 +575,29 @@ service AgentPublicService {
     };
   }
 
-  // Set cell lock state
+  // Lock cell
   //
-  // Sets the lock state of a cell in a table.
-  rpc SetCellLockState(SetCellLockStateRequest) returns (SetCellLockStateResponse) {
+  // Locks a cell in a table.
+  rpc LockCell(LockCellRequest) returns (LockCellResponse) {
     option (google.api.http) = {
-      post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}/cells/{cell_uid}/lock-state"
+      post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}/cells/{cell_uid}/lock"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Unlock cell
+  //
+  // Unlocks a cell in a table.
+  rpc UnlockCell(UnlockCellRequest) returns (UnlockCellResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}/cells/{cell_uid}/unlock"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -143,8 +143,11 @@ enum Type {
   // The type is a boolean.
   TYPE_BOOLEAN = 3;
 
-  // The type is a url of a file resource.
+  // The type is a file resource.
   TYPE_FILE = 4;
+
+  // The type is a document resource.
+  TYPE_DOCUMENT = 5;
 }
 
 // ColumnDefinition represents a column definition in a table.

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -176,7 +176,7 @@ message ColumnDefinition {
     bool enable_web_search = 2 [(google.api.field_behavior) = REQUIRED];
 
     // Whether to enable automatic computation for the column.
-    bool enable_automatic_computation = 3 [(google.api.field_behavior) = REQUIRED];
+    optional bool enable_automatic_computation = 3 [(google.api.field_behavior) = OPTIONAL];
 
     // The context for the agent.
     message Context {
@@ -376,10 +376,10 @@ message StringCell {
   ];
 
   // The value of the cell that directly set by the user.
-  string user_input = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional string user_input = 2 [(google.api.field_behavior) = OPTIONAL];
 
   // The value of the cell that was computed by the automatic computation.
-  string computed_value = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional string computed_value = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // NumberCell represents a cell with a number value.
@@ -391,10 +391,10 @@ message NumberCell {
   ];
 
   // The value of the cell that directly set by the user.
-  float user_input = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional float user_input = 2 [(google.api.field_behavior) = OPTIONAL];
 
   // The value of the cell that was computed by the automatic computation.
-  float computed_value = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional float computed_value = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // BooleanCell represents a cell with a boolean value.
@@ -406,10 +406,10 @@ message BooleanCell {
   ];
 
   // The value of the cell that directly set by the user.
-  bool user_input = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional bool user_input = 2 [(google.api.field_behavior) = OPTIONAL];
 
   // The value of the cell that was computed by the automatic computation.
-  bool computed_value = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional bool computed_value = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // FileCell represents a cell with a file resource.
@@ -626,6 +626,27 @@ message MoveRowsRequest {
 // MoveRowsResponse is an empty response for moving multiple rows.
 message MoveRowsResponse {}
 
+// GetCellRequest represents a request to get a cell.
+message GetCellRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table containing the row.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the row containing the cell.
+  string row_uid = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the cell to get.
+  string cell_uid = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetCellResponse contains the requested cell.
+message GetCellResponse {
+  // The cell resource.
+  Cell cell = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // UpdateCellRequest represents a request to update a cell.
 message UpdateCellRequest {
   // The ID of the namespace that owns the table.
@@ -704,8 +725,8 @@ enum LockState {
   LOCK_STATE_UNLOCKED = 2;
 }
 
-// SetCellLockStateRequest represents a request to set the lock state of a cell.
-message SetCellLockStateRequest {
+// LockCellRequest represents a request to lock a cell.
+message LockCellRequest {
   // The ID of the namespace that owns the table.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
 
@@ -715,15 +736,33 @@ message SetCellLockStateRequest {
   // The unique identifier of the row containing the cell.
   string row_uid = 3 [(google.api.field_behavior) = REQUIRED];
 
-  // The unique identifier of the cell to set lock state for.
+  // The unique identifier of the cell to lock.
   string cell_uid = 4 [(google.api.field_behavior) = REQUIRED];
-
-  // The lock state to set.
-  LockState lock_state = 5 [(google.api.field_behavior) = REQUIRED];
 }
 
-// SetCellLockStateResponse contains the updated cell.
-message SetCellLockStateResponse {
+// LockCellResponse is an empty response for locking a cell.
+message LockCellResponse {
+  // The updated cell resource.
+  Cell cell = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// UnlockCellRequest represents a request to unlock a cell.
+message UnlockCellRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table containing the cell.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the row containing the cell.
+  string row_uid = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the cell to unlock.
+  string cell_uid = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UnlockCellResponse is an empty response for unlocking a cell.
+message UnlockCellResponse {
   // The updated cell resource.
   Cell cell = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -218,7 +218,7 @@ message GetColumnDefinitionsRequest {
 
 // GetColumnDefinitionsResponse contains the column definitions.
 message GetColumnDefinitionsResponse {
-  // Map of column names to their definitions.
+  // Map of column uid to their definitions.
   map<string, ColumnDefinition> column_definitions = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
@@ -230,13 +230,13 @@ message UpdateColumnDefinitionsRequest {
   // The UID of the table whose columns to update.
   string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // Map of column names to their new definitions.
+  // Map of column uid to their new definitions.
   map<string, ColumnDefinition> column_definitions = 3;
 }
 
 // UpdateColumnDefinitionsResponse contains the updated column definitions.
 message UpdateColumnDefinitionsResponse {
-  // The updated column definitions.
+  // Map of column uid to the updated definitions.
   map<string, ColumnDefinition> column_definitions = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -218,7 +218,7 @@ message GetColumnDefinitionsRequest {
 
 // GetColumnDefinitionsResponse contains the column definitions.
 message GetColumnDefinitionsResponse {
-  // Map of column uid to their definitions.
+  // Map of column UID to their definitions.
   map<string, ColumnDefinition> column_definitions = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
@@ -230,13 +230,13 @@ message UpdateColumnDefinitionsRequest {
   // The UID of the table whose columns to update.
   string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // Map of column uid to their new definitions.
+  // Map of column UID to their new definitions.
   map<string, ColumnDefinition> column_definitions = 3;
 }
 
 // UpdateColumnDefinitionsResponse contains the updated column definitions.
 message UpdateColumnDefinitionsResponse {
-  // Map of column uid to the updated definitions.
+  // Map of column UID to the updated definitions.
   map<string, ColumnDefinition> column_definitions = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
@@ -453,7 +453,7 @@ message Row {
   // The unique identifier of the row.
   string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Map of column names to their cell values.
+  // Map of column UID to their cell values.
   map<string, Cell> cells = 2 [(google.api.field_behavior) = REQUIRED];
 
   // The order of the row in the table, starting at 1. This determines the row's position

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -167,10 +167,22 @@ message ColumnDefinition {
   // The configuration for the agent.
   message AgentConfig {
     // The instructions for the agent.
-    string instructions = 1;
+    string instructions = 1 [(google.api.field_behavior) = REQUIRED];
 
     // Whether to enable web search for the column.
-    bool enable_web_search = 2;
+    bool enable_web_search = 2 [(google.api.field_behavior) = REQUIRED];
+
+    // Whether to enable automatic computation for the column.
+    bool enable_automatic_computation = 3 [(google.api.field_behavior) = REQUIRED];
+
+    // The context for the agent.
+    message Context {
+      // The column names to include in the context.
+      repeated string columns = 1 [(google.api.field_behavior) = OPTIONAL];
+    }
+
+    // The context for the agent. This setting is only used if enable_automatic_computation is true.
+    Context context = 4 [(google.api.field_behavior) = OPTIONAL];
   }
 
   // The configuration for the agent.
@@ -224,6 +236,39 @@ message UpdateColumnDefinitionsResponse {
   // The updated column definitions.
   map<string, ColumnDefinition> column_definitions = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
+
+// GetColumnDefinitionRequest represents a request to fetch a column definition.
+message GetColumnDefinitionRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table whose column definition to fetch.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The name of the column whose definition to fetch.
+  string column_name = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetColumnDefinitionResponse contains the requested column definition.
+message GetColumnDefinitionResponse {
+  // The column definition.
+  ColumnDefinition column_definition = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// RecomputeColumnRequest represents a request to recompute a column.
+message RecomputeColumnRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table whose column to recompute.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The name of the column to recompute.
+  string column_name = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RecomputeColumnResponse is an empty response for recomputing a column.
+message RecomputeColumnResponse {}
 
 // CellStatus represents the processing state of a cell.
 enum CellStatus {
@@ -284,8 +329,14 @@ message Cell {
     // The value of the cell as a boolean.
     BooleanCell boolean_value = 8 [(google.api.field_behavior) = OPTIONAL];
 
-    // The value of the cell as a url of a file resource.
+    // The value of the cell as a file resource. This can represent various file types
+    // such as images, documents, audio, or other binary data.
     FileCell file_value = 9 [(google.api.field_behavior) = OPTIONAL];
+
+    // The value of the cell as a document resource. The document resource is a
+    // file resource that is specifically designed for document types, such as
+    // TXT, Markdown, PDF, DOC, and PPT.
+    DocumentCell document_value = 10 [(google.api.field_behavior) = OPTIONAL];
   }
 
   // Additional metadata for the cell.
@@ -305,6 +356,9 @@ message Cell {
 
   // The transparency of the cell.
   Transparency transparency = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The lock state of the cell.
+  LockState lock_state = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // NullCell represents a null cell.
@@ -313,27 +367,54 @@ message NullCell {}
 // StringCell represents a cell with a string value.
 message StringCell {
   // The value of the cell as a string.
-  string value = 1 [(google.api.field_behavior) = REQUIRED];
+  string value = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    deprecated = true
+  ];
+
+  // The value of the cell that directly set by the user.
+  string user_input = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // The value of the cell that was computed by the automatic computation.
+  string computed_value = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // NumberCell represents a cell with a number value.
 message NumberCell {
   // The value of the cell as a number.
-  float value = 1 [(google.api.field_behavior) = REQUIRED];
+  float value = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    deprecated = true
+  ];
+
+  // The value of the cell that directly set by the user.
+  float user_input = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // The value of the cell that was computed by the automatic computation.
+  float computed_value = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // BooleanCell represents a cell with a boolean value.
 message BooleanCell {
   // The value of the cell as a boolean.
-  bool value = 1 [(google.api.field_behavior) = REQUIRED];
+  bool value = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    deprecated = true
+  ];
+
+  // The value of the cell that directly set by the user.
+  bool user_input = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // The value of the cell that was computed by the automatic computation.
+  bool computed_value = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// FileCell represents a cell with a url of a file resource.
+// FileCell represents a cell with a file resource.
 message FileCell {
   // The namespace of the file resource.
   string namespace = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // The UID of the file resource.
+  // The File UID of the file resource.
   string file_uid = 2 [(google.api.field_behavior) = REQUIRED];
 
   // The UID of the raw object that the file resource belongs to.
@@ -343,6 +424,24 @@ message FileCell {
   string name = 4 [(google.api.field_behavior) = REQUIRED];
 
   // MIME type of the file.
+  string mime_type = 5 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DocumentCell represents a cell with a document resource.
+message DocumentCell {
+  // The namespace of the document resource.
+  string namespace = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The File UID of the document resource.
+  string file_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the raw object that the document resource belongs to.
+  string object_uid = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // File name
+  string name = 4 [(google.api.field_behavior) = REQUIRED];
+
+  // MIME type of the document.
   string mime_type = 5 [(google.api.field_behavior) = REQUIRED];
 }
 
@@ -440,6 +539,24 @@ message UpdateRowResponse {
   Row row = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// GetRowRequest represents a request to get a row.
+message GetRowRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table containing the row.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the row to get.
+  string row_uid = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetRowResponse contains the requested row.
+message GetRowResponse {
+  // The row resource.
+  Row row = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // UpdateRowsRequest represents a request to update multiple rows.
 message UpdateRowsRequest {
   // The ID of the namespace that owns the table.
@@ -505,6 +622,108 @@ message MoveRowsRequest {
 
 // MoveRowsResponse is an empty response for moving multiple rows.
 message MoveRowsResponse {}
+
+// UpdateCellRequest represents a request to update a cell.
+message UpdateCellRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table containing the row.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the row containing the cell.
+  string row_uid = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the cell to update.
+  string cell_uid = 4 [(google.api.field_behavior) = REQUIRED];
+
+  // The new cell data.
+  Cell cell = 5;
+}
+
+// UpdateCellResponse contains the updated cell.
+message UpdateCellResponse {
+  // The updated cell resource.
+  Cell cell = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// RecomputeCellRequest represents a request to recompute a cell.
+message RecomputeCellRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table containing the cell.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the row containing the cell.
+  string row_uid = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the cell to recompute.
+  string cell_uid = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// RecomputeCellResponse contains the updated cell.
+message RecomputeCellResponse {
+  // The updated cell resource.
+  Cell cell = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ResetCellRequest represents a request to reset a cell.
+message ResetCellRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table containing the cell.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the row containing the cell.
+  string row_uid = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the cell to reset.
+  string cell_uid = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// ResetCellResponse is an empty response for resetting a cell.
+message ResetCellResponse {
+  // The updated cell resource.
+  Cell cell = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// The lock state of a cell.
+enum LockState {
+  // The lock state is not specified.
+  LOCK_STATE_UNSPECIFIED = 0;
+
+  // The cell is locked.
+  LOCK_STATE_LOCKED = 1;
+
+  // The cell is unlocked.
+  LOCK_STATE_UNLOCKED = 2;
+}
+
+// SetCellLockStateRequest represents a request to set the lock state of a cell.
+message SetCellLockStateRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table containing the cell.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the row containing the cell.
+  string row_uid = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The unique identifier of the cell to set lock state for.
+  string cell_uid = 4 [(google.api.field_behavior) = REQUIRED];
+
+  // The lock state to set.
+  LockState lock_state = 5 [(google.api.field_behavior) = REQUIRED];
+}
+
+// SetCellLockStateResponse contains the updated cell.
+message SetCellLockStateResponse {
+  // The updated cell resource.
+  Cell cell = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
 
 // ExportFormat represents the format to export the data in.
 enum ExportFormat {

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -248,8 +248,8 @@ message GetColumnDefinitionRequest {
   // The UID of the table whose column definition to fetch.
   string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // The name of the column whose definition to fetch.
-  string column_name = 3 [(google.api.field_behavior) = REQUIRED];
+  // The UID of the column whose definition to fetch.
+  string column_uid = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetColumnDefinitionResponse contains the requested column definition.
@@ -266,8 +266,8 @@ message RecomputeColumnRequest {
   // The UID of the table whose column to recompute.
   string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // The name of the column to recompute.
-  string column_name = 3 [(google.api.field_behavior) = REQUIRED];
+  // The UID of the column to recompute.
+  string column_uid = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // RecomputeColumnResponse is an empty response for recomputing a column.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -12513,13 +12513,15 @@ definitions:
       - TYPE_NUMBER
       - TYPE_BOOLEAN
       - TYPE_FILE
+      - TYPE_DOCUMENT
     description: |-
       The type of the column.
 
        - TYPE_STRING: The type is a string.
        - TYPE_NUMBER: The type is a number.
        - TYPE_BOOLEAN: The type is a boolean.
-       - TYPE_FILE: The type is a url of a file resource.
+       - TYPE_FILE: The type is a file resource.
+       - TYPE_DOCUMENT: The type is a document resource.
   v1alpha.View:
     type: string
     enum:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -712,7 +712,11 @@ paths:
       x-stage: alpha
     put:
       summary: Update column definitions
-      description: Updates column definitions for a table.
+      description: |-
+        Updates column definitions for a table. When updating the column
+        definitions, if the column's agent instructions are updated, the existing
+        cells in that column will be cleared and recomputed. This ensures that all
+        data reflects the latest instructions.
       operationId: AgentPublicService_UpdateColumnDefinitions
       responses:
         "200":
@@ -745,6 +749,78 @@ paths:
             type: object
             additionalProperties:
               $ref: '#/definitions/ColumnDefinition'
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/column-definitions/{columnName}:
+    get:
+      summary: Get column definition
+      description: Gets a column definition for a table.
+      operationId: AgentPublicService_GetColumnDefinition
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/GetColumnDefinitionResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table whose column definition to fetch.
+          in: path
+          required: true
+          type: string
+        - name: columnName
+          description: The name of the column whose definition to fetch.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/column-definitions/{columnName}/recompute:
+    post:
+      summary: Recompute column
+      description: Recomputes all the cells in a column.
+      operationId: AgentPublicService_RecomputeColumn
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/RecomputeColumnResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table whose column to recompute.
+          in: path
+          required: true
+          type: string
+        - name: columnName
+          description: The name of the column to recompute.
+          in: path
+          required: true
+          type: string
       tags:
         - Table
       x-stage: alpha
@@ -1007,6 +1083,193 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/MoveRowsBody'
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}/cells/{cellUid}:
+    patch:
+      summary: Update cell
+      description: Updates a cell in a table.
+      operationId: AgentPublicService_UpdateCell
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/UpdateCellResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table containing the row.
+          in: path
+          required: true
+          type: string
+        - name: rowUid
+          description: The unique identifier of the row containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: cellUid
+          description: The unique identifier of the cell to update.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateCellBody'
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}/cells/{cellUid}/reset:
+    post:
+      summary: Reset cell
+      description: |-
+        Resets a cell in a table. Resetting a cell clears its user input and
+        reverts to using the computed value if available. This operation only
+        affects cells that have a user input set.
+      operationId: AgentPublicService_ResetCell
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/ResetCellResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: rowUid
+          description: The unique identifier of the row containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: cellUid
+          description: The unique identifier of the cell to reset.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ResetCellBody'
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}/cells/{cellUid}/recompute:
+    post:
+      summary: Recompute cell
+      description: Recomputes a cell in a table.
+      operationId: AgentPublicService_RecomputeCell
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/RecomputeCellResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: rowUid
+          description: The unique identifier of the row containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: cellUid
+          description: The unique identifier of the cell to recompute.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/RecomputeCellBody'
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}/cells/{cellUid}/lock-state:
+    post:
+      summary: Set cell lock state
+      description: Sets the lock state of a cell in a table.
+      operationId: AgentPublicService_SetCellLockState
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/SetCellLockStateResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: rowUid
+          description: The unique identifier of the row containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: cellUid
+          description: The unique identifier of the cell to set lock state for.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/SetCellLockStateBody'
       tags:
         - Table
       x-stage: alpha
@@ -6203,6 +6466,12 @@ definitions:
       value:
         type: boolean
         description: The value of the cell as a boolean.
+      userInput:
+        type: boolean
+        description: The value of the cell that directly set by the user.
+      computedValue:
+        type: boolean
+        description: The value of the cell that was computed by the automatic computation.
     description: BooleanCell represents a cell with a boolean value.
     required:
       - value
@@ -6416,9 +6685,18 @@ definitions:
         allOf:
           - $ref: '#/definitions/BooleanCell'
       fileValue:
-        description: The value of the cell as a url of a file resource.
+        description: |-
+          The value of the cell as a file resource. This can represent various file types
+          such as images, documents, audio, or other binary data.
         allOf:
           - $ref: '#/definitions/FileCell'
+      documentValue:
+        description: |-
+          The value of the cell as a document resource. The document resource is a
+          file resource that is specifically designed for document types, such as
+          TXT, Markdown, PDF, DOC, and PPT.
+        allOf:
+          - $ref: '#/definitions/DocumentCell'
       metadata:
         type: object
         description: Additional metadata for the cell.
@@ -6439,6 +6717,11 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/Transparency'
+      lockState:
+        description: The lock state of the cell.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/LockState'
     description: Cell represents a cell in a table.
   CellStatus:
     type: string
@@ -6755,7 +7038,18 @@ definitions:
       enableWebSearch:
         type: boolean
         description: Whether to enable web search for the column.
+      enableAutomaticComputation:
+        type: boolean
+        description: Whether to enable automatic computation for the column.
+      context:
+        description: The context for the agent. This setting is only used if enable_automatic_computation is true.
+        allOf:
+          - $ref: '#/definitions/Context'
     description: The configuration for the agent.
+    required:
+      - instructions
+      - enableWebSearch
+      - enableAutomaticComputation
   ColumnDefinitionsUpdatedEvent:
     type: object
     properties:
@@ -7152,6 +7446,15 @@ definitions:
        - CONTENT_TYPE_CHUNK: Chunk.
        - CONTENT_TYPE_SUMMARY: Summary.
        - CONTENT_TYPE_AUGMENTED: Augmented.
+  Context:
+    type: object
+    properties:
+      columns:
+        type: array
+        items:
+          type: string
+        description: The column names to include in the context.
+    description: The context for the agent.
   CreateCatalogBody:
     type: object
     properties:
@@ -7429,6 +7732,31 @@ definitions:
   DeployUserModelAdminResponse:
     type: object
     title: DeployUserModelAdminResponse represents a response for a deployed model
+  DocumentCell:
+    type: object
+    properties:
+      namespace:
+        type: string
+        description: The namespace of the document resource.
+      fileUid:
+        type: string
+        description: The File UID of the document resource.
+      objectUid:
+        type: string
+        description: The UID of the raw object that the document resource belongs to.
+      name:
+        type: string
+        title: File name
+      mimeType:
+        type: string
+        description: MIME type of the document.
+    description: DocumentCell represents a cell with a document resource.
+    required:
+      - namespace
+      - fileUid
+      - objectUid
+      - name
+      - mimeType
   Endpoints:
     type: object
     properties:
@@ -7603,7 +7931,7 @@ definitions:
         description: The namespace of the file resource.
       fileUid:
         type: string
-        description: The UID of the file resource.
+        description: The File UID of the file resource.
       objectUid:
         type: string
         description: The UID of the raw object that the file resource belongs to.
@@ -7613,7 +7941,7 @@ definitions:
       mimeType:
         type: string
         description: MIME type of the file.
-    description: FileCell represents a cell with a url of a file resource.
+    description: FileCell represents a cell with a file resource.
     required:
       - namespace
       - fileUid
@@ -7759,6 +8087,15 @@ definitions:
         allOf:
           - $ref: '#/definitions/v1alpha.Chat'
     title: GetChatResponse returns the chat
+  GetColumnDefinitionResponse:
+    type: object
+    properties:
+      columnDefinition:
+        description: The column definition.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/ColumnDefinition'
+    description: GetColumnDefinitionResponse contains the requested column definition.
   GetColumnDefinitionsResponse:
     type: object
     properties:
@@ -9069,6 +9406,16 @@ definitions:
         description: Total number of users.
         readOnly: true
     description: ListUsersResponse contains a list of users.
+  LockState:
+    type: string
+    enum:
+      - LOCK_STATE_LOCKED
+      - LOCK_STATE_UNLOCKED
+    description: |-
+      The lock state of a cell.
+
+       - LOCK_STATE_LOCKED: The cell is locked.
+       - LOCK_STATE_UNLOCKED: The cell is unlocked.
   LookUpConnectionAdminResponse:
     type: object
     properties:
@@ -9595,6 +9942,14 @@ definitions:
         type: number
         format: float
         description: The value of the cell as a number.
+      userInput:
+        type: number
+        format: float
+        description: The value of the cell that directly set by the user.
+      computedValue:
+        type: number
+        format: float
+        description: The value of the cell that was computed by the automatic computation.
     description: NumberCell represents a cell with a number value.
     required:
       - value
@@ -10289,6 +10644,21 @@ definitions:
           $ref: '#/definitions/SimilarityChunk'
         title: chunks
     title: QuestionAnsweringResponse
+  RecomputeCellBody:
+    type: object
+    description: RecomputeCellRequest represents a request to recompute a cell.
+  RecomputeCellResponse:
+    type: object
+    properties:
+      cell:
+        description: The updated cell resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Cell'
+    description: RecomputeCellResponse contains the updated cell.
+  RecomputeColumnResponse:
+    type: object
+    description: RecomputeColumnResponse is an empty response for recomputing a column.
   Region:
     type: object
     properties:
@@ -10368,6 +10738,18 @@ definitions:
     description: |-
       RepositoryTag contains information about the version of some content in a
       repository.
+  ResetCellBody:
+    type: object
+    description: ResetCellRequest represents a request to reset a cell.
+  ResetCellResponse:
+    type: object
+    properties:
+      cell:
+        description: The updated cell resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Cell'
+    description: ResetCellResponse is an empty response for resetting a cell.
   Role:
     type: string
     enum:
@@ -10541,6 +10923,25 @@ definitions:
         type: string
         title: Description
     description: API secrets allow users to make requests to the Instill AI API.
+  SetCellLockStateBody:
+    type: object
+    properties:
+      lockState:
+        description: The lock state to set.
+        allOf:
+          - $ref: '#/definitions/LockState'
+    description: SetCellLockStateRequest represents a request to set the lock state of a cell.
+    required:
+      - lockState
+  SetCellLockStateResponse:
+    type: object
+    properties:
+      cell:
+        description: The updated cell resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Cell'
+    description: SetCellLockStateResponse contains the updated cell.
   ShareCode:
     type: object
     properties:
@@ -10725,6 +11126,12 @@ definitions:
       value:
         type: string
         description: The value of the cell as a string.
+      userInput:
+        type: string
+        description: The value of the cell that directly set by the user.
+      computedValue:
+        type: string
+        description: The value of the cell that was computed by the automatic computation.
     description: StringCell represents a cell with a string value.
     required:
       - value
@@ -11409,6 +11816,23 @@ definitions:
         allOf:
           - $ref: '#/definitions/Catalog'
     description: UpdateCatalogResponse represents a response for updating a catalog.
+  UpdateCellBody:
+    type: object
+    properties:
+      cell:
+        description: The new cell data.
+        allOf:
+          - $ref: '#/definitions/Cell'
+    description: UpdateCellRequest represents a request to update a cell.
+  UpdateCellResponse:
+    type: object
+    properties:
+      cell:
+        description: The updated cell resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Cell'
+    description: UpdateCellResponse contains the updated cell.
   UpdateChatBody:
     type: object
     properties:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -975,6 +975,41 @@ paths:
         - Table
       x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}:
+    get:
+      summary: Get row
+      description: Gets a row from a table.
+      operationId: AgentPublicService_GetRow
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/GetRowResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table containing the row.
+          in: path
+          required: true
+          type: string
+        - name: rowUid
+          description: The unique identifier of the row to get.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Table
+      x-stage: alpha
     delete:
       summary: Delete row
       description: Deletes a row from a table.
@@ -1087,6 +1122,46 @@ paths:
         - Table
       x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}/cells/{cellUid}:
+    get:
+      summary: Get cell
+      description: Gets a cell from a table.
+      operationId: AgentPublicService_GetCell
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/GetCellResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table containing the row.
+          in: path
+          required: true
+          type: string
+        - name: rowUid
+          description: The unique identifier of the row containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: cellUid
+          description: The unique identifier of the cell to get.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Table
+      x-stage: alpha
     patch:
       summary: Update cell
       description: Updates a cell in a table.
@@ -1227,16 +1302,16 @@ paths:
       tags:
         - Table
       x-stage: alpha
-  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}/cells/{cellUid}/lock-state:
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}/cells/{cellUid}/lock:
     post:
-      summary: Set cell lock state
-      description: Sets the lock state of a cell in a table.
-      operationId: AgentPublicService_SetCellLockState
+      summary: Lock cell
+      description: Locks a cell in a table.
+      operationId: AgentPublicService_LockCell
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/SetCellLockStateResponse'
+            $ref: '#/definitions/LockCellResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -1261,7 +1336,7 @@ paths:
           required: true
           type: string
         - name: cellUid
-          description: The unique identifier of the cell to set lock state for.
+          description: The unique identifier of the cell to lock.
           in: path
           required: true
           type: string
@@ -1269,7 +1344,53 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/SetCellLockStateBody'
+            $ref: '#/definitions/LockCellBody'
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}/cells/{cellUid}/unlock:
+    post:
+      summary: Unlock cell
+      description: Unlocks a cell in a table.
+      operationId: AgentPublicService_UnlockCell
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/UnlockCellResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: rowUid
+          description: The unique identifier of the row containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: cellUid
+          description: The unique identifier of the cell to unlock.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/UnlockCellBody'
       tags:
         - Table
       x-stage: alpha
@@ -6472,6 +6593,7 @@ definitions:
       computedValue:
         type: boolean
         description: The value of the cell that was computed by the automatic computation.
+        readOnly: true
     description: BooleanCell represents a cell with a boolean value.
     required:
       - value
@@ -7049,7 +7171,6 @@ definitions:
     required:
       - instructions
       - enableWebSearch
-      - enableAutomaticComputation
   ColumnDefinitionsUpdatedEvent:
     type: object
     properties:
@@ -8070,6 +8191,15 @@ definitions:
         allOf:
           - $ref: '#/definitions/File'
     description: GetCatalogFileResponse represents a response for getting a catalog file.
+  GetCellResponse:
+    type: object
+    properties:
+      cell:
+        description: The cell resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Cell'
+    description: GetCellResponse contains the requested cell.
   GetChatFileResponse:
     type: object
     properties:
@@ -8407,6 +8537,15 @@ definitions:
         allOf:
           - $ref: '#/definitions/RepositoryTag'
     description: GetRepositoryTagResponse contains the created tag.
+  GetRowResponse:
+    type: object
+    properties:
+      row:
+        description: The row resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Row'
+    description: GetRowResponse contains the requested row.
   GetSourceFileResponse:
     type: object
     properties:
@@ -9406,6 +9545,18 @@ definitions:
         description: Total number of users.
         readOnly: true
     description: ListUsersResponse contains a list of users.
+  LockCellBody:
+    type: object
+    description: LockCellRequest represents a request to lock a cell.
+  LockCellResponse:
+    type: object
+    properties:
+      cell:
+        description: The updated cell resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Cell'
+    description: LockCellResponse is an empty response for locking a cell.
   LockState:
     type: string
     enum:
@@ -9950,6 +10101,7 @@ definitions:
         type: number
         format: float
         description: The value of the cell that was computed by the automatic computation.
+        readOnly: true
     description: NumberCell represents a cell with a number value.
     required:
       - value
@@ -10923,25 +11075,6 @@ definitions:
         type: string
         title: Description
     description: API secrets allow users to make requests to the Instill AI API.
-  SetCellLockStateBody:
-    type: object
-    properties:
-      lockState:
-        description: The lock state to set.
-        allOf:
-          - $ref: '#/definitions/LockState'
-    description: SetCellLockStateRequest represents a request to set the lock state of a cell.
-    required:
-      - lockState
-  SetCellLockStateResponse:
-    type: object
-    properties:
-      cell:
-        description: The updated cell resource.
-        readOnly: true
-        allOf:
-          - $ref: '#/definitions/Cell'
-    description: SetCellLockStateResponse contains the updated cell.
   ShareCode:
     type: object
     properties:
@@ -11796,6 +11929,18 @@ definitions:
   UndeployUserModelAdminResponse:
     type: object
     title: UndeployUserModelAdminResponse represents a response for a undeployed model
+  UnlockCellBody:
+    type: object
+    description: UnlockCellRequest represents a request to unlock a cell.
+  UnlockCellResponse:
+    type: object
+    properties:
+      cell:
+        description: The updated cell resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Cell'
+    description: UnlockCellResponse is an empty response for unlocking a cell.
   UpdateCatalogBody:
     type: object
     properties:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -742,7 +742,7 @@ paths:
           required: true
           type: string
         - name: columnDefinitions
-          description: Map of column names to their new definitions.
+          description: Map of column uid to their new definitions.
           in: body
           required: true
           schema:
@@ -8233,7 +8233,7 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/ColumnDefinition'
-        description: Map of column names to their definitions.
+        description: Map of column uid to their definitions.
         readOnly: true
     description: GetColumnDefinitionsResponse contains the column definitions.
   GetFileCatalogResponse:
@@ -12023,7 +12023,7 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/ColumnDefinition'
-        description: The updated column definitions.
+        description: Map of column uid to the updated definitions.
         readOnly: true
     description: UpdateColumnDefinitionsResponse contains the updated column definitions.
   UpdateMessageBody:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -742,7 +742,7 @@ paths:
           required: true
           type: string
         - name: columnDefinitions
-          description: Map of column uid to their new definitions.
+          description: Map of column UID to their new definitions.
           in: body
           required: true
           schema:
@@ -8233,7 +8233,7 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/ColumnDefinition'
-        description: Map of column uid to their definitions.
+        description: Map of column UID to their definitions.
         readOnly: true
     description: GetColumnDefinitionsResponse contains the column definitions.
   GetFileCatalogResponse:
@@ -10923,7 +10923,7 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/Cell'
-        description: Map of column names to their cell values.
+        description: Map of column UID to their cell values.
       order:
         type: integer
         format: int32
@@ -12023,7 +12023,7 @@ definitions:
         type: object
         additionalProperties:
           $ref: '#/definitions/ColumnDefinition'
-        description: Map of column uid to the updated definitions.
+        description: Map of column UID to the updated definitions.
         readOnly: true
     description: UpdateColumnDefinitionsResponse contains the updated column definitions.
   UpdateMessageBody:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -752,7 +752,7 @@ paths:
       tags:
         - Table
       x-stage: alpha
-  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/column-definitions/{columnName}:
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/column-definitions/{columnUid}:
     get:
       summary: Get column definition
       description: Gets a column definition for a table.
@@ -780,15 +780,15 @@ paths:
           in: path
           required: true
           type: string
-        - name: columnName
-          description: The name of the column whose definition to fetch.
+        - name: columnUid
+          description: The UID of the column whose definition to fetch.
           in: path
           required: true
           type: string
       tags:
         - Table
       x-stage: alpha
-  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/column-definitions/{columnName}/recompute:
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/column-definitions/{columnUid}/recompute:
     post:
       summary: Recompute column
       description: Recomputes all the cells in a column.
@@ -816,8 +816,8 @@ paths:
           in: path
           required: true
           type: string
-        - name: columnName
-          description: The name of the column to recompute.
+        - name: columnUid
+          description: The UID of the column to recompute.
           in: path
           required: true
           type: string


### PR DESCRIPTION
Because:

- We need to introduce new features — for example, more detailed control over column auto-computation, allowing users to fine-tune cell-level behavior.
- We used the column name as the key for the column definition map and the cell map. This isn’t ideal, since the column name might change.

This commit:

- Optimizes table endpoints.
- Uses column UID as the key of column definition map and the cell map.