### PR TITLE
chore(agent): add object UID for chat

### DIFF
--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -33,7 +33,10 @@ message Chat {
   // chat delete time.
   google.protobuf.Timestamp delete_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
   // catalog id
-  string catalog_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string catalog_id = 8 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    deprecated = true
+  ];
 }
 
 // type of the citations message
@@ -116,7 +119,10 @@ message CreateChatRequest {
   // agent config
   AgentConfig agent_config = 3 [(google.api.field_behavior) = OPTIONAL];
   // catalog id
-  string catalog_id = 4 [(google.api.field_behavior) = OPTIONAL];
+  string catalog_id = 4 [
+    (google.api.field_behavior) = OPTIONAL,
+    deprecated = true
+  ];
 }
 
 // CreateChatResponse returns the created chat
@@ -295,9 +301,14 @@ message ChatRequest {
   // User message
   string message = 3 [(google.api.field_behavior) = REQUIRED];
   // file UIDs
-  repeated string file_uids = 4 [(google.api.field_behavior) = OPTIONAL];
+  repeated string file_uids = 4 [
+    (google.api.field_behavior) = OPTIONAL,
+    deprecated = true
+  ];
   // Whether to enable web search for the chat.
   bool enable_web_search = 5 [(google.api.field_behavior) = OPTIONAL];
+  // object UIDs
+  repeated string object_uids = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ChatResponse contains the chatbot response.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6290,6 +6290,11 @@ definitions:
       enableWebSearch:
         type: boolean
         description: Whether to enable web search for the chat.
+      objectUids:
+        type: array
+        items:
+          type: string
+        title: object UIDs
     description: |-
       ChatRequest represents a request to send a message
       to a chatbot synchronously and streams back the results.


### PR DESCRIPTION
Because

- Currently, the chat API accepts a file UID as input, but this requires the frontend to bind the file to the catalog first. We’d like to simplify this flow so that the frontend doesn’t need to manage the catalog. Therefore, we need to allow users to send the file using an object UID, which doesn’t need to be bound to the catalog.

This commit

- Uses the object UID as input.