### PR TITLE
chore(table): use column uids to set column context

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -180,8 +180,8 @@ message ColumnDefinition {
 
     // The context for the agent.
     message Context {
-      // The column names to include in the context.
-      repeated string columns = 1 [(google.api.field_behavior) = OPTIONAL];
+      // The column uids to include in the context.
+      repeated string column_uids = 1 [(google.api.field_behavior) = OPTIONAL];
     }
 
     // The context for the agent. This setting is only used if enable_automatic_computation is true.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7575,11 +7575,11 @@ definitions:
   Context:
     type: object
     properties:
-      columns:
+      columnUids:
         type: array
         items:
           type: string
-        description: The column names to include in the context.
+        description: The column uids to include in the context.
     description: The context for the agent.
   CreateCatalogBody:
     type: object


### PR DESCRIPTION
Because

- We want to use UIDs as the column identifiers

This commit:

- Uses column UIDs to set the column context