### PR TITLE
chore(table): add draft_mode field to the table message

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -35,11 +35,14 @@ message Table {
   // The configuration for the agent.
   message AgentConfig {
     // Whether to enable transparency for the table.
-    bool enable_transparency = 1;
+    bool enable_transparency = 1 [(google.api.field_behavior) = REQUIRED];
   }
 
   // The configuration for the agent.
-  AgentConfig agent_config = 8;
+  AgentConfig agent_config = 8 [(google.api.field_behavior) = REQUIRED];
+
+  // Whether to enable draft mode for the table.
+  bool draft_mode = 9 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListTablesRequest represents a request to list tables.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -11615,10 +11615,15 @@ definitions:
         description: The configuration for the agent.
         allOf:
           - $ref: '#/definitions/Table.AgentConfig'
+      draftMode:
+        type: boolean
+        description: Whether to enable draft mode for the table.
     description: Table represents a table resource.
     required:
       - id
       - title
+      - agentConfig
+      - draftMode
   Table.AgentConfig:
     type: object
     properties:
@@ -11626,6 +11631,8 @@ definitions:
         type: boolean
         description: Whether to enable transparency for the table.
     description: The configuration for the agent.
+    required:
+      - enableTransparency
   TableDeletedEvent:
     type: object
     description: TableDeletedEvent represents an event for a table being deleted.


### PR DESCRIPTION
Because

- The table will support draft mode for constructing the schema without data.

This commit

- Adds the `draft_mode` field to the table message.