### PR TITLE
chore(chat): return message metadata in streaming

### DIFF
--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -330,6 +330,12 @@ message ChatEvent {
 
     // The chat ended.
     ChatEndedEvent chat_ended_event = 12;
+
+    // The chat attachments were updated.
+    ChatAttachmentsUpdatedEvent chat_attachments_updated_event = 13;
+
+    // The chat context was updated.
+    ChatContextUpdatedEvent chat_context_updated_event = 14;
   }
 }
 
@@ -383,6 +389,22 @@ message ChatCitationListUpdatedEvent {
     (google.api.field_behavior) = OUTPUT_ONLY,
     (google.api.field_behavior) = REQUIRED
   ];
+}
+
+// ChatAttachmentsUpdatedEvent represents an event for a attachment list output
+message ChatAttachmentsUpdatedEvent {
+  // The time when attachment list updated
+  google.protobuf.Timestamp create_time = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The attachments
+  ChatAttachments attachments = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ChatContextUpdatedEvent represents an event for a context updated
+message ChatContextUpdatedEvent {
+  // The time when context updated
+  google.protobuf.Timestamp create_time = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The context
+  ChatContext context = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ChatTableCreatedEvent represents an event for a table creation

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6896,6 +6896,20 @@ definitions:
         title: file urls (only for user messages)
         readOnly: true
     title: ChatAttachments represents the attachment for the message
+  ChatAttachmentsUpdatedEvent:
+    type: object
+    properties:
+      createTime:
+        type: string
+        format: date-time
+        title: The time when attachment list updated
+        readOnly: true
+      attachments:
+        title: The attachments
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/ChatAttachments'
+    title: ChatAttachmentsUpdatedEvent represents an event for a attachment list output
   ChatCitationListUpdatedEvent:
     type: object
     properties:
@@ -6923,6 +6937,20 @@ definitions:
           type: string
         description: The table uids to include in the context.
     description: The context for the message.
+  ChatContextUpdatedEvent:
+    type: object
+    properties:
+      createTime:
+        type: string
+        format: date-time
+        title: The time when context updated
+        readOnly: true
+      context:
+        title: The context
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/ChatContext'
+    title: ChatContextUpdatedEvent represents an event for a context updated
   ChatDebugOutputUpdatedEvent:
     type: object
     properties:
@@ -7017,6 +7045,14 @@ definitions:
         description: The chat ended.
         allOf:
           - $ref: '#/definitions/ChatEndedEvent'
+      chatAttachmentsUpdatedEvent:
+        description: The chat attachments were updated.
+        allOf:
+          - $ref: '#/definitions/ChatAttachmentsUpdatedEvent'
+      chatContextUpdatedEvent:
+        description: The chat context was updated.
+        allOf:
+          - $ref: '#/definitions/ChatContextUpdatedEvent'
     description: ChatEvent represents an event for a chat.
   ChatNameUpdatedEvent:
     type: object


### PR DESCRIPTION
Because

- we need to return message metadata so that users can see it in the chat stream

This commit

- returns metadata in chat stream.