### PR TITLE
chore(table): remove table ID

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -14,8 +14,8 @@ message Table {
   // The unique identifier of the table.
   string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // The ID of the table.
-  string id = 2 [(google.api.field_behavior) = REQUIRED];
+  // Removed, the ID of the table.
+  reserved 2;
 
   // The title of the table.
   string title = 3 [(google.api.field_behavior) = REQUIRED];

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -11677,9 +11677,6 @@ definitions:
         type: string
         description: The unique identifier of the table.
         readOnly: true
-      id:
-        type: string
-        description: The ID of the table.
       title:
         type: string
         description: The title of the table.
@@ -11708,7 +11705,6 @@ definitions:
         description: Whether to enable draft mode for the table.
     description: Table represents a table resource.
     required:
-      - id
       - title
       - agentConfig
       - draftMode


### PR DESCRIPTION
Because

- We are not using the table ID for any purpose, and it’s not user-friendly, we’ll keep only the UID and title.

This commit

- Removes the table ID.