### PR TITLE
chore(table): add column selection config

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -249,6 +249,45 @@ message ColumnDefinition {
     // Format for number type columns.
     NumberFormat number_format = 8 [(google.api.field_behavior) = OPTIONAL];
   }
+
+  // The selection settings of the column.
+  message Selection {
+    // The type of the selection.
+    enum SelectionType {
+      // The selection is not specified.
+      SELECTION_TYPE_UNSPECIFIED = 0;
+
+      // No selection.
+      SELECTION_TYPE_NONE = 1;
+
+      // The selection is a single value.
+      SELECTION_TYPE_SINGLE = 2;
+    }
+
+    // An option for the selection.
+    message Option {
+      // The value of the cell as a string.
+      oneof value {
+        // The value of the cell as a string.
+        string string_value = 1 [(google.api.field_behavior) = OPTIONAL];
+
+        // The value of the cell as a number.
+        float number_value = 2 [(google.api.field_behavior) = OPTIONAL];
+      }
+
+      // Display color of the option.
+      string color = 3 [(google.api.field_behavior) = OPTIONAL];
+    }
+
+    // The selection of the column.
+    SelectionType type = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // The options for the selection.
+    repeated Option options = 2 [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // The selection settings of the column.
+  Selection selection = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetColumnDefinitionsRequest represents a request to fetch column definitions.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7486,6 +7486,10 @@ definitions:
         description: Format for number type columns.
         allOf:
           - $ref: '#/definitions/NumberFormat'
+      selection:
+        description: The selection settings of the column.
+        allOf:
+          - $ref: '#/definitions/Selection'
     description: ColumnDefinition represents a column definition in a table.
     required:
       - type
@@ -10598,6 +10602,20 @@ definitions:
        - ONBOARDING_STATUS_IN_PROGRESS: In progress, i.e., the user has initiated the onboarding process
       but has not yet completed it.
        - ONBOARDING_STATUS_COMPLETED: Completed.
+  Option:
+    type: object
+    properties:
+      stringValue:
+        type: string
+        description: The value of the cell as a string.
+      numberValue:
+        type: number
+        format: float
+        description: The value of the cell as a number.
+      color:
+        type: string
+        description: Display color of the option.
+    description: An option for the selection.
   Organization:
     type: object
     properties:
@@ -11444,6 +11462,32 @@ definitions:
         type: string
         title: Description
     description: API secrets allow users to make requests to the Instill AI API.
+  Selection:
+    type: object
+    properties:
+      type:
+        description: The selection of the column.
+        allOf:
+          - $ref: '#/definitions/SelectionType'
+      options:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/Option'
+        description: The options for the selection.
+    description: The selection settings of the column.
+    required:
+      - type
+  SelectionType:
+    type: string
+    enum:
+      - SELECTION_TYPE_NONE
+      - SELECTION_TYPE_SINGLE
+    description: |-
+      The type of the selection.
+
+       - SELECTION_TYPE_NONE: No selection.
+       - SELECTION_TYPE_SINGLE: The selection is a single value.
   ShareCode:
     type: object
     properties:


### PR DESCRIPTION
Because

- users will want to set up the available values for the columns.

this commit

- adds column selection configuration.