### PR TITLE
chore(table): return file_url in file cell object

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -498,19 +498,25 @@ message BooleanCell {
 // FileCell represents a cell with a file resource.
 message FileCell {
   // The namespace of the file resource.
-  string namespace = 1 [(google.api.field_behavior) = REQUIRED];
+  string namespace = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The File UID of the file resource.
-  string file_uid = 2 [(google.api.field_behavior) = REQUIRED];
+  string file_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The UID of the raw object that the file resource belongs to.
   string object_uid = 3 [(google.api.field_behavior) = REQUIRED];
 
   // File name
-  string name = 4 [(google.api.field_behavior) = REQUIRED];
+  string name = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // MIME type of the file.
-  string mime_type = 5 [(google.api.field_behavior) = REQUIRED];
+  string mime_type = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The catalog ID of the file resource.
+  string catalog_id = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The URL of the file resource.
+  string file_url = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // DocumentCell represents a cell with a document resource.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -8361,25 +8361,33 @@ definitions:
       namespace:
         type: string
         description: The namespace of the file resource.
+        readOnly: true
       fileUid:
         type: string
         description: The File UID of the file resource.
+        readOnly: true
       objectUid:
         type: string
         description: The UID of the raw object that the file resource belongs to.
       name:
         type: string
         title: File name
+        readOnly: true
       mimeType:
         type: string
         description: MIME type of the file.
+        readOnly: true
+      catalogId:
+        type: string
+        description: The catalog ID of the file resource.
+        readOnly: true
+      fileUrl:
+        type: string
+        description: The URL of the file resource.
+        readOnly: true
     description: FileCell represents a cell with a file resource.
     required:
-      - namespace
-      - fileUid
       - objectUid
-      - name
-      - mimeType
   FileMediaType:
     type: string
     enum:


### PR DESCRIPTION
Because

- The console needs the full URL path to the file for preview.

This commit

- Returns file_url in the file cell object.