### PR TITLE
chore(model,ray): rename user defined service

### DIFF
--- a/model/ray/README.md
+++ b/model/ray/README.md
@@ -1,0 +1,3 @@
+# Ray Protobuf
+
+This directory contains Ray Serve protocol buffer and custom user defined service.

--- a/model/ray/v1alpha/user_defined.proto
+++ b/model/ray/v1alpha/user_defined.proto
@@ -17,8 +17,8 @@ message CallResponse {
   repeated google.protobuf.Struct task_outputs = 1;
 }
 
-// Ray user defined service for internal process
-service RayUserDefinedService {
+// User defined service for internal process
+service UserDefinedService {
   // Trigger method is the default trigger entry for ray deployment
   // Ray doesn't comply with the naming convention of protobuf, so we need to
   // buf:lint:ignore RPC_PASCAL_CASE


### PR DESCRIPTION
Because

- prefer stick with default naming as in Ray document

This commit

- rename the custom Ray service
