### PR TITLE
chore(table): make the table title optional

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -18,7 +18,9 @@ message Table {
   reserved 2;
 
   // The title of the table.
-  string title = 3 [(google.api.field_behavior) = REQUIRED];
+  // If the table is in draft mode, the title is optional.
+  // If the table is not in draft mode, the title is required.
+  string title = 3 [(google.api.field_behavior) = OPTIONAL];
 
   // A description of the table.
   string description = 4 [(google.api.field_behavior) = OPTIONAL];

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -11770,7 +11770,10 @@ definitions:
         readOnly: true
       title:
         type: string
-        description: The title of the table.
+        description: |-
+          The title of the table.
+          If the table is in draft mode, the title is optional.
+          If the table is not in draft mode, the title is required.
       description:
         type: string
         description: A description of the table.
@@ -11796,7 +11799,6 @@ definitions:
         description: Whether to enable draft mode for the table.
     description: Table represents a table resource.
     required:
-      - title
       - agentConfig
       - draftMode
   Table.AgentConfig:


### PR DESCRIPTION
Because

- The table title can be optional when draft mode is enabled.

This commit

- Makes the table title optional.