### PR TITLE
chore(table): add table template endpoints

### DIFF
--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -238,6 +238,23 @@ service AgentPublicService {
     };
   }
 
+  // Create a table from a table template
+  //
+  // Creates a table from a table template.
+  rpc CreateTableFromTemplate(CreateTableFromTemplateRequest) returns (CreateTableFromTemplateResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/tables/from-template"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // Create a table
   //
   // Creates a table.

--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -196,6 +196,34 @@ service AgentPublicService {
     };
   }
 
+  // List table templates
+  //
+  // Returns a paginated list of table templates.
+  rpc ListTableTemplates(ListTableTemplatesRequest) returns (ListTableTemplatesResponse) {
+    option (google.api.http) = {get: "/v1alpha/table-templates"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Get table template
+  //
+  // Returns a table template.
+  rpc GetTableTemplate(GetTableTemplateRequest) returns (GetTableTemplateResponse) {
+    option (google.api.http) = {get: "/v1alpha/table-templates/{table_template_uid}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // List tables
   //
   // Returns a paginated list of tables.

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -75,6 +75,24 @@ message GetTableTemplateResponse {
   Table table_template = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// CreateTableFromTemplateRequest represents a request to create a table from a table template.
+message CreateTableFromTemplateRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the table template to create the table from.
+  string table_template_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The title of the table.
+  string title = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CreateTableFromTemplateResponse contains the created table.
+message CreateTableFromTemplateResponse {
+  // The created table.
+  Table table = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // ListTablesRequest represents a request to list tables.
 message ListTablesRequest {
   // The ID of the namespace that owns the tables.

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -47,6 +47,34 @@ message Table {
   bool draft_mode = 9 [(google.api.field_behavior) = REQUIRED];
 }
 
+// ListTableTemplatesRequest represents a request to list table templates.
+message ListTableTemplatesRequest {
+  // The page token for pagination.
+  string page_token = 1 [(google.api.field_behavior) = OPTIONAL];
+
+  // The maximum number of table templates to return.
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListTableTemplatesResponse contains the list of table templates.
+message ListTableTemplatesResponse {
+  // The list of table templates.
+  repeated Table table_templates = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetTableTemplateRequest represents a request to get a table template.
+message GetTableTemplateRequest {
+  // The UID of the table template to get.
+  string table_template_uid = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TableTemplate represents a table template.
+// GetTableTemplateResponse contains the requested table template.
+message GetTableTemplateResponse {
+  // The table template.
+  Table table_template = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // ListTablesRequest represents a request to list tables.
 message ListTablesRequest {
   // The ID of the namespace that owns the tables.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -404,6 +404,64 @@ paths:
       tags:
         - Table
       x-stage: alpha
+  /v1alpha/table-templates:
+    get:
+      summary: List table templates
+      description: Returns a paginated list of table templates.
+      operationId: AgentPublicService_ListTableTemplates
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/ListTableTemplatesResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: pageToken
+          description: The page token for pagination.
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          description: The maximum number of table templates to return.
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/table-templates/{tableTemplateUid}:
+    get:
+      summary: Get table template
+      description: Returns a table template.
+      operationId: AgentPublicService_GetTableTemplate
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/GetTableTemplateResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: tableTemplateUid
+          description: The UID of the table template to get.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Table
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/tables:
     get:
       summary: List tables
@@ -8906,6 +8964,17 @@ definitions:
         allOf:
           - $ref: '#/definitions/Table'
     description: GetTableResponse contains the requested table.
+  GetTableTemplateResponse:
+    type: object
+    properties:
+      tableTemplate:
+        description: The table template.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Table'
+    description: |-
+      TableTemplate represents a table template.
+      GetTableTemplateResponse contains the requested table template.
   GetTokenResponse:
     type: object
     properties:
@@ -9820,6 +9889,17 @@ definitions:
         title: message sender profiles
         readOnly: true
     title: ListTableBuilderAgentMessagesResponse returns a list of messages
+  ListTableTemplatesResponse:
+    type: object
+    properties:
+      tableTemplates:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/Table'
+        description: The list of table templates.
+        readOnly: true
+    description: ListTableTemplatesResponse contains the list of table templates.
   ListTablesResponse:
     type: object
     properties:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -532,6 +532,37 @@ paths:
       tags:
         - Table
       x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/from-template:
+    post:
+      summary: Create a table from a table template
+      description: Creates a table from a table template.
+      operationId: AgentPublicService_CreateTableFromTemplate
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/CreateTableFromTemplateResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/CreateTableFromTemplateBody'
+      tags:
+        - Table
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/tables/{tableUid}:
     get:
       summary: Get table
@@ -8089,6 +8120,28 @@ definitions:
         allOf:
           - $ref: '#/definitions/RepositoryTag'
     description: CreateRepositoryTagResponse contains the created tag.
+  CreateTableFromTemplateBody:
+    type: object
+    properties:
+      tableTemplateUid:
+        type: string
+        description: The UID of the table template to create the table from.
+      title:
+        type: string
+        description: The title of the table.
+    description: CreateTableFromTemplateRequest represents a request to create a table from a table template.
+    required:
+      - tableTemplateUid
+      - title
+  CreateTableFromTemplateResponse:
+    type: object
+    properties:
+      table:
+        description: The created table.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Table'
+    description: CreateTableFromTemplateResponse contains the created table.
   CreateTableResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- We’d like to provide the table template feature so that users can easily create tables from templates.

This commit

- Adds table template endpoints.