### PR TITLE
chore(table): remove page token param from table template endpoint

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -48,13 +48,7 @@ message Table {
 }
 
 // ListTableTemplatesRequest represents a request to list table templates.
-message ListTableTemplatesRequest {
-  // The page token for pagination.
-  string page_token = 1 [(google.api.field_behavior) = OPTIONAL];
-
-  // The maximum number of table templates to return.
-  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
-}
+message ListTableTemplatesRequest {}
 
 // ListTableTemplatesResponse contains the list of table templates.
 message ListTableTemplatesResponse {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -421,18 +421,6 @@ paths:
           description: An unexpected error response.
           schema:
             $ref: '#/definitions/rpc.Status'
-      parameters:
-        - name: pageToken
-          description: The page token for pagination.
-          in: query
-          required: false
-          type: string
-        - name: pageSize
-          description: The maximum number of table templates to return.
-          in: query
-          required: false
-          type: integer
-          format: int32
       tags:
         - Table
       x-stage: alpha


### PR DESCRIPTION
Because

- the number of templates is limited, we don't need pagination for this API.

This commit

- remove page token param from table template endpoint.
