### PR TITLE
chore(table): refactor template endpoints

### DIFF
--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -196,34 +196,6 @@ service AgentPublicService {
     };
   }
 
-  // List table templates
-  //
-  // Returns a paginated list of table templates.
-  rpc ListTableTemplates(ListTableTemplatesRequest) returns (ListTableTemplatesResponse) {
-    option (google.api.http) = {get: "/v1alpha/table-templates"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Table"
-      extensions: {
-        key: "x-stage"
-        value: {string_value: "alpha"}
-      }
-    };
-  }
-
-  // Get table template
-  //
-  // Returns a table template.
-  rpc GetTableTemplate(GetTableTemplateRequest) returns (GetTableTemplateResponse) {
-    option (google.api.http) = {get: "/v1alpha/table-templates/{table_template_uid}"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "Table"
-      extensions: {
-        key: "x-stage"
-        value: {string_value: "alpha"}
-      }
-    };
-  }
-
   // List tables
   //
   // Returns a paginated list of tables.

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -45,6 +45,15 @@ message Table {
 
   // Whether to enable draft mode for the table.
   bool draft_mode = 9 [(google.api.field_behavior) = REQUIRED];
+
+  // Permission defines how a table can be used.
+  message Permission {
+    // Defines whether the table can be modified.
+    bool can_edit = 1;
+  }
+
+  // Permission defines how a table can be used.
+  Permission permission = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateTableFromTemplateRequest represents a request to create a table from a table template.

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -47,44 +47,19 @@ message Table {
   bool draft_mode = 9 [(google.api.field_behavior) = REQUIRED];
 }
 
-// ListTableTemplatesRequest represents a request to list table templates.
-message ListTableTemplatesRequest {
-  // The page token for pagination.
-  string page_token = 1 [(google.api.field_behavior) = OPTIONAL];
-
-  // The maximum number of table templates to return.
-  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// ListTableTemplatesResponse contains the list of table templates.
-message ListTableTemplatesResponse {
-  // The list of table templates.
-  repeated Table table_templates = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
-// GetTableTemplateRequest represents a request to get a table template.
-message GetTableTemplateRequest {
-  // The UID of the table template to get.
-  string table_template_uid = 1 [(google.api.field_behavior) = REQUIRED];
-}
-
-// TableTemplate represents a table template.
-// GetTableTemplateResponse contains the requested table template.
-message GetTableTemplateResponse {
-  // The table template.
-  Table table_template = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
 // CreateTableFromTemplateRequest represents a request to create a table from a table template.
 message CreateTableFromTemplateRequest {
   // The ID of the namespace that owns the table.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // The UID of the table template to create the table from.
-  string table_template_uid = 2 [(google.api.field_behavior) = REQUIRED];
+  // The table resource to create.
+  Table table = 2 [(google.api.field_behavior) = REQUIRED];
 
-  // The title of the table.
-  string title = 3 [(google.api.field_behavior) = REQUIRED];
+  // The ID of the table namespace to create the table from.
+  string template_namespace_id = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The ID of the table to create the table from.
+  string template_table_uid = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 // CreateTableFromTemplateResponse contains the created table.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -404,64 +404,6 @@ paths:
       tags:
         - Table
       x-stage: alpha
-  /v1alpha/table-templates:
-    get:
-      summary: List table templates
-      description: Returns a paginated list of table templates.
-      operationId: AgentPublicService_ListTableTemplates
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/ListTableTemplatesResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpc.Status'
-      parameters:
-        - name: pageToken
-          description: The page token for pagination.
-          in: query
-          required: false
-          type: string
-        - name: pageSize
-          description: The maximum number of table templates to return.
-          in: query
-          required: false
-          type: integer
-          format: int32
-      tags:
-        - Table
-      x-stage: alpha
-  /v1alpha/table-templates/{tableTemplateUid}:
-    get:
-      summary: Get table template
-      description: Returns a table template.
-      operationId: AgentPublicService_GetTableTemplate
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/GetTableTemplateResponse'
-        "401":
-          description: Returned when the client credentials are not valid.
-          schema: {}
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpc.Status'
-      parameters:
-        - name: tableTemplateUid
-          description: The UID of the table template to get.
-          in: path
-          required: true
-          type: string
-      tags:
-        - Table
-      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/tables:
     get:
       summary: List tables
@@ -8123,16 +8065,21 @@ definitions:
   CreateTableFromTemplateBody:
     type: object
     properties:
-      tableTemplateUid:
+      table:
+        description: The table resource to create.
+        allOf:
+          - $ref: '#/definitions/Table'
+      templateNamespaceId:
         type: string
-        description: The UID of the table template to create the table from.
-      title:
+        description: The ID of the table namespace to create the table from.
+      templateTableUid:
         type: string
-        description: The title of the table.
+        description: The ID of the table to create the table from.
     description: CreateTableFromTemplateRequest represents a request to create a table from a table template.
     required:
-      - tableTemplateUid
-      - title
+      - table
+      - templateNamespaceId
+      - templateTableUid
   CreateTableFromTemplateResponse:
     type: object
     properties:
@@ -9017,17 +8964,6 @@ definitions:
         allOf:
           - $ref: '#/definitions/Table'
     description: GetTableResponse contains the requested table.
-  GetTableTemplateResponse:
-    type: object
-    properties:
-      tableTemplate:
-        description: The table template.
-        readOnly: true
-        allOf:
-          - $ref: '#/definitions/Table'
-    description: |-
-      TableTemplate represents a table template.
-      GetTableTemplateResponse contains the requested table template.
   GetTokenResponse:
     type: object
     properties:
@@ -9942,17 +9878,6 @@ definitions:
         title: message sender profiles
         readOnly: true
     title: ListTableBuilderAgentMessagesResponse returns a list of messages
-  ListTableTemplatesResponse:
-    type: object
-    properties:
-      tableTemplates:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/Table'
-        description: The list of table templates.
-        readOnly: true
-    description: ListTableTemplatesResponse contains the list of table templates.
   ListTablesResponse:
     type: object
     properties:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -11855,6 +11855,11 @@ definitions:
       draftMode:
         type: boolean
         description: Whether to enable draft mode for the table.
+      permission:
+        description: Permission defines how a table can be used.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Table.Permission'
     description: Table represents a table resource.
     required:
       - agentConfig
@@ -11868,6 +11873,13 @@ definitions:
     description: The configuration for the agent.
     required:
       - enableTransparency
+  Table.Permission:
+    type: object
+    properties:
+      canEdit:
+        type: boolean
+        description: Defines whether the table can be modified.
+    description: Permission defines how a table can be used.
   TableDeletedEvent:
     type: object
     description: TableDeletedEvent represents an event for a table being deleted.


### PR DESCRIPTION
Because

- We are going to treat the table template as a read-only table instead of a new kind of resource.

This commit

- Refactors the template endpoints
- Adds a permission field to the table