### PR TITLE
chore(table): use double instead of float for numeric data to improve precision and consistency.

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -304,7 +304,7 @@ message ColumnDefinition {
         string string_value = 1 [(google.api.field_behavior) = OPTIONAL];
 
         // The value of the cell as a number.
-        float number_value = 2 [(google.api.field_behavior) = OPTIONAL];
+        double number_value = 2 [(google.api.field_behavior) = OPTIONAL];
       }
 
       // Display color of the option.
@@ -500,16 +500,16 @@ message StringCell {
 // NumberCell represents a cell with a number value.
 message NumberCell {
   // The value of the cell as a number.
-  float value = 1 [
+  double value = 1 [
     (google.api.field_behavior) = REQUIRED,
     deprecated = true
   ];
 
   // The value of the cell that directly set by the user.
-  optional float user_input = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional double user_input = 2 [(google.api.field_behavior) = OPTIONAL];
 
   // The value of the cell that was computed by the automatic computation.
-  optional float computed_value = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  optional double computed_value = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // BooleanCell represents a cell with a boolean value.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -10509,15 +10509,15 @@ definitions:
     properties:
       value:
         type: number
-        format: float
+        format: double
         description: The value of the cell as a number.
       userInput:
         type: number
-        format: float
+        format: double
         description: The value of the cell that directly set by the user.
       computedValue:
         type: number
-        format: float
+        format: double
         description: The value of the cell that was computed by the automatic computation.
         readOnly: true
     description: NumberCell represents a cell with a number value.
@@ -10676,7 +10676,7 @@ definitions:
         description: The value of the cell as a string.
       numberValue:
         type: number
-        format: float
+        format: double
         description: The value of the cell as a number.
       color:
         type: string


### PR DESCRIPTION
Because

- the low precision of the numeric data cause inconsistent data export.

This commit

- Uses double instead of float for numeric data to improve precision and consistency.