### PR TITLE
chore(agent): add folder APIs

### DIFF
--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -5,6 +5,7 @@ package agent.agent.v1alpha;
 // Agent definitions
 import "agent/agent/v1alpha/agent.proto";
 import "agent/agent/v1alpha/chat.proto";
+import "agent/agent/v1alpha/folder.proto";
 import "agent/agent/v1alpha/table.proto";
 // Google API
 import "google/api/annotations.proto";
@@ -631,6 +632,82 @@ service AgentPublicService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // List folders
+  //
+  // Returns a list of folders.
+  rpc ListFolders(ListFoldersRequest) returns (ListFoldersResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/folders"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Folder"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Create folder
+  //
+  // Creates a folder.
+  rpc CreateFolder(CreateFolderRequest) returns (CreateFolderResponse) {
+    option (google.api.http) = {
+      post: "/v1alpha/namespaces/{namespace_id}/folders"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Folder"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Get folder
+  //
+  // Gets a folder.
+  rpc GetFolder(GetFolderRequest) returns (GetFolderResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/folders/{folder_uid}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Folder"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Update folder
+  //
+  // Updates a folder.
+  rpc UpdateFolder(UpdateFolderRequest) returns (UpdateFolderResponse) {
+    option (google.api.http) = {
+      patch: "/v1alpha/namespaces/{namespace_id}/folders/{folder_uid}"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Folder"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
+  // Delete folder
+  //
+  // Deletes a folder.
+  rpc DeleteFolder(DeleteFolderRequest) returns (DeleteFolderResponse) {
+    option (google.api.http) = {delete: "/v1alpha/namespaces/{namespace_id}/folders/{folder_uid}"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Folder"
       extensions: {
         key: "x-stage"
         value: {string_value: "alpha"}

--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -35,10 +35,7 @@ message Chat {
   // chat delete time.
   google.protobuf.Timestamp delete_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
   // catalog id
-  string catalog_id = 8 [
-    (google.api.field_behavior) = OUTPUT_ONLY,
-    deprecated = true
-  ];
+  string catalog_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Message represents a single message in a conversation

--- a/agent/agent/v1alpha/folder.proto
+++ b/agent/agent/v1alpha/folder.proto
@@ -1,0 +1,129 @@
+syntax = "proto3";
+
+package agent.agent.v1alpha;
+
+// Google API
+import "google/api/field_behavior.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+// Folder represents a folder resource.
+message Folder {
+  // The unique identifier of the folder.
+  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The name of the folder.
+  string name = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // A description of the folder.
+  string description = 3 [(google.api.field_behavior) = OPTIONAL];
+
+  // Additional metadata associated with the folder.
+  google.protobuf.Struct metadata = 4 [(google.api.field_behavior) = OPTIONAL];
+
+  // The timestamp when the folder was created.
+  google.protobuf.Timestamp create_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp when the folder was last updated.
+  google.protobuf.Timestamp update_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Permission defines how a folder can be used.
+  message Permission {
+    // Defines whether the folder can be modified.
+    bool can_edit = 1;
+  }
+
+  // The ID of the catalog that this folder is bound to.
+  string catalog_id = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Permission defines how a folder can be used.
+  Permission permission = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// ListFoldersRequest represents a request to list folders.
+message ListFoldersRequest {
+  // The ID of the namespace that owns the folders.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The page token for pagination.
+  string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+
+  // The maximum number of folders to return.
+  int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListFoldersResponse contains the list of folders.
+message ListFoldersResponse {
+  // The list of folders.
+  repeated Folder folders = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The token for the next page of results.
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The total number of tables.
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CreateFolderRequest represents a request to create a folder.
+message CreateFolderRequest {
+  // The ID of the namespace where the folder will be created.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The folder resource to create.
+  Folder folder = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CreateFolderResponse contains the created folder.
+message CreateFolderResponse {
+  // The created folder resource.
+  Folder folder = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetFolderRequest represents a request to fetch a folder.
+message GetFolderRequest {
+  // The ID of the namespace that owns the folder.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the folder to fetch.
+  string folder_uid = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetFolderResponse contains the requested folder.
+message GetFolderResponse {
+  // The folder resource.
+  Folder folder = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// UpdateFolderRequest represents a request to update a folder.
+message UpdateFolderRequest {
+  // The ID of the namespace that owns the folder.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the folder to update.
+  string folder_uid = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The folder fields that will replace the existing ones.
+  Folder folder = 3;
+
+  // The update mask specifies the subset of fields that should be modified.
+  google.protobuf.FieldMask update_mask = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+// UpdateFolderResponse contains the updated folder.
+message UpdateFolderResponse {
+  // The updated folder resource.
+  Folder folder = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// DeleteFolderRequest represents a request to delete a folder.
+message DeleteFolderRequest {
+  // The ID of the namespace that owns the folder.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The UID of the folder to delete.
+  string folder_uid = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// DeleteFolderResponse is an empty response for deleting a folder.
+message DeleteFolderResponse {}

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -54,6 +54,9 @@ message Table {
 
   // Permission defines how a table can be used.
   Permission permission = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The ID of the catalog that this table is bound to.
+  string catalog_id = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateTableFromTemplateRequest represents a request to create a table from a table template.
@@ -320,6 +323,9 @@ message ColumnDefinition {
 
   // The selection settings of the column.
   Selection selection = 9 [(google.api.field_behavior) = OPTIONAL];
+
+  // The metadata of the column.
+  google.protobuf.Struct metadata = 10 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetColumnDefinitionsRequest represents a request to fetch column definitions.

--- a/openapi/v2/conf.proto
+++ b/openapi/v2/conf.proto
@@ -45,6 +45,10 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
       description: "Table resources for agents."
     },
     {
+      name: "Folder"
+      description: "Folder resources for agents."
+    },
+    {
       name: "📊 Metrics"
       description: "Resource usage metrics."
     },

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -24,6 +24,8 @@ tags:
     description: Ready-to-use AI agents.
   - name: Table
     description: Table resources for agents.
+  - name: Folder
+    description: Folder resources for agents.
   - name: "\U0001F4CA Metrics"
     description: Resource usage metrics.
   - name: "\U0001F91D Subscription"
@@ -1478,6 +1480,169 @@ paths:
             $ref: '#/definitions/ExportTableBody'
       tags:
         - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/folders:
+    get:
+      summary: List folders
+      description: Returns a list of folders.
+      operationId: AgentPublicService_ListFolders
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/ListFoldersResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the folders.
+          in: path
+          required: true
+          type: string
+        - name: pageToken
+          description: The page token for pagination.
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          description: The maximum number of folders to return.
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - Folder
+      x-stage: alpha
+    post:
+      summary: Create folder
+      description: Creates a folder.
+      operationId: AgentPublicService_CreateFolder
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/CreateFolderResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace where the folder will be created.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/CreateFolderBody'
+      tags:
+        - Folder
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/folders/{folderUid}:
+    get:
+      summary: Get folder
+      description: Gets a folder.
+      operationId: AgentPublicService_GetFolder
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/GetFolderResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the folder.
+          in: path
+          required: true
+          type: string
+        - name: folderUid
+          description: The UID of the folder to fetch.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Folder
+      x-stage: alpha
+    delete:
+      summary: Delete folder
+      description: Deletes a folder.
+      operationId: AgentPublicService_DeleteFolder
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/DeleteFolderResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the folder.
+          in: path
+          required: true
+          type: string
+        - name: folderUid
+          description: The UID of the folder to delete.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Folder
+      x-stage: alpha
+    patch:
+      summary: Update folder
+      description: Updates a folder.
+      operationId: AgentPublicService_UpdateFolder
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/UpdateFolderResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the folder.
+          in: path
+          required: true
+          type: string
+        - name: folderUid
+          description: The UID of the folder to update.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateFolderBody'
+      tags:
+        - Folder
       x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs:
     get:
@@ -7521,6 +7686,9 @@ definitions:
         description: The selection settings of the column.
         allOf:
           - $ref: '#/definitions/Selection'
+      metadata:
+        type: object
+        description: The metadata of the column.
     description: ColumnDefinition represents a column definition in a table.
     required:
       - type
@@ -8000,6 +8168,25 @@ definitions:
         allOf:
           - $ref: '#/definitions/Chat'
     title: CreateChatResponse returns the created chat
+  CreateFolderBody:
+    type: object
+    properties:
+      folder:
+        description: The folder resource to create.
+        allOf:
+          - $ref: '#/definitions/Folder'
+    description: CreateFolderRequest represents a request to create a folder.
+    required:
+      - folder
+  CreateFolderResponse:
+    type: object
+    properties:
+      folder:
+        description: The created folder resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Folder'
+    description: CreateFolderResponse contains the created folder.
   CreateNamespaceConnectionResponse:
     type: object
     properties:
@@ -8169,6 +8356,9 @@ definitions:
   DeleteChatResponse:
     type: object
     title: DeleteChatResponse is empty as no content needs to be returned
+  DeleteFolderResponse:
+    type: object
+    description: DeleteFolderResponse is an empty response for deleting a folder.
   DeleteNamespaceConnectionResponse:
     type: object
     description: DeleteNamespaceConnectionResponse is an empty response.
@@ -8536,6 +8726,51 @@ definitions:
        - FILE_TYPE_XLSX: XLSX
        - FILE_TYPE_CSV: CSV
     title: file type
+  Folder:
+    type: object
+    properties:
+      uid:
+        type: string
+        description: The unique identifier of the folder.
+        readOnly: true
+      name:
+        type: string
+        description: The name of the folder.
+      description:
+        type: string
+        description: A description of the folder.
+      metadata:
+        type: object
+        description: Additional metadata associated with the folder.
+      createTime:
+        type: string
+        format: date-time
+        description: The timestamp when the folder was created.
+        readOnly: true
+      updateTime:
+        type: string
+        format: date-time
+        description: The timestamp when the folder was last updated.
+        readOnly: true
+      catalogId:
+        type: string
+        description: The ID of the catalog that this folder is bound to.
+        readOnly: true
+      permission:
+        description: Permission defines how a folder can be used.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Folder.Permission'
+    description: Folder represents a folder resource.
+    required:
+      - name
+  Folder.Permission:
+    type: object
+    properties:
+      canEdit:
+        type: boolean
+        description: Defines whether the folder can be modified.
+    description: Permission defines how a folder can be used.
   Format:
     type: string
     enum:
@@ -8695,6 +8930,15 @@ definitions:
         title: summary of the file
         readOnly: true
     title: get file summary response
+  GetFolderResponse:
+    type: object
+    properties:
+      folder:
+        description: The folder resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Folder'
+    description: GetFolderResponse contains the requested folder.
   GetIntegrationResponse:
     type: object
     properties:
@@ -9313,6 +9557,26 @@ definitions:
     description: |-
       ListCreditConsumptionChartRecordsResponse contains a list of credit consumption
       chart records.
+  ListFoldersResponse:
+    type: object
+    properties:
+      folders:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/Folder'
+        description: The list of folders.
+        readOnly: true
+      nextPageToken:
+        type: string
+        description: The token for the next page of results.
+        readOnly: true
+      totalSize:
+        type: integer
+        format: int32
+        description: The total number of tables.
+        readOnly: true
+    description: ListFoldersResponse contains the list of folders.
   ListIntegrationsResponse:
     type: object
     properties:
@@ -11860,6 +12124,10 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/Table.Permission'
+      catalogId:
+        type: string
+        description: The ID of the catalog that this table is bound to.
+        readOnly: true
     description: Table represents a table resource.
     required:
       - agentConfig
@@ -12522,6 +12790,28 @@ definitions:
         description: Map of column UID to the updated definitions.
         readOnly: true
     description: UpdateColumnDefinitionsResponse contains the updated column definitions.
+  UpdateFolderBody:
+    type: object
+    properties:
+      folder:
+        description: The folder fields that will replace the existing ones.
+        allOf:
+          - $ref: '#/definitions/Folder'
+      updateMask:
+        type: string
+        description: The update mask specifies the subset of fields that should be modified.
+    description: UpdateFolderRequest represents a request to update a folder.
+    required:
+      - updateMask
+  UpdateFolderResponse:
+    type: object
+    properties:
+      folder:
+        description: The updated folder resource.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Folder'
+    description: UpdateFolderResponse contains the updated folder.
   UpdateNamespaceConnectionResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- we are introducing folders for users to organize their files.
- we need to provide metadata field in column-definition for Console to store UI-related metadata.

This commit

- exposes folder APIs
- add metadata field for column-definition