### PR TITLE
chore(table): make table.draft_mode optional

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -44,7 +44,7 @@ message Table {
   AgentConfig agent_config = 8 [(google.api.field_behavior) = REQUIRED];
 
   // Whether to enable draft mode for the table.
-  bool draft_mode = 9 [(google.api.field_behavior) = REQUIRED];
+  optional bool draft_mode = 9 [(google.api.field_behavior) = OPTIONAL];
 
   // Permission defines how a table can be used.
   message Permission {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -12131,7 +12131,6 @@ definitions:
     description: Table represents a table resource.
     required:
       - agentConfig
-      - draftMode
   Table.AgentConfig:
     type: object
     properties:


### PR DESCRIPTION
Because

- we'd like to support patch operation for draft_mode field in the table.

This commit

- makes `table.draft_mode` optional
