### PR TITLE
chore(table): removes deprecated `value` field in cell

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -490,11 +490,8 @@ message NullCell {}
 
 // StringCell represents a cell with a string value.
 message StringCell {
-  // The value of the cell as a string.
-  string value = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    deprecated = true
-  ];
+  // reserved field for the old `value` field.
+  reserved 1;
 
   // The value of the cell that directly set by the user.
   optional string user_input = 2 [(google.api.field_behavior) = OPTIONAL];
@@ -505,11 +502,8 @@ message StringCell {
 
 // NumberCell represents a cell with a number value.
 message NumberCell {
-  // The value of the cell as a number.
-  double value = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    deprecated = true
-  ];
+  // reserved field for the old `value` field.
+  reserved 1;
 
   // The value of the cell that directly set by the user.
   optional double user_input = 2 [(google.api.field_behavior) = OPTIONAL];
@@ -520,11 +514,8 @@ message NumberCell {
 
 // BooleanCell represents a cell with a boolean value.
 message BooleanCell {
-  // The value of the cell as a boolean.
-  bool value = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    deprecated = true
-  ];
+  // reserved field for the old `value` field.
+  reserved 1;
 
   // The value of the cell that directly set by the user.
   optional bool user_input = 2 [(google.api.field_behavior) = OPTIONAL];

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6742,9 +6742,6 @@ definitions:
   BooleanCell:
     type: object
     properties:
-      value:
-        type: boolean
-        description: The value of the cell as a boolean.
       userInput:
         type: boolean
         description: The value of the cell that directly set by the user.
@@ -6753,8 +6750,6 @@ definitions:
         description: The value of the cell that was computed by the automatic computation.
         readOnly: true
     description: BooleanCell represents a cell with a boolean value.
-    required:
-      - value
   CallResponse:
     type: object
     properties:
@@ -10771,10 +10766,6 @@ definitions:
   NumberCell:
     type: object
     properties:
-      value:
-        type: number
-        format: double
-        description: The value of the cell as a number.
       userInput:
         type: number
         format: double
@@ -10785,8 +10776,6 @@ definitions:
         description: The value of the cell that was computed by the automatic computation.
         readOnly: true
     description: NumberCell represents a cell with a number value.
-    required:
-      - value
   NumberFormat:
     type: object
     properties:
@@ -11999,9 +11988,6 @@ definitions:
   StringCell:
     type: object
     properties:
-      value:
-        type: string
-        description: The value of the cell as a string.
       userInput:
         type: string
         description: The value of the cell that directly set by the user.
@@ -12009,8 +11995,6 @@ definitions:
         type: string
         description: The value of the cell that was computed by the automatic computation.
     description: StringCell represents a cell with a string value.
-    required:
-      - value
   StripeSubscriptionDetail:
     type: object
     properties:


### PR DESCRIPTION
Because

- The value field in cell is deprecated, and Console has stopped using it.

This commit

- Removes the deprecated value field in cell.