### PR TITLE
chore(subscription): rename PLAN_PRO as PLAN_STARTER

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1096,8 +1096,10 @@ message UserSubscription {
     PLAN_UNSPECIFIED = 0;
     // Free plan.
     PLAN_FREE = 1;
-    // Pro plan.
-    PLAN_PRO = 2;
+    // 2 is reserved for the deprecated PLAN_PRO value.
+    reserved 2;
+    // Starter plan.
+    PLAN_STARTER = 3;
   }
 
   // Plan identifier.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -13019,12 +13019,12 @@ definitions:
     type: string
     enum:
       - PLAN_FREE
-      - PLAN_PRO
+      - PLAN_STARTER
     description: |-
       Enumerates the plan types for the user subscription.
 
        - PLAN_FREE: Free plan.
-       - PLAN_PRO: Pro plan.
+       - PLAN_STARTER: Starter plan.
   ValidateNamespacePipelineBody:
     type: object
     description: |-


### PR DESCRIPTION
This commit

- Renames the `PLAN_PRO` as `PLAN_STARTER` in the `Subscription` type.
