### PR TITLE
chore(agent): adjust message format

### DIFF
--- a/agent/agent/v1alpha/agent_public_service.proto
+++ b/agent/agent/v1alpha/agent_public_service.proto
@@ -574,6 +574,20 @@ service AgentPublicService {
     };
   }
 
+  // List cell messages
+  //
+  // Lists the internal LLM messages that used to generate the cell value.
+  rpc ListCellAutofillAgentMessages(ListCellAutofillAgentMessagesRequest) returns (ListCellAutofillAgentMessagesResponse) {
+    option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/tables/{table_uid}/rows/{row_uid}/cells/{cell_uid}/autofill-agent/messages"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Table"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // Lock cell
   //
   // Locks a cell in a table.

--- a/agent/agent/v1alpha/chat.proto
+++ b/agent/agent/v1alpha/chat.proto
@@ -38,56 +38,6 @@ message Chat {
   string catalog_id = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// Message represents a single message in a conversation
-message Message {
-  // message type
-  enum MessageType {
-    // unspecified
-    MESSAGE_TYPE_UNSPECIFIED = 0;
-    // text
-    MESSAGE_TYPE_TEXT = 1;
-  }
-  // message uid
-  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // chat uid
-  string chat_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // message content
-  string content = 3 [(google.api.field_behavior) = REQUIRED];
-  // message role e.g., "user" or "assistant" or "agent"
-  string role = 4 [(google.api.field_behavior) = REQUIRED];
-  // message type
-  MessageType type = 5 [(google.api.field_behavior) = REQUIRED];
-  // creation time of the message
-  google.protobuf.Timestamp create_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // update time of the message
-  google.protobuf.Timestamp update_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // message sender uid(only for user messages)
-  string msg_sender_uid = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // citations (only for agent messages)
-  repeated Citation citations = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // context for the message
-  ChatContext context = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // attachments for the message
-  ChatAttachments attachments = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // enable web search (only for user messages)
-  bool enable_web_search = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
-// The context for the message.
-message ChatContext {
-  // The table uids to include in the context.
-  repeated string table_uids = 1 [(google.api.field_behavior) = OPTIONAL];
-}
-
-// ChatAttachments represents the attachment for the message
-message ChatAttachments {
-  // file urls (only for user messages)
-  repeated string file_urls = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
 // CreateChatRequest is used to create a new chat
 message CreateChatRequest {
   // namespace id
@@ -202,6 +152,8 @@ message ListMessagesRequest {
   string page_token = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // If true, all messages will be returned. This has higher priority over page_size and page_token.
   bool if_all = 5 [(google.api.field_behavior) = OPTIONAL];
+  // If true, the raw messages will be returned.
+  bool return_raw_messages = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListMessagesResponse returns a list of messages
@@ -263,6 +215,8 @@ message ListTableBuilderAgentMessagesRequest {
   string page_token = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   // If true, all messages will be returned. This has higher priority over page_size and page_token.
   bool if_all = 5 [(google.api.field_behavior) = OPTIONAL];
+  // If true, the raw messages will be returned.
+  bool return_raw_messages = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListTableBuilderAgentMessagesResponse returns a list of messages

--- a/agent/agent/v1alpha/common.proto
+++ b/agent/agent/v1alpha/common.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package agent.agent.v1alpha;
 
 import "google/api/field_behavior.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 // type of the citations message
 enum CitationType {
@@ -43,4 +45,60 @@ message Citation {
   optional string summary = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Citation extract method type
   CitationExtractMethodType extract_method = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// The context for the message.
+message ChatContext {
+  // The table uids to include in the context.
+  repeated string table_uids = 1 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ChatAttachments represents the attachment for the message
+message ChatAttachments {
+  // file urls (only for user messages)
+  repeated string file_urls = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// Message represents a single message in a conversation
+message Message {
+  // message type
+  enum MessageType {
+    // unspecified
+    MESSAGE_TYPE_UNSPECIFIED = 0;
+    // text
+    MESSAGE_TYPE_TEXT = 1;
+  }
+  // message uid
+  string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // chat uid
+  string chat_uid = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // message content
+  string content = 3 [(google.api.field_behavior) = REQUIRED];
+  // message role e.g., "user" or "assistant" or "agent"
+  string role = 4 [(google.api.field_behavior) = REQUIRED];
+  // message type
+  MessageType type = 5 [(google.api.field_behavior) = REQUIRED];
+  // creation time of the message
+  google.protobuf.Timestamp create_time = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // update time of the message
+  google.protobuf.Timestamp update_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // message sender uid(only for user messages)
+  string msg_sender_uid = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // citations (only for agent messages)
+  repeated Citation citations = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // context for the message
+  ChatContext context = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // attachments for the message
+  ChatAttachments attachments = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // enable web search (only for user messages)
+  bool enable_web_search = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // internal flag for the message, if true, the message is the intermediate message happened in the LLM flow.
+  bool internal = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // raw message for the message
+  optional google.protobuf.Struct raw_message = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -831,6 +831,36 @@ message ResetCellResponse {
   Cell cell = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
+// ListCellAutofillAgentMessagesRequest is used to list messages in a conversation
+message ListCellAutofillAgentMessagesRequest {
+  // The ID of the namespace that owns the table.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The UID of the table containing the cell.
+  string table_uid = 2 [(google.api.field_behavior) = REQUIRED];
+  // The unique identifier of the row containing the cell.
+  string row_uid = 3 [(google.api.field_behavior) = REQUIRED];
+  // The unique identifier of the cell to reset.
+  string cell_uid = 4 [(google.api.field_behavior) = REQUIRED];
+  // page size
+  int32 page_size = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // page token
+  string page_token = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // If true, all messages will be returned. This has higher priority over page_size and page_token.
+  bool if_all = 7 [(google.api.field_behavior) = OPTIONAL];
+  // If true, the raw messages will be returned.
+  bool return_raw_messages = 8 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// ListCellAutofillAgentMessagesResponse is a response to a request to list messages in a cell.
+message ListCellAutofillAgentMessagesResponse {
+  // The messages in the cell.
+  repeated Message messages = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The token for the next page of results.
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The total number of messages.
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
 // The lock state of a cell.
 enum LockState {
   // The lock state is not specified.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -258,6 +258,11 @@ paths:
           in: query
           required: false
           type: boolean
+        - name: returnRawMessages
+          description: If true, the raw messages will be returned.
+          in: query
+          required: false
+          type: boolean
       tags:
         - "\U0001F34E Agent"
       x-stage: alpha
@@ -687,6 +692,11 @@ paths:
           type: string
         - name: ifAll
           description: If true, all messages will be returned. This has higher priority over page_size and page_token.
+          in: query
+          required: false
+          type: boolean
+        - name: returnRawMessages
+          description: If true, the raw messages will be returned.
           in: query
           required: false
           type: boolean
@@ -1313,6 +1323,68 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/RecomputeCellBody'
+      tags:
+        - Table
+      x-stage: alpha
+  /v1alpha/namespaces/{namespaceId}/tables/{tableUid}/rows/{rowUid}/cells/{cellUid}/autofill-agent/messages:
+    get:
+      summary: List cell messages
+      description: Lists the internal LLM messages that used to generate the cell value.
+      operationId: AgentPublicService_ListCellAutofillAgentMessages
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/ListCellAutofillAgentMessagesResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The ID of the namespace that owns the table.
+          in: path
+          required: true
+          type: string
+        - name: tableUid
+          description: The UID of the table containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: rowUid
+          description: The unique identifier of the row containing the cell.
+          in: path
+          required: true
+          type: string
+        - name: cellUid
+          description: The unique identifier of the cell to reset.
+          in: path
+          required: true
+          type: string
+        - name: pageSize
+          description: page size
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: pageToken
+          description: page token
+          in: query
+          required: false
+          type: string
+        - name: ifAll
+          description: If true, all messages will be returned. This has higher priority over page_size and page_token.
+          in: query
+          required: false
+          type: boolean
+        - name: returnRawMessages
+          description: If true, the raw messages will be returned.
+          in: query
+          required: false
+          type: boolean
       tags:
         - Table
       x-stage: alpha
@@ -9450,6 +9522,26 @@ definitions:
           $ref: '#/definitions/Catalog'
         description: The catalogs container.
     description: GetCatalogsResponse represents a response for getting all catalogs from users.
+  ListCellAutofillAgentMessagesResponse:
+    type: object
+    properties:
+      messages:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/agent.v1alpha.Message'
+        description: The messages in the cell.
+        readOnly: true
+      nextPageToken:
+        type: string
+        description: The token for the next page of results.
+        readOnly: true
+      totalSize:
+        type: integer
+        format: int32
+        description: The total number of messages.
+        readOnly: true
+    description: ListCellAutofillAgentMessagesResponse is a response to a request to list messages in a cell.
   ListChatTablesResponse:
     type: object
     properties:
@@ -13148,6 +13240,14 @@ definitions:
       enableWebSearch:
         type: boolean
         title: enable web search (only for user messages)
+        readOnly: true
+      internal:
+        type: boolean
+        description: internal flag for the message, if true, the message is the intermediate message happened in the LLM flow.
+        readOnly: true
+      rawMessage:
+        type: object
+        title: raw message for the message
         readOnly: true
     title: Message represents a single message in a conversation
     required:


### PR DESCRIPTION
Because

- We want to expose more information about the agent request for evaluation.

This commit

- Adjusts the message format to return the raw messages used in the LLM calls.