### PR TITLE
chore(agent): add Catalog Info into folder response

### DIFF
--- a/agent/agent/v1alpha/folder.proto
+++ b/agent/agent/v1alpha/folder.proto
@@ -39,6 +39,18 @@ message Folder {
 
   // Permission defines how a folder can be used.
   Permission permission = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The information about the catalog.
+  CatalogInfo catalog_info = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// CatalogInfo contains the information about the catalog.
+message CatalogInfo {
+  // The number of files in the catalog.
+  int32 file_count = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The total size of all files in the catalog in bytes.
+  int64 total_size_bytes = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListFoldersRequest represents a request to list folders.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -6898,6 +6898,20 @@ definitions:
           type: string
         description: The catalog summarizing pipelines.
     description: Catalog represents a catalog.
+  CatalogInfo:
+    type: object
+    properties:
+      fileCount:
+        type: integer
+        format: int32
+        description: The number of files in the catalog.
+        readOnly: true
+      totalSizeBytes:
+        type: string
+        format: int64
+        description: The total size of all files in the catalog in bytes.
+        readOnly: true
+    description: CatalogInfo contains the information about the catalog.
   CatalogRun:
     type: object
     properties:
@@ -8828,6 +8842,11 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/Folder.Permission'
+      catalogInfo:
+        description: The information about the catalog.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/CatalogInfo'
     description: Folder represents a folder resource.
     required:
       - name


### PR DESCRIPTION
Because

- we want to return the file count and total size of the folder catalog in the response.

This commit

- add CatalogInfo into folder response.
