### PR TITLE
fix(catalog): correct converting_pipelines param documentation

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -289,17 +289,17 @@ message CreateCatalogRequest {
   repeated string tags = 4;
   // The catalog type. default is PERSISTENT
   CatalogType type = 5;
-  // Pipelines used for converting documents (i.e., files with pdf, doc* or
-  // ppt* extension) to Markdown. The pipelines must have the following
+  // Pipelines used for converting documents (i.e., files with pdf, doc[x] or
+  // ppt[x] extension) to Markdown. The pipelines must have the following
   // variable and output fields:
-  // ```
+  // ```yaml variable
   // variable:
   //   document_input:
   //     title: document-input
   //     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)
   //     type: file
   // ```
-  // ```
+  // ```yaml output
   // output:
   //  convert_result:
   //    title: convert-result

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -8222,17 +8222,17 @@ definitions:
         items:
           type: string
         description: |-
-          Pipelines used for converting documents (i.e., files with pdf, doc* or
-          ppt* extension) to Markdown. The pipelines must have the following
+          Pipelines used for converting documents (i.e., files with pdf, doc[x] or
+          ppt[x] extension) to Markdown. The pipelines must have the following
           variable and output fields:
-          ```
+          ```yaml variable
           variable:
             document_input:
               title: document-input
               description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)
               type: file
           ```
-          ```
+          ```yaml output
           output:
            convert_result:
              title: convert-result


### PR DESCRIPTION
This commit

- Corrects the syntax in the `converting_pipelines` documentation:
  - `doc*` created an unwanted emphasis.
  - The code blocks produce one tab per block and accept a language and
    a tab title.
