### PR TITLE
chore(catalog): specify format in convertingPipelines field

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -290,8 +290,9 @@ message CreateCatalogRequest {
   // The catalog type. default is PERSISTENT
   CatalogType type = 5;
   // Pipelines used for converting documents (i.e., files with pdf, doc[x] or
-  // ppt[x] extension) to Markdown. The pipelines must have the following
-  // variable and output fields:
+  // ppt[x] extension) to Markdown. The strings in the list identify the
+  // pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.
+  // The pipeline recipes MUST have the following variable and output fields:
   // ```yaml variable
   // variable:
   //   document_input:


### PR DESCRIPTION
This commit

- Includes the format specification for conversion pipelines in the
  `CreateCatalog` request.
