### PR TITLE
chore(chat): update the ChatAttachments object

### DIFF
--- a/agent/agent/v1alpha/common.proto
+++ b/agent/agent/v1alpha/common.proto
@@ -55,8 +55,21 @@ message ChatContext {
 
 // ChatAttachments represents the attachment for the message
 message ChatAttachments {
+  // FileAttachment represents the file attachment for the message.
+  message FileAttachment {
+    // file name
+    string file_name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // file size
+    uint64 file_size = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // file type
+    string content_type = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // file extension
+    string file_extension = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // file download url
+    string download_url = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
   // file urls (only for user messages)
-  repeated string file_urls = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  repeated FileAttachment file_attachments = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Message represents a single message in a conversation

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7166,10 +7166,11 @@ definitions:
   ChatAttachments:
     type: object
     properties:
-      fileUrls:
+      fileAttachments:
         type: array
         items:
-          type: string
+          type: object
+          $ref: '#/definitions/FileAttachment'
         title: file urls (only for user messages)
         readOnly: true
     title: ChatAttachments represents the attachment for the message
@@ -8715,6 +8716,31 @@ definitions:
         title: download url of the file
         readOnly: true
     title: file
+  FileAttachment:
+    type: object
+    properties:
+      fileName:
+        type: string
+        title: file name
+        readOnly: true
+      fileSize:
+        type: string
+        format: uint64
+        title: file size
+        readOnly: true
+      contentType:
+        type: string
+        title: file type
+        readOnly: true
+      fileExtension:
+        type: string
+        title: file extension
+        readOnly: true
+      downloadUrl:
+        type: string
+        title: file download url
+        readOnly: true
+    description: FileAttachment represents the file attachment for the message.
   FileCell:
     type: object
     properties:


### PR DESCRIPTION
Because

- We’re no longer relying on the catalog for files uploaded in chat, so we need to provide more file details directly in the message response.

This commit

- Updates the ChatAttachments object.