### PR TITLE
chore(chat): allow user to set folder and files as context

### DIFF
--- a/agent/agent/v1alpha/common.proto
+++ b/agent/agent/v1alpha/common.proto
@@ -51,6 +51,17 @@ message Citation {
 message ChatContext {
   // The table uids to include in the context.
   repeated string table_uids = 1 [(google.api.field_behavior) = OPTIONAL];
+
+  // Represents specific files within a folder.
+  message FolderFiles {
+    // The folder containing the files
+    string folder_uid = 1 [(google.api.field_behavior) = REQUIRED];
+    // Specific file UIDs within the folder, leave empty to include all files in the folder
+    repeated string file_uids = 2 [(google.api.field_behavior) = OPTIONAL];
+  }
+
+  // The folders and files to include in the context.
+  repeated FolderFiles folder_files = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ChatAttachments represents the attachment for the message

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7214,6 +7214,12 @@ definitions:
         items:
           type: string
         description: The table uids to include in the context.
+      folderFiles:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/FolderFiles'
+        description: The folders and files to include in the context.
     description: The context for the message.
   ChatContextUpdatedEvent:
     type: object
@@ -8914,6 +8920,20 @@ definitions:
         type: boolean
         description: Defines whether the folder can be modified.
     description: Permission defines how a folder can be used.
+  FolderFiles:
+    type: object
+    properties:
+      folderUid:
+        type: string
+        title: The folder containing the files
+      fileUids:
+        type: array
+        items:
+          type: string
+        title: Specific file UIDs within the folder, leave empty to include all files in the folder
+    description: Represents specific files within a folder.
+    required:
+      - folderUid
   Format:
     type: string
     enum:


### PR DESCRIPTION
Because

- We want to allow users to set folders and files as context.

This commit

- Updates the ChatContext message to include folder and file information.