### PR TITLE
chore(usage): update protobuf and deprecate connector

### DIFF
--- a/core/usage/v1beta/usage.proto
+++ b/core/usage/v1beta/usage.proto
@@ -36,9 +36,10 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
-// Session represents a unique session whenever a new instance of Instill Core service
-// gets started. The usage server returns a token that should be used as part of
-// the challenge when sending a report with data collected from this session
+// Session represents a unique session whenever a new instance of Instill Core
+// service gets started. The usage server returns a token that should be used as
+// part of the challenge when sending a report with data collected from this
+// session
 message Session {
   option (google.api.resource) = {pattern: "sessions/{session}"};
 
@@ -48,7 +49,7 @@ message Session {
     SERVICE_UNSPECIFIED = 0;
     // Service: MGMT
     SERVICE_MGMT = 1;
-    // Service: CONNECTOR
+    // Service: CONNECTOR (Deprecated)
     SERVICE_CONNECTOR = 2;
     // Service: MODEL
     SERVICE_MODEL = 3;
@@ -133,7 +134,7 @@ message ModelUsageData {
   message UserUsageData {
     // Per trigger usage metadata
     message ModelTriggerData {
-      // UID for the trigged model
+      // UID for the triggered model
       string model_uid = 1 [(google.api.field_behavior) = REQUIRED];
       // UID for the trigger log
       string trigger_uid = 2 [(google.api.field_behavior) = REQUIRED];

--- a/core/usage/v1beta/usage_service.proto
+++ b/core/usage/v1beta/usage_service.proto
@@ -10,7 +10,7 @@ import "google/api/visibility.proto";
 
 // UsageService responds to incoming usage requests.
 service UsageService {
-  option (google.api.default_host) = "usage.instill.tech";
+  option (google.api.default_host) = "usage.instill-ai.com";
 
   // Liveness method receives a LivenessRequest message and returns a
   // LivenessResponse message.


### PR DESCRIPTION
Because

- connector is no longer an independent service. It's integrated into pipeline component.

This commit

- mart it deprecated for now.
