### PR TITLE
chore(openapi): update contact email

### DIFF
--- a/openapi/v2/conf.proto
+++ b/openapi/v2/conf.proto
@@ -12,7 +12,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     contact: {
       name: "Instill AI"
       url: "https://github.com/instill-ai"
-      email: "hello@instill.tech"
+      email: "hello@instill-ai.com"
     }
     license: {
       name: "Elastic License 2.0 (ELv2)"

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7,7 +7,7 @@ info:
   contact:
     name: Instill AI
     url: https://github.com/instill-ai
-    email: hello@instill.tech
+    email: hello@instill-ai.com
   license:
     name: Elastic License 2.0 (ELv2)
     url: https://github.com/instill-ai/protobufs/blob/main/LICENSE


### PR DESCRIPTION
Because

- the root domain has been changed to `instill-ai.com`

This commit

- updated the contact email
