### PR TITLE
chore(table): expose cell error messages

### DIFF
--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -483,6 +483,9 @@ message Cell {
 
   // The lock state of the cell.
   LockState lock_state = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The error message of the cell.
+  string error_message = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // NullCell represents a null cell.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7052,6 +7052,10 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/LockState'
+      errorMessage:
+        type: string
+        description: The error message of the cell.
+        readOnly: true
     description: Cell represents a cell in a table.
   CellStatus:
     type: string


### PR DESCRIPTION
Because

- we need to let users know the reason why a cell value cannot be generated

This commit

- exposes cell error messages