### PR TITLE
chore(table): replace free-form color values with a predefined color enum for selection

### DIFF
--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Sync OpenAPI docs 📜
         uses: readmeio/rdme@v10
         with:
-          rdme: openapi upload openapi/v2/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --branch=v0-beta-dev
+          rdme: openapi upload openapi/v2/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --branch=v0-dev
 
   sync-openapi-private-staging:
     name: Keep private (staging) docs in sync with `main`
@@ -41,7 +41,7 @@ jobs:
       - name: Sync OpenAPI docs 📜
         uses: readmeio/rdme@v10
         with:
-          rdme: openapi upload openapi/v2/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --branch=v0-beta-staging
+          rdme: openapi upload openapi/v2/service.swagger.yaml --key=${{ secrets.README_API_KEY }} --branch=v0-rc
 
       - name: Check new release 🔍
         id: check-new-release

--- a/agent/agent/v1alpha/table.proto
+++ b/agent/agent/v1alpha/table.proto
@@ -246,7 +246,7 @@ message Selection {
     }
 
     // Display color of the option.
-    string color = 3 [(google.api.field_behavior) = OPTIONAL];
+    Color color = 3 [(google.api.field_behavior) = OPTIONAL];
   }
 
   // The selection of the column.
@@ -254,6 +254,45 @@ message Selection {
 
   // The options for the selection.
   repeated Option options = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// Color represents a color.
+enum Color {
+  // The color is not specified.
+  COLOR_UNSPECIFIED = 0;
+
+  // Default - #F8F9FC
+  COLOR_DEFAULT = 1;
+
+  // Light neutral - #F1F3F9
+  COLOR_LIGHT_NEUTRAL = 2;
+
+  // Dark neutral - #3F444D
+  COLOR_DARK_NEUTRAL = 3;
+
+  // Light blue - #F0F5FF
+  COLOR_LIGHT_BLUE = 4;
+
+  // Dark blue - #316FED
+  COLOR_DARK_BLUE = 5;
+
+  // Light green - #EAFBF5
+  COLOR_LIGHT_GREEN = 6;
+
+  // Dark green - #23956F
+  COLOR_DARK_GREEN = 7;
+
+  // Light purple - #F8F5FF
+  COLOR_LIGHT_PURPLE = 8;
+
+  // Dark purple - #8B55F7
+  COLOR_DARK_PURPLE = 9;
+
+  // Light yellow - #FFF8EB
+  COLOR_LIGHT_YELLOW = 10;
+
+  // Light red - #FEF1F2
+  COLOR_LIGHT_RED = 11;
 }
 
 // ColumnDefinition represents a column definition in a table.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7775,6 +7775,34 @@ definitions:
   CloneNamespacePipelineResponse:
     type: object
     description: CloneNamespacePipelineResponse contains a cloned pipeline.
+  Color:
+    type: string
+    enum:
+      - COLOR_DEFAULT
+      - COLOR_LIGHT_NEUTRAL
+      - COLOR_DARK_NEUTRAL
+      - COLOR_LIGHT_BLUE
+      - COLOR_DARK_BLUE
+      - COLOR_LIGHT_GREEN
+      - COLOR_DARK_GREEN
+      - COLOR_LIGHT_PURPLE
+      - COLOR_DARK_PURPLE
+      - COLOR_LIGHT_YELLOW
+      - COLOR_LIGHT_RED
+    description: |-
+      Color represents a color.
+
+       - COLOR_DEFAULT: Default - #F8F9FC
+       - COLOR_LIGHT_NEUTRAL: Light neutral - #F1F3F9
+       - COLOR_DARK_NEUTRAL: Dark neutral - #3F444D
+       - COLOR_LIGHT_BLUE: Light blue - #F0F5FF
+       - COLOR_DARK_BLUE: Dark blue - #316FED
+       - COLOR_LIGHT_GREEN: Light green - #EAFBF5
+       - COLOR_DARK_GREEN: Dark green - #23956F
+       - COLOR_LIGHT_PURPLE: Light purple - #F8F5FF
+       - COLOR_DARK_PURPLE: Dark purple - #8B55F7
+       - COLOR_LIGHT_YELLOW: Light yellow - #FFF8EB
+       - COLOR_LIGHT_RED: Light red - #FEF1F2
   ColumnDefinition:
     type: object
     properties:
@@ -11138,8 +11166,9 @@ definitions:
         format: double
         description: The value of the cell as a number.
       color:
-        type: string
         description: Display color of the option.
+        allOf:
+          - $ref: '#/definitions/Color'
     description: An option for the selection.
   Organization:
     type: object


### PR DESCRIPTION
This commit

- replaces free-form color values with a predefined color enum for selection