### PR TITLE
chore(chat): change catalog context

### DIFF
--- a/agent/agent/v1alpha/common.proto
+++ b/agent/agent/v1alpha/common.proto
@@ -66,7 +66,7 @@ message ChatContext {
   // Represents a catalog.
   message Catalog {
     // The catalog containing the files
-    string catalog_id = 1 [(google.api.field_behavior) = REQUIRED];
+    string catalog_uid = 1 [(google.api.field_behavior) = REQUIRED];
     // Specific file UIDs within the catalog, leave empty to include all files in the catalog
     repeated string file_uids = 2 [(google.api.field_behavior) = OPTIONAL];
   }

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7300,7 +7300,7 @@ definitions:
   ChatContext.Catalog:
     type: object
     properties:
-      catalogId:
+      catalogUid:
         type: string
         title: The catalog containing the files
       fileUids:
@@ -7310,7 +7310,7 @@ definitions:
         title: Specific file UIDs within the catalog, leave empty to include all files in the catalog
     description: Represents a catalog.
     required:
-      - catalogId
+      - catalogUid
   ChatContext.Folder:
     type: object
     properties:


### PR DESCRIPTION
This commit

- change catalog context from using `id` to `uid`
