### PR TITLE
chore(artifact): remove filename uniqueness

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -35,44 +35,6 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1;
 }
 
-/*
-
-   This API is under development and, therefore, some of its entities and
-   endpoints are not implemented yet. This section aims to give context about the
-   current interface and how it fits in the Artifact vision.
-
-   # Artifact
-
-   The Artifact domain is responsible of storing data that will later be used for
-   processing unstructured data. Artifact will support the following types of
-   data:
-
-   - Repositories
-   - Objects
-   - Vectors
-
-   ## Repositories
-
-   An implementation of the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec?tab=readme-ov-file)
-   is used to manage versioned content. The main use for repositories is storing
-   container images that can be used to deploy AI models or pipelines.
-
-   The ID of a repository has 2 segments, the owner (an Instill user or
-   organization) and the content ID (the AI model or pipeline ID), e.g.
-   `curious-wombat/llava-34b`.
-
-   ## Objects
-
-   Raw data is stored in binary blobs. Object storage allows users to upload data
-   (e.g. images, audio) that can be used by pipelines or to store the results or a
-   pipeline trigger.
-
-   ## Vectors
-
-   Vector embeddings have their own storage, which allows fast retrieval and similarity search.
-
-*/
-
 // RepositoryTag contains information about the version of some content in a
 // repository.
 message RepositoryTag {

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -38,6 +38,17 @@ service ArtifactPrivateService {
   // Update Object
   rpc UpdateObject(UpdateObjectRequest) returns (UpdateObjectResponse);
 
-  // Get Chat file
-  rpc GetChatFile(GetChatFileRequest) returns (GetChatFileResponse);
+  // Get file as Markdown
+  //
+  // Returns the Markdown representation of a file.
+  rpc GetFileAsMarkdown(GetFileAsMarkdownRequest) returns (GetFileAsMarkdownResponse);
+
+  // Get file as Markdown (deprecated)
+  //
+  // Returns the contents of a file conversion to Markdown as a binary blob.
+  // This method is deprecated as it identifies the file by namespace and
+  // filename instead of UID, which isn't a unique identifier anymore.
+  rpc GetChatFile(GetChatFileRequest) returns (GetChatFileResponse) {
+    option deprecated = true;
+  }
 }

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -289,7 +289,7 @@ service ArtifactPublicService {
 
   // Retrieve similar chunks
   //
-  // Returns the similar chunks.
+  // Returns the top-K most similar chunks to a text prompt.
   rpc SimilarityChunksSearch(SimilarityChunksSearchRequest) returns (SimilarityChunksSearchResponse) {
     option (google.api.http) = {
       post:

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -343,10 +343,14 @@ service ArtifactPublicService {
     };
   }
 
-  // Get file catalog
-  //
   // Get the catalog file.
+  //
+  // Returns a view of the file within the catalog, with the text and chunks it
+  // generated after being processed.
   rpc GetFileCatalog(GetFileCatalogRequest) returns (GetFileCatalogResponse) {
+    // TODO use a more meaningful method name and path, e.g.:
+    //   - name: GetConversionOutputsForCatalogFile
+    //   - path: v1alpha/files/{file_uid}/conversion-outputs
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/catalogs/{catalog_id}"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Artifact"

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -160,20 +160,26 @@ message UpdateChunkResponse {
 
 // Similar chunk search request
 message SimilarityChunksSearchRequest {
-  // owner/namespace id
+  // ID of the namespace owning the catalog.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // catalog id
+  // ID of the catalog.
   string catalog_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // text prompt
+  // Text prompt to look for similarities.
   string text_prompt = 3 [(google.api.field_behavior) = REQUIRED];
-  // top k
+  // Top K. Default value: 5.
   uint32 top_k = 4 [(google.api.field_behavior) = OPTIONAL];
-  // file name
-  string file_name = 5 [(google.api.field_behavior) = OPTIONAL];
-  // content type
+  // File name. This field is deprecated as the file ID isn't a unique
+  // identifier within a catalog. The file UID should be used, instead.
+  string file_name = 5 [
+    (google.api.field_behavior) = OPTIONAL,
+    deprecated = true
+  ];
+  // Content type.
   ContentType content_type = 6 [(google.api.field_behavior) = OPTIONAL];
-  // file type
+  // File type.
   FileMediaType file_media_type = 7 [(google.api.field_behavior) = OPTIONAL];
+  // File UID.
+  string file_uid = 8 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Similar chunk search response

--- a/artifact/artifact/v1alpha/file_catalog.proto
+++ b/artifact/artifact/v1alpha/file_catalog.proto
@@ -102,8 +102,24 @@ message GetFileCatalogResponse {
   repeated Chunk chunks = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetChatFileRequest
+// GetFileAsMarkdownRequest represents a request to fetch the Markdown
+// representation of a file.
+message GetFileAsMarkdownRequest {
+  // File UID.
+  string file_uid = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// GetFileAsMarkdownResponse contains a blob with the Markdown representation
+// of a file.
+message GetFileAsMarkdownResponse {
+  // The Markdown representation of a file.
+  string markdown = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// GetChatFileRequest ...
 message GetChatFileRequest {
+  option deprecated = true;
+
   // id of the namespace
   string namespace_id = 1;
   // id of the catalog
@@ -112,8 +128,10 @@ message GetChatFileRequest {
   string file_id = 3;
 }
 
-// GetChatFileResponse
+// GetChatFileResponse ...
 message GetChatFileResponse {
+  option deprecated = true;
+
   // converted markdown content
   bytes markdown = 1;
 }

--- a/artifact/artifact/v1alpha/file_catalog.proto
+++ b/artifact/artifact/v1alpha/file_catalog.proto
@@ -4,93 +4,102 @@ package artifact.artifact.v1alpha;
 
 // Artifact definitions
 import "artifact/artifact/v1alpha/artifact.proto";
+// Google API
+import "google/api/field_behavior.proto";
 // Protocol Buffers Well-Known Types
 import "google/protobuf/timestamp.proto";
 
-// GetFileCatalogRequest
+// GetFileCatalogRequest represents a request to view the processing outputs of
+// a file in a catalog.
 message GetFileCatalogRequest {
-  // id of the namespace
-  string namespace_id = 1;
-  // id of the catalog
-  string catalog_id = 2;
-  // id of the file(i.e. file name)
-  string file_id = 3;
-  // Uid of the file
-  string file_uid = 4;
+  // Namespace ID and catalog ID are kept for backwards compatibility, but we
+  // might consider flattening the structure.
+
+  // Namespace ID.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Catalog ID.
+  string catalog_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // File UID.
+  string file_uid = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
-// GetFileCatalogResponse
+// GetFileCatalogResponse contains the processing outputs of a file in a
+// catalog.
 message GetFileCatalogResponse {
-  // metadata
-  message Metadata {
-    // file uid
-    string file_uid = 1;
-    // file id
-    string file_id = 2;
-    // file type
-    FileType file_type = 3;
-    // file size in bytes
-    int64 file_size = 4;
-    // upload time
-    google.protobuf.Timestamp file_upload_time = 5;
-    // file process status
-    FileProcessStatus file_process_status = 6;
+  // FileMetadata contains information about the file.
+  message FileMetadata {
+    // File UID.
+    string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Filename
+    string filename = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // File Type.
+    FileType file_type = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Size.
+    int64 size = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Creation timestamp
+    google.protobuf.Timestamp create_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Processing status of the file.
+    FileProcessStatus process_status = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
-  // text message
+
+  // Text contains the text representation of the file.
   message Text {
-    // pipelines
-    repeated string pipeline_ids = 1;
-    // transformed content
-    string transformed_content = 2;
-    // transformed content chunk number
-    int32 transformed_content_chunk_num = 3;
-    // transformed content token number
-    int32 transformed_content_token_num = 4;
-    // transformed content update time
-    google.protobuf.Timestamp transformed_content_update_time = 5;
+    // Pipelines used to process the file.
+    repeated string pipelines = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Text representation of the file.
+    string content = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Chunk count in the text.
+    int32 chunk_count = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Token count in the text
+    int32 token_count = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Last update timestamp for the text.
+    google.protobuf.Timestamp update_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
-  // chunk type
+
+  // ChunkType contains the different types of a chunk.
   enum ChunkType {
-    // unspecified
+    // Unspecified.
     CHUNK_TYPE_UNSPECIFIED = 0;
-    // text
+    // Text.
     CHUNK_TYPE_TEXT = 1;
-    // image
+    // Image.
     CHUNK_TYPE_IMAGE = 2;
-    // audio
+    // Audio.
     CHUNK_TYPE_AUDIO = 3;
-    // video
+    // Video.
     CHUNK_TYPE_VIDEO = 4;
   }
-  // chunk message
+
+  // Chunk is a delimited part of the converted text.
   message Chunk {
-    // chunk uid
-    string uid = 1;
-    // chunk type. i.e. text, image, audio, and video
-    ChunkType type = 2;
-    // chunk start position
-    int32 start_pos = 3;
-    // chunk end position
-    int32 end_pos = 4;
-    // chunk content
-    string content = 5;
-    // chunk tokens num
-    int32 tokens_num = 6;
-    // embedding. float32 array
-    repeated float embedding = 7;
-    // chunk create time
-    google.protobuf.Timestamp create_time = 8;
-    // chunk retrievable
-    bool retrievable = 9;
+    // Chunk UID.
+    string uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Chunk type. I.e: text, image, audio, video.
+    ChunkType type = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Start position in the text.
+    int32 start_position = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // End position in the text.
+    int32 end_position = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Content.
+    string content = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Token count in the chunk.
+    int32 token_count = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Chunk embedding.
+    repeated float embedding = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Creation time of the chunk.
+    google.protobuf.Timestamp create_time = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // Retrievability of the chunk.
+    bool retrievable = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
   }
-  // original data is encoded in base64
-  string original_data = 1;
-  // file catalog
-  Metadata metadata = 2;
-  // text
-  Text text = 3;
-  // chunks
-  repeated Chunk chunks = 4;
+
+  // Base-64 representation of the original file contents.
+  string original_data = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // File metadata.
+  FileMetadata file_metadata = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Converted text.
+  Text text = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Chunks.
+  repeated Chunk chunks = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // GetChatFileRequest

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -1872,8 +1872,10 @@ paths:
       x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}:
     get:
-      summary: Get file catalog
-      description: Get the catalog file.
+      summary: Get the catalog file.
+      description: |-
+        Returns a view of the file within the catalog, with the text and chunks it
+        generated after being processed.
       operationId: ArtifactPublicService_GetFileCatalog
       responses:
         "200":
@@ -1889,24 +1891,19 @@ paths:
             $ref: '#/definitions/rpc.Status'
       parameters:
         - name: namespaceId
-          description: id of the namespace
+          description: Namespace ID.
           in: path
           required: true
           type: string
         - name: catalogId
-          description: id of the catalog
+          description: Catalog ID.
           in: path
           required: true
           type: string
-        - name: fileId
-          description: id of the file(i.e. file name)
-          in: query
-          required: false
-          type: string
         - name: fileUid
-          description: Uid of the file
+          description: File UID.
           in: query
-          required: false
+          required: true
           type: string
       tags:
         - Artifact
@@ -7741,11 +7738,12 @@ definitions:
       - CHUNK_TYPE_AUDIO
       - CHUNK_TYPE_VIDEO
     description: |-
-      - CHUNK_TYPE_TEXT: text
-       - CHUNK_TYPE_IMAGE: image
-       - CHUNK_TYPE_AUDIO: audio
-       - CHUNK_TYPE_VIDEO: video
-    title: chunk type
+      ChunkType contains the different types of a chunk.
+
+       - CHUNK_TYPE_TEXT: Text.
+       - CHUNK_TYPE_IMAGE: Image.
+       - CHUNK_TYPE_AUDIO: Audio.
+       - CHUNK_TYPE_VIDEO: Video.
   Citation:
     type: object
     properties:
@@ -8972,6 +8970,38 @@ definitions:
        - FILE_MEDIA_TYPE_IMAGE: Image.
        - FILE_MEDIA_TYPE_AUDIO: Audio.
        - FILE_MEDIA_TYPE_VIDEO: Video.
+  FileMetadata:
+    type: object
+    properties:
+      uid:
+        type: string
+        description: File UID.
+        readOnly: true
+      filename:
+        type: string
+        title: Filename
+        readOnly: true
+      fileType:
+        description: File Type.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/FileType'
+      size:
+        type: string
+        format: int64
+        description: Size.
+        readOnly: true
+      createTime:
+        type: string
+        format: date-time
+        title: Creation timestamp
+        readOnly: true
+      processStatus:
+        description: Processing status of the file.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/FileProcessStatus'
+    description: FileMetadata contains information about the file.
   FileOption:
     type: object
     properties:
@@ -9160,7 +9190,7 @@ definitions:
         type: string
         format: byte
         title: converted markdown content
-    title: GetChatFileResponse
+    description: GetChatFileResponse ...
   GetChatResponse:
     type: object
     properties:
@@ -9189,18 +9219,31 @@ definitions:
         description: Map of column UID to their definitions.
         readOnly: true
     description: GetColumnDefinitionsResponse contains the column definitions.
+  GetFileAsMarkdownResponse:
+    type: object
+    properties:
+      markdown:
+        type: string
+        description: The Markdown representation of a file.
+        readOnly: true
+    description: |-
+      GetFileAsMarkdownResponse contains a blob with the Markdown representation
+      of a file.
   GetFileCatalogResponse:
     type: object
     properties:
       originalData:
         type: string
-        title: original data is encoded in base64
-      metadata:
-        title: file catalog
+        description: Base-64 representation of the original file contents.
+        readOnly: true
+      fileMetadata:
+        description: File metadata.
+        readOnly: true
         allOf:
-          - $ref: '#/definitions/Metadata'
+          - $ref: '#/definitions/FileMetadata'
       text:
-        title: text
+        description: Converted text.
+        readOnly: true
         allOf:
           - $ref: '#/definitions/Text'
       chunks:
@@ -9208,47 +9251,59 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/GetFileCatalogResponse.Chunk'
-        title: chunks
-    title: GetFileCatalogResponse
+        description: Chunks.
+        readOnly: true
+    description: |-
+      GetFileCatalogResponse contains the processing outputs of a file in a
+      catalog.
   GetFileCatalogResponse.Chunk:
     type: object
     properties:
       uid:
         type: string
-        title: chunk uid
+        description: Chunk UID.
+        readOnly: true
       type:
-        title: chunk type. i.e. text, image, audio, and video
+        description: 'Chunk type. I.e: text, image, audio, video.'
+        readOnly: true
         allOf:
           - $ref: '#/definitions/ChunkType'
-      startPos:
+      startPosition:
         type: integer
         format: int32
-        title: chunk start position
-      endPos:
+        description: Start position in the text.
+        readOnly: true
+      endPosition:
         type: integer
         format: int32
-        title: chunk end position
+        description: End position in the text.
+        readOnly: true
       content:
         type: string
-        title: chunk content
-      tokensNum:
+        description: Content.
+        readOnly: true
+      tokenCount:
         type: integer
         format: int32
-        title: chunk tokens num
+        description: Token count in the chunk.
+        readOnly: true
       embedding:
         type: array
         items:
           type: number
           format: float
-        title: embedding. float32 array
+        description: Chunk embedding.
+        readOnly: true
       createTime:
         type: string
         format: date-time
-        title: chunk create time
+        description: Creation time of the chunk.
+        readOnly: true
       retrievable:
         type: boolean
-        title: chunk retrievable
-    title: chunk message
+        description: Retrievability of the chunk.
+        readOnly: true
+    description: Chunk is a delimited part of the converted text.
   GetFileSummaryResponse:
     type: object
     properties:
@@ -10701,32 +10756,6 @@ definitions:
       - MESSAGE_TYPE_TEXT
     description: '- MESSAGE_TYPE_TEXT: text'
     title: message type
-  Metadata:
-    type: object
-    properties:
-      fileUid:
-        type: string
-        title: file uid
-      fileId:
-        type: string
-        title: file id
-      fileType:
-        title: file type
-        allOf:
-          - $ref: '#/definitions/FileType'
-      fileSize:
-        type: string
-        format: int64
-        title: file size in bytes
-      fileUploadTime:
-        type: string
-        format: date-time
-        title: upload time
-      fileProcessStatus:
-        title: file process status
-        allOf:
-          - $ref: '#/definitions/FileProcessStatus'
-    title: metadata
   Method:
     type: string
     enum:
@@ -12628,27 +12657,32 @@ definitions:
   Text:
     type: object
     properties:
-      pipelineIds:
+      pipelines:
         type: array
         items:
           type: string
-        title: pipelines
-      transformedContent:
+        description: Pipelines used to process the file.
+        readOnly: true
+      content:
         type: string
-        title: transformed content
-      transformedContentChunkNum:
+        description: Text representation of the file.
+        readOnly: true
+      chunkCount:
         type: integer
         format: int32
-        title: transformed content chunk number
-      transformedContentTokenNum:
+        description: Chunk count in the text.
+        readOnly: true
+      tokenCount:
         type: integer
         format: int32
-        title: transformed content token number
-      transformedContentUpdateTime:
+        title: Token count in the text
+        readOnly: true
+      updateTime:
         type: string
         format: date-time
-        title: transformed content update time
-    title: text message
+        description: Last update timestamp for the text.
+        readOnly: true
+    description: Text contains the text representation of the file.
   Trace:
     type: object
     properties:

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -2362,7 +2362,7 @@ paths:
   /v1alpha/namespaces/{namespaceId}/catalogs/{catalogId}/chunks/retrieve:
     post:
       summary: Retrieve similar chunks
-      description: Returns the similar chunks.
+      description: Returns the top-K most similar chunks to a text prompt.
       operationId: ArtifactPublicService_SimilarityChunksSearch
       responses:
         "200":
@@ -2378,12 +2378,12 @@ paths:
             $ref: '#/definitions/rpc.Status'
       parameters:
         - name: namespaceId
-          description: owner/namespace id
+          description: ID of the namespace owning the catalog.
           in: path
           required: true
           type: string
         - name: catalogId
-          description: catalog id
+          description: ID of the catalog.
           in: path
           required: true
           type: string
@@ -12301,22 +12301,27 @@ definitions:
     properties:
       textPrompt:
         type: string
-        title: text prompt
+        description: Text prompt to look for similarities.
       topK:
         type: integer
         format: int64
-        title: top k
+        description: 'Top K. Default value: 5.'
       fileName:
         type: string
-        title: file name
+        description: |-
+          File name. This field is deprecated as the file ID isn't a unique
+          identifier within a catalog. The file UID should be used, instead.
       contentType:
-        title: content type
+        description: Content type.
         allOf:
           - $ref: '#/definitions/ContentType'
       fileMediaType:
-        title: file type
+        description: File type.
         allOf:
           - $ref: '#/definitions/FileMediaType'
+      fileUid:
+        type: string
+        description: File UID.
     title: Similar chunk search request
     required:
       - textPrompt


### PR DESCRIPTION
Because

- Catalog files shouldn't be identified by their filename but by their UID.

This commit

- Removes the file ID param as a file identifier from the API.
- Refactors / polishes the API to align with other services.
  - Some of these changes introduce new fields with better names /
    definitions but don't delete the previous ones for backwards
    compatibility. When the clients have been updated, the fields will be
    removed.
