### PR TITLE
chore(workflows): add PR path conditoin for api doc update

### DIFF
--- a/.github/workflows/sync-api-docs.yml
+++ b/.github/workflows/sync-api-docs.yml
@@ -1,11 +1,14 @@
 name: Sync docs in ReadMe 🦉
 
 on:
+  # This workflow will run every time changes in the OpenAPI docs are pushed to
+  # the `main` branch or a pull request is opened or updated that contains
+  # changes in the OpenAPI docs.
   pull_request:
+    paths:
+      - "openapi/v2/**"
   push:
     branches:
-      # This workflow will run every time changes in the OpenAPI docs are
-      # pushed to the `main` branch.
       - main
     paths:
       - "openapi/v2/**"


### PR DESCRIPTION
Because

- PR should trigger the OpenAPI docs update workflow only when the OpenAPI docs have changes

This commit

- fixes the logic
