### PR TITLE
chore(artifact): clean up legacy filename params from requests

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -193,64 +193,32 @@ message UpdateObjectResponse {
   Object object = 1;
 }
 
-// Catalog represents a catalog.
+// A Catalog is a unified AI-ready format that serves as a knowledge base,
+// processing files and preparing them for Retrieval-Augmented Generation
+// (RAG).
 message Catalog {
-  // The catalog uid.
-  string catalog_uid = 1;
-  // The catalog id.
-  string catalog_id = 2;
-  // The catalog name.
-  string name = 3;
-  // The catalog description.
-  string description = 4;
-  // The creation time of the catalog.
-  string create_time = 5;
-  // The last update time of the catalog.
-  string update_time = 6;
-  // The owner/namespace of the catalog.
-  string owner_name = 7;
-  // The catalog tags.
-  repeated string tags = 8;
-  // The catalog converting pipelines.
-  repeated string converting_pipelines = 9;
-  // The catalog splitting pipelines.
-  repeated string splitting_pipelines = 10;
-  // The catalog embedding pipelines.
-  repeated string embedding_pipelines = 11;
-  // The downstream apps
-  repeated string downstream_apps = 12;
-  // The total files in catalog.
-  uint32 total_files = 13;
-  // The total tokens in catalog.
-  uint32 total_tokens = 14;
-  // The current used storage in catalog.
-  uint64 used_storage = 15;
-  // The catalog summarizing pipelines.
-  repeated string summarizing_pipelines = 16;
-}
-
-// Catalog Type. e.g. "persistent" or "ephemeral"
-enum CatalogType {
-  // UNSPECIFIED
-  CATALOG_TYPE_UNSPECIFIED = 0;
-  // PERSISTENT
-  CATALOG_TYPE_PERSISTENT = 1;
-  // EPHEMERAL
-  CATALOG_TYPE_EPHEMERAL = 2;
-}
-
-// CreateCatalogRequest represents a request to create a catalog.
-message CreateCatalogRequest {
-  // The catalog's owner(namespaces).
-  string namespace_id = 1;
-  // The catalog name.
-  string name = 2;
-  // The catalog description.
-  string description = 3;
-  // The catalog tags.
-  repeated string tags = 4;
-  // The catalog type. default is PERSISTENT
-  CatalogType type = 5;
+  // Catalog UID.
+  string uid = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Catalog resource ID (used in `name` as the last segment). This conforms
+  // to RFC-1034, which restricts to letters, numbers, and hyphen, with the
+  // first character a letter, the last a letter or a number, and a 63
+  // character maximum.
+  string id = 18 [(google.api.field_behavior) = IMMUTABLE];
+  // ID of the namespace owning the catalog.
+  string namespace_id = 19 [(google.api.field_behavior) = REQUIRED];
+  // The name of the catalog, defined by its parent namespace and its ID.
+  // - Format: `namespaces/{namespace.id}/catalogs/{catalog.id}`.
+  string name = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Type (by default, persistent).
+  CatalogType type = 20 [(google.api.field_behavior) = OPTIONAL];
+  // Catalog description.
+  string description = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Creation timestamp.
+  google.protobuf.Timestamp create_time = 5;
+  // Timestamp of the last update
+  google.protobuf.Timestamp update_time = 6;
+  // Tags.
+  repeated string tags = 8 [(google.api.field_behavior) = OPTIONAL];
   // Pipelines used for converting documents (i.e., files with pdf, doc[x] or
   // ppt[x] extension) to Markdown. The strings in the list identify the
   // pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.
@@ -277,13 +245,57 @@ message CreateCatalogRequest {
   // non-document catalog files, the conversion pipeline is deterministic (such
   // files are typically trivial to convert and don't require a dedicated
   // pipeline to improve the conversion performance).
-  repeated string converting_pipelines = 6;
+  repeated string converting_pipelines = 9 [(google.api.field_behavior) = OPTIONAL];
+  // Pipelines used for text splitting within the catalog.
+  repeated string splitting_pipelines = 10 [(google.api.field_behavior) = OPTIONAL];
+  // Pipelines used for text embedding within the catalog.
+  repeated string embedding_pipelines = 11 [(google.api.field_behavior) = OPTIONAL];
+  // Pipelines used for summarization within the catalog.
+  repeated string summarizing_pipelines = 16 [(google.api.field_behavior) = OPTIONAL];
+  // File count.
+  uint32 total_files = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Token count.
+  uint32 total_tokens = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Current storage use, in bytes.
+  uint64 used_storage = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  /* Deprecated fields, maintained until clients no longer use them. */
+
+  // Catalog UID.
+  // Deprecated. Use uid instead.
+  string catalog_uid = 1 [deprecated = true];
+  // Catalog ID.
+  // Deprecated. Use id instead.
+  string catalog_id = 2 [deprecated = true];
+  // The owner/namespace of the catalog.
+  // Deprecated. Use namespace_id instead.
+  string owner_name = 7 [deprecated = true];
+  // The downstream apps
+  repeated string downstream_apps = 12 [deprecated = true];
 }
 
-// CreateCatalogResponse represents a response for creating a catalog.
+// CatalogType defines the lifecycle of the catalog.
+enum CatalogType {
+  // Unspecified.
+  CATALOG_TYPE_UNSPECIFIED = 0;
+  // Persistent.
+  CATALOG_TYPE_PERSISTENT = 1;
+  // Ephemeral.
+  CATALOG_TYPE_EPHEMERAL = 2;
+}
+
+// CreateCatalogRequest represents a request to create a catalog.
+message CreateCatalogRequest {
+  // The namespace that will own the catalog.
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The properties of the catalog to be created.
+  Catalog catalog = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// CreateCatalogResponse contains the created catalog.
 message CreateCatalogResponse {
   // The created catalog.
-  Catalog catalog = 1;
+  Catalog catalog = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Request message for ListCatalogs(not include the ephemeral catalogs)
@@ -298,7 +310,8 @@ message ListCatalogsResponse {
   repeated Catalog catalogs = 1;
 }
 
-// UpdateCatalogRequest represents a request to update a catalog.
+// UpdateCatalogRequest represents a request to update a catalog, identified by
+// its owner and ID.
 message UpdateCatalogRequest {
   // The catalog id.
   string catalog_id = 1;
@@ -719,4 +732,55 @@ message MoveFileToCatalogRequest {
 message MoveFileToCatalogResponse {
   // The file uid.
   string file_uid = 1;
+}
+
+/* Deprecated */
+
+// CreateNamespaceCatalogRequest represents a request to create a catalog.
+// This method is deprecated and CreateCatalog should be used instead.
+message CreateNamespaceCatalogRequest {
+  // The catalog's owner(namespaces).
+  string namespace_id = 1;
+  // The catalog name.
+  string name = 2;
+  // The catalog description.
+  string description = 3;
+  // The catalog tags.
+  repeated string tags = 4;
+  // The catalog type. default is PERSISTENT
+  CatalogType type = 5;
+  // Pipelines used for converting documents (i.e., files with pdf, doc[x] or
+  // ppt[x] extension) to Markdown. The strings in the list identify the
+  // pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.
+  // The pipeline recipes MUST have the following variable and output fields:
+  // ```yaml variable
+  // variable:
+  //   document_input:
+  //     title: document-input
+  //     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)
+  //     type: file
+  // ```
+  // ```yaml output
+  // output:
+  //  convert_result:
+  //    title: convert-result
+  //    value: ${merge-markdown-refinement.output.results[0]}
+  // ```
+  // Other variable and output fields will be ignored.
+  //
+  // The pipelines will be executed in order until one produces a successful,
+  // non-empty result.
+  //
+  // If no pipelines are provided, a default pipeline will be used. For
+  // non-document catalog files, the conversion pipeline is deterministic (such
+  // files are typically trivial to convert and don't require a dedicated
+  // pipeline to improve the conversion performance).
+  repeated string converting_pipelines = 6;
+}
+
+// CreateNamespaceCatalogResponse represents a response for creating a catalog.
+// This method is deprecated and CreateCatalog should be used instead.
+message CreateNamespaceCatalogResponse {
+  // The created catalog.
+  Catalog catalog = 1;
 }

--- a/artifact/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/artifact/v1alpha/artifact_private_service.proto
@@ -42,13 +42,4 @@ service ArtifactPrivateService {
   //
   // Returns the Markdown representation of a file.
   rpc GetFileAsMarkdown(GetFileAsMarkdownRequest) returns (GetFileAsMarkdownResponse);
-
-  // Get file as Markdown (deprecated)
-  //
-  // Returns the contents of a file conversion to Markdown as a binary blob.
-  // This method is deprecated as it identifies the file by namespace and
-  // filename instead of UID, which isn't a unique identifier anymore.
-  rpc GetChatFile(GetChatFileRequest) returns (GetChatFileResponse) {
-    option deprecated = true;
-  }
 }

--- a/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -43,10 +43,38 @@ service ArtifactPublicService {
     option (google.api.method_visibility).restriction = "INTERNAL";
   }
 
+  // Create a new catalog
+  //
+  // Creates a catalog under the parenthood of a namespace.
+  rpc CreateCatalog(CreateCatalogRequest) returns (CreateCatalogResponse) {
+    option (google.api.http) = {
+      // TODO when clients stop using CreateNamespaceCatalog, update the path
+      post: "/v1alpha/namespaces/{namespace_id}/catalogs/create"
+      body: "catalog"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Artifact"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "alpha"}
+      }
+    };
+  }
+
   // Create a catalog
   //
-  // Creates a catalog.
-  rpc CreateCatalog(CreateCatalogRequest) returns (CreateCatalogResponse) {
+  // Creates a catalog. This method is deprecated and CreateCatalog
+  // should be used instead.
+  // TODO:
+  // 1. Deploy CreateCatalog.
+  // 2. Update clients (HTTP and gRPC) to CreateCatalog.
+  // 3. Delete CreateNamespaceCatalog and update CreateCatalog's HTTP path,
+  //    mapping it temporarily to the one clients are currently using.
+  // 4. Update HTTP clients to RESTful path.
+  // 5. Remove temporary HTTP path mapping.
+  rpc CreateNamespaceCatalog(CreateNamespaceCatalogRequest) returns (CreateNamespaceCatalogResponse) {
+    option deprecated = true;
+
     option (google.api.http) = {
       post: "/v1alpha/namespaces/{namespace_id}/catalogs"
       body: "*"

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -158,7 +158,8 @@ message UpdateChunkResponse {
   Chunk chunk = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// Similar chunk search request
+// SimilarityChunksSearchRequest represents a request to retrieve the K most
+// similar chunks to a prompt.
 message SimilarityChunksSearchRequest {
   // ID of the namespace owning the catalog.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
@@ -168,35 +169,37 @@ message SimilarityChunksSearchRequest {
   string text_prompt = 3 [(google.api.field_behavior) = REQUIRED];
   // Top K. Default value: 5.
   uint32 top_k = 4 [(google.api.field_behavior) = OPTIONAL];
-  // 5 is reserved for file_name, deprecated by file_uid.
-  reserved 5;
-  // Content type.
+  // Content type filter.
   ContentType content_type = 6 [(google.api.field_behavior) = OPTIONAL];
-  // File type.
+  // File type filter.
   FileMediaType file_media_type = 7 [(google.api.field_behavior) = OPTIONAL];
-  // 8 is reserved for file_uid, deprecated by file_uids.
-  reserved 8;
   // File UIDs. When this field is provided, the response will return only
   // chunks that belong to the specified file UIDs.
   repeated string file_uids = 9 [(google.api.field_behavior) = OPTIONAL];
+
+  // 5 is reserved for file_name, deprecated by file_uid.
+  reserved 5;
+  // 8 is reserved for file_uid, deprecated by file_uids.
+  reserved 8;
 }
 
-// Similar chunk search response
+// SimilarityChunksSearchResponse contains the retrieved similar chunks.
 message SimilarityChunksSearchResponse {
-  // chunks
+  // A list of chunks and their distance to the original prompt.
   repeated SimilarityChunk similar_chunks = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// similarity chunks
+// SimilarityChunk contains information about a chunk retrieved in a similarity
+// search.
 message SimilarityChunk {
-  // chunk uid
+  // Chunk UID.
   string chunk_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // similarity score
+  // Similarity score (distance to the text provided in the search).
   float similarity_score = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // content
+  // Chunk content.
   string text_content = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // source file's name
+  // Name of the file the chunk was extracted from.
   string source_file = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // chunk
+  // Chunk information.
   Chunk chunk_metadata = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }

--- a/artifact/artifact/v1alpha/file_catalog.proto
+++ b/artifact/artifact/v1alpha/file_catalog.proto
@@ -115,23 +115,3 @@ message GetFileAsMarkdownResponse {
   // The Markdown representation of a file.
   string markdown = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
-
-// GetChatFileRequest ...
-message GetChatFileRequest {
-  option deprecated = true;
-
-  // id of the namespace
-  string namespace_id = 1;
-  // id of the catalog
-  string catalog_id = 2;
-  // id of the file(i.e. file name)
-  string file_id = 3;
-}
-
-// GetChatFileResponse ...
-message GetChatFileResponse {
-  option deprecated = true;
-
-  // converted markdown content
-  bytes markdown = 1;
-}

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -31,6 +31,40 @@ consumes:
 produces:
   - application/json
 paths:
+  /v1alpha/namespaces/{namespaceId}/catalogs/create:
+    post:
+      summary: Create a new catalog
+      description: Creates a catalog under the parenthood of a namespace.
+      operationId: ArtifactPublicService_CreateCatalog
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/CreateCatalogResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: namespaceId
+          description: The namespace that will own the catalog.
+          in: path
+          required: true
+          type: string
+        - name: catalog
+          description: The properties of the catalog to be created.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Catalog'
+            required:
+              - catalog
+      tags:
+        - Artifact
+      x-stage: alpha
   /v1alpha/namespaces/{namespaceId}/catalogs:
     get:
       summary: Get all catalogs info
@@ -59,13 +93,22 @@ paths:
       x-stage: alpha
     post:
       summary: Create a catalog
-      description: Creates a catalog.
-      operationId: ArtifactPublicService_CreateCatalog
+      description: |-
+        Creates a catalog. This method is deprecated and CreateCatalog
+        should be used instead.
+        TODO:
+        1. Deploy CreateCatalog.
+        2. Update clients (HTTP and gRPC) to CreateCatalog.
+        3. Delete CreateNamespaceCatalog and update CreateCatalog's HTTP path,
+           mapping it temporarily to the one clients are currently using.
+        4. Update HTTP clients to RESTful path.
+        5. Remove temporary HTTP path mapping.
+      operationId: ArtifactPublicService_CreateNamespaceCatalog
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/CreateCatalogResponse'
+            $ref: '#/definitions/CreateNamespaceCatalogResponse'
         "401":
           description: Returned when the client credentials are not valid.
           schema: {}
@@ -83,7 +126,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/CreateCatalogBody'
+            $ref: '#/definitions/CreateNamespaceCatalogBody'
       tags:
         - Artifact
       x-stage: alpha
@@ -5055,70 +5098,133 @@ definitions:
   Catalog:
     type: object
     properties:
-      catalogUid:
+      uid:
         type: string
-        description: The catalog uid.
-      catalogId:
+        description: Catalog UID.
+        readOnly: true
+      id:
         type: string
-        description: The catalog id.
+        description: |-
+          Catalog resource ID (used in `name` as the last segment). This conforms
+          to RFC-1034, which restricts to letters, numbers, and hyphen, with the
+          first character a letter, the last a letter or a number, and a 63
+          character maximum.
+      namespaceId:
+        type: string
+        description: ID of the namespace owning the catalog.
       name:
         type: string
-        description: The catalog name.
+        description: |-
+          The name of the catalog, defined by its parent namespace and its ID.
+          - Format: `namespaces/{namespace.id}/catalogs/{catalog.id}`.
+        readOnly: true
+      type:
+        description: Type (by default, persistent).
+        allOf:
+          - $ref: '#/definitions/CatalogType'
       description:
         type: string
-        description: The catalog description.
+        description: Catalog description.
       createTime:
         type: string
-        description: The creation time of the catalog.
+        format: date-time
+        description: Creation timestamp.
       updateTime:
         type: string
-        description: The last update time of the catalog.
-      ownerName:
-        type: string
-        description: The owner/namespace of the catalog.
+        format: date-time
+        title: Timestamp of the last update
       tags:
         type: array
         items:
           type: string
-        description: The catalog tags.
+        description: Tags.
       convertingPipelines:
         type: array
         items:
           type: string
-        description: The catalog converting pipelines.
+        description: |-
+          Pipelines used for converting documents (i.e., files with pdf, doc[x] or
+          ppt[x] extension) to Markdown. The strings in the list identify the
+          pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.
+          The pipeline recipes MUST have the following variable and output fields:
+          ```yaml variable
+          variable:
+            document_input:
+              title: document-input
+              description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)
+              type: file
+          ```
+          ```yaml output
+          output:
+           convert_result:
+             title: convert-result
+             value: ${merge-markdown-refinement.output.results[0]}
+          ```
+          Other variable and output fields will be ignored.
+
+          The pipelines will be executed in order until one produces a successful,
+          non-empty result.
+
+          If no pipelines are provided, a default pipeline will be used. For
+          non-document catalog files, the conversion pipeline is deterministic (such
+          files are typically trivial to convert and don't require a dedicated
+          pipeline to improve the conversion performance).
       splittingPipelines:
         type: array
         items:
           type: string
-        description: The catalog splitting pipelines.
+        description: Pipelines used for text splitting within the catalog.
       embeddingPipelines:
         type: array
         items:
           type: string
-        description: The catalog embedding pipelines.
+        description: Pipelines used for text embedding within the catalog.
+      summarizingPipelines:
+        type: array
+        items:
+          type: string
+        description: Pipelines used for summarization within the catalog.
+      totalFiles:
+        type: integer
+        format: int64
+        description: File count.
+        readOnly: true
+      totalTokens:
+        type: integer
+        format: int64
+        description: Token count.
+        readOnly: true
+      usedStorage:
+        type: string
+        format: uint64
+        description: Current storage use, in bytes.
+        readOnly: true
+      catalogUid:
+        type: string
+        description: |-
+          Catalog UID.
+          Deprecated. Use uid instead.
+      catalogId:
+        type: string
+        description: |-
+          Catalog ID.
+          Deprecated. Use id instead.
+      ownerName:
+        type: string
+        description: |-
+          The owner/namespace of the catalog.
+          Deprecated. Use namespace_id instead.
       downstreamApps:
         type: array
         items:
           type: string
         title: The downstream apps
-      totalFiles:
-        type: integer
-        format: int64
-        description: The total files in catalog.
-      totalTokens:
-        type: integer
-        format: int64
-        description: The total tokens in catalog.
-      usedStorage:
-        type: string
-        format: uint64
-        description: The current used storage in catalog.
-      summarizingPipelines:
-        type: array
-        items:
-          type: string
-        description: The catalog summarizing pipelines.
-    description: Catalog represents a catalog.
+    description: |-
+      A Catalog is a unified AI-ready format that serves as a knowledge base,
+      processing files and preparing them for Retrieval-Augmented Generation
+      (RAG).
+    required:
+      - namespaceId
   CatalogRun:
     type: object
     properties:
@@ -5212,9 +5318,10 @@ definitions:
       - CATALOG_TYPE_PERSISTENT
       - CATALOG_TYPE_EPHEMERAL
     description: |-
-      - CATALOG_TYPE_PERSISTENT: PERSISTENT
-       - CATALOG_TYPE_EPHEMERAL: EPHEMERAL
-    title: Catalog Type. e.g. "persistent" or "ephemeral"
+      CatalogType defines the lifecycle of the catalog.
+
+       - CATALOG_TYPE_PERSISTENT: Persistent.
+       - CATALOG_TYPE_EPHEMERAL: Ephemeral.
   CheckNamespaceAdminResponse:
     type: object
     properties:
@@ -5770,7 +5877,16 @@ definitions:
        - CONTENT_TYPE_CHUNK: Chunk.
        - CONTENT_TYPE_SUMMARY: Summary.
        - CONTENT_TYPE_AUGMENTED: Augmented.
-  CreateCatalogBody:
+  CreateCatalogResponse:
+    type: object
+    properties:
+      catalog:
+        description: The created catalog.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Catalog'
+    description: CreateCatalogResponse contains the created catalog.
+  CreateNamespaceCatalogBody:
     type: object
     properties:
       name:
@@ -5819,15 +5935,19 @@ definitions:
           non-document catalog files, the conversion pipeline is deterministic (such
           files are typically trivial to convert and don't require a dedicated
           pipeline to improve the conversion performance).
-    description: CreateCatalogRequest represents a request to create a catalog.
-  CreateCatalogResponse:
+    description: |-
+      CreateNamespaceCatalogRequest represents a request to create a catalog.
+      This method is deprecated and CreateCatalog should be used instead.
+  CreateNamespaceCatalogResponse:
     type: object
     properties:
       catalog:
         description: The created catalog.
         allOf:
           - $ref: '#/definitions/Catalog'
-    description: CreateCatalogResponse represents a response for creating a catalog.
+    description: |-
+      CreateNamespaceCatalogResponse represents a response for creating a catalog.
+      This method is deprecated and CreateCatalog should be used instead.
   CreateNamespaceConnectionResponse:
     type: object
     properties:
@@ -6284,14 +6404,6 @@ definitions:
         allOf:
           - $ref: '#/definitions/File'
     description: GetCatalogFileResponse represents a response for getting a catalog file.
-  GetChatFileResponse:
-    type: object
-    properties:
-      markdown:
-        type: string
-        format: byte
-        title: converted markdown content
-    description: GetChatFileResponse ...
   GetFileAsMarkdownResponse:
     type: object
     properties:
@@ -8794,27 +8906,29 @@ definitions:
     properties:
       chunkUid:
         type: string
-        title: chunk uid
+        description: Chunk UID.
         readOnly: true
       similarityScore:
         type: number
         format: float
-        title: similarity score
+        description: Similarity score (distance to the text provided in the search).
         readOnly: true
       textContent:
         type: string
-        title: content
+        description: Chunk content.
         readOnly: true
       sourceFile:
         type: string
-        title: source file's name
+        description: Name of the file the chunk was extracted from.
         readOnly: true
       chunkMetadata:
-        title: chunk
+        description: Chunk information.
         readOnly: true
         allOf:
           - $ref: '#/definitions/v1alpha.Chunk'
-    title: similarity chunks
+    description: |-
+      SimilarityChunk contains information about a chunk retrieved in a similarity
+      search.
   SimilarityChunksSearchBody:
     type: object
     properties:
@@ -8826,11 +8940,11 @@ definitions:
         format: int64
         description: 'Top K. Default value: 5.'
       contentType:
-        description: Content type.
+        description: Content type filter.
         allOf:
           - $ref: '#/definitions/ContentType'
       fileMediaType:
-        description: File type.
+        description: File type filter.
         allOf:
           - $ref: '#/definitions/FileMediaType'
       fileUids:
@@ -8840,7 +8954,9 @@ definitions:
         description: |-
           File UIDs. When this field is provided, the response will return only
           chunks that belong to the specified file UIDs.
-    title: Similar chunk search request
+    description: |-
+      SimilarityChunksSearchRequest represents a request to retrieve the K most
+      similar chunks to a prompt.
     required:
       - textPrompt
   SimilarityChunksSearchResponse:
@@ -8851,9 +8967,9 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/SimilarityChunk'
-        title: chunks
+        description: A list of chunks and their distance to the original prompt.
         readOnly: true
-    title: Similar chunk search response
+    description: SimilarityChunksSearchResponse contains the retrieved similar chunks.
   SourceFile:
     type: object
     properties:
@@ -9417,7 +9533,9 @@ definitions:
           non-document catalog files, the conversion pipeline is deterministic (such
           files are typically trivial to convert and don't require a dedicated
           pipeline to improve the conversion performance).
-    description: UpdateCatalogRequest represents a request to update a catalog.
+    description: |-
+      UpdateCatalogRequest represents a request to update a catalog, identified by
+      its owner and ID.
   UpdateCatalogResponse:
     type: object
     properties:


### PR DESCRIPTION
Because

- The duplicate filename feature in Artifact kept some filename references
  in the requests for backwards compatibility.

This commit

- Removes the filename as a file identifier in the Artifact API.
- Updates Catalog and its creation endpoint (in a backwards-compatible
  manner) to align with other service APIs.
