### PR TITLE
feat(subscription): update documentation and entities for user/org subscription

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1046,27 +1046,35 @@ message DeleteOrganizationMembershipRequest {
 // DeleteOrganizationMembershipResponse is an empty response.
 message DeleteOrganizationMembershipResponse {}
 
-// StripeSubscriptionDetail describes the details of a subscription in Stripe.
+// StripeSubscriptionDetail ontains the details of a subscription in Stripe.
 message StripeSubscriptionDetail {
-  // Enumerates the status types for the user's subscription.
+  // Enumerates the status types for the user's subscription. Please refer to
+  // the [Stripe
+  // documentation](https://docs.stripe.com/billing/subscriptions/overview#subscription-statuses)
+  // for more details.
   enum Status {
     // Unspecified status.
     STATUS_UNSPECIFIED = 0;
-    // Incomplete.
+    // The customer must do a payment-related action to activate the
+    // subscription.
     STATUS_INCOMPLETE = 1;
-    // Incomplete Expired.
+    // The subscription failed to activate because no successful payments were
+    // registered in time.
     STATUS_INCOMPLETE_EXPIRED = 2;
-    // Trialing.
+    // The subscription is currently in a trial period.
     STATUS_TRIALING = 3;
-    // Active.
+    // The subscription is in good standing.
     STATUS_ACTIVE = 4;
-    // Past due.
+    // Payment on the latest finalised invoice either failed or wasn’t
+    // attempted.
     STATUS_PAST_DUE = 5;
-    // Canceled.
+    // The subscription was cancelled by either the user or the admins.
     STATUS_CANCELED = 6;
-    // Unpaid.
+    // The latest invoice hasn’t been paid but the subscription remains in
+    // place.
     STATUS_UNPAID = 7;
-    // Paused.
+    // The subscription has ended its trial period without a default payment
+    // method.
     STATUS_PAUSED = 8;
   }
 
@@ -1088,17 +1096,23 @@ message StripeSubscriptionDetail {
   string description = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// UserSubscription details describe the plan (i.e., features) a user has access to.
+// UserSubscription details describe the plan of an individual user (i.e., the
+// features they have access to).
 message UserSubscription {
   // Enumerates the plan types for the user subscription.
   enum Plan {
-    // Unspecified plan.
+    // Empty value for Plan, it means that the user has no recorded
+    // subscriptions.
     PLAN_UNSPECIFIED = 0;
-    // Free plan.
-    PLAN_FREE = 1;
+    // 1 is reserved for the PLAN_FREE value, deprecated now that PLAN_STARTER
+    // offers a free trial.
+    reserved 1;
     // 2 is reserved for the deprecated PLAN_PRO value.
     reserved 2;
-    // Starter plan.
+    // The starter plan is an individual plan for developers and early-stage
+    // projects. This plan offers a free trial period that deoesn't require the
+    // customer to have a default payment method. After the free trial period
+    // is over, the subscription state will transition from trialing to paused.
     PLAN_STARTER = 3;
   }
 
@@ -1108,17 +1122,22 @@ message UserSubscription {
   StripeSubscriptionDetail detail = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// OrganizationSubscription details describe the plan (i.e., features) an organization has access to.
+// OrganizationSubscription details describe the plan of an organization (i.e.
+// the features and purchased seats it has access to).
 message OrganizationSubscription {
   // Enumerates the plan types for the organization subscription.
   enum Plan {
     // Unspecified plan.
     PLAN_UNSPECIFIED = 0;
-    // Free plan.
-    PLAN_FREE = 1;
-    // Team plan.
+    // 1 is reserved for the PLAN_FREE value, deprecated nnow that PLAN_TEAM
+    // offers a free trial.
+    reserved 1;
+    // The team plan is a subscription that offers collaboration features for
+    // small teams.
     PLAN_TEAM = 2;
-    // Enterprise plan.
+    // The enterprise plan is a subscription for large teams and/or high-volume
+    // deployments. This kind of subscription doesn't contain Stripe
+    // subscription details.
     PLAN_ENTERPRISE = 3;
   }
 
@@ -1132,11 +1151,12 @@ message OrganizationSubscription {
   int32 used_seats = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetAuthenticatedUserSubscriptionRequest represents a query to fetch the subscription
-// details of the authenticated user.
+// GetAuthenticatedUserSubscriptionRequest represents a query to fetch the
+// subscription details of the authenticated user.
 message GetAuthenticatedUserSubscriptionRequest {}
 
-// GetAuthenticatedUserSubscriptionResponse contains the requested subscription.
+// GetAuthenticatedUserSubscriptionResponse contains the requested
+// subscription.
 message GetAuthenticatedUserSubscriptionResponse {
   // The subscription resource.
   UserSubscription subscription = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
@@ -1157,30 +1177,33 @@ message GetOrganizationSubscriptionResponse {
   OrganizationSubscription subscription = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// GetUserSubscriptionAdminRequest
+// GetUserSubscriptionAdminRequest represents a query to fetch the subscription
+// details of a user.
 message GetUserSubscriptionAdminRequest {
-  // Resever for `parant`
+  // Resever for `parent`
   reserved 1;
   // User ID
   string user_id = 2;
 }
 
-// GetUserSubscriptionAdminResponse
+// GetUserSubscriptionAdminResponse contains the requested subscription.
 message GetUserSubscriptionAdminResponse {
-  // Subscription
+  // The subscription resource.
   UserSubscription subscription = 1;
 }
 
-// GetOrganizationSubscriptionAdminRequest
+// GetOrganizationSubscriptionAdminRequest represents a query to fetch the
+// subscription details of an organization.
 message GetOrganizationSubscriptionAdminRequest {
-  // Resever for `parant`
+  // Resever for `parent`
   reserved 1;
   // Oragnization ID
   string organization_id = 2;
 }
 
-// GetOrganizationSubscriptionAdminResponse
+// GetOrganizationSubscriptionAdminResponse contains the requested
+// subscription.
 message GetOrganizationSubscriptionAdminResponse {
-  // Subscription
+  // The subscription resource.
   OrganizationSubscription subscription = 1;
 }

--- a/core/mgmt/v1beta/mgmt_private_service.proto
+++ b/core/mgmt/v1beta/mgmt_private_service.proto
@@ -30,10 +30,11 @@ service MgmtPrivateService {
   // returns a LookUpOrganizationAdminResponse
   rpc LookUpOrganizationAdmin(LookUpOrganizationAdminRequest) returns (LookUpOrganizationAdminResponse) {}
 
-  // GetUserSubscriptionAdmin
+  // GetUserSubscriptionAdmin returns the subscription details of a user.
   rpc GetUserSubscriptionAdmin(GetUserSubscriptionAdminRequest) returns (GetUserSubscriptionAdminResponse) {}
 
-  // GetOrganizationSubscriptionAdmin
+  // GetOrganizationSubscriptionAdmin returns the subscription details of an
+  // organization.
   rpc GetOrganizationSubscriptionAdmin(GetOrganizationSubscriptionAdminRequest) returns (GetOrganizationSubscriptionAdminResponse) {}
 
   // Subtract Instill Credit from a user or organization account.

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -304,7 +304,10 @@ service MgmtPublicService {
 
   // Get the subscription of the authenticated user
   //
-  // Returns the subscription details of the authenticated user.
+  // Returns the subscription details for the authenticated user's individual
+  // plan. If several subscriptions exist (e.g. if the user upgraded to and
+  // downgraded from a plan several times), the most recent subscription is
+  // returned.
   rpc GetAuthenticatedUserSubscription(GetAuthenticatedUserSubscriptionRequest) returns (GetAuthenticatedUserSubscriptionResponse) {
     option (google.api.http) = {get: "/v1beta/user/subscription"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -318,7 +321,10 @@ service MgmtPublicService {
 
   // Get the subscription of an organization
   //
-  // Returns the subscription details of an organization.
+  // Returns the subscription details for an organization's team plan. If
+  // several subscriptions exist (e.g. if the organization has upgraded to and
+  // downgraded from a plan several times), the most recent subscription is
+  // returned.
   rpc GetOrganizationSubscription(GetOrganizationSubscriptionRequest) returns (GetOrganizationSubscriptionResponse) {
     option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/subscription"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -3254,7 +3254,11 @@ paths:
   /v1beta/user/subscription:
     get:
       summary: Get the subscription of the authenticated user
-      description: Returns the subscription details of the authenticated user.
+      description: |-
+        Returns the subscription details for the authenticated user's individual
+        plan. If several subscriptions exist (e.g. if the user upgraded to and
+        downgraded from a plan several times), the most recent subscription is
+        returned.
       operationId: MgmtPublicService_GetAuthenticatedUserSubscription
       responses:
         "200":
@@ -3274,7 +3278,11 @@ paths:
   /v1beta/organizations/{organizationId}/subscription:
     get:
       summary: Get the subscription of an organization
-      description: Returns the subscription details of an organization.
+      description: |-
+        Returns the subscription details for an organization's team plan. If
+        several subscriptions exist (e.g. if the organization has upgraded to and
+        downgraded from a plan several times), the most recent subscription is
+        returned.
       operationId: MgmtPublicService_GetOrganizationSubscription
       responses:
         "200":
@@ -9167,7 +9175,9 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/UserSubscription'
-    description: GetAuthenticatedUserSubscriptionResponse contains the requested subscription.
+    description: |-
+      GetAuthenticatedUserSubscriptionResponse contains the requested
+      subscription.
   GetCatalogFileResponse:
     type: object
     properties:
@@ -9502,10 +9512,12 @@ definitions:
     type: object
     properties:
       subscription:
-        title: Subscription
+        description: The subscription resource.
         allOf:
           - $ref: '#/definitions/OrganizationSubscription'
-    title: GetOrganizationSubscriptionAdminResponse
+    description: |-
+      GetOrganizationSubscriptionAdminResponse contains the requested
+      subscription.
   GetOrganizationSubscriptionResponse:
     type: object
     properties:
@@ -9631,10 +9643,10 @@ definitions:
     type: object
     properties:
       subscription:
-        title: Subscription
+        description: The subscription resource.
         allOf:
           - $ref: '#/definitions/UserSubscription'
-    title: GetUserSubscriptionAdminResponse
+    description: GetUserSubscriptionAdminResponse contains the requested subscription.
   Hardware:
     type: object
     properties:
@@ -11469,19 +11481,22 @@ definitions:
         format: int32
         description: Number of used seats within the organization subscription.
         readOnly: true
-    description: OrganizationSubscription details describe the plan (i.e., features) an organization has access to.
+    description: |-
+      OrganizationSubscription details describe the plan of an organization (i.e.
+      the features and purchased seats it has access to).
   OrganizationSubscription.Plan:
     type: string
     enum:
-      - PLAN_FREE
       - PLAN_TEAM
       - PLAN_ENTERPRISE
     description: |-
       Enumerates the plan types for the organization subscription.
 
-       - PLAN_FREE: Free plan.
-       - PLAN_TEAM: Team plan.
-       - PLAN_ENTERPRISE: Enterprise plan.
+       - PLAN_TEAM: The team plan is a subscription that offers collaboration features for
+      small teams.
+       - PLAN_ENTERPRISE: The enterprise plan is a subscription for large teams and/or high-volume
+      deployments. This kind of subscription doesn't contain Stripe
+      subscription details.
   Owner:
     type: object
     properties:
@@ -12448,7 +12463,7 @@ definitions:
         type: string
         description: Description of the subscription.
         readOnly: true
-    description: StripeSubscriptionDetail describes the details of a subscription in Stripe.
+    description: StripeSubscriptionDetail ontains the details of a subscription in Stripe.
   StripeSubscriptionDetail.Status:
     type: string
     enum:
@@ -12461,16 +12476,24 @@ definitions:
       - STATUS_UNPAID
       - STATUS_PAUSED
     description: |-
-      Enumerates the status types for the user's subscription.
+      Enumerates the status types for the user's subscription. Please refer to
+      the [Stripe
+      documentation](https://docs.stripe.com/billing/subscriptions/overview#subscription-statuses)
+      for more details.
 
-       - STATUS_INCOMPLETE: Incomplete.
-       - STATUS_INCOMPLETE_EXPIRED: Incomplete Expired.
-       - STATUS_TRIALING: Trialing.
-       - STATUS_ACTIVE: Active.
-       - STATUS_PAST_DUE: Past due.
-       - STATUS_CANCELED: Canceled.
-       - STATUS_UNPAID: Unpaid.
-       - STATUS_PAUSED: Paused.
+       - STATUS_INCOMPLETE: The customer must do a payment-related action to activate the
+      subscription.
+       - STATUS_INCOMPLETE_EXPIRED: The subscription failed to activate because no successful payments were
+      registered in time.
+       - STATUS_TRIALING: The subscription is currently in a trial period.
+       - STATUS_ACTIVE: The subscription is in good standing.
+       - STATUS_PAST_DUE: Payment on the latest finalised invoice either failed or wasn’t
+      attempted.
+       - STATUS_CANCELED: The subscription was cancelled by either the user or the admins.
+       - STATUS_UNPAID: The latest invoice hasn’t been paid but the subscription remains in
+      place.
+       - STATUS_PAUSED: The subscription has ended its trial period without a default payment
+      method.
   SubtractCreditAdminResponse:
     type: object
     properties:
@@ -13485,17 +13508,20 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/StripeSubscriptionDetail'
-    description: UserSubscription details describe the plan (i.e., features) a user has access to.
+    description: |-
+      UserSubscription details describe the plan of an individual user (i.e., the
+      features they have access to).
   UserSubscription.Plan:
     type: string
     enum:
-      - PLAN_FREE
       - PLAN_STARTER
     description: |-
       Enumerates the plan types for the user subscription.
 
-       - PLAN_FREE: Free plan.
-       - PLAN_STARTER: Starter plan.
+       - PLAN_STARTER: The starter plan is an individual plan for developers and early-stage
+      projects. This plan offers a free trial period that deoesn't require the
+      customer to have a default payment method. After the free trial period
+      is over, the subscription state will transition from trialing to paused.
   ValidateNamespacePipelineBody:
     type: object
     description: |-


### PR DESCRIPTION
Because

- Instead of having a `PLAN_FREE` subscription (which exists only in the
  backend, not on Stripe), we're going to offer a free trial for the
  starter and team plans.

This commit

- Updates the subscription object and methods to reflect this change,
  deprecating the free plan enums and documenting the plan and status
  enums.
