### PR TITLE
chore(mgnt): return number of users in the organization

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -771,6 +771,15 @@ message Organization {
   OrganizationProfile profile = 12 [(google.api.field_behavior) = REQUIRED];
   // Permission
   Permission permission = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The Organization stats.
+  message Stats {
+    // The number of users in the organization.
+    int32 user_count = 1;
+  }
+
+  // The organization stats.
+  Stats stats = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListOrganizationsRequest represents a request to list all organizations

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -11436,11 +11436,24 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/mgmt.v1beta.Permission'
+      stats:
+        description: The organization stats.
+        readOnly: true
+        allOf:
+          - $ref: '#/definitions/Organization.Stats'
     description: |-
       Organizations group several users. As entities, they can own resources such
       as pipelines or releases.
     required:
       - profile
+  Organization.Stats:
+    type: object
+    properties:
+      userCount:
+        type: integer
+        format: int32
+        description: The number of users in the organization.
+    description: The Organization stats.
   OrganizationMembership:
     type: object
     properties:


### PR DESCRIPTION
Because

- We want to make it easier for users to get the number of users in the organization.

This commit

- Returns the number of users in the organization.