### PR TITLE
chore(mgmt): add invite-members endpoints

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1251,3 +1251,16 @@ message GetOrganizationSubscriptionAdminResponse {
   // The subscription resource.
   OrganizationSubscription subscription = 1;
 }
+
+// InviteOrganizationMembersRequest represents a request to invite members to an
+// organization.
+message InviteOrganizationMembersRequest {
+  // The organization ID.
+  string organization_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // The members to invite.
+  repeated string emails = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// InviteOrganizationMembersResponse represents a response to a request to invite
+// members to an organization.
+message InviteOrganizationMembersResponse {}

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -302,6 +302,23 @@ service MgmtPublicService {
     };
   }
 
+  // Invite members to an organization
+  //
+  // Invites members to an organization.
+  rpc InviteOrganizationMembers(InviteOrganizationMembersRequest) returns (InviteOrganizationMembersResponse) {
+    option (google.api.http) = {
+      post: "/v1beta/organizations/{organization_id}/invite-members"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Namespace"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
+  }
+
   // Get the subscription of the authenticated user
   //
   // Returns the subscription details for the authenticated user's individual

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -3251,6 +3251,37 @@ paths:
       tags:
         - Namespace
       x-stage: beta
+  /v1beta/organizations/{organizationId}/invite-members:
+    post:
+      summary: Invite members to an organization
+      description: Invites members to an organization.
+      operationId: MgmtPublicService_InviteOrganizationMembers
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/InviteOrganizationMembersResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: organizationId
+          description: The organization ID.
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/InviteOrganizationMembersBody'
+      tags:
+        - Namespace
+      x-stage: beta
   /v1beta/user/subscription:
     get:
       summary: Get the subscription of the authenticated user
@@ -9770,6 +9801,24 @@ definitions:
     description: |-
       Integration contains the parameters to create a connection between
       components and 3rd party apps.
+  InviteOrganizationMembersBody:
+    type: object
+    properties:
+      emails:
+        type: array
+        items:
+          type: string
+        description: The members to invite.
+    description: |-
+      InviteOrganizationMembersRequest represents a request to invite members to an
+      organization.
+    required:
+      - emails
+  InviteOrganizationMembersResponse:
+    type: object
+    description: |-
+      InviteOrganizationMembersResponse represents a response to a request to invite
+      members to an organization.
   Link:
     type: object
     properties:


### PR DESCRIPTION
Because

- We want to allow users to invite others to become organization members via email.

This commit

- Adds invite-members endpoints.