### PR TITLE
chore(mgmt): add an API to manually trigger a Stripe data sync

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -1266,3 +1266,22 @@ message InviteOrganizationMembersRequest {
 // InviteOrganizationMembersResponse represents a response to a request to invite
 // members to an organization.
 message InviteOrganizationMembersResponse {}
+
+// SyncAuthenticatedUserSubscriptionRequest represents a request to sync the
+// subscription of the authenticated user.
+message SyncAuthenticatedUserSubscriptionRequest {}
+
+// SyncAuthenticatedUserSubscriptionResponse represents a response to a request
+// to sync the subscription of the authenticated user.
+message SyncAuthenticatedUserSubscriptionResponse {}
+
+// SyncOrganizationSubscriptionRequest represents a request to sync the
+// subscription of an organization.
+message SyncOrganizationSubscriptionRequest {
+  // The organization ID.
+  string organization_id = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// SyncOrganizationSubscriptionResponse represents a response to a request to
+// sync the subscription of an organization.
+message SyncOrganizationSubscriptionResponse {}

--- a/core/mgmt/v1beta/mgmt_public_service.proto
+++ b/core/mgmt/v1beta/mgmt_public_service.proto
@@ -336,6 +336,20 @@ service MgmtPublicService {
     };
   }
 
+  // Sync the subscription of the authenticated user
+  //
+  // Syncs the subscription of the authenticated user with Stripe.
+  rpc SyncAuthenticatedUserSubscription(SyncAuthenticatedUserSubscriptionRequest) returns (SyncAuthenticatedUserSubscriptionResponse) {
+    option (google.api.http) = {post: "/v1beta/user/subscription/sync"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Subscription"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
+  }
+
   // Get the subscription of an organization
   //
   // Returns the subscription details for an organization's team plan. If
@@ -344,6 +358,20 @@ service MgmtPublicService {
   // returned.
   rpc GetOrganizationSubscription(GetOrganizationSubscriptionRequest) returns (GetOrganizationSubscriptionResponse) {
     option (google.api.http) = {get: "/v1beta/organizations/{organization_id}/subscription"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "Subscription"
+      extensions: {
+        key: "x-stage"
+        value: {string_value: "beta"}
+      }
+    };
+  }
+
+  // Sync the subscription of an organization
+  //
+  // Syncs the subscription of an organization with Stripe.
+  rpc SyncOrganizationSubscription(SyncOrganizationSubscriptionRequest) returns (SyncOrganizationSubscriptionResponse) {
+    option (google.api.http) = {post: "/v1beta/organizations/{organization_id}/subscription/sync"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Subscription"
       extensions: {

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -3463,6 +3463,26 @@ paths:
       tags:
         - Subscription
       x-stage: beta
+  /v1beta/user/subscription/sync:
+    post:
+      summary: Sync the subscription of the authenticated user
+      description: Syncs the subscription of the authenticated user with Stripe.
+      operationId: MgmtPublicService_SyncAuthenticatedUserSubscription
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/SyncAuthenticatedUserSubscriptionResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      tags:
+        - Subscription
+      x-stage: beta
   /v1beta/organizations/{organizationId}/subscription:
     get:
       summary: Get the subscription of an organization
@@ -3487,6 +3507,32 @@ paths:
       parameters:
         - name: organizationId
           description: Organization ID
+          in: path
+          required: true
+          type: string
+      tags:
+        - Subscription
+      x-stage: beta
+  /v1beta/organizations/{organizationId}/subscription/sync:
+    post:
+      summary: Sync the subscription of an organization
+      description: Syncs the subscription of an organization with Stripe.
+      operationId: MgmtPublicService_SyncOrganizationSubscription
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/SyncOrganizationSubscriptionResponse'
+        "401":
+          description: Returned when the client credentials are not valid.
+          schema: {}
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpc.Status'
+      parameters:
+        - name: organizationId
+          description: The organization ID.
           in: path
           required: true
           type: string
@@ -12891,6 +12937,16 @@ definitions:
         description: The error message of the suggestion.
         readOnly: true
     description: SuggestColumnDefinitionResponse represents a response to a request to suggest a column definition.
+  SyncAuthenticatedUserSubscriptionResponse:
+    type: object
+    description: |-
+      SyncAuthenticatedUserSubscriptionResponse represents a response to a request
+      to sync the subscription of the authenticated user.
+  SyncOrganizationSubscriptionResponse:
+    type: object
+    description: |-
+      SyncOrganizationSubscriptionResponse represents a response to a request to
+      sync the subscription of an organization.
   Table.AgentConfig:
     type: object
     properties:


### PR DESCRIPTION
This commit

- adds an API to manually trigger a Stripe data sync.
