### PR TITLE
chore(mgmt): add a field to indicate whether the user is eligible for org trial

### DIFF
--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -163,6 +163,8 @@ message AuthenticatedUser {
   OnboardingStatus onboarding_status = 17 [(google.api.field_behavior) = OPTIONAL];
   // Profile.
   UserProfile profile = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Is eligible for organization trial.
+  bool is_eligible_for_organization_trial = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Owner is a wrapper for User and Organization, used to embed owner information in other resources.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -7157,6 +7157,10 @@ definitions:
         readOnly: true
         allOf:
           - $ref: '#/definitions/UserProfile'
+      isEligibleForOrganizationTrial:
+        type: boolean
+        description: Is eligible for organization trial.
+        readOnly: true
     description: |-
       AuthenticatedUser contains the information of an authenticated user, i.e.,
       the public user information plus some fields that should only be accessed by


### PR DESCRIPTION
Because

- We need to determine whether users are eligible to create an organization under the trial plan.

This commit

- Adds a field to indicate whether a user is eligible for an organization trial.