### PR TITLE
feat(catalog): add multiple file UID filter to similarity chunk search

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -466,6 +466,36 @@ message UploadCatalogFileRequest {
   string catalog_id = 2 [(google.api.field_behavior) = REQUIRED];
   // file
   File file = 3;
+  // Pipelines used for converting the document file (i.e., files with pdf,
+  // doc[x] or ppt[x] extension) to Markdown. The strings in the list identify
+  // the pipelines and MUST have the format
+  // `{namespaceID}/{pipelineID}@{version}`.
+  // The pipeline recipes MUST have the following variable and output fields:
+  // ```yaml variable
+  // variable:
+  //   document_input:
+  //     title: document-input
+  //     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)
+  //     type: file
+  // ```
+  // ```yaml output
+  // output:
+  //  convert_result:
+  //    title: convert-result
+  //    value: ${merge-markdown-refinement.output.results[0]}
+  // ```
+  // Other variable and output fields will be ignored.
+  //
+  // The pipelines will be executed in order until one produces a successful,
+  // non-empty result.
+  //
+  // If no pipelines are provided, the catalog's conversion pipelines will be
+  // used (see the catalog creation request).
+  //
+  // For non-document catalog files, the conversion pipeline is deterministic
+  // (such files are typically trivial to convert and don't require a dedicated
+  // pipeline to improve the conversion performance).
+  repeated string converting_pipelines = 6;
 }
 
 // upload file response

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -170,6 +170,8 @@ message SimilarityChunksSearchRequest {
   uint32 top_k = 4 [(google.api.field_behavior) = OPTIONAL];
   // File name. This field is deprecated as the file ID isn't a unique
   // identifier within a catalog. The file UID should be used, instead.
+  // When this file is provided, the service will search a file by UID and
+  // it'll use the UID in the first match.
   string file_name = 5 [
     (google.api.field_behavior) = OPTIONAL,
     deprecated = true
@@ -178,8 +180,14 @@ message SimilarityChunksSearchRequest {
   ContentType content_type = 6 [(google.api.field_behavior) = OPTIONAL];
   // File type.
   FileMediaType file_media_type = 7 [(google.api.field_behavior) = OPTIONAL];
-  // File UID.
-  string file_uid = 8 [(google.api.field_behavior) = OPTIONAL];
+  // File UID. This field is deprecated, the file_uids should be used instead.
+  string file_uid = 8 [
+    (google.api.field_behavior) = OPTIONAL,
+    deprecated = true
+  ];
+  // File UIDs. When this field is provided, the response will return only
+  // chunks that belong to the specified file UIDs.
+  repeated string file_uids = 9 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Similar chunk search response


### PR DESCRIPTION
Because

- We want to filter by more than one file UID in the chunk similarity
  search

This commit

- Takes an optional array of file UIDs in the chunk similarity search.
- Allows users to customize the converting pipeline for documents at the
  file upload level, not only the catalog level.
