### PR TITLE
fix(catalog): make conversion pipeline part of file, not file upload request

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -456,16 +456,6 @@ message File {
   string summary = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
   // download url of the file
   string download_url = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
-// upload file request
-message UploadCatalogFileRequest {
-  // owner/namespace uid
-  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // catalog id
-  string catalog_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // file
-  File file = 3;
   // Pipeline used for converting the file to Markdown if the file is a
   // document (i.e., a file with pdf, doc[x] or ppt[x] extension). The value
   // identifies the pipeline release and and MUST have the format
@@ -493,7 +483,17 @@ message UploadCatalogFileRequest {
   // For non-document catalog files, the conversion pipeline is deterministic
   // (such files are typically trivial to convert and don't require a dedicated
   // pipeline to improve the conversion performance).
-  string converting_pipeline = 4;
+  optional string converting_pipeline = 21;
+}
+
+// upload file request
+message UploadCatalogFileRequest {
+  // owner/namespace uid
+  string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // catalog id
+  string catalog_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // file
+  File file = 3;
 }
 
 // upload file response


### PR DESCRIPTION
Because

- The file upload HTTP request flattens the request to the `file` field.
- We want to expose the pipeline used for conversion.

This commit

- Removes the `converting_pipeline` field from the file upload request
  and moves it as a field within the `File` message.
