### PR TITLE
chore(openapi): remove protobuf exposing to BSR

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Instill
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/buf.yaml
+++ b/buf.yaml
@@ -18,6 +18,7 @@ lint:
     - FIELD_NOT_REQUIRED
   ignore:
     - model/ray/serve.proto # protobuf file copied from ray repo
+    - openapi/ # exclude OpenAPI protobuf files
   enum_zero_value_suffix: _UNSPECIFIED
   service_suffix: Service
   disallow_comment_ignores: false

--- a/openapi/v2/conf.proto
+++ b/openapi/v2/conf.proto
@@ -1,21 +1,19 @@
 syntax = "proto3";
 
-package openapi.v2;
-
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
     title: "Instill Core API"
-    description: "Interact with Instill Core through its public API"
+    description: "Interact with Instill Core through API"
     version: "v0.54.1"
     contact: {
       name: "Instill AI"
       url: "https://github.com/instill-ai"
-      email: "hello@instill-ai.com"
+      email: "support@instill-ai.com"
     }
     license: {
-      name: "Elastic License 2.0 (ELv2)"
+      name: "MIT"
       url: "https://github.com/instill-ai/protobufs/blob/main/LICENSE"
     }
   }
@@ -28,7 +26,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     },
     {
       name: "Pipeline"
-      description: "Pipeline orchestration in Instill Core."
+      description: "Pipeline orchestration."
     },
     {
       name: "Artifact"
@@ -38,19 +36,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
     },
     {
       name: "Model"
-      description: "AI Model resources for MLOps/LLMOps."
-    },
-    {
-      name: "Agent"
-      description: "Ready-to-use AI agents."
-    },
-    {
-      name: "Table"
-      description: "Table resources for agents."
-    },
-    {
-      name: "Folder"
-      description: "Folder resources for agents."
+      description: "AI Model orchestration"
     },
     {
       name: "Metrics"
@@ -64,7 +50,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   host: "api.instill-ai.com"
   external_docs: {
     url: "https://docs.instill-ai.com"
-    description: "More about Instill AI"
+    description: "More about Instill Core"
   }
   schemes: HTTPS
   schemes: HTTP
@@ -79,7 +65,7 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
         name: "Authorization"
         description:
           "Enter the token with the `Bearer ` prefix, e.g. `Bearer "
-          "abcde12345`"
+          "instill_sk_***`"
         extensions: {
           key: "x-default"
           value: {string_value: "Bearer instill_sk_***"}

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -2,30 +2,24 @@
 swagger: "2.0"
 info:
   title: Instill Core API
-  description: Interact with Instill Core through its public API
+  description: Interact with Instill Core through API
   version: v0.54.1
   contact:
     name: Instill AI
     url: https://github.com/instill-ai
-    email: hello@instill-ai.com
+    email: support@instill-ai.com
   license:
-    name: Elastic License 2.0 (ELv2)
+    name: MIT
     url: https://github.com/instill-ai/protobufs/blob/main/LICENSE
 tags:
   - name: Namespace
     description: Namespaces (e.g. User, Organization) that structure the resource hierarchy.
   - name: Pipeline
-    description: Pipeline orchestration in Instill Core.
+    description: Pipeline orchestration.
   - name: Artifact
     description: Data orchestration for unified unstructured data representation.
   - name: Model
-    description: AI Model resources for MLOps/LLMOps.
-  - name: Agent
-    description: Ready-to-use AI agents.
-  - name: Table
-    description: Table resources for agents.
-  - name: Folder
-    description: Folder resources for agents.
+    description: AI Model orchestration
   - name: Metrics
     description: Resource usage metrics.
   - name: Subscription
@@ -10447,12 +10441,12 @@ definitions:
 securityDefinitions:
   Bearer:
     type: apiKey
-    description: Enter the token with the `Bearer ` prefix, e.g. `Bearer abcde12345`
+    description: Enter the token with the `Bearer ` prefix, e.g. `Bearer instill_sk_***`
     name: Authorization
     in: header
     x-default: Bearer instill_sk_***
 security:
   - Bearer: []
 externalDocs:
-  description: More about Instill AI
+  description: More about Instill Core
   url: https://docs.instill-ai.com


### PR DESCRIPTION
Because

- OpenAPI protobuf is for only configuration for the auto-gen logic

This commit

- removes OpenAPI protobuf exposing to BSR