### PR TITLE
chore(buf): exclude openapi in buf generate

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -7,6 +7,10 @@ managed:
   override:
     - file_option: go_package_prefix
       value: github.com/instill-ai/protogen-go
+inputs:
+  - directory: .
+    exclude_paths:
+      - openapi/
 plugins:
   - remote: buf.build/protocolbuffers/python:v23.1
     out: gen/python


### PR DESCRIPTION
Because

- the OpenAPI protobuf shouldn't be protogen-ed in Go and Python.

This commit

- adds `inputs` configuration in `buf.gen.yaml`.
