### PR TITLE
feat(artifact): add file length and chunk references

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -5,8 +5,10 @@ package artifact.artifact.v1alpha;
 import "artifact/artifact/v1alpha/object.proto";
 import "common/healthcheck/v1beta/healthcheck.proto";
 import "common/run/v1alpha/run.proto";
+
 // Google API
 import "google/api/field_behavior.proto";
+
 // Protocol Buffers Well-Known Types
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
@@ -379,7 +381,7 @@ enum FileProcessStatus {
   FILE_PROCESS_STATUS_SUMMARIZING = 8;
 }
 
-// file type
+// FileType determines the type of a file, based on its extension.
 enum FileType {
   // unspecified
   FILE_TYPE_UNSPECIFIED = 0;
@@ -413,48 +415,77 @@ enum FileType {
   FILE_TYPE_CSV = 14;
 }
 
-// file
+// FilePosition represents a position within a file using a specific unit.
+// The position can be multi-dimensional based on the unit type:
+// - 1 element for 1D positions (characters, pages, time)
+// - 2 elements for 2D positions (pixels: [x, y])
+// - N elements for N-dimensional positions
+message FilePosition {
+  // Unit describes the unit of measurement for a position within a file.
+  enum Unit {
+    // Unspecified.
+    UNIT_UNSPECIFIED = 0;
+    // Character positions (for Markdown and other text files).
+    UNIT_CHARACTER = 1;
+    // Page positions (for documents).
+    UNIT_PAGE = 2;
+    // Time positions in milliseconds (for audio/video files).
+    UNIT_TIME_MS = 3;
+    // Pixel positions (for images and other 2D content).
+    UNIT_PIXEL = 4;
+  }
+
+  // Unit of measurement for the position
+  Unit unit = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Position coordinates as an array
+  // For 1D: [position]
+  // For 2D: [x, y]
+  // For 3D: [x, y, z], etc.
+  repeated uint32 coordinates = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// File represents an object ingested by a catalog, which will later be
+// processed (converted to text, broken down into chunks and embedded) in order
+// to be used for retrieval and question answering.
 message File {
-  // file uid
+  // Unique identifier of the file.
   string file_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // file name
+  // Filename. Note that this field isn't unique.
   string name = 2 [(google.api.field_behavior) = OPTIONAL];
-  // file type
+  // File type, inferred from the extension in the filename.
   FileType type = 3 [(google.api.field_behavior) = OPTIONAL];
-  // file process status
+  // Processing status of the file.
   FileProcessStatus process_status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // file process message
+  // Message with the outcome of the processing.
   string process_outcome = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // retrievable(this is reserved for future use)
-  bool retrievable = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // content(this is reserved for future use)
-  string content = 7 [(google.api.field_behavior) = OPTIONAL];
-  // owner/namespace uid
+  // UID of the file owner.
   string owner_uid = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // creator uid from authn token
+  // UID of the file creator, i.e., the authenticated user who uploaded the
+  // file.
   string creator_uid = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // catalog uid
+  // UID of the catalog to which the file belongs.
   string catalog_uid = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // create time
+  // Creation timestamp.
   google.protobuf.Timestamp create_time = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // update time
+  // Last update timestamp.
   google.protobuf.Timestamp update_time = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // delete time
+  // Deletion timestamp.
   google.protobuf.Timestamp delete_time = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // file size in bytes
+  // File size in bytes.
   int64 size = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // total chunks
+  // Total number of chunks.
   int32 total_chunks = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // total tokens
+  // Total number of tokens.
   int32 total_tokens = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Custom metadata provided by the user during file upload
   optional google.protobuf.Struct external_metadata = 17 [(google.api.field_behavior) = OPTIONAL];
-  // objectUid in blob storage. user can upload to blob storage directly, then put objectUid here.
-  // then no need the base64 encoding for the file content.
+  // Object UID in blob storage. This will be present when the file is first
+  // uploaded as a blob, then added to the catalog by reference (instead of
+  // explicitly passing the base64-encoded file content).
   string object_uid = 18 [(google.api.field_behavior) = OPTIONAL];
-  // summary of the file
+  // Summary of the file.
   string summary = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // download url of the file
+  // Download URL of the file.
   string download_url = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Pipeline used for converting the file to Markdown if the file is a
   // document (i.e., a file with pdf, doc[x] or ppt[x] extension). The value
@@ -484,6 +515,19 @@ message File {
   // (such files are typically trivial to convert and don't require a dedicated
   // pipeline to improve the conversion performance).
   optional string converting_pipeline = 21;
+
+  // Length of the file in the specified unit type. It is defined as a
+  // FilePosition, so it reflects the number of positions (the unit will depend
+  // on the file type) that can be accessed in the file.
+  FilePosition length = 22 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Text representation of the file.
+  // TODO this field will be implemented along with the FULL view of the file
+  // message.
+  string content = 7 [(google.api.field_behavior) = OPTIONAL];
+
+  // 6 is reserved for the retrievable field.
+  reserved 6;
 }
 
 // upload file request

--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -535,31 +535,38 @@ message ListCatalogFilesFilter {
   FileProcessStatus process_status = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// list files request
+// ListCatalogFilesRequest represents a request to list files in a catalog.
 message ListCatalogFilesRequest {
-  // The owner/namespace uid id.
+  // ID of the catalog owner.
   string namespace_id = 1;
-  // The catalog id.
+  // Catalog ID.
   string catalog_id = 2;
-  // The page size (default:10; max 100).
+  // The maximum number of files to return. If this parameter is unspecified,
+  // at most 10 files will be returned. The cap value for this parameter is 100
+  // (i.e. any value above that will be coerced to 100).
   int32 page_size = 3 [(google.api.field_behavior) = OPTIONAL];
-  // The next page token(default from first file's token).
+  // Page token. By default, the first page will be returned.
   string page_token = 4 [(google.api.field_behavior) = OPTIONAL];
-  // The filter.
+  // Filter to apply to the list of files.
   ListCatalogFilesFilter filter = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Order by field, with options for ordering by `create_time` or
+  // `update_time`.
+  // Format: `order_by=create_time asc` or `order_by=update_time desc`, default
+  // is `create_time asc`.
+  optional string order_by = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// list files response
+// ListCatalogFilesResponse contains a paginated list of catalog files.
 message ListCatalogFilesResponse {
-  // The list of files.
+  // A list of files matching the request parameters.
   repeated File files = 1;
-  // The total number of files.
+  // Total number of files.
   int32 total_size = 2;
-  // The requested page size.
+  // Requested page size.
   int32 page_size = 3;
-  // next page token
+  // Next page token.
   string next_page_token = 4;
-  // The filter.
+  // The filter applied to the list of files.
   ListCatalogFilesFilter filter = 5;
 }
 

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -6,6 +6,9 @@ package artifact.artifact.v1alpha;
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 
+// Common definitions
+import "common/view/v1beta/view.proto";
+
 // FileMediaType describes the type of a catalog file.
 enum FileMediaType {
   // Unspecified.
@@ -85,6 +88,15 @@ message Chunk {
   Reference reference = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
   // reference to the position of the chunk within the markdown (source) file.
   optional Reference md_reference = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // View defines how the chunk is presented. The following fields are
+  // only shown in the FULL view:
+  // - content
+  // - embedding
+  common.view.v1beta.View view = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // String representation of the chunk.
+  string content = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Vector representation of the chunk.
+  repeated float embedding = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // start position of the chunk in the source file
   // Deprecated: use reference instead
@@ -94,22 +106,40 @@ message Chunk {
   uint32 end_pos = 5 [deprecated = true, (google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// The ListChunksRequest message represents a request to list chunks in the artifact system.
-// The response will be a list of chunks based on the request, i.e., response will
-// have chunks of the file with file_uid and chunks specified in chunk_uids.
+// ListChunksRequest represents a request to list the chunks of a catalog file.
 message ListChunksRequest {
-  // owner/namespace id (not uid)
+  // ID of the catalog owner.
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // catalog id (not uid)
+  // Catalog ID.
   string catalog_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // unique identifier of the file
+  // Unique file identifier.
   string file_uid = 3 [(google.api.field_behavior) = REQUIRED];
+  // The maximum number of items to return. The default and cap values are 10
+  // and 100, respectively.
+  optional int32 page_size = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Page token. By default, the first page will be returned.
+  optional string page_token = 5 [(google.api.field_behavior) = OPTIONAL];
+
+  // View allows clients to specify the desired view in the response.
+  optional common.view.v1beta.View view = 6 [(google.api.field_behavior) = OPTIONAL];
+
+  // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter expression.
+  // The following filters are supported:
+  // - `contentType`
+  //
+  // **Examples**:
+  // - List chunks with a "chunk" content type: `contentType="CONTENT_TYPE_CHUNK"`.
+  optional string filter = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
-// The ListChunksResponse message represents a response containing a list of chunks in the artifact system.
+// ListChunksResponse contains a paginated list of chunks.
 message ListChunksResponse {
-  // repeated chunks
+  // A list of chunks matching the request parameters.
   repeated Chunk chunks = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Next page token.
+  string next_page_token = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Total number of items.
+  int32 total_size = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Search chunks request

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -2,12 +2,13 @@ syntax = "proto3";
 
 package artifact.artifact.v1alpha;
 
+import "common/view/v1beta/view.proto";
+import "artifact/artifact/v1alpha/artifact.proto";
+
 // Protocol Buffers Well-Known Types
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 
-// Common definitions
-import "common/view/v1beta/view.proto";
 
 // FileMediaType describes the type of a catalog file.
 enum FileMediaType {
@@ -35,43 +36,17 @@ enum ContentType {
   CONTENT_TYPE_AUGMENTED = 3;
 }
 
-// ReferenceType describes the type of position reference in a file.
-enum ReferenceType {
-  // Unspecified.
-  REFERENCE_TYPE_UNSPECIFIED = 0;
-  // Character positions (for Markdown and other text files).
-  REFERENCE_TYPE_CHARACTER = 1;
-  // Page positions (for documents).
-  REFERENCE_TYPE_PAGE = 2;
-  // Time positions in milliseconds (for audio/video files).
-  REFERENCE_TYPE_TIME_MS = 3;
-  // Pixel positions (for images and other 2D content).
-  REFERENCE_TYPE_PIXEL = 4;
-}
-
-// Reference represents the position of a chunk within its source file.
-// The position arrays can have different dimensions based on the reference type:
-// - 1 element for 1D references (characters, pages, time)
-// - 2 elements for 2D references (pixels: [x, y])
-// - N elements for N-dimensional references
-message Reference {
-  // type of reference (characters, pages, milliseconds, or pixels)
-  ReferenceType type = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // start position coordinates as an array
-  // For 1D: [position]
-  // For 2D: [x, y]
-  // For 3D: [x, y, z], etc.
-  repeated uint32 start_position = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // end position coordinates as an array
-  // For 1D: [position]
-  // For 2D: [x, y]
-  // For 3D: [x, y, z], etc.
-  repeated uint32 end_position = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-}
-
 // Chunk represents a part of the original file, which will be used for
 // embedding and, later, retrieval.
 message Chunk {
+  // Reference represents the position of a chunk within its source file.
+  message Reference {
+    // Start position of the chunk within the file
+    FilePosition start = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // End position of the chunk within the file
+    FilePosition end = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+
   // Unique identifier of the chunk
   string chunk_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Chunk searchability

--- a/artifact/artifact/v1alpha/chunk.proto
+++ b/artifact/artifact/v1alpha/chunk.proto
@@ -24,32 +24,74 @@ enum FileMediaType {
 enum ContentType {
   // Unspecified.
   CONTENT_TYPE_UNSPECIFIED = 0;
-  // Chunk.
+  // Chunks represent a part of the original file.
   CONTENT_TYPE_CHUNK = 1;
-  // Summary.
+  // Summary of the original file.
   CONTENT_TYPE_SUMMARY = 2;
-  // Augmented.
+  // Original chunk content enhanced with additional information.
   CONTENT_TYPE_AUGMENTED = 3;
 }
 
-// The Chunk message represents a chunk of data in the artifact system.
+// ReferenceType describes the type of position reference in a file.
+enum ReferenceType {
+  // Unspecified.
+  REFERENCE_TYPE_UNSPECIFIED = 0;
+  // Character positions (for Markdown and other text files).
+  REFERENCE_TYPE_CHARACTER = 1;
+  // Page positions (for documents).
+  REFERENCE_TYPE_PAGE = 2;
+  // Time positions in milliseconds (for audio/video files).
+  REFERENCE_TYPE_TIME_MS = 3;
+  // Pixel positions (for images and other 2D content).
+  REFERENCE_TYPE_PIXEL = 4;
+}
+
+// Reference represents the position of a chunk within its source file.
+// The position arrays can have different dimensions based on the reference type:
+// - 1 element for 1D references (characters, pages, time)
+// - 2 elements for 2D references (pixels: [x, y])
+// - N elements for N-dimensional references
+message Reference {
+  // type of reference (characters, pages, milliseconds, or pixels)
+  ReferenceType type = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // start position coordinates as an array
+  // For 1D: [position]
+  // For 2D: [x, y]
+  // For 3D: [x, y, z], etc.
+  repeated uint32 start_position = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // end position coordinates as an array
+  // For 1D: [position]
+  // For 2D: [x, y]
+  // For 3D: [x, y, z], etc.
+  repeated uint32 end_position = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// Chunk represents a part of the original file, which will be used for
+// embedding and, later, retrieval.
 message Chunk {
-  // unique identifier of the chunk
+  // Unique identifier of the chunk
   string chunk_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // whether the chunk is retrievable
+  // Chunk searchability
   bool retrievable = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // start position of the chunk in the source file
-  uint32 start_pos = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // end position of the chunk in the source file
-  uint32 end_pos = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // tokens of the chunk
+  // Token count for the chunk
   uint32 tokens = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // creation time of the chunk
+  // Chunk creation time
   google.protobuf.Timestamp create_time = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // original file unique identifier
+  // Unique identifier of the original file
   string original_file_uid = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // content type
+  // Content type
   ContentType content_type = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // reference to the position of the chunk within the original file
+  Reference reference = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // reference to the position of the chunk within the markdown (source) file.
+  optional Reference md_reference = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // start position of the chunk in the source file
+  // Deprecated: use reference instead
+  uint32 start_pos = 4 [deprecated = true, (google.api.field_behavior) = OUTPUT_ONLY];
+  // end position of the chunk in the source file
+  // Deprecated: use reference instead
+  uint32 end_pos = 5 [deprecated = true, (google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // The ListChunksRequest message represents a request to list chunks in the artifact system.

--- a/artifact/artifact/v1alpha/file_catalog.proto
+++ b/artifact/artifact/v1alpha/file_catalog.proto
@@ -26,6 +26,9 @@ message GetFileCatalogRequest {
 // GetFileCatalogResponse contains the processing outputs of a file in a
 // catalog.
 message GetFileCatalogResponse {
+  // TODO GetFileCatalog should be deprecated. GetCatalogFile with a FULL view
+  // (to be implemented) parameter should be used instead.
+
   // FileMetadata contains information about the file.
   message FileMetadata {
     // File UID.

--- a/common/view/v1beta/view.proto
+++ b/common/view/v1beta/view.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package common.view.v1beta;
+
+// View defines how a resource is presented. Most resources can share this view
+// definition, the particular meaning of each value should be defined in the
+// resource itself. Certain resources might have their own View definition if
+// they need to implement more than 2 (basic / full) views.
+enum View {
+  // Unspecified, equivalent to BASIC.
+  VIEW_UNSPECIFIED = 0;
+  // Default view.
+  VIEW_BASIC = 1;
+  // Full representation.
+  VIEW_FULL = 2;
+}

--- a/core/mgmt/v1beta/mgmt.proto
+++ b/core/mgmt/v1beta/mgmt.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package core.mgmt.v1beta;
 
 import "common/healthcheck/v1beta/healthcheck.proto";
+import "common/view/v1beta/view.proto";
 import "google/api/field_behavior.proto";
 // Google API
 import "google/api/resource.proto";
@@ -37,17 +38,6 @@ message ReadinessResponse {
   common.healthcheck.v1beta.HealthCheckResponse health_check_response = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// View defines how a resource is presented. It can be used as a parameter in a
-// method request to allow clients to select the amount of information they
-// want in the response.
-enum View {
-  // Unspecified, equivalent to BASIC.
-  VIEW_UNSPECIFIED = 0;
-  // Default view, only includes basic information.
-  VIEW_BASIC = 1;
-  // Full representation.
-  VIEW_FULL = 2;
-}
 
 // OwnerType enumerates the owner type of any resource
 enum OwnerType {
@@ -218,7 +208,7 @@ message ListUsersAdminRequest {
   // Page token.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
@@ -240,7 +230,7 @@ message GetUserAdminRequest {
   // Reserved for `user_id`
   reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2;
+  optional common.view.v1beta.View view = 2;
   // User ID
   string user_id = 3;
 }
@@ -257,7 +247,7 @@ message LookUpUserAdminRequest {
   // Reserved for `permalink`
   reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2;
+  optional common.view.v1beta.View view = 2;
   // User UUID
   string user_uid = 3;
 }
@@ -277,7 +267,7 @@ message ListOrganizationsAdminRequest {
   // Page token.
   optional string page_token = 2;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 3;
+  optional common.view.v1beta.View view = 3;
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
@@ -299,7 +289,7 @@ message GetOrganizationAdminRequest {
   // Reserved for `name`
   reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2;
+  optional common.view.v1beta.View view = 2;
   // Organization ID
   string organization_id = 3;
 }
@@ -316,7 +306,7 @@ message LookUpOrganizationAdminRequest {
   // Reserved for `permalink`
   reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2;
+  optional common.view.v1beta.View view = 2;
   // Organization UID
   string organization_uid = 3;
 }
@@ -336,7 +326,7 @@ message ListUsersRequest {
   // Page token.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
@@ -359,7 +349,7 @@ message GetUserRequest {
   reserved 1;
 
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
   // User ID
   string user_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
@@ -735,7 +725,7 @@ message ListOrganizationsRequest {
   // Page token.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // - Example: `create_time>timestamp("2000-06-19T23:31:08.657Z")`.
@@ -770,7 +760,7 @@ message GetOrganizationRequest {
   // Reserved for `name`
   reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
   // Organization ID
   string organization_id = 3 [(google.api.field_behavior) = REQUIRED];
 }
@@ -878,7 +868,7 @@ message GetUserMembershipRequest {
   // Reserved for `name`
   reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
   // User ID
   string user_id = 3 [(google.api.field_behavior) = REQUIRED];
   // Organization ID
@@ -949,7 +939,7 @@ message GetOrganizationMembershipRequest {
   reserved 1;
 
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 
   // Organization ID
   string organization_id = 3 [(google.api.field_behavior) = REQUIRED];

--- a/model/model/v1alpha/model.proto
+++ b/model/model/v1alpha/model.proto
@@ -2,10 +2,11 @@ syntax = "proto3";
 
 package model.model.v1alpha;
 
-// common definitions
+// Common definitions
 import "common/healthcheck/v1beta/healthcheck.proto";
 import "common/run/v1alpha/run.proto";
 import "common/task/v1alpha/task.proto";
+import "common/view/v1beta/view.proto";
 // Core definitions
 import "core/mgmt/v1beta/mgmt.proto";
 // Google API
@@ -18,7 +19,6 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 // Model definitions
 import "model/model/v1alpha/common.proto";
-import "model/model/v1alpha/model_definition.proto";
 // OpenAPI definition
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -239,7 +239,7 @@ message ListModelsRequest {
   // Page token.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View allows clients to specify the desired model view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Include soft-deleted models in the result.
   optional bool show_deleted = 4 [(google.api.field_behavior) = OPTIONAL];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
@@ -270,7 +270,7 @@ message LookUpModelRequest {
   // - Format: `models/{model.uid}`.
   string permalink = 1 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired model view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // LookUpModelResponse contains the requested model.
@@ -290,7 +290,7 @@ message ListNamespaceModelsRequest {
   // Page token.
   optional string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
   // View allows clients to specify the desired model view in the response.
-  optional View view = 4 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 4 [(google.api.field_behavior) = OPTIONAL];
   // Include soft-deleted models in the result.
   optional bool show_deleted = 5 [(google.api.field_behavior) = OPTIONAL];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
@@ -338,7 +338,7 @@ message GetNamespaceModelRequest {
   // Model ID
   string model_id = 2 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired model view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetNamespaceModelResponse contains the requested model.
@@ -631,7 +631,7 @@ message GetNamespaceLatestModelOperationRequest {
   string model_id = 2 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired operation result in the
   // response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetNamespaceLatestModelOperationResponse represents a response to query a
@@ -653,7 +653,7 @@ message GetNamespaceModelOperationRequest {
   string version = 3 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired operation result in the
   // response.
-  optional View view = 4 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetNamespaceModelOperationResponse represents a response to query a
@@ -731,7 +731,7 @@ message ListUserModelsRequest {
   // Page token.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View allows clients to specify the desired model view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // The parent resource, i.e., the user that created the models.
   // - Format: `users/{user.id}`.
   string parent = 4 [
@@ -778,7 +778,7 @@ message GetUserModelRequest {
     }
   ];
   // View allows clients to specify the desired model view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetUserModelResponse contains the requested model.
@@ -1139,7 +1139,7 @@ message ListOrganizationModelsRequest {
   // Page token.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View allows clients to specify the desired model view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // The parent resource, i.e., the organization that created the models.
   // - Format: `organizations/{organizations.id}`.
   string parent = 4 [
@@ -1187,7 +1187,7 @@ message GetOrganizationModelRequest {
     }
   ];
   // View allows clients to specify the desired model view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetOrganizationModelResponse contains the requested model.
@@ -1518,7 +1518,7 @@ message GetModelOperationRequest {
   // The resource name of the model, which allows its access ID.
   string operation_id = 1 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired model view in the response.
-  optional View view = 2 [
+  optional common.view.v1beta.View view = 2 [
     deprecated = true,
     (google.api.field_behavior) = OPTIONAL
   ];
@@ -1559,7 +1559,7 @@ message GetUserLatestModelOperationRequest {
   ];
   // View allows clients to specify the desired operation result in the
   // response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetUserLatestModelOperationRequest represents a request to query a
@@ -1584,7 +1584,7 @@ message GetOrganizationLatestModelOperationRequest {
   ];
   // View allows clients to specify the desired operation result in the
   // response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetOrganizationLatestModelOperationRequest represents a request to query a
@@ -1620,7 +1620,7 @@ message ListModelsAdminRequest {
   // Model view (default is VIEW_BASIC)
   // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
   // VIEW_FULL: show full information
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Return soft_deleted models
   optional bool show_deleted = 4 [(google.api.field_behavior) = OPTIONAL];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
@@ -1648,7 +1648,7 @@ message LookUpModelAdminRequest {
   // Model view (default is VIEW_BASIC)
   // VIEW_UNSPECIFIED/VIEW_BASIC: omit `Model.configuration`
   // VIEW_FULL: show full information
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // LookUpModelResponse represents a response for a model

--- a/model/model/v1alpha/model_definition.proto
+++ b/model/model/v1alpha/model_definition.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package model.model.v1alpha;
 
 // Google API
+import "common/view/v1beta/view.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 // Protocol Buffers Well-Known Types
@@ -67,15 +68,6 @@ message ModelDefinition {
   google.protobuf.Timestamp update_time = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
-// View defines how a model definition is presented.
-enum View {
-  // Unspecified, equivalent to BASIC.
-  VIEW_UNSPECIFIED = 0;
-  // Default view, only includes basic information (omits `model_spec`).
-  VIEW_BASIC = 1;
-  // Full representation.
-  VIEW_FULL = 2;
-}
 
 // ListModelDefinitionsRequest represents a request to list all supported model
 // definitions.
@@ -87,7 +79,7 @@ message ListModelDefinitionsRequest {
   // Page token.
   optional string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListModelDefinitionsResponse contains a list of model definitions.
@@ -106,7 +98,7 @@ message GetModelDefinitionRequest {
   // Reserved for `name`
   reserved 1;
   // View allows clients to specify the desired resource view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
   // The resource name of the model definition, which allows its access by ID.
   // - Format: `model-definitions/{id}`.
   string model_definition_id = 3 [(google.api.field_behavior) = REQUIRED];

--- a/pipeline/pipeline/v1beta/common.proto
+++ b/pipeline/pipeline/v1beta/common.proto
@@ -133,16 +133,3 @@ enum ComponentType {
   // Generic.
   COMPONENT_TYPE_GENERIC = 6;
 }
-
-// View defines how a resource is presented. Most resources can share this view
-// definition, the particular meaning of each value should be defined in the
-// resource itself. Certain resources might have their own View definition if
-// they need to implement more than 2 (basic / full) views.
-enum View {
-  // Unspecified, equivalent to BASIC.
-  VIEW_UNSPECIFIED = 0;
-  // Default view.
-  VIEW_BASIC = 1;
-  // Full representation.
-  VIEW_FULL = 2;
-}

--- a/pipeline/pipeline/v1beta/component_definition.proto
+++ b/pipeline/pipeline/v1beta/component_definition.proto
@@ -6,6 +6,8 @@ package pipeline.pipeline.v1beta;
 import "google/api/field_behavior.proto";
 // Protocol Buffers Well-Known Types
 import "google/protobuf/struct.proto";
+// Common definitions
+import "common/view/v1beta/view.proto";
 // Pipeline definitions
 import "pipeline/pipeline/v1beta/common.proto";
 
@@ -15,17 +17,6 @@ import "pipeline/pipeline/v1beta/common.proto";
 
 // ComponentDefinition describes a certain type of Component.
 message ComponentDefinition {
-  // View defines how a component definition is presented.
-  enum View {
-    // Unspecified, equivalent to BASIC.
-    VIEW_UNSPECIFIED = 0;
-    // Default view, only includes basic information (removes the `spec`
-    // field).
-    VIEW_BASIC = 1;
-    // Full representation.
-    VIEW_FULL = 2;
-  }
-
   // ReleaseStage defines the release stage of a component. This is used to
   // group components with the same pre-relase groups (e.g. `0.1.0-beta`,
   // `0.1.0-beta.1` -> `RELEASE_STAGE_BETA`) and to include other "in progress"
@@ -172,7 +163,7 @@ message ListComponentDefinitionsRequest {
   // cursor information from the server.
   reserved 2;
   // View allows clients to specify the desired resource view in the response.
-  optional ComponentDefinition.View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
   // Filter can hold an [AIP-160](https://google.aip.dev/160)-compliant filter
   // expression.
   // - Example: `component_type="COMPONENT_TYPE_AI"`.

--- a/pipeline/pipeline/v1beta/integration.proto
+++ b/pipeline/pipeline/v1beta/integration.proto
@@ -8,8 +8,8 @@ import "google/api/field_behavior.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-// Pipeline definitions
-import "pipeline/pipeline/v1beta/common.proto";
+// Common definitions
+import "common/view/v1beta/view.proto";
 
 // Connection contains the parameters to communicate with a 3rd party app. A
 // component may reference a connection in their setup. One connection may be
@@ -65,7 +65,7 @@ message Connection {
   // - setup
   // - scopes
   // - oAuthAccessDetails
-  View view = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  common.view.v1beta.View view = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Creation timestamp.
   google.protobuf.Timestamp create_time = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
   // Last update timestamp.
@@ -110,7 +110,7 @@ message GetNamespaceConnectionRequest {
   // Connection ID.
   string connection_id = 2 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired view in the response.
-  optional View view = 3 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetNamespaceConnectionResponse contains the requested connection.
@@ -236,7 +236,7 @@ message Integration {
   // only shown in the FULL view:
   // - setupSchema
   // - oAuthConfig
-  View view = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  common.view.v1beta.View view = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // ListPipelineIDsByConnectionIDRequest represents a request to list the
@@ -298,7 +298,7 @@ message GetIntegrationRequest {
   // Integration ID.
   string integration_id = 1 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired view in the response.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // GetIntegrationResponse contains the requested integration.
@@ -314,7 +314,7 @@ message LookUpConnectionAdminRequest {
   string uid = 1 [(google.api.field_behavior) = REQUIRED];
   // View allows clients to specify the desired view in the response. It
   // defaults to `VIEW_BASIC`.
-  optional View view = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional common.view.v1beta.View view = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // LookUpConnectionAdminResponse contains the requested connection.


### PR DESCRIPTION
Because

- When retrieving information from a file or catalog (e.g. in
  question-answering), we want to position the source within the original
  file.

This commit

- Returns context to position the chunk within its source and original
  files.
- Returns the file length as a file property.
- Improves the Artifact API to be more aligned with other services and with
  Google's AIP.
