### PR TITLE
chore(catalog): specify 1-based index for page citation

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -415,8 +415,8 @@ enum FileType {
 
 // file
 message File {
-  // Position represents a position within a file using a specific unit. The
-  // number of dimensions of the position value depends on the unit type.
+  // Position within a file, as coordinates in a a specific unit. The
+  // number of dimensions of the coordinate depends on the unit type.
   message Position {
     // Unit of measurement for a position within a file.
     enum Unit {
@@ -424,7 +424,8 @@ message File {
       UNIT_UNSPECIFIED = 0;
       // Character positions (for Markdown and other text files).
       UNIT_CHARACTER = 1;
-      // Page positions (for documents).
+      // Page positions (for documents). For pages, positions are 1-indexed
+      // (e.g., page 4 of 4) to align with document visualization standards.
       UNIT_PAGE = 2;
       // Time positions in milliseconds (for audio/video files).
       UNIT_TIME_MS = 3;

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -8532,8 +8532,8 @@ definitions:
         description: Position value.
         readOnly: true
     description: |-
-      Position represents a position within a file using a specific unit. The
-      number of dimensions of the position value depends on the unit type.
+      Position within a file, as coordinates in a a specific unit. The
+      number of dimensions of the coordinate depends on the unit type.
   ProcessCatalogFilesRequest:
     type: object
     properties:
@@ -9426,7 +9426,8 @@ definitions:
       Unit of measurement for a position within a file.
 
        - UNIT_CHARACTER: Character positions (for Markdown and other text files).
-       - UNIT_PAGE: Page positions (for documents).
+       - UNIT_PAGE: Page positions (for documents). For pages, positions are 1-indexed
+      (e.g., page 4 of 4) to align with document visualization standards.
        - UNIT_TIME_MS: Time positions in milliseconds (for audio/video files).
        - UNIT_PIXEL: Pixel positions (for images and other 2D content).
   UpdateCatalogBody:


### PR DESCRIPTION
This commit

- Documents the indexing (1-based) in chunk references for paged
  documents.
