### PR TITLE
chore(artifact): update conversion pipeline specs

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -251,10 +251,11 @@ message CreateCatalogRequest {
   repeated string tags = 4;
   // The catalog type. default is PERSISTENT
   CatalogType type = 5;
-  // Pipelines used for converting documents (i.e., files with pdf, doc[x] or
-  // ppt[x] extension) to Markdown. The strings in the list identify the
-  // pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.
-  // The pipeline recipes MUST have the following variable and output fields:
+  // Pipelines used for converting page-based documents (i.e., files with pdf,
+  // doc[x] or ppt[x] extension) to Markdown. The strings in the list identify
+  // the pipelines and MUST have the format
+  // `{namespaceID}/{pipelineID}@{version}`. The pipeline recipes MUST have the
+  // following variable and output fields:
   // ```yaml variable
   // variable:
   //   document_input:
@@ -262,6 +263,7 @@ message CreateCatalogRequest {
   //     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)
   //     type: file
   // ```
+  // The `convert_result` output should be a list of strings, one per page.
   // ```yaml output
   // output:
   //  convert_result:
@@ -308,10 +310,11 @@ message UpdateCatalogRequest {
   repeated string tags = 3;
   // The catalog owner(namespace).
   string namespace_id = 4;
-  // Pipelines used for converting documents (i.e., files with pdf, doc[x] or
-  // ppt[x] extension) to Markdown. The strings in the list identify the
-  // pipelines and MUST have the format `{namespaceID}/{pipelineID}@{version}`.
-  // The pipeline recipes MUST have the following variable and output fields:
+  // Pipelines used for converting page-based documents (i.e., files with pdf,
+  // doc[x] or ppt[x] extension) to Markdown. The strings in the list identify
+  // the pipelines and MUST have the format
+  // `{namespaceID}/{pipelineID}@{version}`. The pipeline recipes MUST have the
+  // following variable and output fields:
   // ```yaml variable
   // variable:
   //   document_input:
@@ -319,6 +322,7 @@ message UpdateCatalogRequest {
   //     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)
   //     type: file
   // ```
+  // The `convert_result` output should be a list of strings, one per page.
   // ```yaml output
   // output:
   //  convert_result:
@@ -493,6 +497,7 @@ message File {
   //     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)
   //     type: file
   // ```
+  // The `convert_result` output should be a list of strings, one per page.
   // ```yaml output
   // output:
   //  convert_result:


### PR DESCRIPTION
Because

- The conversion pipeline for documents should now return a list of
  strings (one per page) so the chunks can have page reference metadata.

This commit

- Updates the documentation for the `converting_pipeline[s]` fields in
  order to clarify the pipeline required output.
