### PR TITLE
chore(artifact): deprecate file process status and add file types

### DIFF
--- a/artifact/artifact/v1alpha/artifact.proto
+++ b/artifact/artifact/v1alpha/artifact.proto
@@ -367,10 +367,10 @@ enum FileProcessStatus {
   FILE_PROCESS_STATUS_UNSPECIFIED = 0;
   // NOTSTARTED
   FILE_PROCESS_STATUS_NOTSTARTED = 1;
-  // file is waiting for embedding process
-  FILE_PROCESS_STATUS_WAITING = 2;
-  // file is converting
-  FILE_PROCESS_STATUS_CONVERTING = 3;
+  // file is waiting for embedding process (deprecated - sequential architecture)
+  FILE_PROCESS_STATUS_WAITING = 2 [deprecated = true];
+  // file is converting (deprecated - sequential architecture)
+  FILE_PROCESS_STATUS_CONVERTING = 3 [deprecated = true];
   // file is chunking
   FILE_PROCESS_STATUS_CHUNKING = 4;
   // file is embedding
@@ -379,28 +379,30 @@ enum FileProcessStatus {
   FILE_PROCESS_STATUS_COMPLETED = 6;
   // failed
   FILE_PROCESS_STATUS_FAILED = 7;
-  // file is summarizing
-  FILE_PROCESS_STATUS_SUMMARIZING = 8;
+  // file is summarizing (deprecated - sequential architecture)
+  FILE_PROCESS_STATUS_SUMMARIZING = 8 [deprecated = true];
+  // file is being processed (parallel architecture: conversion + summarization)
+  FILE_PROCESS_STATUS_PROCESSING = 9;
 }
 
 // file type
 enum FileType {
   // unspecified
   FILE_TYPE_UNSPECIFIED = 0;
+
+  // Text-based document types
   // text
   FILE_TYPE_TEXT = 1;
   // PDF
   FILE_TYPE_PDF = 2;
-  //MARKDOWN
+  // MARKDOWN
   FILE_TYPE_MARKDOWN = 3;
-  // PNG(not supported yet)
-  FILE_TYPE_PNG = 4;
-  // JPEG(not supported yet)
-  FILE_TYPE_JPEG = 5;
-  // JPG(not supported yet)
-  FILE_TYPE_JPG = 6;
   // HTML
   FILE_TYPE_HTML = 7;
+  // CSV
+  FILE_TYPE_CSV = 14;
+
+  // Microsoft Office document types
   // DOCX
   FILE_TYPE_DOCX = 8;
   // DOC
@@ -413,8 +415,64 @@ enum FileType {
   FILE_TYPE_XLS = 12;
   // XLSX
   FILE_TYPE_XLSX = 13;
-  // CSV
-  FILE_TYPE_CSV = 14;
+
+  // Image types (supported by pipeline-backend/pkg/data/image.go)
+  // PNG
+  FILE_TYPE_PNG = 4;
+  // JPEG
+  FILE_TYPE_JPEG = 5;
+  // JPG
+  FILE_TYPE_JPG = 6;
+  // GIF
+  FILE_TYPE_GIF = 15;
+  // WEBP
+  FILE_TYPE_WEBP = 16;
+  // TIFF
+  FILE_TYPE_TIFF = 17;
+  // BMP
+  FILE_TYPE_BMP = 18;
+  // HEIC
+  FILE_TYPE_HEIC = 19;
+  // HEIF
+  FILE_TYPE_HEIF = 20;
+  // AVIF
+  FILE_TYPE_AVIF = 21;
+
+  // Audio types (supported by pipeline-backend/pkg/data/audio.go)
+  // MP3
+  FILE_TYPE_MP3 = 22;
+  // WAV
+  FILE_TYPE_WAV = 23;
+  // AAC
+  FILE_TYPE_AAC = 24;
+  // OGG
+  FILE_TYPE_OGG = 25;
+  // FLAC
+  FILE_TYPE_FLAC = 26;
+  // M4A
+  FILE_TYPE_M4A = 27;
+  // WMA
+  FILE_TYPE_WMA = 28;
+  // AIFF
+  FILE_TYPE_AIFF = 29;
+
+  // Video types (supported by pipeline-backend/pkg/data/video.go)
+  // MP4
+  FILE_TYPE_MP4 = 30;
+  // AVI
+  FILE_TYPE_AVI = 31;
+  // MOV
+  FILE_TYPE_MOV = 32;
+  // WEBM (video)
+  FILE_TYPE_WEBM_VIDEO = 33;
+  // MKV
+  FILE_TYPE_MKV = 34;
+  // FLV
+  FILE_TYPE_FLV = 35;
+  // WMV
+  FILE_TYPE_WMV = 36;
+  // MPEG
+  FILE_TYPE_MPEG = 37;
 }
 
 // file

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -242,13 +242,14 @@ paths:
             Processing status of the files.
 
              - FILE_PROCESS_STATUS_NOTSTARTED: NOTSTARTED
-             - FILE_PROCESS_STATUS_WAITING: file is waiting for embedding process
-             - FILE_PROCESS_STATUS_CONVERTING: file is converting
+             - FILE_PROCESS_STATUS_WAITING: file is waiting for embedding process (deprecated - sequential architecture)
+             - FILE_PROCESS_STATUS_CONVERTING: file is converting (deprecated - sequential architecture)
              - FILE_PROCESS_STATUS_CHUNKING: file is chunking
              - FILE_PROCESS_STATUS_EMBEDDING: file is embedding
              - FILE_PROCESS_STATUS_COMPLETED: completed
              - FILE_PROCESS_STATUS_FAILED: failed
-             - FILE_PROCESS_STATUS_SUMMARIZING: file is summarizing
+             - FILE_PROCESS_STATUS_SUMMARIZING: file is summarizing (deprecated - sequential architecture)
+             - FILE_PROCESS_STATUS_PROCESSING: file is being processed (parallel architecture: conversion + summarization)
           in: query
           required: false
           type: string
@@ -261,6 +262,7 @@ paths:
             - FILE_PROCESS_STATUS_COMPLETED
             - FILE_PROCESS_STATUS_FAILED
             - FILE_PROCESS_STATUS_SUMMARIZING
+            - FILE_PROCESS_STATUS_PROCESSING
       tags:
         - Artifact
       x-stage: alpha
@@ -6207,15 +6209,17 @@ definitions:
       - FILE_PROCESS_STATUS_COMPLETED
       - FILE_PROCESS_STATUS_FAILED
       - FILE_PROCESS_STATUS_SUMMARIZING
+      - FILE_PROCESS_STATUS_PROCESSING
     description: |-
       - FILE_PROCESS_STATUS_NOTSTARTED: NOTSTARTED
-       - FILE_PROCESS_STATUS_WAITING: file is waiting for embedding process
-       - FILE_PROCESS_STATUS_CONVERTING: file is converting
+       - FILE_PROCESS_STATUS_WAITING: file is waiting for embedding process (deprecated - sequential architecture)
+       - FILE_PROCESS_STATUS_CONVERTING: file is converting (deprecated - sequential architecture)
        - FILE_PROCESS_STATUS_CHUNKING: file is chunking
        - FILE_PROCESS_STATUS_EMBEDDING: file is embedding
        - FILE_PROCESS_STATUS_COMPLETED: completed
        - FILE_PROCESS_STATUS_FAILED: failed
-       - FILE_PROCESS_STATUS_SUMMARIZING: file is summarizing
+       - FILE_PROCESS_STATUS_SUMMARIZING: file is summarizing (deprecated - sequential architecture)
+       - FILE_PROCESS_STATUS_PROCESSING: file is being processed (parallel architecture: conversion + summarization)
     title: file embedding process status
   FileReference:
     type: object
@@ -6245,32 +6249,83 @@ definitions:
       - FILE_TYPE_TEXT
       - FILE_TYPE_PDF
       - FILE_TYPE_MARKDOWN
-      - FILE_TYPE_PNG
-      - FILE_TYPE_JPEG
-      - FILE_TYPE_JPG
       - FILE_TYPE_HTML
+      - FILE_TYPE_CSV
       - FILE_TYPE_DOCX
       - FILE_TYPE_DOC
       - FILE_TYPE_PPT
       - FILE_TYPE_PPTX
       - FILE_TYPE_XLS
       - FILE_TYPE_XLSX
-      - FILE_TYPE_CSV
+      - FILE_TYPE_PNG
+      - FILE_TYPE_JPEG
+      - FILE_TYPE_JPG
+      - FILE_TYPE_GIF
+      - FILE_TYPE_WEBP
+      - FILE_TYPE_TIFF
+      - FILE_TYPE_BMP
+      - FILE_TYPE_HEIC
+      - FILE_TYPE_HEIF
+      - FILE_TYPE_AVIF
+      - FILE_TYPE_MP3
+      - FILE_TYPE_WAV
+      - FILE_TYPE_AAC
+      - FILE_TYPE_OGG
+      - FILE_TYPE_FLAC
+      - FILE_TYPE_M4A
+      - FILE_TYPE_WMA
+      - FILE_TYPE_AIFF
+      - FILE_TYPE_MP4
+      - FILE_TYPE_AVI
+      - FILE_TYPE_MOV
+      - FILE_TYPE_WEBM_VIDEO
+      - FILE_TYPE_MKV
+      - FILE_TYPE_FLV
+      - FILE_TYPE_WMV
+      - FILE_TYPE_MPEG
     description: |-
-      - FILE_TYPE_TEXT: text
+      - FILE_TYPE_TEXT: Text-based document types
+      text
        - FILE_TYPE_PDF: PDF
        - FILE_TYPE_MARKDOWN: MARKDOWN
-       - FILE_TYPE_PNG: PNG(not supported yet)
-       - FILE_TYPE_JPEG: JPEG(not supported yet)
-       - FILE_TYPE_JPG: JPG(not supported yet)
        - FILE_TYPE_HTML: HTML
-       - FILE_TYPE_DOCX: DOCX
+       - FILE_TYPE_CSV: CSV
+       - FILE_TYPE_DOCX: Microsoft Office document types
+      DOCX
        - FILE_TYPE_DOC: DOC
        - FILE_TYPE_PPT: PPT
        - FILE_TYPE_PPTX: PPTX
        - FILE_TYPE_XLS: XLS
        - FILE_TYPE_XLSX: XLSX
-       - FILE_TYPE_CSV: CSV
+       - FILE_TYPE_PNG: Image types (supported by pipeline-backend/pkg/data/image.go)
+      PNG
+       - FILE_TYPE_JPEG: JPEG
+       - FILE_TYPE_JPG: JPG
+       - FILE_TYPE_GIF: GIF
+       - FILE_TYPE_WEBP: WEBP
+       - FILE_TYPE_TIFF: TIFF
+       - FILE_TYPE_BMP: BMP
+       - FILE_TYPE_HEIC: HEIC
+       - FILE_TYPE_HEIF: HEIF
+       - FILE_TYPE_AVIF: AVIF
+       - FILE_TYPE_MP3: Audio types (supported by pipeline-backend/pkg/data/audio.go)
+      MP3
+       - FILE_TYPE_WAV: WAV
+       - FILE_TYPE_AAC: AAC
+       - FILE_TYPE_OGG: OGG
+       - FILE_TYPE_FLAC: FLAC
+       - FILE_TYPE_M4A: M4A
+       - FILE_TYPE_WMA: WMA
+       - FILE_TYPE_AIFF: AIFF
+       - FILE_TYPE_MP4: Video types (supported by pipeline-backend/pkg/data/video.go)
+      MP4
+       - FILE_TYPE_AVI: AVI
+       - FILE_TYPE_MOV: MOV
+       - FILE_TYPE_WEBM_VIDEO: WEBM (video)
+       - FILE_TYPE_MKV: MKV
+       - FILE_TYPE_FLV: FLV
+       - FILE_TYPE_WMV: WMV
+       - FILE_TYPE_MPEG: MPEG
     title: file type
   FruitCosts:
     type: object


### PR DESCRIPTION
Because

- file processing workflow running conversion and summarization child workflow in parallel now and by adopting Temporal, we no longer need `FILE_PROCESS_STATUS_WAITING`.

This commit

- deprecates `FILE_PROCESS_STATUS_WAITING`, `FILE_PROCESS_STATUS_CONVERTING`, `FILE_PROCESS_STATUS_SUMMARIZING`, and introduces `FILE_PROCESS_STATUS_PROCESSING`
- adds up-to-date supported file types.
