### PR TITLE
fix(artifact): replace embedded Owner/Creator with denormalized display fields

### DIFF
--- a/artifact/v1alpha/file.proto
+++ b/artifact/v1alpha/file.proto
@@ -9,8 +9,6 @@ import "google/api/resource.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
-// Core definitions
-import "mgmt/v1beta/mgmt.proto";
 
 // file embedding process status
 enum FileProcessStatus {
@@ -310,16 +308,15 @@ message File {
   // Example: "namespaces/usr-7k2m9p4w1n3" or "namespaces/org-3t8f5q2x6b1"
   string owner_name = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // File owner (User or Organization).
-  optional mgmt.v1beta.Owner owner = 19 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reserved: previously embedded full Owner/User objects which leaked
+  // internal data (email, metadata, permissions) to cross-workspace callers.
+  // Replaced by denormalized display fields (32-35).
+  reserved 19, 21;
+  reserved "owner", "creator";
 
   // Full resource name of the user who created this file.
   // Format: `users/{user}`
   string creator_name = 20 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-  // The user who created this file.
-  // Populated when creator_name is present.
-  optional mgmt.v1beta.User creator = 21 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // ===== Upload and content fields =====
 
@@ -375,6 +372,28 @@ message File {
   // Computed at ingestion time for both inline content uploads and object
   // reference uploads.
   string content_sha256 = 31 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // ===== Denormalized display fields =====
+  // These replace the removed embedded owner/creator objects (fields 19, 21)
+  // to avoid leaking internal user data to cross-workspace callers.
+  // Same pattern as Collection (collection.proto fields 23-26).
+
+  // Human-readable display name of the owner namespace.
+  // Populated server-side to avoid an extra frontend API call.
+  // Example: "Instill AI" (for an org) or "John Doe" (for a user).
+  string owner_display_name = 32 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Avatar URL of the owner namespace.
+  // Populated server-side alongside owner_display_name.
+  optional string owner_avatar = 33 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Human-readable display name of the user who created this file.
+  // Populated server-side to avoid an extra frontend API call.
+  string creator_display_name = 34 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Avatar URL of the user who created this file.
+  // Populated server-side alongside creator_display_name.
+  optional string creator_avatar = 35 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateFileRequest represents a request to create a file in a knowledge base.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -717,24 +717,12 @@ paths:
                   Resource name of the owner namespace.
                   Example: "namespaces/usr-7k2m9p4w1n3" or "namespaces/org-3t8f5q2x6b1"
                 readOnly: true
-              owner:
-                description: File owner (User or Organization).
-                readOnly: true
-                allOf:
-                  - $ref: '#/definitions/Owner'
               creatorName:
                 type: string
                 title: |-
                   Full resource name of the user who created this file.
                   Format: `users/{user}`
                 readOnly: true
-              creator:
-                description: |-
-                  The user who created this file.
-                  Populated when creator_name is present.
-                readOnly: true
-                allOf:
-                  - $ref: '#/definitions/v1beta.User'
               content:
                 type: string
                 description: |-
@@ -797,6 +785,31 @@ paths:
                   SHA256 hash of the file content for content-based deduplication.
                   Computed at ingestion time for both inline content uploads and object
                   reference uploads.
+                readOnly: true
+              ownerDisplayName:
+                type: string
+                description: |-
+                  Human-readable display name of the owner namespace.
+                  Populated server-side to avoid an extra frontend API call.
+                  Example: "Instill AI" (for an org) or "John Doe" (for a user).
+                readOnly: true
+              ownerAvatar:
+                type: string
+                description: |-
+                  Avatar URL of the owner namespace.
+                  Populated server-side alongside owner_display_name.
+                readOnly: true
+              creatorDisplayName:
+                type: string
+                description: |-
+                  Human-readable display name of the user who created this file.
+                  Populated server-side to avoid an extra frontend API call.
+                readOnly: true
+              creatorAvatar:
+                type: string
+                description: |-
+                  Avatar URL of the user who created this file.
+                  Populated server-side alongside creator_display_name.
                 readOnly: true
             title: |-
               The file resource to update. The file's `name` field identifies the
@@ -6485,24 +6498,12 @@ definitions:
           Resource name of the owner namespace.
           Example: "namespaces/usr-7k2m9p4w1n3" or "namespaces/org-3t8f5q2x6b1"
         readOnly: true
-      owner:
-        description: File owner (User or Organization).
-        readOnly: true
-        allOf:
-          - $ref: '#/definitions/Owner'
       creatorName:
         type: string
         title: |-
           Full resource name of the user who created this file.
           Format: `users/{user}`
         readOnly: true
-      creator:
-        description: |-
-          The user who created this file.
-          Populated when creator_name is present.
-        readOnly: true
-        allOf:
-          - $ref: '#/definitions/v1beta.User'
       content:
         type: string
         description: |-
@@ -6565,6 +6566,31 @@ definitions:
           SHA256 hash of the file content for content-based deduplication.
           Computed at ingestion time for both inline content uploads and object
           reference uploads.
+        readOnly: true
+      ownerDisplayName:
+        type: string
+        description: |-
+          Human-readable display name of the owner namespace.
+          Populated server-side to avoid an extra frontend API call.
+          Example: "Instill AI" (for an org) or "John Doe" (for a user).
+        readOnly: true
+      ownerAvatar:
+        type: string
+        description: |-
+          Avatar URL of the owner namespace.
+          Populated server-side alongside owner_display_name.
+        readOnly: true
+      creatorDisplayName:
+        type: string
+        description: |-
+          Human-readable display name of the user who created this file.
+          Populated server-side to avoid an extra frontend API call.
+        readOnly: true
+      creatorAvatar:
+        type: string
+        description: |-
+          Avatar URL of the user who created this file.
+          Populated server-side alongside creator_display_name.
         readOnly: true
     title: |-
       File represents a file in a knowledge base.


### PR DESCRIPTION
## Summary

Because

- File proto embeds full `mgmt.v1beta.Owner` and `mgmt.v1beta.User` objects, leaking internal data (email, metadata, permissions, org stats) to cross-workspace users and visitors accessing public collection files

This commit

- Reserve fields 19 (`owner`) and 21 (`creator`) to remove the embedded objects
- Add denormalized fields 32-35 (`owner_display_name`, `owner_avatar`, `creator_display_name`, `creator_avatar`) as lightweight replacements
- Remove the `mgmt/v1beta/mgmt.proto` import that is no longer needed