### PR TITLE
feat(artifact): add TransferObjectsNamespaceAdmin RPC for visitor chat claim

### DIFF
--- a/artifact/v1alpha/artifact_private_service.proto
+++ b/artifact/v1alpha/artifact_private_service.proto
@@ -166,4 +166,13 @@ service ArtifactPrivateService {
   // the seeds via the kb_entity / kb_entity_file graph. Used by agent-backend
   // for two-phase semantic search expansion.
   rpc EntityHopAdmin(EntityHopAdminRequest) returns (EntityHopAdminResponse);
+
+  // Transfer objects to a different namespace (admin only)
+  //
+  // Batch-updates the namespace and creator of the specified objects. The
+  // underlying blob storage is not moved — only the ownership metadata in the
+  // database is changed. Used by agent-backend to transfer visitor-generated
+  // artifacts (images, code outputs, etc.) to the user's namespace after
+  // signup.
+  rpc TransferObjectsNamespaceAdmin(TransferObjectsNamespaceAdminRequest) returns (TransferObjectsNamespaceAdminResponse);
 }

--- a/artifact/v1alpha/object.proto
+++ b/artifact/v1alpha/object.proto
@@ -234,3 +234,29 @@ message UpdateObjectAdminResponse {
   // The updated object.
   Object object = 1;
 }
+
+// TransferObjectsNamespaceAdminRequest transfers objects from one namespace to
+// another (admin only). Follows AIP-136 (custom method).
+//
+// Used by agent-backend during visitor chat claim to move generated artifacts
+// (images, code outputs, etc.) to the new user's namespace after signup.
+message TransferObjectsNamespaceAdminRequest {
+  // The object IDs to transfer.
+  // Format: hash-based IDs (e.g., "obj-a1b2c3d4e5f6g7h8").
+  repeated string object_ids = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The target namespace resource name.
+  // Format: `namespaces/{namespace}`
+  string new_namespace = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The new creator's user resource name.
+  // Format: `users/{user}`
+  string new_creator = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// TransferObjectsNamespaceAdminResponse is the response after transferring
+// objects.
+message TransferObjectsNamespaceAdminResponse {
+  // The number of objects successfully transferred.
+  int32 transferred_count = 1;
+}


### PR DESCRIPTION
Because

- Visitor-generated artifacts (images, code outputs) are stored in the `org_visitor` namespace during the visitor chat preview phase
- After visitor signup, these artifacts need to be transferred to the new user's namespace for correct data ownership
- No existing API supports batch namespace transfer for objects

This commit

- Add `TransferObjectsNamespaceAdmin` RPC to `ArtifactPrivateService`
- Add `TransferObjectsNamespaceAdminRequest`/`Response` messages to `object.proto`
- Use AIP resource name format for `new_namespace` and `new_creator` fields

## Context

Part of the **Visitor Chat Preview** feature. When a visitor on a public collection link (`/r/{token}`) chats and generates artifacts (via image tool, code tool, etc.), those artifacts are temporarily stored in a system `org_visitor` namespace. After the visitor signs up, `agent-backend-ee` calls this RPC to transfer artifact ownership to the new user's namespace.

This is a private/admin-only endpoint — only called service-to-service by `agent-backend-ee`.



Made with [Cursor](https://cursor.com)