### PR TITLE
feat(artifact): add Visibility enum and field to File message

### DIFF
--- a/artifact/v1alpha/file.proto
+++ b/artifact/v1alpha/file.proto
@@ -394,6 +394,25 @@ message File {
   // Avatar URL of the user who created this file.
   // Populated server-side alongside creator_display_name.
   optional string creator_avatar = 35 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // ===== Visibility =====
+
+  // Visibility defines who can discover and access the file.
+  enum Visibility {
+    // Unspecified, treated as WORKSPACE.
+    VISIBILITY_UNSPECIFIED = 0;
+    // Reserved for future: truly private (only creator + invited users).
+    VISIBILITY_PRIVATE = 1;
+    // Discoverable by anyone, including anonymous visitors.
+    VISIBILITY_PUBLIC = 2;
+    // Org members can access via all-members grant. Default for files.
+    VISIBILITY_WORKSPACE = 3;
+    // Anyone with the share link (/r/{token}) can access via capability token.
+    VISIBILITY_LINK_SHARED = 4;
+  }
+
+  // Visibility of the file.
+  Visibility visibility = 36 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // CreateFileRequest represents a request to create a file in a knowledge base.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -811,6 +811,10 @@ paths:
                   Avatar URL of the user who created this file.
                   Populated server-side alongside creator_display_name.
                 readOnly: true
+              visibility:
+                description: Visibility of the file.
+                allOf:
+                  - $ref: '#/definitions/File.Visibility'
             title: |-
               The file resource to update. The file's `name` field identifies the
               resource. Format:
@@ -6592,6 +6596,10 @@ definitions:
           Avatar URL of the user who created this file.
           Populated server-side alongside creator_display_name.
         readOnly: true
+      visibility:
+        description: Visibility of the file.
+        allOf:
+          - $ref: '#/definitions/File.Visibility'
     title: |-
       File represents a file in a knowledge base.
       Field ordering follows AIP standard: name(1), id(2), display_name(3),
@@ -6712,6 +6720,20 @@ definitions:
        - VIEW_ORIGINAL_FILE_TYPE: Returns MinIO pre-signed URL to the original uploaded file.
        - VIEW_CACHE: Returns Gemini cache resource name.
        - VIEW_PATCH: Returns MinIO pre-signed URL to patch.md (user-submitted content patches).
+  File.Visibility:
+    type: string
+    enum:
+      - VISIBILITY_PRIVATE
+      - VISIBILITY_PUBLIC
+      - VISIBILITY_WORKSPACE
+      - VISIBILITY_LINK_SHARED
+    description: |-
+      Visibility defines who can discover and access the file.
+
+       - VISIBILITY_PRIVATE: Reserved for future: truly private (only creator + invited users).
+       - VISIBILITY_PUBLIC: Discoverable by anyone, including anonymous visitors.
+       - VISIBILITY_WORKSPACE: Org members can access via all-members grant. Default for files.
+       - VISIBILITY_LINK_SHARED: Anyone with the share link (/r/{token}) can access via capability token.
   FileMediaType:
     type: string
     enum:


### PR DESCRIPTION
## Summary

Because

- Files need their own visibility field to support independent share link generation, aligning with Collection and future Note resources
- The 4-value enum (PRIVATE/PUBLIC/WORKSPACE/LINK_SHARED) matches the Collection visibility model for consistency

This commit

- Add `Visibility` enum inside `message File` with 5 values (UNSPECIFIED, PRIVATE, PUBLIC, WORKSPACE, LINK_SHARED)
- Add `visibility` field at position 36 (OPTIONAL)

## Context

Part of Share Link Foundation: unified visibility model across Collection, File, and Note.

Companion PR: instill-ai/protobufs-ee#108 (Collection enum changes)

**Note**: `buf generate` and `generate openapi` hooks were skipped due to BSR rate limiting. CI will generate these files.

Made with [Cursor](https://cursor.com)