### PR TITLE
feat(artifact): add parent_project field to File message

### DIFF
--- a/artifact/v1alpha/file.proto
+++ b/artifact/v1alpha/file.proto
@@ -441,6 +441,18 @@ message File {
   // the preferred card-tile source and fall back to `derived_resource_uri`
   // / mime-type icon when absent.
   optional string thumbnail_uri = 38 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The project that this file belongs to (single parent).
+  // File permissions cascade from this project — the file inherits
+  // viewer/editor/commenter/resource_owner from its parent project.
+  // Format: `namespaces/{namespace}/projects/{project}`
+  // Populated server-side from the file's parent_project_uid DB column.
+  // Files without an explicit parent project default to the namespace's
+  // root project ("Workspace").
+  optional string parent_project = 39 [
+    (google.api.field_behavior) = OUTPUT_ONLY,
+    (google.api.resource_reference) = {type: "agent.instill.tech/Project"}
+  ];
 }
 
 // CreateFileRequest represents a request to create a file in a knowledge base.

--- a/openapi/v2/service.swagger.yaml
+++ b/openapi/v2/service.swagger.yaml
@@ -875,6 +875,17 @@ paths:
                   the preferred card-tile source and fall back to `derived_resource_uri`
                   / mime-type icon when absent.
                 readOnly: true
+              parentProject:
+                type: string
+                description: |-
+                  The project that this file belongs to (single parent).
+                  File permissions cascade from this project — the file inherits
+                  viewer/editor/commenter/resource_owner from its parent project.
+                  Format: `namespaces/{namespace}/projects/{project}`
+                  Populated server-side from the file's parent_project_uid DB column.
+                  Files without an explicit parent project default to the namespace's
+                  root project ("Workspace").
+                readOnly: true
             title: |-
               The file resource to update. The file's `name` field identifies the
               resource. Format:
@@ -6684,6 +6695,17 @@ definitions:
           historical rows; ingest covers new ones). Clients should treat this as
           the preferred card-tile source and fall back to `derived_resource_uri`
           / mime-type icon when absent.
+        readOnly: true
+      parentProject:
+        type: string
+        description: |-
+          The project that this file belongs to (single parent).
+          File permissions cascade from this project — the file inherits
+          viewer/editor/commenter/resource_owner from its parent project.
+          Format: `namespaces/{namespace}/projects/{project}`
+          Populated server-side from the file's parent_project_uid DB column.
+          Files without an explicit parent project default to the namespace's
+          root project ("Workspace").
         readOnly: true
     title: |-
       File represents a file in a knowledge base.


### PR DESCRIPTION
Because

- Phase 4 moves files to a single-parent model where permissions cascade from the owning project rather than from collections
- Frontend needs to know which project a file belongs to for breadcrumb display and future move-file UI

This commit

- Add optional `OUTPUT_ONLY` `parent_project` field (number 39) to the `File` message with `resource_reference` to `agent.instill.tech/Project`
- Format: `namespaces/{namespace}/projects/{project}`
- Auto-generated OpenAPI spec update

Made with [Cursor](https://cursor.com)